### PR TITLE
feat: solicitar programacion de turno del catalogo

### DIFF
--- a/infra/environments/dev/main.tf
+++ b/infra/environments/dev/main.tf
@@ -44,6 +44,9 @@ module "service_bus" {
     "eventos-programacion" = {
       subscriptions = []
     }
+    "programacion-turno-diario-solicitada" = {
+      subscriptions = []
+    }
   }
   tags                = local.tags
 }

--- a/src/Bitakora.ControlAsistencia.Contracts/Bitakora.ControlAsistencia.Contracts.csproj
+++ b/src/Bitakora.ControlAsistencia.Contracts/Bitakora.ControlAsistencia.Contracts.csproj
@@ -12,7 +12,6 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Bitakora.ControlAsistencia.Contracts.Tests" />
-    <InternalsVisibleTo Include="Bitakora.ControlAsistencia.Programacion" />
   </ItemGroup>
 
 </Project>

--- a/src/Bitakora.ControlAsistencia.Contracts/Bitakora.ControlAsistencia.Contracts.csproj
+++ b/src/Bitakora.ControlAsistencia.Contracts/Bitakora.ControlAsistencia.Contracts.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Bitakora.ControlAsistencia.Contracts.Tests" />
+    <InternalsVisibleTo Include="Bitakora.ControlAsistencia.Programacion" />
   </ItemGroup>
 
 </Project>

--- a/src/Bitakora.ControlAsistencia.Contracts/Eventos/ProgramacionTurnoDiarioSolicitada.cs
+++ b/src/Bitakora.ControlAsistencia.Contracts/Eventos/ProgramacionTurnoDiarioSolicitada.cs
@@ -1,7 +1,7 @@
 using Bitakora.ControlAsistencia.Contracts.ValueObjects;
 using Cosmos.EventDriven.Abstractions;
 
-namespace Bitakora.ControlAsistencia.Programacion.SolicitarProgramacionTurnoFunction.Eventos;
+namespace Bitakora.ControlAsistencia.Contracts.Eventos;
 
 /// <summary>
 /// Evento publico que se publica al Service Bus via IPublicEventSender.

--- a/src/Bitakora.ControlAsistencia.Contracts/ValueObjects/DetalleFranjaOrdinaria.cs
+++ b/src/Bitakora.ControlAsistencia.Contracts/ValueObjects/DetalleFranjaOrdinaria.cs
@@ -1,0 +1,11 @@
+namespace Bitakora.ControlAsistencia.Contracts.ValueObjects;
+
+/// <summary>
+/// Representacion plana de una franja ordinaria que viaja en eventos entre dominios.
+/// </summary>
+public record DetalleFranjaOrdinaria(
+    TimeOnly HoraInicio,
+    TimeOnly HoraFin,
+    int DiaOffsetFin,
+    IReadOnlyList<DetalleSubFranja> Descansos,
+    IReadOnlyList<DetalleSubFranja> Extras);

--- a/src/Bitakora.ControlAsistencia.Contracts/ValueObjects/DetalleSubFranja.cs
+++ b/src/Bitakora.ControlAsistencia.Contracts/ValueObjects/DetalleSubFranja.cs
@@ -1,0 +1,10 @@
+namespace Bitakora.ControlAsistencia.Contracts.ValueObjects;
+
+/// <summary>
+/// Representacion plana de una sub-franja (descanso o extra) que viaja en eventos entre dominios.
+/// </summary>
+public record DetalleSubFranja(
+    TimeOnly HoraInicio,
+    TimeOnly HoraFin,
+    int DiaOffsetInicio,
+    int DiaOffsetFin);

--- a/src/Bitakora.ControlAsistencia.Contracts/ValueObjects/DetalleTurno.cs
+++ b/src/Bitakora.ControlAsistencia.Contracts/ValueObjects/DetalleTurno.cs
@@ -1,0 +1,9 @@
+namespace Bitakora.ControlAsistencia.Contracts.ValueObjects;
+
+/// <summary>
+/// Representacion plana del turno que viaja en eventos entre dominios.
+/// No tiene comportamiento de dominio, solo datos.
+/// </summary>
+public record DetalleTurno(
+    string Nombre,
+    IReadOnlyList<DetalleFranjaOrdinaria> FranjasOrdinarias);

--- a/src/Bitakora.ControlAsistencia.Contracts/ValueObjects/FranjaOrdinaria.cs
+++ b/src/Bitakora.ControlAsistencia.Contracts/ValueObjects/FranjaOrdinaria.cs
@@ -66,12 +66,11 @@ public sealed class FranjaOrdinaria : FranjaTemporal, IEquatable<FranjaOrdinaria
         return ordinaria;
     }
 
-    // Propiedades internas para mapeo a DetalleFranjaOrdinaria en eventos entre dominios
-    internal TimeOnly HoraInicio => _horaInicio;
-    internal TimeOnly HoraFin => _horaFin;
-    internal int DiaOffsetFin => _diaOffsetFin;
-    internal IReadOnlyList<SubFranja> Descansos => _descansos.AsReadOnly();
-    internal IReadOnlyList<SubFranja> Extras => _extras.AsReadOnly();
+    // Conversion a DTO plano para eventos entre dominios
+    public DetalleFranjaOrdinaria ToDetalle() => new(
+        _horaInicio, _horaFin, _diaOffsetFin,
+        _descansos.Select(d => d.ToDetalle()).ToList().AsReadOnly(),
+        _extras.Select(e => e.ToDetalle()).ToList().AsReadOnly());
 
     // CA-20, CA-21: formato "(06:00-12:00)" o "(22:00-06:00+1)"
     public override string ToString()

--- a/src/Bitakora.ControlAsistencia.Contracts/ValueObjects/FranjaOrdinaria.cs
+++ b/src/Bitakora.ControlAsistencia.Contracts/ValueObjects/FranjaOrdinaria.cs
@@ -66,6 +66,13 @@ public sealed class FranjaOrdinaria : FranjaTemporal, IEquatable<FranjaOrdinaria
         return ordinaria;
     }
 
+    // Propiedades internas para mapeo a DetalleFranjaOrdinaria en eventos entre dominios
+    internal TimeOnly HoraInicio => _horaInicio;
+    internal TimeOnly HoraFin => _horaFin;
+    internal int DiaOffsetFin => _diaOffsetFin;
+    internal IReadOnlyList<SubFranja> Descansos => _descansos.AsReadOnly();
+    internal IReadOnlyList<SubFranja> Extras => _extras.AsReadOnly();
+
     // CA-20, CA-21: formato "(06:00-12:00)" o "(22:00-06:00+1)"
     public override string ToString()
     {
@@ -115,10 +122,10 @@ public sealed class FranjaOrdinaria : FranjaTemporal, IEquatable<FranjaOrdinaria
     private static void ValidarSolapamiento(List<FranjaTemporal> hijas)
     {
         for (var i = 0; i < hijas.Count; i++)
-        for (var j = i + 1; j < hijas.Count; j++)
-            if (hijas[i].MinutosAbsolutoInicio < hijas[j].MinutosAbsolutoFin
-                && hijas[j].MinutosAbsolutoInicio < hijas[i].MinutosAbsolutoFin)
-                throw new ArgumentException(Mensajes.FranjasHijasSeSuperponen);
+            for (var j = i + 1; j < hijas.Count; j++)
+                if (hijas[i].MinutosAbsolutoInicio < hijas[j].MinutosAbsolutoFin
+                    && hijas[j].MinutosAbsolutoInicio < hijas[i].MinutosAbsolutoFin)
+                    throw new ArgumentException(Mensajes.FranjasHijasSeSuperponen);
     }
 
     // Mapping de serializacion - vive aqui porque cambia con la clase

--- a/src/Bitakora.ControlAsistencia.Contracts/ValueObjects/InformacionEmpleado.cs
+++ b/src/Bitakora.ControlAsistencia.Contracts/ValueObjects/InformacionEmpleado.cs
@@ -1,0 +1,11 @@
+namespace Bitakora.ControlAsistencia.Contracts.ValueObjects;
+
+/// <summary>
+/// Datos de identificacion del empleado que viajan en eventos entre dominios.
+/// </summary>
+public record InformacionEmpleado(
+    string EmpleadoId,
+    string TipoIdentificacion,
+    string NumeroIdentificacion,
+    string Nombres,
+    string Apellidos);

--- a/src/Bitakora.ControlAsistencia.Contracts/ValueObjects/SubFranja.cs
+++ b/src/Bitakora.ControlAsistencia.Contracts/ValueObjects/SubFranja.cs
@@ -28,6 +28,12 @@ public sealed class SubFranja : FranjaTemporal, IEquatable<SubFranja>
         return new SubFranja(horaInicio, horaFin, diaOffsetInicio, diaOffsetFin);
     }
 
+    // Propiedades internas para mapeo a DetalleSubFranja en eventos entre dominios
+    internal TimeOnly HoraInicio => _horaInicio;
+    internal TimeOnly HoraFin => _horaFin;
+    internal int DiaOffsetInicio => _diaOffsetInicio;
+    internal int DiaOffsetFin => _diaOffsetFin;
+
     // CA-20, CA-21: formato legible con offsets
     public override string ToString() =>
         $"({FormatearHora(_horaInicio, _diaOffsetInicio)}-{FormatearHora(_horaFin, _diaOffsetFin)})";

--- a/src/Bitakora.ControlAsistencia.Contracts/ValueObjects/SubFranja.cs
+++ b/src/Bitakora.ControlAsistencia.Contracts/ValueObjects/SubFranja.cs
@@ -28,11 +28,9 @@ public sealed class SubFranja : FranjaTemporal, IEquatable<SubFranja>
         return new SubFranja(horaInicio, horaFin, diaOffsetInicio, diaOffsetFin);
     }
 
-    // Propiedades internas para mapeo a DetalleSubFranja en eventos entre dominios
-    internal TimeOnly HoraInicio => _horaInicio;
-    internal TimeOnly HoraFin => _horaFin;
-    internal int DiaOffsetInicio => _diaOffsetInicio;
-    internal int DiaOffsetFin => _diaOffsetFin;
+    // Conversion a DTO plano para eventos entre dominios
+    public DetalleSubFranja ToDetalle() =>
+        new(_horaInicio, _horaFin, _diaOffsetInicio, _diaOffsetFin);
 
     // CA-20, CA-21: formato legible con offsets
     public override string ToString() =>

--- a/src/Bitakora.ControlAsistencia.Programacion/Entities/CatalogoTurnos.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/Entities/CatalogoTurnos.cs
@@ -32,15 +32,7 @@ public partial class CatalogoTurnos : AggregateRoot
     // Devuelve una representacion plana del turno para usar en eventos entre dominios
     internal DetalleTurno ObtenerDetalle() => new(
         _nombre,
-        _franjasOrdinarias.Select(f => new DetalleFranjaOrdinaria(
-            f.HoraInicio,
-            f.HoraFin,
-            f.DiaOffsetFin,
-            f.Descansos.Select(d => new DetalleSubFranja(
-                d.HoraInicio, d.HoraFin, d.DiaOffsetInicio, d.DiaOffsetFin)).ToList().AsReadOnly(),
-            f.Extras.Select(e => new DetalleSubFranja(
-                e.HoraInicio, e.HoraFin, e.DiaOffsetInicio, e.DiaOffsetFin)).ToList().AsReadOnly()
-        )).ToList().AsReadOnly());
+        _franjasOrdinarias.Select(f => f.ToDetalle()).ToList().AsReadOnly());
 
     // Factory interno: crea el aggregate con el evento en _uncommittedEvents
     // Usado por el handler para StartStream -- no es parte de la interfaz publica del dominio

--- a/src/Bitakora.ControlAsistencia.Programacion/Entities/CatalogoTurnos.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/Entities/CatalogoTurnos.cs
@@ -29,6 +29,19 @@ public partial class CatalogoTurnos : AggregateRoot
     public override string ToString() =>
         $"{_nombre} {string.Join("", _franjasOrdinarias)}";
 
+    // Devuelve una representacion plana del turno para usar en eventos entre dominios
+    internal DetalleTurno ObtenerDetalle() => new(
+        _nombre,
+        _franjasOrdinarias.Select(f => new DetalleFranjaOrdinaria(
+            f.HoraInicio,
+            f.HoraFin,
+            f.DiaOffsetFin,
+            f.Descansos.Select(d => new DetalleSubFranja(
+                d.HoraInicio, d.HoraFin, d.DiaOffsetInicio, d.DiaOffsetFin)).ToList().AsReadOnly(),
+            f.Extras.Select(e => new DetalleSubFranja(
+                e.HoraInicio, e.HoraFin, e.DiaOffsetInicio, e.DiaOffsetFin)).ToList().AsReadOnly()
+        )).ToList().AsReadOnly());
+
     // Factory interno: crea el aggregate con el evento en _uncommittedEvents
     // Usado por el handler para StartStream -- no es parte de la interfaz publica del dominio
     internal static CatalogoTurnos Iniciar(TurnoCreado evento)

--- a/src/Bitakora.ControlAsistencia.Programacion/Entities/SolicitudProgramacionAggregateRoot.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/Entities/SolicitudProgramacionAggregateRoot.cs
@@ -10,8 +10,19 @@ public partial class SolicitudProgramacionAggregateRoot : AggregateRoot
     internal IReadOnlyList<DateOnly> Fechas { get; private set; } = [];
     internal DetalleTurno? DetalleTurno { get; private set; }
 
-    private void Apply(ProgramacionTurnoSolicitada e) => throw new NotImplementedException();
+    public void Apply(ProgramacionTurnoSolicitada e)
+    {
+        Id = e.Id.ToString();
+        Empleado = e.Empleado;
+        Fechas = e.Fechas;
+        DetalleTurno = e.DetalleTurno;
+    }
 
     internal static SolicitudProgramacionAggregateRoot Iniciar(ProgramacionTurnoSolicitada evento)
-        => throw new NotImplementedException();
+    {
+        var solicitud = new SolicitudProgramacionAggregateRoot();
+        solicitud._uncommittedEvents.Add(evento);
+        solicitud.Apply(evento);
+        return solicitud;
+    }
 }

--- a/src/Bitakora.ControlAsistencia.Programacion/Entities/SolicitudProgramacionAggregateRoot.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/Entities/SolicitudProgramacionAggregateRoot.cs
@@ -1,0 +1,17 @@
+using Bitakora.ControlAsistencia.Contracts.ValueObjects;
+using Bitakora.ControlAsistencia.Programacion.SolicitarProgramacionTurnoFunction.Eventos;
+using Cosmos.EventSourcing.Abstractions;
+
+namespace Bitakora.ControlAsistencia.Programacion.Entities;
+
+public partial class SolicitudProgramacionAggregateRoot : AggregateRoot
+{
+    internal InformacionEmpleado? Empleado { get; private set; }
+    internal IReadOnlyList<DateOnly> Fechas { get; private set; } = [];
+    internal DetalleTurno? DetalleTurno { get; private set; }
+
+    private void Apply(ProgramacionTurnoSolicitada e) => throw new NotImplementedException();
+
+    internal static SolicitudProgramacionAggregateRoot Iniciar(ProgramacionTurnoSolicitada evento)
+        => throw new NotImplementedException();
+}

--- a/src/Bitakora.ControlAsistencia.Programacion/Program.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/Program.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Bitakora.ControlAsistencia.Programacion;
 using Bitakora.ControlAsistencia.Programacion.Infraestructura;
+using Bitakora.ControlAsistencia.Programacion.SolicitarProgramacionTurnoFunction.Eventos;
 using Cosmos.EventDriven.CritterStack;
 using Cosmos.EventDriven.CritterStack.AzureServiceBus;
 using Cosmos.EventSourcing.CritterStack;
@@ -24,6 +25,8 @@ builder.Services.AgregarWolverineParaComandosServerless(
     options =>
     {
         options.HabilitarAzureServiceBusParaServerLess(serviceBusConnectionString);
+        options.PublicarEventoServerless<ProgramacionTurnoDiarioSolicitada>(
+            "programacion-turno-diario-solicitada");
     });
 
 builder.Services.AgregarMartenEventStore();

--- a/src/Bitakora.ControlAsistencia.Programacion/Program.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/Program.cs
@@ -9,7 +9,6 @@ using FluentValidation;
 using Microsoft.Azure.Functions.Worker.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using OpenTelemetry.Trace;
 
 var builder = FunctionsApplication.CreateBuilder(args);
 builder.ConfigureFunctionsWebApplication();

--- a/src/Bitakora.ControlAsistencia.Programacion/Program.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/Program.cs
@@ -1,7 +1,7 @@
 using System.Text.Json;
 using Bitakora.ControlAsistencia.Programacion;
 using Bitakora.ControlAsistencia.Programacion.Infraestructura;
-using Bitakora.ControlAsistencia.Programacion.SolicitarProgramacionTurnoFunction.Eventos;
+using Bitakora.ControlAsistencia.Contracts.Eventos;
 using Cosmos.EventDriven.CritterStack;
 using Cosmos.EventDriven.CritterStack.AzureServiceBus;
 using Cosmos.EventSourcing.CritterStack;

--- a/src/Bitakora.ControlAsistencia.Programacion/SolicitarProgramacionTurnoFunction/CommandHandler/SolicitarProgramacionTurnoCommandHandler.Mensajes.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/SolicitarProgramacionTurnoFunction/CommandHandler/SolicitarProgramacionTurnoCommandHandler.Mensajes.cs
@@ -1,0 +1,19 @@
+using System.Resources;
+
+namespace Bitakora.ControlAsistencia.Programacion.SolicitarProgramacionTurnoFunction.CommandHandler;
+
+public partial class SolicitarProgramacionTurnoCommandHandler
+{
+    private static readonly ResourceManager ResourceManager = new(
+        "Bitakora.ControlAsistencia.Programacion.SolicitarProgramacionTurnoFunction.CommandHandler.SolicitarProgramacionTurnoCommandHandlerMensajes",
+        typeof(SolicitarProgramacionTurnoCommandHandler).Assembly);
+
+    internal static class Mensajes
+    {
+        public static string SolicitudYaExiste =>
+            ResourceManager.GetString(nameof(SolicitudYaExiste))!;
+
+        public static string TurnoNoEncontrado =>
+            ResourceManager.GetString(nameof(TurnoNoEncontrado))!;
+    }
+}

--- a/src/Bitakora.ControlAsistencia.Programacion/SolicitarProgramacionTurnoFunction/CommandHandler/SolicitarProgramacionTurnoCommandHandler.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/SolicitarProgramacionTurnoFunction/CommandHandler/SolicitarProgramacionTurnoCommandHandler.cs
@@ -2,7 +2,6 @@ using Bitakora.ControlAsistencia.Contracts.ValueObjects;
 using Bitakora.ControlAsistencia.Programacion.Entities;
 using Bitakora.ControlAsistencia.Programacion.SolicitarProgramacionTurnoFunction.Eventos;
 using Cosmos.EventDriven.Abstractions;
-using Cosmos.EventSourcing.Abstractions;
 using Cosmos.EventSourcing.Abstractions.Commands;
 
 namespace Bitakora.ControlAsistencia.Programacion.SolicitarProgramacionTurnoFunction.CommandHandler;
@@ -21,6 +20,38 @@ public partial class SolicitarProgramacionTurnoCommandHandler
         _publicEventSender = publicEventSender;
     }
 
-    public Task HandleAsync(SolicitarProgramacionTurno command, CancellationToken ct = default)
-        => throw new NotImplementedException();
+    public async Task HandleAsync(SolicitarProgramacionTurno command, CancellationToken ct = default)
+    {
+        var solicitudExiste = await _eventStore.ExistsAsync<SolicitudProgramacionAggregateRoot>(
+            command.Id, ct);
+        if (solicitudExiste)
+            throw new InvalidOperationException(Mensajes.SolicitudYaExiste);
+
+        var catalogo = await _eventStore.GetAggregateRootAsync<CatalogoTurnos>(command.TurnoId, ct);
+        if (catalogo is null)
+            throw new KeyNotFoundException(Mensajes.TurnoNoEncontrado);
+
+        var empleado = new InformacionEmpleado(
+            command.Empleado.EmpleadoId,
+            command.Empleado.TipoIdentificacion,
+            command.Empleado.NumeroIdentificacion,
+            command.Empleado.Nombres,
+            command.Empleado.Apellidos);
+
+        var detalleTurno = catalogo.ObtenerDetalle();
+        var fechas = command.Fechas.AsReadOnly();
+
+        var evento = new ProgramacionTurnoSolicitada(command.Id, empleado, fechas, detalleTurno);
+        var solicitud = SolicitudProgramacionAggregateRoot.Iniciar(evento);
+
+        _eventStore.StartStream(solicitud);
+
+        var eventosPublicos = command.Fechas
+            .Select(fecha => new ProgramacionTurnoDiarioSolicitada(
+                command.Id, empleado, fecha, detalleTurno))
+            .Cast<IPublicEvent>()
+            .ToArray();
+
+        await _publicEventSender.PublishAsync(eventosPublicos);
+    }
 }

--- a/src/Bitakora.ControlAsistencia.Programacion/SolicitarProgramacionTurnoFunction/CommandHandler/SolicitarProgramacionTurnoCommandHandler.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/SolicitarProgramacionTurnoFunction/CommandHandler/SolicitarProgramacionTurnoCommandHandler.cs
@@ -1,3 +1,4 @@
+using Bitakora.ControlAsistencia.Contracts.Eventos;
 using Bitakora.ControlAsistencia.Contracts.ValueObjects;
 using Bitakora.ControlAsistencia.Programacion.Entities;
 using Bitakora.ControlAsistencia.Programacion.SolicitarProgramacionTurnoFunction.Eventos;
@@ -31,25 +32,17 @@ public partial class SolicitarProgramacionTurnoCommandHandler
         if (catalogo is null)
             throw new KeyNotFoundException(Mensajes.TurnoNoEncontrado);
 
-        var empleado = new InformacionEmpleado(
-            command.Empleado.EmpleadoId,
-            command.Empleado.TipoIdentificacion,
-            command.Empleado.NumeroIdentificacion,
-            command.Empleado.Nombres,
-            command.Empleado.Apellidos);
-
         var detalleTurno = catalogo.ObtenerDetalle();
         var fechas = command.Fechas.AsReadOnly();
 
-        var evento = new ProgramacionTurnoSolicitada(command.Id, empleado, fechas, detalleTurno);
+        var evento = new ProgramacionTurnoSolicitada(command.Id, command.Empleado, fechas, detalleTurno);
         var solicitud = SolicitudProgramacionAggregateRoot.Iniciar(evento);
 
         _eventStore.StartStream(solicitud);
 
         var eventosPublicos = command.Fechas
-            .Select(fecha => new ProgramacionTurnoDiarioSolicitada(
-                command.Id, empleado, fecha, detalleTurno))
-            .Cast<IPublicEvent>()
+            .Select(fecha => (IPublicEvent)new ProgramacionTurnoDiarioSolicitada(
+                command.Id, command.Empleado, fecha, detalleTurno))
             .ToArray();
 
         await _publicEventSender.PublishAsync(eventosPublicos);

--- a/src/Bitakora.ControlAsistencia.Programacion/SolicitarProgramacionTurnoFunction/CommandHandler/SolicitarProgramacionTurnoCommandHandler.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/SolicitarProgramacionTurnoFunction/CommandHandler/SolicitarProgramacionTurnoCommandHandler.cs
@@ -1,0 +1,26 @@
+using Bitakora.ControlAsistencia.Contracts.ValueObjects;
+using Bitakora.ControlAsistencia.Programacion.Entities;
+using Bitakora.ControlAsistencia.Programacion.SolicitarProgramacionTurnoFunction.Eventos;
+using Cosmos.EventDriven.Abstractions;
+using Cosmos.EventSourcing.Abstractions;
+using Cosmos.EventSourcing.Abstractions.Commands;
+
+namespace Bitakora.ControlAsistencia.Programacion.SolicitarProgramacionTurnoFunction.CommandHandler;
+
+public partial class SolicitarProgramacionTurnoCommandHandler
+    : ICommandHandlerAsync<SolicitarProgramacionTurno>
+{
+    private readonly IEventStore _eventStore;
+    private readonly IPublicEventSender _publicEventSender;
+
+    public SolicitarProgramacionTurnoCommandHandler(
+        IEventStore eventStore,
+        IPublicEventSender publicEventSender)
+    {
+        _eventStore = eventStore;
+        _publicEventSender = publicEventSender;
+    }
+
+    public Task HandleAsync(SolicitarProgramacionTurno command, CancellationToken ct = default)
+        => throw new NotImplementedException();
+}

--- a/src/Bitakora.ControlAsistencia.Programacion/SolicitarProgramacionTurnoFunction/CommandHandler/SolicitarProgramacionTurnoCommandHandlerMensajes.resx
+++ b/src/Bitakora.ControlAsistencia.Programacion/SolicitarProgramacionTurnoFunction/CommandHandler/SolicitarProgramacionTurnoCommandHandlerMensajes.resx
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" msdata:Ordinal="0" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter</value></resheader>
+  <data name="SolicitudYaExiste" xml:space="preserve">
+    <value>Ya existe una solicitud de programacion con ese Id</value>
+  </data>
+  <data name="TurnoNoEncontrado" xml:space="preserve">
+    <value>No se encontro el turno con el Id especificado en el catalogo</value>
+  </data>
+</root>

--- a/src/Bitakora.ControlAsistencia.Programacion/SolicitarProgramacionTurnoFunction/CommandHandler/SolicitarProgramacionTurnoValidator.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/SolicitarProgramacionTurnoFunction/CommandHandler/SolicitarProgramacionTurnoValidator.cs
@@ -1,0 +1,12 @@
+using FluentValidation;
+
+namespace Bitakora.ControlAsistencia.Programacion.SolicitarProgramacionTurnoFunction.CommandHandler;
+
+public class SolicitarProgramacionTurnoValidator
+    : AbstractValidator<SolicitarProgramacionTurno>
+{
+    public SolicitarProgramacionTurnoValidator()
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/Bitakora.ControlAsistencia.Programacion/SolicitarProgramacionTurnoFunction/CommandHandler/SolicitarProgramacionTurnoValidator.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/SolicitarProgramacionTurnoFunction/CommandHandler/SolicitarProgramacionTurnoValidator.cs
@@ -7,6 +7,15 @@ public class SolicitarProgramacionTurnoValidator
 {
     public SolicitarProgramacionTurnoValidator()
     {
-        throw new NotImplementedException();
+        RuleFor(x => x.Id).NotEmpty();
+        RuleFor(x => x.TurnoId).NotEmpty();
+
+        RuleFor(x => x.Empleado.EmpleadoId).NotEmpty();
+        RuleFor(x => x.Empleado.TipoIdentificacion).NotEmpty();
+        RuleFor(x => x.Empleado.NumeroIdentificacion).NotEmpty();
+        RuleFor(x => x.Empleado.Nombres).NotEmpty();
+        RuleFor(x => x.Empleado.Apellidos).NotEmpty();
+
+        RuleFor(x => x.Fechas).NotEmpty();
     }
 }

--- a/src/Bitakora.ControlAsistencia.Programacion/SolicitarProgramacionTurnoFunction/Eventos/ProgramacionTurnoDiarioSolicitada.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/SolicitarProgramacionTurnoFunction/Eventos/ProgramacionTurnoDiarioSolicitada.cs
@@ -1,0 +1,32 @@
+using Bitakora.ControlAsistencia.Contracts.ValueObjects;
+using Cosmos.EventDriven.Abstractions;
+
+namespace Bitakora.ControlAsistencia.Programacion.SolicitarProgramacionTurnoFunction.Eventos;
+
+/// <summary>
+/// Evento publico que se publica al Service Bus via IPublicEventSender.
+/// Se emite uno por cada fecha del arreglo del comando.
+/// Consumidor: ControlHoras.
+/// </summary>
+public sealed class ProgramacionTurnoDiarioSolicitada : IPublicEvent
+{
+    public Guid SolicitudId { get; private set; }
+    public InformacionEmpleado Empleado { get; private set; } = null!;
+    public DateOnly Fecha { get; private set; }
+    public DetalleTurno DetalleTurno { get; private set; } = null!;
+
+    public ProgramacionTurnoDiarioSolicitada(
+        Guid solicitudId,
+        InformacionEmpleado empleado,
+        DateOnly fecha,
+        DetalleTurno detalleTurno)
+    {
+        SolicitudId = solicitudId;
+        Empleado = empleado;
+        Fecha = fecha;
+        DetalleTurno = detalleTurno;
+    }
+
+    // Constructor para Marten/serializacion
+    private ProgramacionTurnoDiarioSolicitada() { }
+}

--- a/src/Bitakora.ControlAsistencia.Programacion/SolicitarProgramacionTurnoFunction/Eventos/ProgramacionTurnoSolicitada.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/SolicitarProgramacionTurnoFunction/Eventos/ProgramacionTurnoSolicitada.cs
@@ -1,0 +1,30 @@
+using Bitakora.ControlAsistencia.Contracts.ValueObjects;
+
+namespace Bitakora.ControlAsistencia.Programacion.SolicitarProgramacionTurnoFunction.Eventos;
+
+/// <summary>
+/// Evento de event sourcing (privado). Se persiste en el stream de SolicitudProgramacionAggregateRoot.
+/// No se publica al Service Bus.
+/// </summary>
+public sealed class ProgramacionTurnoSolicitada
+{
+    public Guid Id { get; private set; }
+    public InformacionEmpleado Empleado { get; private set; } = null!;
+    public IReadOnlyList<DateOnly> Fechas { get; private set; } = [];
+    public DetalleTurno DetalleTurno { get; private set; } = null!;
+
+    public ProgramacionTurnoSolicitada(
+        Guid id,
+        InformacionEmpleado empleado,
+        IReadOnlyList<DateOnly> fechas,
+        DetalleTurno detalleTurno)
+    {
+        Id = id;
+        Empleado = empleado;
+        Fechas = fechas;
+        DetalleTurno = detalleTurno;
+    }
+
+    // Constructor para Marten/serializacion
+    private ProgramacionTurnoSolicitada() { }
+}

--- a/src/Bitakora.ControlAsistencia.Programacion/SolicitarProgramacionTurnoFunction/FunctionEndpoint.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/SolicitarProgramacionTurnoFunction/FunctionEndpoint.cs
@@ -1,0 +1,36 @@
+using Bitakora.ControlAsistencia.Programacion.Infraestructura;
+using Cosmos.EventSourcing.Abstractions.Commands;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+
+namespace Bitakora.ControlAsistencia.Programacion.SolicitarProgramacionTurnoFunction;
+
+public class FunctionEndpoint(IRequestValidator requestValidator, ICommandRouter commandRouter)
+{
+    [Function(nameof(SolicitarProgramacionTurno))]
+    public async Task<IActionResult> Run(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "programacion/solicitudes")]
+        HttpRequest req,
+        CancellationToken ct)
+    {
+        var (comando, error) = await requestValidator.ValidarAsync<SolicitarProgramacionTurno>(req, ct);
+        if (error is not null)
+            return error;
+
+        try
+        {
+            await commandRouter.InvokeAsync(comando!, ct);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return new ConflictObjectResult(ex.Message);
+        }
+        catch (KeyNotFoundException ex)
+        {
+            return new NotFoundObjectResult(ex.Message);
+        }
+
+        return new AcceptedResult();
+    }
+}

--- a/src/Bitakora.ControlAsistencia.Programacion/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurno.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurno.cs
@@ -1,15 +1,9 @@
+using Bitakora.ControlAsistencia.Contracts.ValueObjects;
+
 namespace Bitakora.ControlAsistencia.Programacion.SolicitarProgramacionTurnoFunction;
 
 public record SolicitarProgramacionTurno(
     Guid Id,
     Guid TurnoId,
-    SolicitarProgramacionTurno.DatosEmpleado Empleado,
-    List<DateOnly> Fechas)
-{
-    public record DatosEmpleado(
-        string EmpleadoId,
-        string TipoIdentificacion,
-        string NumeroIdentificacion,
-        string Nombres,
-        string Apellidos);
-}
+    InformacionEmpleado Empleado,
+    List<DateOnly> Fechas);

--- a/src/Bitakora.ControlAsistencia.Programacion/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurno.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurno.cs
@@ -1,0 +1,15 @@
+namespace Bitakora.ControlAsistencia.Programacion.SolicitarProgramacionTurnoFunction;
+
+public record SolicitarProgramacionTurno(
+    Guid Id,
+    Guid TurnoId,
+    SolicitarProgramacionTurno.DatosEmpleado Empleado,
+    List<DateOnly> Fechas)
+{
+    public record DatosEmpleado(
+        string EmpleadoId,
+        string TipoIdentificacion,
+        string NumeroIdentificacion,
+        string Nombres,
+        string Apellidos);
+}

--- a/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoSmokeTests.cs
@@ -1,0 +1,203 @@
+using System.Net;
+using System.Net.Http.Json;
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Programacion.SmokeTests.Fixtures;
+
+namespace Bitakora.ControlAsistencia.Programacion.SmokeTests.SolicitarProgramacionTurnoFunction;
+
+public class SolicitarProgramacionTurnoSmokeTests(ApiFixture api)
+{
+    private readonly HttpClient _client = api.Client;
+
+    private static object PayloadValido(Guid? id = null, Guid? turnoId = null) => new
+    {
+        id = id ?? Guid.CreateVersion7(),
+        turnoId = turnoId ?? Guid.CreateVersion7(),
+        empleado = new
+        {
+            empleadoId = Guid.CreateVersion7().ToString(),
+            tipoIdentificacion = "CC",
+            numeroIdentificacion = "123456789",
+            nombres = "[TEST] Juan Carlos",
+            apellidos = "[TEST] Perez Lopez"
+        },
+        fechas = new[] { "2025-08-01", "2025-08-02" }
+    };
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task SolicitarProgramacionTurno_DebeRetornar202_CuandoPayloadEsValido()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        // El turnoId debe existir en el catalogo; primero lo creamos
+        var turnoId = Guid.CreateVersion7();
+        var turnoPayload = new
+        {
+            turnoId,
+            nombre = "[TEST] Turno para Programacion",
+            ordinarias = new[]
+            {
+                new
+                {
+                    inicio = "08:00:00",
+                    fin = "16:00:00",
+                    descansos = Array.Empty<object>(),
+                    extras = Array.Empty<object>()
+                }
+            }
+        };
+        var crearTurnoResponse = await _client.PostAsJsonAsync("/api/programacion/turnos", turnoPayload, ct);
+        crearTurnoResponse.StatusCode.Should().Be(HttpStatusCode.Accepted);
+
+        var response = await _client.PostAsJsonAsync("/api/programacion/solicitudes", PayloadValido(turnoId: turnoId), ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+    }
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task SolicitarProgramacionTurno_DebeRetornar409_CuandoSolicitudYaExiste()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        // Crear turno en catalogo
+        var turnoId = Guid.CreateVersion7();
+        var turnoPayload = new
+        {
+            turnoId,
+            nombre = "[TEST] Turno para Duplicado",
+            ordinarias = new[]
+            {
+                new
+                {
+                    inicio = "07:00:00",
+                    fin = "15:00:00",
+                    descansos = Array.Empty<object>(),
+                    extras = Array.Empty<object>()
+                }
+            }
+        };
+        await _client.PostAsJsonAsync("/api/programacion/turnos", turnoPayload, ct);
+
+        var solicitudId = Guid.CreateVersion7();
+        var payload = PayloadValido(id: solicitudId, turnoId: turnoId);
+
+        await _client.PostAsJsonAsync("/api/programacion/solicitudes", payload, ct);
+        var response = await _client.PostAsJsonAsync("/api/programacion/solicitudes", payload, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task SolicitarProgramacionTurno_DebeRetornar404_CuandoTurnoNoExiste()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var payload = PayloadValido(turnoId: Guid.CreateVersion7());
+
+        var response = await _client.PostAsJsonAsync("/api/programacion/solicitudes", payload, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task SolicitarProgramacionTurno_DebeRetornar400_CuandoIdEsGuidVacio()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var payload = new
+        {
+            id = Guid.Empty,
+            turnoId = Guid.CreateVersion7(),
+            empleado = new
+            {
+                empleadoId = Guid.CreateVersion7().ToString(),
+                tipoIdentificacion = "CC",
+                numeroIdentificacion = "123456789",
+                nombres = "[TEST] Juan",
+                apellidos = "[TEST] Perez"
+            },
+            fechas = new[] { "2025-08-01" }
+        };
+
+        var response = await _client.PostAsJsonAsync("/api/programacion/solicitudes", payload, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task SolicitarProgramacionTurno_DebeRetornar400_CuandoTurnoIdEsGuidVacio()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var payload = new
+        {
+            id = Guid.CreateVersion7(),
+            turnoId = Guid.Empty,
+            empleado = new
+            {
+                empleadoId = Guid.CreateVersion7().ToString(),
+                tipoIdentificacion = "CC",
+                numeroIdentificacion = "123456789",
+                nombres = "[TEST] Juan",
+                apellidos = "[TEST] Perez"
+            },
+            fechas = new[] { "2025-08-01" }
+        };
+
+        var response = await _client.PostAsJsonAsync("/api/programacion/solicitudes", payload, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task SolicitarProgramacionTurno_DebeRetornar400_CuandoEmpleadoTieneCamposVacios()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var payload = new
+        {
+            id = Guid.CreateVersion7(),
+            turnoId = Guid.CreateVersion7(),
+            empleado = new
+            {
+                empleadoId = "",
+                tipoIdentificacion = "",
+                numeroIdentificacion = "",
+                nombres = "",
+                apellidos = ""
+            },
+            fechas = new[] { "2025-08-01" }
+        };
+
+        var response = await _client.PostAsJsonAsync("/api/programacion/solicitudes", payload, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task SolicitarProgramacionTurno_DebeRetornar400_CuandoFechasEstaVacia()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var payload = new
+        {
+            id = Guid.CreateVersion7(),
+            turnoId = Guid.CreateVersion7(),
+            empleado = new
+            {
+                empleadoId = Guid.CreateVersion7().ToString(),
+                tipoIdentificacion = "CC",
+                numeroIdentificacion = "123456789",
+                nombres = "[TEST] Juan",
+                apellidos = "[TEST] Perez"
+            },
+            fechas = Array.Empty<string>()
+        };
+
+        var response = await _client.PostAsJsonAsync("/api/programacion/solicitudes", payload, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/FunctionEndpointTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/FunctionEndpointTests.cs
@@ -1,0 +1,139 @@
+// HU-10: Solicitar programacion de turno del catalogo - tests del endpoint HTTP
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Programacion.Infraestructura;
+using Bitakora.ControlAsistencia.Programacion.SolicitarProgramacionTurnoFunction;
+using Cosmos.EventSourcing.Abstractions.Commands;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Bitakora.ControlAsistencia.Programacion.Tests.SolicitarProgramacionTurnoFunction;
+
+/// <summary>
+/// Tests del endpoint HTTP POST /programacion/solicitudes.
+/// Verifica el mapeo de excepciones del handler a respuestas HTTP:
+/// - InvalidOperationException -> 409 (solicitud duplicada)
+/// - KeyNotFoundException -> 404 (turno no encontrado en catalogo)
+/// - Exito -> 202 Accepted
+/// - Error de validacion -> 400 Bad Request
+/// </summary>
+public class FunctionEndpointTests
+{
+    private static SolicitarProgramacionTurno ComandoValido() => new(
+        Guid.NewGuid(),
+        Guid.NewGuid(),
+        new SolicitarProgramacionTurno.DatosEmpleado("E001", "CC", "12345678", "Juan", "Perez"),
+        [new DateOnly(2026, 4, 7)]);
+
+    private static HttpRequest FakeHttpRequest()
+    {
+        var context = new DefaultHttpContext();
+        return context.Request;
+    }
+
+    // CA-13: POST exitoso retorna 202 Accepted
+    [Fact]
+    public async Task DebeRetornar202_CuandoComandoEsValido()
+    {
+        var validator = new FakeSolicitudRequestValidator(ComandoValido());
+        var router = new FakeSolicitudCommandRouter();
+        var function = new FunctionEndpoint(validator, router);
+
+        var result = await function.Run(FakeHttpRequest(), CancellationToken.None);
+
+        result.Should().BeOfType<AcceptedResult>();
+    }
+
+    // CA-5: Falla de validacion retorna 400 Bad Request
+    [Fact]
+    public async Task DebeRetornar400_CuandoFallaValidacion()
+    {
+        var errorDeValidacion = new BadRequestObjectResult("Campos requeridos faltantes");
+        var validator = new FakeSolicitudRequestValidator(error: errorDeValidacion);
+        var router = new FakeSolicitudCommandRouter();
+        var function = new FunctionEndpoint(validator, router);
+
+        var result = await function.Run(FakeHttpRequest(), CancellationToken.None);
+
+        result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    // CA-6: Solicitud ya existe retorna 409 Conflict
+    [Fact]
+    public async Task DebeRetornar409_CuandoSolicitudYaExiste()
+    {
+        var validator = new FakeSolicitudRequestValidator(ComandoValido());
+        var router = new FakeSolicitudCommandRouter(
+            lanzar: new InvalidOperationException("La solicitud ya existe"));
+        var function = new FunctionEndpoint(validator, router);
+
+        var result = await function.Run(FakeHttpRequest(), CancellationToken.None);
+
+        result.Should().BeOfType<ConflictObjectResult>();
+    }
+
+    // CA-7: Turno no encontrado en el catalogo retorna 404 Not Found
+    [Fact]
+    public async Task DebeRetornar404_CuandoTurnoNoExisteEnElCatalogo()
+    {
+        var validator = new FakeSolicitudRequestValidator(ComandoValido());
+        var router = new FakeSolicitudCommandRouter(
+            lanzar: new KeyNotFoundException("Turno no encontrado"));
+        var function = new FunctionEndpoint(validator, router);
+
+        var result = await function.Run(FakeHttpRequest(), CancellationToken.None);
+
+        result.Should().BeOfType<NotFoundObjectResult>();
+    }
+}
+
+// ---- Fakes manuales - NO NSubstitute ----
+
+internal class FakeSolicitudRequestValidator : IRequestValidator
+{
+    private readonly SolicitarProgramacionTurno? _comando;
+    private readonly IActionResult? _error;
+
+    public FakeSolicitudRequestValidator(
+        SolicitarProgramacionTurno? comando = null,
+        IActionResult? error = null)
+    {
+        _comando = comando;
+        _error = error;
+    }
+
+    public Task<(T? Comando, IActionResult? Error)> ValidarAsync<T>(
+        HttpRequest req, CancellationToken ct)
+    {
+        if (_error is not null)
+            return Task.FromResult<(T?, IActionResult?)>((default, _error));
+
+        if (_comando is T resultado)
+            return Task.FromResult<(T?, IActionResult?)>((resultado, null));
+
+        return Task.FromResult<(T?, IActionResult?)>((default, null));
+    }
+}
+
+internal class FakeSolicitudCommandRouter : ICommandRouter
+{
+    private readonly Exception? _excepcion;
+
+    public FakeSolicitudCommandRouter(Exception? lanzar = null)
+    {
+        _excepcion = lanzar;
+    }
+
+    public Task InvokeAsync<TCommand>(TCommand command, CancellationToken ct = default)
+        where TCommand : class
+    {
+        if (_excepcion is not null)
+            throw _excepcion;
+        return Task.CompletedTask;
+    }
+
+    public Task<TResult> InvokeAsync<TCommand, TResult>(
+        TCommand command, CancellationToken ct = default)
+        where TCommand : class
+        => throw new NotImplementedException();
+}

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/FunctionEndpointTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/FunctionEndpointTests.cs
@@ -1,6 +1,7 @@
 // HU-10: Solicitar programacion de turno del catalogo - tests del endpoint HTTP
 
 using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Contracts.ValueObjects;
 using Bitakora.ControlAsistencia.Programacion.Infraestructura;
 using Bitakora.ControlAsistencia.Programacion.SolicitarProgramacionTurnoFunction;
 using Cosmos.EventSourcing.Abstractions.Commands;
@@ -22,7 +23,7 @@ public class FunctionEndpointTests
     private static SolicitarProgramacionTurno ComandoValido() => new(
         Guid.NewGuid(),
         Guid.NewGuid(),
-        new SolicitarProgramacionTurno.DatosEmpleado("E001", "CC", "12345678", "Juan", "Perez"),
+        new InformacionEmpleado("E001", "CC", "12345678", "Juan", "Perez"),
         [new DateOnly(2026, 4, 7)]);
 
     private static HttpRequest FakeHttpRequest()

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoCommandHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoCommandHandlerTests.cs
@@ -86,10 +86,11 @@ public class SolicitarProgramacionTurnoCommandHandlerTests
 
         Then(new ProgramacionTurnoSolicitada(
             GuidAggregateId, EmpleadoEsperado, [Fecha1, Fecha2], DetalleEsperado));
-        ThenIsPublishedPublicly(new ProgramacionTurnoDiarioSolicitada(
-            GuidAggregateId, EmpleadoEsperado, Fecha1, DetalleEsperado));
-        ThenIsPublishedPublicly(new ProgramacionTurnoDiarioSolicitada(
-            GuidAggregateId, EmpleadoEsperado, Fecha2, DetalleEsperado));
+        ThenIsPublishedPublicly(
+            new ProgramacionTurnoDiarioSolicitada(
+                GuidAggregateId, EmpleadoEsperado, Fecha1, DetalleEsperado),
+            new ProgramacionTurnoDiarioSolicitada(
+                GuidAggregateId, EmpleadoEsperado, Fecha2, DetalleEsperado));
         And<SolicitudProgramacionAggregateRoot, int>(s => s.Fechas.Count, 2);
     }
 

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoCommandHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoCommandHandlerTests.cs
@@ -1,0 +1,197 @@
+// HU-10: Solicitar programacion de turno del catalogo
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Contracts.ValueObjects;
+using Bitakora.ControlAsistencia.Programacion.CrearTurnoFunction;
+using Bitakora.ControlAsistencia.Programacion.CrearTurnoFunction.Eventos;
+using Bitakora.ControlAsistencia.Programacion.Entities;
+using Bitakora.ControlAsistencia.Programacion.SolicitarProgramacionTurnoFunction;
+using Bitakora.ControlAsistencia.Programacion.SolicitarProgramacionTurnoFunction.CommandHandler;
+using Bitakora.ControlAsistencia.Programacion.SolicitarProgramacionTurnoFunction.Eventos;
+using Cosmos.EventDriven.Abstractions;
+using Cosmos.EventSourcing.Abstractions;
+using Cosmos.EventSourcing.Abstractions.Commands;
+using Cosmos.EventSourcing.Testing.Utilities;
+
+namespace Bitakora.ControlAsistencia.Programacion.Tests.SolicitarProgramacionTurnoFunction;
+
+public class SolicitarProgramacionTurnoCommandHandlerTests
+    : CommandHandlerAsyncTest<SolicitarProgramacionTurno>
+{
+    // --- Constantes de prueba ---
+    private static readonly Guid TurnoId =
+        Guid.Parse("018e4c1a-4f2b-7000-8000-aabbccddeeff");
+    private static readonly DateOnly Fecha1 = new(2026, 4, 7);
+    private static readonly DateOnly Fecha2 = new(2026, 4, 8);
+
+    private static readonly SolicitarProgramacionTurno.DatosEmpleado DatosEmpleado =
+        new("E001", "CC", "12345678", "Juan", "Perez");
+
+    private static readonly InformacionEmpleado EmpleadoEsperado =
+        new("E001", "CC", "12345678", "Juan", "Perez");
+
+    // El DetalleTurno esperado corresponde al catalogo creado en CrearCatalogoConUnaFranja()
+    private static readonly DetalleTurno DetalleEsperado = new(
+        "Turno Manana",
+        new List<DetalleFranjaOrdinaria>
+        {
+            new(new TimeOnly(6, 0), new TimeOnly(14, 0), 0, [], [])
+        }.AsReadOnly());
+
+    // --- Configuracion del handler ---
+
+    // El handler del camino feliz usa un EventStore que tambien conoce el CatalogoTurnos
+    protected override ICommandHandlerAsync<SolicitarProgramacionTurno> Handler =>
+        new SolicitarProgramacionTurnoCommandHandler(
+            new EventStoreConCatalogo(EventStore, CrearCatalogoConUnaFranja(), TurnoId),
+            PublicEventSender);
+
+    // --- Factory methods ---
+
+    private static CatalogoTurnos CrearCatalogoConUnaFranja()
+    {
+        var evento = TurnoCreado.Crear(new CrearTurno(
+            TurnoId,
+            "Turno Manana",
+            [new CrearTurno.Franja(new TimeOnly(6, 0), new TimeOnly(14, 0), [], [])]));
+        return CatalogoTurnos.Iniciar(evento);
+    }
+
+    private static ProgramacionTurnoSolicitada EventoSolicitudParaFecha1() =>
+        new(Guid.Empty, EmpleadoEsperado, [Fecha1], DetalleEsperado);
+
+    // --- Tests del camino feliz ---
+
+    // CA-9, CA-10, CA-11, CA-12: emite evento de ES y publica evento publico por cada fecha
+    [Fact]
+    public async Task DebeEmitirProgramacionSolicitadaYPublicarEvento_CuandoDatosValidos()
+    {
+        Given();
+        await WhenAsync(new SolicitarProgramacionTurno(
+            GuidAggregateId, TurnoId, DatosEmpleado, [Fecha1]));
+
+        Then(new ProgramacionTurnoSolicitada(
+            GuidAggregateId, EmpleadoEsperado, [Fecha1], DetalleEsperado));
+        ThenIsPublishedPublicly(new ProgramacionTurnoDiarioSolicitada(
+            GuidAggregateId, EmpleadoEsperado, Fecha1, DetalleEsperado));
+        And<SolicitudProgramacionAggregateRoot, int>(s => s.Fechas.Count, 1);
+    }
+
+    // CA-11, CA-12: publica un evento publico por cada fecha (N fechas = N eventos)
+    [Fact]
+    public async Task DebePublicarUnEventoPorCadaFecha_CuandoHayMultiplesFechas()
+    {
+        Given();
+        await WhenAsync(new SolicitarProgramacionTurno(
+            GuidAggregateId, TurnoId, DatosEmpleado, [Fecha1, Fecha2]));
+
+        Then(new ProgramacionTurnoSolicitada(
+            GuidAggregateId, EmpleadoEsperado, [Fecha1, Fecha2], DetalleEsperado));
+        ThenIsPublishedPublicly(new ProgramacionTurnoDiarioSolicitada(
+            GuidAggregateId, EmpleadoEsperado, Fecha1, DetalleEsperado));
+        ThenIsPublishedPublicly(new ProgramacionTurnoDiarioSolicitada(
+            GuidAggregateId, EmpleadoEsperado, Fecha2, DetalleEsperado));
+        And<SolicitudProgramacionAggregateRoot, int>(s => s.Fechas.Count, 2);
+    }
+
+    // CA-6: idempotencia - solicitud ya existe lanza excepcion que el endpoint mapea a 409
+    [Fact]
+    public async Task DebeLanzarExcepcion_CuandoSolicitudYaExiste()
+    {
+        Given(new ProgramacionTurnoSolicitada(
+            GuidAggregateId, EmpleadoEsperado, [Fecha1], DetalleEsperado));
+
+        var act = async () => await WhenAsync(new SolicitarProgramacionTurno(
+            GuidAggregateId, TurnoId, DatosEmpleado, [Fecha1]));
+
+        await act.Should().ThrowExactlyAsync<InvalidOperationException>()
+            .WithMessage($"*{SolicitarProgramacionTurnoCommandHandler.Mensajes.SolicitudYaExiste}*");
+    }
+
+    // CA-7: turno no existe en el catalogo - lanza excepcion que el endpoint mapea a 404
+    [Fact]
+    public async Task DebeLanzarExcepcion_CuandoTurnoNoExisteEnElCatalogo()
+    {
+        var handlerSinCatalogo = new SolicitarProgramacionTurnoCommandHandler(
+            new EventStoreConCatalogo(EventStore, catalogo: null, TurnoId),
+            PublicEventSender);
+
+        var act = async () => await handlerSinCatalogo.HandleAsync(
+            new SolicitarProgramacionTurno(GuidAggregateId, TurnoId, DatosEmpleado, [Fecha1]));
+
+        await act.Should().ThrowExactlyAsync<KeyNotFoundException>()
+            .WithMessage($"*{SolicitarProgramacionTurnoCommandHandler.Mensajes.TurnoNoEncontrado}*");
+    }
+
+    // --- Fake manual: EventStore que ademas conoce el CatalogoTurnos ---
+
+    /// <summary>
+    /// Wrapper de IEventStore que intercepta GetAggregateRootAsync para CatalogoTurnos
+    /// y sirve el catalogo pre-configurado. Todas las demas operaciones delegan al inner.
+    /// </summary>
+    private sealed class EventStoreConCatalogo : IEventStore
+    {
+        private readonly IEventStore _inner;
+        private readonly CatalogoTurnos? _catalogo;
+        private readonly Guid _turnoId;
+
+        public EventStoreConCatalogo(IEventStore inner, CatalogoTurnos? catalogo, Guid turnoId)
+        {
+            _inner = inner;
+            _catalogo = catalogo;
+            _turnoId = turnoId;
+        }
+
+        public Task<bool> ExistsAsync<T>(Guid id, CancellationToken ct = default)
+            where T : AggregateRoot
+            => _inner.ExistsAsync<T>(id, ct);
+
+        public Task<bool> ExistsAsync<T>(string id, CancellationToken ct = default)
+            where T : AggregateRoot
+            => _inner.ExistsAsync<T>(id, ct);
+
+        public Task<T?> GetAggregateRootAsync<T>(Guid id, CancellationToken ct = default)
+            where T : AggregateRoot
+        {
+            if (typeof(T) == typeof(CatalogoTurnos) && id == _turnoId)
+                return Task.FromResult(_catalogo as T);
+            return _inner.GetAggregateRootAsync<T>(id, ct);
+        }
+
+        public Task<T?> GetAggregateRootAsync<T>(string id, CancellationToken ct = default)
+            where T : AggregateRoot
+        {
+            if (typeof(T) == typeof(CatalogoTurnos) && id == _turnoId.ToString())
+                return Task.FromResult(_catalogo as T);
+            return _inner.GetAggregateRootAsync<T>(id, ct);
+        }
+
+        public Task<T?> GetAggregateRootAsync<T>(Guid id, int version, CancellationToken ct = default)
+            where T : AggregateRoot
+            => _inner.GetAggregateRootAsync<T>(id, version, ct);
+
+        public Task<T?> GetAggregateRootAsync<T>(string id, int version, CancellationToken ct = default)
+            where T : AggregateRoot
+            => _inner.GetAggregateRootAsync<T>(id, version, ct);
+
+        public Task<T?> GetAggregateRootAsync<T>(Guid id, DateTimeOffset? timestamp, CancellationToken ct = default)
+            where T : AggregateRoot
+            => _inner.GetAggregateRootAsync<T>(id, timestamp, ct);
+
+        public Task<T?> GetAggregateRootAsync<T>(string id, DateTimeOffset? timestamp, CancellationToken ct = default)
+            where T : AggregateRoot
+            => _inner.GetAggregateRootAsync<T>(id, timestamp, ct);
+
+        public void StartStream(AggregateRoot aggregate)
+            => _inner.StartStream(aggregate);
+
+        public void AppendEvent(Guid streamId, object @event)
+            => _inner.AppendEvent(streamId, @event);
+
+        public void AppendEvent(string streamId, object @event)
+            => _inner.AppendEvent(streamId, @event);
+
+        public Task SaveChangesAsync(CancellationToken ct = default)
+            => _inner.SaveChangesAsync(ct);
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoCommandHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoCommandHandlerTests.cs
@@ -8,7 +8,6 @@ using Bitakora.ControlAsistencia.Programacion.Entities;
 using Bitakora.ControlAsistencia.Programacion.SolicitarProgramacionTurnoFunction;
 using Bitakora.ControlAsistencia.Programacion.SolicitarProgramacionTurnoFunction.CommandHandler;
 using Bitakora.ControlAsistencia.Programacion.SolicitarProgramacionTurnoFunction.Eventos;
-using Cosmos.EventDriven.Abstractions;
 using Cosmos.EventSourcing.Abstractions;
 using Cosmos.EventSourcing.Abstractions.Commands;
 using Cosmos.EventSourcing.Testing.Utilities;

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoCommandHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoCommandHandlerTests.cs
@@ -1,6 +1,7 @@
 // HU-10: Solicitar programacion de turno del catalogo
 
 using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Contracts.Eventos;
 using Bitakora.ControlAsistencia.Contracts.ValueObjects;
 using Bitakora.ControlAsistencia.Programacion.CrearTurnoFunction;
 using Bitakora.ControlAsistencia.Programacion.CrearTurnoFunction.Eventos;
@@ -8,7 +9,6 @@ using Bitakora.ControlAsistencia.Programacion.Entities;
 using Bitakora.ControlAsistencia.Programacion.SolicitarProgramacionTurnoFunction;
 using Bitakora.ControlAsistencia.Programacion.SolicitarProgramacionTurnoFunction.CommandHandler;
 using Bitakora.ControlAsistencia.Programacion.SolicitarProgramacionTurnoFunction.Eventos;
-using Cosmos.EventSourcing.Abstractions;
 using Cosmos.EventSourcing.Abstractions.Commands;
 using Cosmos.EventSourcing.Testing.Utilities;
 
@@ -23,13 +23,10 @@ public class SolicitarProgramacionTurnoCommandHandlerTests
     private static readonly DateOnly Fecha1 = new(2026, 4, 7);
     private static readonly DateOnly Fecha2 = new(2026, 4, 8);
 
-    private static readonly SolicitarProgramacionTurno.DatosEmpleado DatosEmpleado =
+    private static readonly InformacionEmpleado Empleado =
         new("E001", "CC", "12345678", "Juan", "Perez");
 
-    private static readonly InformacionEmpleado EmpleadoEsperado =
-        new("E001", "CC", "12345678", "Juan", "Perez");
-
-    // El DetalleTurno esperado corresponde al catalogo creado en CrearCatalogoConUnaFranja()
+    // El DetalleTurno esperado corresponde al catalogo creado en CrearEventoTurno()
     private static readonly DetalleTurno DetalleEsperado = new(
         "Turno Manana",
         new List<DetalleFranjaOrdinaria>
@@ -39,25 +36,16 @@ public class SolicitarProgramacionTurnoCommandHandlerTests
 
     // --- Configuracion del handler ---
 
-    // El handler del camino feliz usa un EventStore que tambien conoce el CatalogoTurnos
     protected override ICommandHandlerAsync<SolicitarProgramacionTurno> Handler =>
-        new SolicitarProgramacionTurnoCommandHandler(
-            new EventStoreConCatalogo(EventStore, CrearCatalogoConUnaFranja(), TurnoId),
-            PublicEventSender);
+        new SolicitarProgramacionTurnoCommandHandler(EventStore, PublicEventSender);
 
     // --- Factory methods ---
 
-    private static CatalogoTurnos CrearCatalogoConUnaFranja()
-    {
-        var evento = TurnoCreado.Crear(new CrearTurno(
+    private static TurnoCreado CrearEventoTurno() =>
+        TurnoCreado.Crear(new CrearTurno(
             TurnoId,
             "Turno Manana",
             [new CrearTurno.Franja(new TimeOnly(6, 0), new TimeOnly(14, 0), [], [])]));
-        return CatalogoTurnos.Iniciar(evento);
-    }
-
-    private static ProgramacionTurnoSolicitada EventoSolicitudParaFecha1() =>
-        new(Guid.Empty, EmpleadoEsperado, [Fecha1], DetalleEsperado);
 
     // --- Tests del camino feliz ---
 
@@ -65,14 +53,14 @@ public class SolicitarProgramacionTurnoCommandHandlerTests
     [Fact]
     public async Task DebeEmitirProgramacionSolicitadaYPublicarEvento_CuandoDatosValidos()
     {
-        Given();
+        Given(TurnoId.ToString(), CrearEventoTurno());
         await WhenAsync(new SolicitarProgramacionTurno(
-            GuidAggregateId, TurnoId, DatosEmpleado, [Fecha1]));
+            GuidAggregateId, TurnoId, Empleado, [Fecha1]));
 
         Then(new ProgramacionTurnoSolicitada(
-            GuidAggregateId, EmpleadoEsperado, [Fecha1], DetalleEsperado));
+            GuidAggregateId, Empleado, [Fecha1], DetalleEsperado));
         ThenIsPublishedPublicly(new ProgramacionTurnoDiarioSolicitada(
-            GuidAggregateId, EmpleadoEsperado, Fecha1, DetalleEsperado));
+            GuidAggregateId, Empleado, Fecha1, DetalleEsperado));
         And<SolicitudProgramacionAggregateRoot, int>(s => s.Fechas.Count, 1);
     }
 
@@ -80,17 +68,17 @@ public class SolicitarProgramacionTurnoCommandHandlerTests
     [Fact]
     public async Task DebePublicarUnEventoPorCadaFecha_CuandoHayMultiplesFechas()
     {
-        Given();
+        Given(TurnoId.ToString(), CrearEventoTurno());
         await WhenAsync(new SolicitarProgramacionTurno(
-            GuidAggregateId, TurnoId, DatosEmpleado, [Fecha1, Fecha2]));
+            GuidAggregateId, TurnoId, Empleado, [Fecha1, Fecha2]));
 
         Then(new ProgramacionTurnoSolicitada(
-            GuidAggregateId, EmpleadoEsperado, [Fecha1, Fecha2], DetalleEsperado));
+            GuidAggregateId, Empleado, [Fecha1, Fecha2], DetalleEsperado));
         ThenIsPublishedPublicly(
             new ProgramacionTurnoDiarioSolicitada(
-                GuidAggregateId, EmpleadoEsperado, Fecha1, DetalleEsperado),
+                GuidAggregateId, Empleado, Fecha1, DetalleEsperado),
             new ProgramacionTurnoDiarioSolicitada(
-                GuidAggregateId, EmpleadoEsperado, Fecha2, DetalleEsperado));
+                GuidAggregateId, Empleado, Fecha2, DetalleEsperado));
         And<SolicitudProgramacionAggregateRoot, int>(s => s.Fechas.Count, 2);
     }
 
@@ -98,11 +86,12 @@ public class SolicitarProgramacionTurnoCommandHandlerTests
     [Fact]
     public async Task DebeLanzarExcepcion_CuandoSolicitudYaExiste()
     {
+        Given(TurnoId.ToString(), CrearEventoTurno());
         Given(new ProgramacionTurnoSolicitada(
-            GuidAggregateId, EmpleadoEsperado, [Fecha1], DetalleEsperado));
+            GuidAggregateId, Empleado, [Fecha1], DetalleEsperado));
 
         var act = async () => await WhenAsync(new SolicitarProgramacionTurno(
-            GuidAggregateId, TurnoId, DatosEmpleado, [Fecha1]));
+            GuidAggregateId, TurnoId, Empleado, [Fecha1]));
 
         await act.Should().ThrowExactlyAsync<InvalidOperationException>()
             .WithMessage($"*{SolicitarProgramacionTurnoCommandHandler.Mensajes.SolicitudYaExiste}*");
@@ -112,86 +101,10 @@ public class SolicitarProgramacionTurnoCommandHandlerTests
     [Fact]
     public async Task DebeLanzarExcepcion_CuandoTurnoNoExisteEnElCatalogo()
     {
-        var handlerSinCatalogo = new SolicitarProgramacionTurnoCommandHandler(
-            new EventStoreConCatalogo(EventStore, catalogo: null, TurnoId),
-            PublicEventSender);
-
-        var act = async () => await handlerSinCatalogo.HandleAsync(
-            new SolicitarProgramacionTurno(GuidAggregateId, TurnoId, DatosEmpleado, [Fecha1]));
+        var act = async () => await WhenAsync(new SolicitarProgramacionTurno(
+            GuidAggregateId, TurnoId, Empleado, [Fecha1]));
 
         await act.Should().ThrowExactlyAsync<KeyNotFoundException>()
             .WithMessage($"*{SolicitarProgramacionTurnoCommandHandler.Mensajes.TurnoNoEncontrado}*");
-    }
-
-    // --- Fake manual: EventStore que ademas conoce el CatalogoTurnos ---
-
-    /// <summary>
-    /// Wrapper de IEventStore que intercepta GetAggregateRootAsync para CatalogoTurnos
-    /// y sirve el catalogo pre-configurado. Todas las demas operaciones delegan al inner.
-    /// </summary>
-    private sealed class EventStoreConCatalogo : IEventStore
-    {
-        private readonly IEventStore _inner;
-        private readonly CatalogoTurnos? _catalogo;
-        private readonly Guid _turnoId;
-
-        public EventStoreConCatalogo(IEventStore inner, CatalogoTurnos? catalogo, Guid turnoId)
-        {
-            _inner = inner;
-            _catalogo = catalogo;
-            _turnoId = turnoId;
-        }
-
-        public Task<bool> ExistsAsync<T>(Guid id, CancellationToken ct = default)
-            where T : AggregateRoot
-            => _inner.ExistsAsync<T>(id, ct);
-
-        public Task<bool> ExistsAsync<T>(string id, CancellationToken ct = default)
-            where T : AggregateRoot
-            => _inner.ExistsAsync<T>(id, ct);
-
-        public Task<T?> GetAggregateRootAsync<T>(Guid id, CancellationToken ct = default)
-            where T : AggregateRoot
-        {
-            if (typeof(T) == typeof(CatalogoTurnos) && id == _turnoId)
-                return Task.FromResult(_catalogo as T);
-            return _inner.GetAggregateRootAsync<T>(id, ct);
-        }
-
-        public Task<T?> GetAggregateRootAsync<T>(string id, CancellationToken ct = default)
-            where T : AggregateRoot
-        {
-            if (typeof(T) == typeof(CatalogoTurnos) && id == _turnoId.ToString())
-                return Task.FromResult(_catalogo as T);
-            return _inner.GetAggregateRootAsync<T>(id, ct);
-        }
-
-        public Task<T?> GetAggregateRootAsync<T>(Guid id, int version, CancellationToken ct = default)
-            where T : AggregateRoot
-            => _inner.GetAggregateRootAsync<T>(id, version, ct);
-
-        public Task<T?> GetAggregateRootAsync<T>(string id, int version, CancellationToken ct = default)
-            where T : AggregateRoot
-            => _inner.GetAggregateRootAsync<T>(id, version, ct);
-
-        public Task<T?> GetAggregateRootAsync<T>(Guid id, DateTimeOffset? timestamp, CancellationToken ct = default)
-            where T : AggregateRoot
-            => _inner.GetAggregateRootAsync<T>(id, timestamp, ct);
-
-        public Task<T?> GetAggregateRootAsync<T>(string id, DateTimeOffset? timestamp, CancellationToken ct = default)
-            where T : AggregateRoot
-            => _inner.GetAggregateRootAsync<T>(id, timestamp, ct);
-
-        public void StartStream(AggregateRoot aggregate)
-            => _inner.StartStream(aggregate);
-
-        public void AppendEvent(Guid streamId, object @event)
-            => _inner.AppendEvent(streamId, @event);
-
-        public void AppendEvent(string streamId, object @event)
-            => _inner.AppendEvent(streamId, @event);
-
-        public Task SaveChangesAsync(CancellationToken ct = default)
-            => _inner.SaveChangesAsync(ct);
     }
 }

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoValidatorTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoValidatorTests.cs
@@ -1,6 +1,7 @@
 // HU-10: Solicitar programacion de turno del catalogo - tests del validator
 
 using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Contracts.ValueObjects;
 using Bitakora.ControlAsistencia.Programacion.SolicitarProgramacionTurnoFunction;
 using Bitakora.ControlAsistencia.Programacion.SolicitarProgramacionTurnoFunction.CommandHandler;
 
@@ -10,7 +11,7 @@ public class SolicitarProgramacionTurnoValidatorTests
 {
     private readonly SolicitarProgramacionTurnoValidator _validator = new();
 
-    private static SolicitarProgramacionTurno.DatosEmpleado DatosEmpleadoValidos() =>
+    private static InformacionEmpleado DatosEmpleadoValidos() =>
         new("E001", "CC", "12345678", "Juan", "Perez");
 
     private static SolicitarProgramacionTurno ComandoValido() => new(
@@ -69,7 +70,7 @@ public class SolicitarProgramacionTurnoValidatorTests
 
         resultado.IsValid.Should().BeFalse();
         resultado.Errors.Should().Contain(e =>
-            e.PropertyName.Contains(nameof(SolicitarProgramacionTurno.DatosEmpleado.EmpleadoId)));
+            e.PropertyName.Contains(nameof(InformacionEmpleado.EmpleadoId)));
     }
 
     // CA-3: TipoIdentificacion no puede estar vacio
@@ -84,7 +85,7 @@ public class SolicitarProgramacionTurnoValidatorTests
 
         resultado.IsValid.Should().BeFalse();
         resultado.Errors.Should().Contain(e =>
-            e.PropertyName.Contains(nameof(SolicitarProgramacionTurno.DatosEmpleado.TipoIdentificacion)));
+            e.PropertyName.Contains(nameof(InformacionEmpleado.TipoIdentificacion)));
     }
 
     // CA-3: NumeroIdentificacion no puede estar vacio
@@ -99,7 +100,7 @@ public class SolicitarProgramacionTurnoValidatorTests
 
         resultado.IsValid.Should().BeFalse();
         resultado.Errors.Should().Contain(e =>
-            e.PropertyName.Contains(nameof(SolicitarProgramacionTurno.DatosEmpleado.NumeroIdentificacion)));
+            e.PropertyName.Contains(nameof(InformacionEmpleado.NumeroIdentificacion)));
     }
 
     // CA-3: Nombres no puede estar vacio
@@ -114,7 +115,7 @@ public class SolicitarProgramacionTurnoValidatorTests
 
         resultado.IsValid.Should().BeFalse();
         resultado.Errors.Should().Contain(e =>
-            e.PropertyName.Contains(nameof(SolicitarProgramacionTurno.DatosEmpleado.Nombres)));
+            e.PropertyName.Contains(nameof(InformacionEmpleado.Nombres)));
     }
 
     // CA-3: Apellidos no puede estar vacio
@@ -129,7 +130,7 @@ public class SolicitarProgramacionTurnoValidatorTests
 
         resultado.IsValid.Should().BeFalse();
         resultado.Errors.Should().Contain(e =>
-            e.PropertyName.Contains(nameof(SolicitarProgramacionTurno.DatosEmpleado.Apellidos)));
+            e.PropertyName.Contains(nameof(InformacionEmpleado.Apellidos)));
     }
 
     // CA-4: Fechas debe tener al menos un elemento

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoValidatorTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoValidatorTests.cs
@@ -1,0 +1,148 @@
+// HU-10: Solicitar programacion de turno del catalogo - tests del validator
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Programacion.SolicitarProgramacionTurnoFunction;
+using Bitakora.ControlAsistencia.Programacion.SolicitarProgramacionTurnoFunction.CommandHandler;
+
+namespace Bitakora.ControlAsistencia.Programacion.Tests.SolicitarProgramacionTurnoFunction;
+
+public class SolicitarProgramacionTurnoValidatorTests
+{
+    private readonly SolicitarProgramacionTurnoValidator _validator = new();
+
+    private static SolicitarProgramacionTurno.DatosEmpleado DatosEmpleadoValidos() =>
+        new("E001", "CC", "12345678", "Juan", "Perez");
+
+    private static SolicitarProgramacionTurno ComandoValido() => new(
+        Guid.NewGuid(),
+        Guid.NewGuid(),
+        DatosEmpleadoValidos(),
+        [new DateOnly(2026, 4, 7)]);
+
+    // Camino feliz - todos los campos correctos
+    [Fact]
+    public async Task DebeSerValido_CuandoTodosLosCamposSonCorrectos()
+    {
+        var resultado = await _validator.ValidateAsync(
+            ComandoValido(), TestContext.Current.CancellationToken);
+
+        resultado.IsValid.Should().BeTrue();
+    }
+
+    // CA-1: Id no puede ser Guid vacio
+    [Fact]
+    public async Task DebeTenerError_CuandoIdEsGuidVacio()
+    {
+        var comando = ComandoValido() with { Id = Guid.Empty };
+
+        var resultado = await _validator.ValidateAsync(
+            comando, TestContext.Current.CancellationToken);
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e =>
+            e.PropertyName == nameof(SolicitarProgramacionTurno.Id));
+    }
+
+    // CA-2: TurnoId no puede ser Guid vacio
+    [Fact]
+    public async Task DebeTenerError_CuandoTurnoIdEsGuidVacio()
+    {
+        var comando = ComandoValido() with { TurnoId = Guid.Empty };
+
+        var resultado = await _validator.ValidateAsync(
+            comando, TestContext.Current.CancellationToken);
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e =>
+            e.PropertyName == nameof(SolicitarProgramacionTurno.TurnoId));
+    }
+
+    // CA-3: EmpleadoId no puede estar vacio
+    [Fact]
+    public async Task DebeTenerError_CuandoEmpleadoIdEstaVacio()
+    {
+        var datosInvalidos = DatosEmpleadoValidos() with { EmpleadoId = "" };
+        var comando = ComandoValido() with { Empleado = datosInvalidos };
+
+        var resultado = await _validator.ValidateAsync(
+            comando, TestContext.Current.CancellationToken);
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e =>
+            e.PropertyName.Contains(nameof(SolicitarProgramacionTurno.DatosEmpleado.EmpleadoId)));
+    }
+
+    // CA-3: TipoIdentificacion no puede estar vacio
+    [Fact]
+    public async Task DebeTenerError_CuandoTipoIdentificacionEstaVacio()
+    {
+        var datosInvalidos = DatosEmpleadoValidos() with { TipoIdentificacion = "" };
+        var comando = ComandoValido() with { Empleado = datosInvalidos };
+
+        var resultado = await _validator.ValidateAsync(
+            comando, TestContext.Current.CancellationToken);
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e =>
+            e.PropertyName.Contains(nameof(SolicitarProgramacionTurno.DatosEmpleado.TipoIdentificacion)));
+    }
+
+    // CA-3: NumeroIdentificacion no puede estar vacio
+    [Fact]
+    public async Task DebeTenerError_CuandoNumeroIdentificacionEstaVacio()
+    {
+        var datosInvalidos = DatosEmpleadoValidos() with { NumeroIdentificacion = " " };
+        var comando = ComandoValido() with { Empleado = datosInvalidos };
+
+        var resultado = await _validator.ValidateAsync(
+            comando, TestContext.Current.CancellationToken);
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e =>
+            e.PropertyName.Contains(nameof(SolicitarProgramacionTurno.DatosEmpleado.NumeroIdentificacion)));
+    }
+
+    // CA-3: Nombres no puede estar vacio
+    [Fact]
+    public async Task DebeTenerError_CuandoNombresEstanVacios()
+    {
+        var datosInvalidos = DatosEmpleadoValidos() with { Nombres = "" };
+        var comando = ComandoValido() with { Empleado = datosInvalidos };
+
+        var resultado = await _validator.ValidateAsync(
+            comando, TestContext.Current.CancellationToken);
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e =>
+            e.PropertyName.Contains(nameof(SolicitarProgramacionTurno.DatosEmpleado.Nombres)));
+    }
+
+    // CA-3: Apellidos no puede estar vacio
+    [Fact]
+    public async Task DebeTenerError_CuandoApellidosEstanVacios()
+    {
+        var datosInvalidos = DatosEmpleadoValidos() with { Apellidos = "   " };
+        var comando = ComandoValido() with { Empleado = datosInvalidos };
+
+        var resultado = await _validator.ValidateAsync(
+            comando, TestContext.Current.CancellationToken);
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e =>
+            e.PropertyName.Contains(nameof(SolicitarProgramacionTurno.DatosEmpleado.Apellidos)));
+    }
+
+    // CA-4: Fechas debe tener al menos un elemento
+    [Fact]
+    public async Task DebeTenerError_CuandoFechasEstaVacia()
+    {
+        var comando = ComandoValido() with { Fechas = [] };
+
+        var resultado = await _validator.ValidateAsync(
+            comando, TestContext.Current.CancellationToken);
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e =>
+            e.PropertyName == nameof(SolicitarProgramacionTurno.Fechas));
+    }
+}


### PR DESCRIPTION
## Summary

- Implementa el comando `SolicitarProgramacionTurno` para asignar turnos del catálogo a empleados en fechas específicas
- Crea value objects compartidos en Contracts: `DetalleTurno`, `DetalleFranjaOrdinaria`, `DetalleSubFranja`, `InformacionEmpleado`
- Publica `ProgramacionTurnoDiarioSolicitada` (uno por fecha) al Service Bus para consumo de ControlHoras
- Configura topic de Service Bus en Terraform

## Test plan

- [x] 41/41 tests de Programacion pasando (validator, handler, endpoint)
- [x] 109/109 tests totales pasando
- [ ] CI pasa en GitHub Actions
- [ ] Verificar `terraform plan` no destruye recursos existentes

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)