### PR TITLE
feat(scaffolder): integrar Marten, Wolverine y PostgreSQL

### DIFF
--- a/.claude/agents/domain-scaffolder.md
+++ b/.claude/agents/domain-scaffolder.md
@@ -89,23 +89,37 @@ Una vez creado, lee el archivo `.csproj` generado para ver su contenido actual a
 
 Luego aplica los siguientes ajustes al `.csproj`:
 
-**1. Agregar el paquete de Service Bus** si no esta presente, dentro del primer `<ItemGroup>` de PackageReferences:
+**1. Remover los paquetes de ApplicationInsights** que `func init` agrega por defecto (los reemplazamos con OpenTelemetry):
+
+Elimina estas lineas del `.csproj`:
+```xml
+<PackageReference Include="Microsoft.ApplicationInsights.WorkerService" ... />
+<PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" ... />
+```
+
+**2. Agregar los paquetes de Marten, Wolverine y OpenTelemetry** dentro del `<ItemGroup>` de PackageReferences:
 
 ```xml
 <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.*" />
+<PackageReference Include="Cosmos.EventDriven.Abstractions" Version="0.0.8" />
+<PackageReference Include="Cosmos.EventDriven.CritterStack" Version="0.0.5" />
+<PackageReference Include="Cosmos.EventDriven.CritterStack.AzureServiceBus" Version="0.0.6" />
+<PackageReference Include="Cosmos.EventSourcing.Abstractions" Version="0.0.12" />
+<PackageReference Include="Cosmos.EventSourcing.CritterStack" Version="0.1.9" />
+<PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.4.0" />
 ```
 
-**2. Agregar la referencia al proyecto Contracts:**
+**3. Agregar la referencia al proyecto Contracts:**
 
 ```xml
 <ProjectReference Include="..\Bitakora.ControlAsistencia.Contracts\Bitakora.ControlAsistencia.Contracts.csproj" />
 ```
 
-**3. Verificar que el `<RootNamespace>` sea correcto:**
+**4. Verificar que el `<RootNamespace>` sea correcto:**
 
 El `<RootNamespace>` debe ser `Bitakora.ControlAsistencia.{PascalCase}`. Si no existe el elemento, agregalo dentro del primer `<PropertyGroup>`. Si ya existe con otro valor, corrígelo.
 
-**4. Crear carpetas estructurales:**
+**5. Crear carpetas estructurales:**
 
 ```bash
 mkdir -p "$REPO_ROOT/src/Bitakora.ControlAsistencia.{PascalCase}/Functions"
@@ -115,7 +129,106 @@ touch "$REPO_ROOT/src/Bitakora.ControlAsistencia.{PascalCase}/Dominio/.gitkeep"
 touch "$REPO_ROOT/src/Bitakora.ControlAsistencia.{PascalCase}/Infraestructura/.gitkeep"
 ```
 
-**5. Crear el HealthCheck en `Functions/HealthCheck.cs`:**
+**6. Reemplazar el `Program.cs`** generado por `func init` con el patron de Marten y Wolverine:
+
+```csharp
+using Cosmos.EventDriven.CritterStack;
+using Cosmos.EventDriven.CritterStack.AzureServiceBus;
+using Cosmos.EventSourcing.CritterStack;
+using Cosmos.EventSourcing.CritterStack.Commands;
+using Microsoft.Azure.Functions.Worker.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using OpenTelemetry.Trace;
+using Bitakora.ControlAsistencia.{PascalCase};
+
+var builder = FunctionsApplication.CreateBuilder(args);
+builder.ConfigureFunctionsWebApplication();
+
+var martenConnectionString = Environment.GetEnvironmentVariable("MartenConnectionString")!;
+var serviceBusConnectionString = Environment.GetEnvironmentVariable("SERVICE_BUS_CONNECTION")!;
+
+builder.Services.AgregarWolverineParaComandosServerless(
+    typeof(I{PascalCase}AssemblyMarker).Assembly,
+    martenConnectionString,
+    "{snake_case}",
+    builder.Environment.IsDevelopment(),
+    options =>
+    {
+        options.HabilitarAzureServiceBusParaServerLess(serviceBusConnectionString);
+        // options.PublicarEventoServerless<MiEvento>("eventos-{kebab}");
+    });
+
+builder.Services.AgregarMartenEventStore();
+builder.Services.AgregarWolverineCommandRouter();
+builder.Services.AgregarWolverineEventSender();
+
+builder.Services.AddOpenTelemetry()
+    .WithTracing(tracing => tracing
+        .AddSource("Wolverine")
+        .AddSource("Marten")
+        .AddSource("Bitakora.ControlAsistencia.{PascalCase}.*"));
+
+await builder.Build().RunAsync();
+```
+
+**7. Crear la interface marker `I{PascalCase}AssemblyMarker.cs`** en la raiz del proyecto:
+
+```csharp
+namespace Bitakora.ControlAsistencia.{PascalCase};
+
+/// <summary>
+/// Marker interface para assembly scanning de Wolverine.
+/// </summary>
+public interface I{PascalCase}AssemblyMarker;
+```
+
+**8. Actualizar `host.json`** para agregar la configuracion de Service Bus. Lee el archivo generado por `func init` y agrega la seccion `extensions` al JSON:
+
+```json
+{
+    "version": "2.0",
+    "logging": {
+        "applicationInsights": {
+            "samplingSettings": {
+                "isEnabled": true,
+                "excludedTypes": "Request"
+            },
+            "enableLiveMetricsFilters": true
+        }
+    },
+    "extensions": {
+        "serviceBus": {
+            "autoCompleteMessages": false,
+            "maxAutoLockRenewalDuration": "00:05:00",
+            "maxConcurrentCalls": 1,
+            "maxConcurrentSessions": 16,
+            "prefetchCount": 10,
+            "sessionIdleTimeout": "00:00:01"
+        }
+    }
+}
+```
+
+**9. Actualizar `local.settings.json`** para incluir `MartenConnectionString` para desarrollo local. Lee el archivo y agrega la clave dentro de `Values`:
+
+```json
+"MartenConnectionString": "Host=localhost;Database=controlasistencias;Username=postgres;Password=postgres"
+```
+
+**10. Verificar que Contracts tenga `Cosmos.EventDriven.Abstractions`:**
+
+Lee `src/Bitakora.ControlAsistencia.Contracts/Bitakora.ControlAsistencia.Contracts.csproj`. Si no tiene el paquete, agregalo:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="Cosmos.EventDriven.Abstractions" Version="0.0.8" />
+</ItemGroup>
+```
+
+Si ya lo tiene, no hagas nada.
+
+**11. Crear el HealthCheck en `Functions/HealthCheck.cs`:**
 
 ```csharp
 using Microsoft.Azure.Functions.Worker;
@@ -228,12 +341,16 @@ module "function_app_{snake_case}" {
   app_settings = {
     SERVICE_BUS_CONNECTION = module.service_bus.default_primary_connection_string
     DOMINIO                = "{kebab}"
+    MartenConnectionString = "Host=${module.postgresql.server_fqdn};Database=${module.postgresql.database_name};Username=pgadmin;Password=${var.postgresql_admin_password};SSL Mode=Require"
   }
   tags = local.tags
 }
 ```
 
 Donde `{kebab-sin-guiones}` es el nombre del dominio con los guiones eliminados (ej: `calculo-horas` -> `calculohoras`).
+
+> **Nota**: el bloque hace referencia a `module.postgresql` que debe existir en la infraestructura base. Si el modulo PostgreSQL no esta presente en `main.tf`, agrega la siguiente advertencia al usuario antes de hacer commit:
+> "Recuerda que el modulo `postgresql` debe estar en la infraestructura base antes de ejecutar `terraform apply`."
 
 ---
 

--- a/.github/workflows/infra-cd.yml
+++ b/.github/workflows/infra-cd.yml
@@ -18,6 +18,8 @@ jobs:
       ARM_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
       ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      TF_VAR_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      TF_VAR_postgresql_admin_password: ${{ secrets.POSTGRESQL_ADMIN_PASSWORD }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -17,6 +17,8 @@ jobs:
       ARM_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
       ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      TF_VAR_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      TF_VAR_postgresql_admin_password: ${{ secrets.POSTGRESQL_ADMIN_PASSWORD }}
 
     steps:
       - name: Checkout

--- a/.gitignore
+++ b/.gitignore
@@ -494,6 +494,7 @@ $RECYCLE.BIN/
 *.tfstate.backup
 *.tfplan
 .terraform.lock.hcl
+*.tfvars
 
 # Azure Functions
 **/local.settings.json

--- a/docs/adr/0006-event-sourcing-marten-wolverine.md
+++ b/docs/adr/0006-event-sourcing-marten-wolverine.md
@@ -1,0 +1,105 @@
+# ADR-0006: Event Sourcing con Marten y Wolverine
+
+## Estado
+
+Aceptado
+
+## Contexto
+
+El sistema necesita persistir el estado de cada dominio de negocio. Las opciones consideradas
+fueron el patron CRUD tradicional (una tabla por entidad con el estado actual) y Event Sourcing
+(persistir los eventos que producen los cambios de estado, en lugar del estado resultante).
+
+Adicionalmente, cada dominio necesita un mecanismo para recibir comandos internos y publicar
+eventos hacia otros dominios via Azure Service Bus. Las opciones evaluadas fueron implementar
+este flujo manualmente (deserializar mensajes, llamar handlers, publicar resultados) o usar
+una libreria que lo estandarice.
+
+El proyecto ControlPlane del mismo equipo ya valido en produccion el uso de Marten como event
+store y Wolverine como mediador de comandos, encapsulados en los paquetes Cosmos.* publicados
+en NuGet.org. Este conocimiento esta disponible para ser reutilizado.
+
+## Decision
+
+Se adoptan los siguientes paquetes para todos los dominios de ControlAsistencias:
+
+| Paquete | Version | Rol |
+|---------|---------|-----|
+| `Cosmos.EventSourcing.CritterStack` | 0.1.9 | Configura Marten como event store |
+| `Cosmos.EventSourcing.Abstractions` | 0.0.12 | Interfaces de event sourcing (IEventStore, etc.) |
+| `Cosmos.EventDriven.CritterStack` | 0.0.5 | Configura Wolverine como mediador de comandos |
+| `Cosmos.EventDriven.CritterStack.AzureServiceBus` | 0.0.6 | Integra Wolverine con Azure Service Bus |
+| `Cosmos.EventDriven.Abstractions` | 0.0.8 | Interfaces de mensajeria (ICommandRouter, IPublicEventSender, etc.) |
+| `Azure.Monitor.OpenTelemetry.AspNetCore` | 1.4.0 | Observabilidad via OpenTelemetry |
+
+Los paquetes `Microsoft.ApplicationInsights.WorkerService` y
+`Microsoft.Azure.Functions.Worker.ApplicationInsights` se reemplazan por OpenTelemetry.
+La infraestructura de Azure Monitor sigue configurada via app settings (no hay cambios en
+Terraform para esta parte); solo cambia el SDK usado en el codigo C#.
+
+### Patron de configuracion en Program.cs
+
+Cada Function App configura Wolverine y Marten con el metodo de extension
+`AgregarWolverineParaComandosServerless`, que recibe:
+- El assembly del dominio (via una interface marker) para el discovery automatico de handlers
+- La connection string de PostgreSQL para Marten
+- El nombre del schema de Marten para ese dominio (aislamiento de datos)
+- Un callback para configurar Service Bus y declarar que eventos se publican a que topics
+
+```csharp
+builder.Services.AgregarWolverineParaComandosServerless(
+    typeof(IDominioAssemblyMarker).Assembly,
+    martenConnectionString,
+    "nombre_schema",
+    builder.Environment.IsDevelopment(),
+    options =>
+    {
+        options.HabilitarAzureServiceBusParaServerLess(serviceBusConnectionString);
+        options.PublicarEventoServerless<MiEvento>("eventos-dominio");
+    });
+```
+
+### Interface marker
+
+Cada dominio define una interface vacia en su namespace raiz para que Wolverine pueda
+escanear el assembly y registrar los handlers automaticamente sin necesidad de nombrarlos
+explicitamente:
+
+```csharp
+namespace Bitakora.ControlAsistencia.MiDominio;
+public interface IMiDominioAssemblyMarker;
+```
+
+### Modo serverless
+
+Wolverine opera en modo serverless: no hay bus in-process. Los eventos se publican
+explicitamente a Azure Service Bus usando `IPublicEventSender` o `IPrivateEventSender`.
+Los triggers de Service Bus (`[ServiceBusTrigger]`) despachan mensajes al `ICommandRouter`.
+
+### Observabilidad
+
+Se configura OpenTelemetry con AddSource para "Wolverine", "Marten" y el namespace del
+dominio, en lugar del SDK propietario de ApplicationInsights. La infraestructura de Azure
+Monitor (APPLICATIONINSIGHTS_CONNECTION_STRING en app settings) sigue siendo necesaria para
+que el agente de Application Insights reciba las trazas de OpenTelemetry.
+
+## Consecuencias
+
+**Positivas**
+
+- Event Sourcing provee un log de auditoria completo e inmutable de todo lo que sucede en
+  cada dominio, critico para el calculo de horas y la liquidacion de nomina.
+- El patron es identico en todos los dominios: cualquier desarrollador puede entender la
+  configuracion de un dominio nuevo leyendo la de cualquier otro.
+- Wolverine en modo serverless no introduce overhead de infraestructura in-process y es
+  compatible con el modelo de escalado de Azure Functions.
+- Los paquetes Cosmos.* ya estan probados en produccion en ControlPlane, reduciendo el
+  riesgo de adopcion.
+
+**Negativas**
+
+- Los paquetes `Cosmos.*` son mantenidos internamente por el equipo. Si hay un bug o se
+  necesita una nueva version, el equipo debe publicar una nueva version en NuGet.org.
+- Event Sourcing agrega complejidad en las consultas (queries requieren proyecciones o
+  snapshots), lo cual no se necesita para simples operaciones CRUD de baja frecuencia.
+- La curva de aprendizaje de Marten y Wolverine es mas alta que la de un ORM tradicional.

--- a/docs/adr/0007-postgresql-compartido-schemas-por-dominio.md
+++ b/docs/adr/0007-postgresql-compartido-schemas-por-dominio.md
@@ -1,0 +1,97 @@
+# ADR-0007: PostgreSQL compartido con schemas separados por dominio
+
+## Estado
+
+Aceptado
+
+## Contexto
+
+Marten (el event store adoptado en ADR-0006) requiere una base de datos PostgreSQL. Hay que
+decidir como organizar esa base de datos dado que el sistema tiene multiples dominios, cada
+uno con su propia Function App.
+
+Las opciones consideradas fueron:
+
+1. **Un servidor PostgreSQL por dominio**: maxima autonomia, pero costo y complejidad
+   operacional muy altos para la etapa actual del proyecto.
+2. **Un servidor compartido, una base de datos por dominio**: cada dominio tiene su propia
+   base de datos dentro del mismo servidor. Buen aislamiento, pero requiere gestionar
+   multiples connection strings y bases de datos.
+3. **Un servidor compartido, una base de datos, schemas separados por dominio**: un unico
+   servidor y una unica base de datos, pero cada dominio opera en su propio schema de
+   PostgreSQL. Marten soporta esto nativamente via el parametro de schema en la
+   configuracion del event store.
+
+## Decision
+
+Se aprovisiona un unico `azurerm_postgresql_flexible_server` en la infraestructura base
+del ambiente (no por dominio). Todos los dominios comparten el mismo servidor y la misma
+base de datos (`controlasistencias`), pero cada uno opera en su propio schema de Marten.
+
+### Configuracion del servidor
+
+- **SKU**: `B_Standard_B1ms` (1 vCore, 2 GB RAM) - suficiente para desarrollo
+- **Version**: PostgreSQL 17
+- **Storage**: 32 GB
+- **Collation**: `es_ES.utf8` (soporte correcto del espanol en texto y ordenamiento)
+- **Firewall**: regla `0.0.0.0 - 0.0.0.0` para permitir acceso desde cualquier servicio Azure
+- `lifecycle { prevent_destroy = true }` para proteger los datos ante cambios accidentales
+  en Terraform
+
+### Schemas por dominio
+
+Cada Function App configura Marten con el nombre de su dominio como schema:
+
+| Dominio | Schema de Marten |
+|---------|------------------|
+| Programacion | `programacion` |
+| Marcaciones | `marcaciones` |
+| CalculoHoras | `calculo_horas` |
+| (etc.) | `{snake_case del dominio}` |
+
+El nombre del schema usa la variante `snake_case` del nombre del dominio para seguir las
+convenciones de nombrado de PostgreSQL.
+
+### Connection string
+
+La connection string de Marten se inyecta como app_setting `MartenConnectionString` en
+cada Function App. Se construye en Terraform usando los outputs del modulo postgresql:
+
+```
+Host={server_fqdn};Database=controlasistencias;Username=pgadmin;Password={password};SSL Mode=Require
+```
+
+Para desarrollo local, `local.settings.json` apunta a un servidor PostgreSQL local:
+
+```
+Host=localhost;Database=controlasistencias;Username=postgres;Password=postgres
+```
+
+### Ubicacion en la infraestructura
+
+El modulo `postgresql` se declara en la infraestructura base del ambiente (`main.tf`),
+al mismo nivel que `monitoring` y `service_bus`. No se genera un servidor por dominio
+cuando se usa el domain-scaffolder.
+
+## Consecuencias
+
+**Positivas**
+
+- Un unico servidor minimiza el costo en la etapa de desarrollo.
+- La administracion es mas simple: backups, actualizaciones de version y monitoreo aplican
+  a un solo recurso.
+- Marten gestiona la creacion y migracion de schemas automaticamente en el primer arranque
+  de cada Function App, sin scripts manuales de DDL.
+- Si en el futuro un dominio necesita su propio servidor (por carga o aislamiento de datos
+  regulatorio), la migracion es transparente: solo cambia la connection string en los
+  app settings de Terraform.
+
+**Negativas**
+
+- Todos los dominios comparten el mismo servidor: un pico de carga en un dominio puede
+  afectar el rendimiento de los demas. Aceptable en dev, deberia reevaluarse en produccion
+  para dominios de alta carga como Marcaciones.
+- La contrasena del administrador de PostgreSQL es una variable de Terraform sensible
+  (`postgresql_admin_password`) que debe proveerse via `TF_VAR_postgresql_admin_password`
+  en el CI o en un `terraform.tfvars` excluido del control de versiones. No usar
+  Key Vault references es deuda tecnica aceptada para esta etapa.

--- a/infra/environments/dev/main.tf
+++ b/infra/environments/dev/main.tf
@@ -23,6 +23,17 @@ module "monitoring" {
   tags                = local.tags
 }
 
+module "postgresql" {
+  source                 = "../../modules/postgresql"
+  name                   = "psql-${local.prefix}"
+  resource_group_name    = module.resource_group.name
+  location               = module.resource_group.location
+  administrator_login    = "pgadmin"
+  administrator_password = var.postgresql_admin_password
+  database_name          = "controlasistencias"
+  tags                   = local.tags
+}
+
 module "service_bus" {
   source              = "../../modules/service-bus"
   name                = "sb-${local.prefix}"
@@ -64,6 +75,7 @@ module "function_app_programacion" {
   app_settings = {
     SERVICE_BUS_CONNECTION = module.service_bus.default_primary_connection_string
     DOMINIO                = "programacion"
+    MartenConnectionString = "Host=${module.postgresql.server_fqdn};Database=${module.postgresql.database_name};Username=pgadmin;Password=${var.postgresql_admin_password};SSL Mode=Require"
   }
   tags = local.tags
 }

--- a/infra/environments/dev/outputs.tf
+++ b/infra/environments/dev/outputs.tf
@@ -7,3 +7,8 @@ output "service_bus_name" {
   description = "Nombre del Service Bus namespace"
   value       = module.service_bus.name
 }
+
+output "postgresql_fqdn" {
+  description = "FQDN del servidor PostgreSQL"
+  value       = module.postgresql.server_fqdn
+}

--- a/infra/environments/dev/terraform.tfvars
+++ b/infra/environments/dev/terraform.tfvars
@@ -1,1 +1,0 @@
-subscription_id = "50fc1901-9723-4971-9d63-b3f1a015e8b8"

--- a/infra/environments/dev/variables.tf
+++ b/infra/environments/dev/variables.tf
@@ -21,6 +21,11 @@ variable "location" {
   default     = "eastus2"
 }
 
+variable "postgresql_admin_password" {
+  description = "Contrasena del administrador de PostgreSQL"
+  type        = string
+  sensitive   = true
+}
 
 locals {
   prefix      = "${var.project}-${var.environment}"

--- a/infra/modules/postgresql/main.tf
+++ b/infra/modules/postgresql/main.tf
@@ -1,0 +1,83 @@
+variable "name" {
+  description = "Nombre del servidor PostgreSQL"
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "Nombre del resource group"
+  type        = string
+}
+
+variable "location" {
+  description = "Region de Azure"
+  type        = string
+}
+
+variable "administrator_login" {
+  description = "Usuario administrador de PostgreSQL"
+  type        = string
+}
+
+variable "administrator_password" {
+  description = "Contrasena del administrador de PostgreSQL"
+  type        = string
+  sensitive   = true
+}
+
+variable "database_name" {
+  description = "Nombre de la base de datos a crear"
+  type        = string
+}
+
+variable "tags" {
+  description = "Tags comunes del proyecto"
+  type        = map(string)
+  default     = {}
+}
+
+resource "azurerm_postgresql_flexible_server" "this" {
+  name                   = var.name
+  resource_group_name    = var.resource_group_name
+  location               = var.location
+  version                = "17"
+  administrator_login    = var.administrator_login
+  administrator_password = var.administrator_password
+
+  sku_name   = "B_Standard_B1ms"
+  storage_mb = 32768
+
+  tags = var.tags
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "azurerm_postgresql_flexible_server_database" "this" {
+  name      = var.database_name
+  server_id = azurerm_postgresql_flexible_server.this.id
+  collation = "es_ES.utf8"
+  charset   = "UTF8"
+}
+
+resource "azurerm_postgresql_flexible_server_firewall_rule" "azure_services" {
+  name             = "allow-azure-services"
+  server_id        = azurerm_postgresql_flexible_server.this.id
+  start_ip_address = "0.0.0.0"
+  end_ip_address   = "0.0.0.0"
+}
+
+output "server_fqdn" {
+  description = "FQDN del servidor PostgreSQL"
+  value       = azurerm_postgresql_flexible_server.this.fqdn
+}
+
+output "database_name" {
+  description = "Nombre de la base de datos"
+  value       = azurerm_postgresql_flexible_server_database.this.name
+}
+
+output "administrator_login" {
+  description = "Usuario administrador"
+  value       = azurerm_postgresql_flexible_server.this.administrator_login
+}

--- a/src/Bitakora.ControlAsistencia.Contracts/Bitakora.ControlAsistencia.Contracts.csproj
+++ b/src/Bitakora.ControlAsistencia.Contracts/Bitakora.ControlAsistencia.Contracts.csproj
@@ -6,4 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Cosmos.EventDriven.Abstractions" Version="0.0.8" />
+  </ItemGroup>
+
 </Project>

--- a/src/Bitakora.ControlAsistencia.Programacion/Bitakora.ControlAsistencia.Programacion.csproj
+++ b/src/Bitakora.ControlAsistencia.Programacion/Bitakora.ControlAsistencia.Programacion.csproj
@@ -11,12 +11,16 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.51.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.50.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.*" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
+    <PackageReference Include="Cosmos.EventDriven.Abstractions" Version="0.0.8" />
+    <PackageReference Include="Cosmos.EventDriven.CritterStack" Version="0.0.5" />
+    <PackageReference Include="Cosmos.EventDriven.CritterStack.AzureServiceBus" Version="0.0.6" />
+    <PackageReference Include="Cosmos.EventSourcing.Abstractions" Version="0.0.12" />
+    <PackageReference Include="Cosmos.EventSourcing.CritterStack" Version="0.1.9" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Bitakora.ControlAsistencia.Programacion/IProgramacionAssemblyMarker.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/IProgramacionAssemblyMarker.cs
@@ -1,0 +1,6 @@
+namespace Bitakora.ControlAsistencia.Programacion;
+
+/// <summary>
+/// Marker interface para assembly scanning de Wolverine.
+/// </summary>
+public interface IProgramacionAssemblyMarker;

--- a/src/Bitakora.ControlAsistencia.Programacion/Program.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/Program.cs
@@ -1,14 +1,38 @@
-using Microsoft.Azure.Functions.Worker;
+using Cosmos.EventDriven.CritterStack;
+using Cosmos.EventDriven.CritterStack.AzureServiceBus;
+using Cosmos.EventSourcing.CritterStack;
+using Cosmos.EventSourcing.CritterStack.Commands;
 using Microsoft.Azure.Functions.Worker.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using OpenTelemetry.Trace;
+using Bitakora.ControlAsistencia.Programacion;
 
 var builder = FunctionsApplication.CreateBuilder(args);
-
 builder.ConfigureFunctionsWebApplication();
 
-builder.Services
-    .AddApplicationInsightsTelemetryWorkerService()
-    .ConfigureFunctionsApplicationInsights();
+var martenConnectionString = Environment.GetEnvironmentVariable("MartenConnectionString")!;
+var serviceBusConnectionString = Environment.GetEnvironmentVariable("SERVICE_BUS_CONNECTION")!;
 
-builder.Build().Run();
+builder.Services.AgregarWolverineParaComandosServerless(
+    typeof(IProgramacionAssemblyMarker).Assembly,
+    martenConnectionString,
+    "programacion",
+    builder.Environment.IsDevelopment(),
+    options =>
+    {
+        options.HabilitarAzureServiceBusParaServerLess(serviceBusConnectionString);
+        // options.PublicarEventoServerless<MiEvento>("eventos-programacion");
+    });
+
+builder.Services.AgregarMartenEventStore();
+builder.Services.AgregarWolverineCommandRouter();
+builder.Services.AgregarWolverineEventSender();
+
+builder.Services.AddOpenTelemetry()
+    .WithTracing(tracing => tracing
+        .AddSource("Wolverine")
+        .AddSource("Marten")
+        .AddSource("Bitakora.ControlAsistencia.Programacion.*"));
+
+await builder.Build().RunAsync();

--- a/src/Bitakora.ControlAsistencia.Programacion/host.json
+++ b/src/Bitakora.ControlAsistencia.Programacion/host.json
@@ -8,5 +8,15 @@
             },
             "enableLiveMetricsFilters": true
         }
+    },
+    "extensions": {
+        "serviceBus": {
+            "autoCompleteMessages": false,
+            "maxAutoLockRenewalDuration": "00:05:00",
+            "maxConcurrentCalls": 1,
+            "maxConcurrentSessions": 16,
+            "prefetchCount": 10,
+            "sessionIdleTimeout": "00:00:01"
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Agrega módulo Terraform `postgresql` (Flexible Server B_Standard_B1ms v17) a la infraestructura base del ambiente dev
- Migra el dominio `Programacion` del patrón ApplicationInsights al patrón Marten/Wolverine/OpenTelemetry
- Actualiza el `domain-scaffolder` para que todos los dominios nuevos nazcan con el patrón completo: Event Sourcing (Marten), mediador de comandos (Wolverine), Service Bus y OpenTelemetry
- Documenta las decisiones arquitectónicas en ADR-0006 y ADR-0007

## Cambios principales

### Infraestructura
- Nuevo módulo `infra/modules/postgresql/main.tf` — Flexible Server PostgreSQL 17 con `prevent_destroy`
- `infra/environments/dev/main.tf` — agrega `module "postgresql"` y `MartenConnectionString` en las Function Apps
- Nueva variable `postgresql_admin_password` (sensitive) para el ambiente dev

### Código
- `src/Bitakora.ControlAsistencia.Programacion/Program.cs` — reemplaza ApplicationInsights por Marten + Wolverine + OpenTelemetry
- Nuevo `IProgramacionAssemblyMarker.cs` — marker interface para assembly scanning de Wolverine
- `host.json` actualizado con configuración de Service Bus (`autoCompleteMessages: false`, etc.)
- Paquetes NuGet: reemplaza `Microsoft.ApplicationInsights.*` por `Cosmos.EventDriven.*`, `Cosmos.EventSourcing.*` y `Azure.Monitor.OpenTelemetry.AspNetCore`

### Scaffolder
- El agente `domain-scaffolder` ahora genera dominios con el patrón completo (Program.cs, marker, host.json, paquetes Cosmos.*)

### ADRs
- `docs/adr/0006-event-sourcing-marten-wolverine.md` — adopción de Marten y Wolverine
- `docs/adr/0007-postgresql-compartido-schemas-por-dominio.md` — un servidor compartido, schemas separados por dominio

## Test plan

- [x] `terraform validate` pasa en `infra/environments/dev/`
- [x] `dotnet build ControlAsistencias.slnx` compila sin errores
- [x] `dotnet test` — exit 0
- [ ] Ejecutar `terraform apply` con `TF_VAR_postgresql_admin_password` para provisionar el servidor PostgreSQL en Azure

🤖 Generated with [Claude Code](https://claude.com/claude-code)