### PR TITLE
fix: deserializacion de TurnoCreado en Marten

### DIFF
--- a/src/Bitakora.ControlAsistencia.Contracts/ValueObjects/FranjaOrdinaria.cs
+++ b/src/Bitakora.ControlAsistencia.Contracts/ValueObjects/FranjaOrdinaria.cs
@@ -128,7 +128,7 @@ public sealed class FranjaOrdinaria : FranjaTemporal, IEquatable<FranjaOrdinaria
     }
 
     // Mapping de serializacion - vive aqui porque cambia con la clase
-    internal static void ConfigurarSerializacion(DefaultJsonTypeInfoResolver resolver)
+    public static void ConfigurarSerializacion(DefaultJsonTypeInfoResolver resolver)
     {
         var ctor = typeof(FranjaOrdinaria)
             .GetConstructor(BindingFlags.NonPublic | BindingFlags.Instance, Type.EmptyTypes)!;

--- a/src/Bitakora.ControlAsistencia.Contracts/ValueObjects/SubFranja.cs
+++ b/src/Bitakora.ControlAsistencia.Contracts/ValueObjects/SubFranja.cs
@@ -50,7 +50,7 @@ public sealed class SubFranja : FranjaTemporal, IEquatable<SubFranja>
         HashCode.Combine(_horaInicio, _horaFin, _diaOffsetInicio, _diaOffsetFin);
 
     // Mapping de serializacion - vive aqui porque cambia con la clase
-    internal static void ConfigurarSerializacion(DefaultJsonTypeInfoResolver resolver)
+    public static void ConfigurarSerializacion(DefaultJsonTypeInfoResolver resolver)
     {
         var ctor = typeof(SubFranja)
             .GetConstructor(BindingFlags.NonPublic | BindingFlags.Instance, Type.EmptyTypes)!;

--- a/src/Bitakora.ControlAsistencia.Programacion/CrearTurnoFunction/Eventos/TurnoCreado.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/CrearTurnoFunction/Eventos/TurnoCreado.cs
@@ -15,6 +15,8 @@ public sealed partial class TurnoCreado
     public IReadOnlyList<FranjaOrdinaria> FranjasOrdinarias { get; private set; }
 
     // CA-12: constructor real privado -- solo el factory lo invoca
+    // JsonConstructor permite a STJ/Marten deserializar sin exponer el constructor
+    [System.Text.Json.Serialization.JsonConstructor]
     private TurnoCreado(Guid turnoId, string nombre, IReadOnlyList<FranjaOrdinaria> franjasOrdinarias)
     {
         TurnoId = turnoId;

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/CrearTurnoFunction/Eventos/TurnoCreadoSerializacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/CrearTurnoFunction/Eventos/TurnoCreadoSerializacionTests.cs
@@ -1,0 +1,49 @@
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Contracts.ValueObjects;
+using Bitakora.ControlAsistencia.Programacion.CrearTurnoFunction;
+using Bitakora.ControlAsistencia.Programacion.CrearTurnoFunction.Eventos;
+
+namespace Bitakora.ControlAsistencia.Programacion.Tests.CrearTurnoFunction.Eventos;
+
+/// <summary>
+/// Verifica que TurnoCreado (con FranjaOrdinaria y SubFranja) sobrevive
+/// un roundtrip de serializacion STJ — requerido por Marten.
+/// </summary>
+public class TurnoCreadoSerializacionTests
+{
+    private static readonly Guid TurnoId = Guid.Parse("019600a0-0000-7000-8000-000000000001");
+
+    private static JsonSerializerOptions CrearOpciones()
+    {
+        var resolver = new DefaultJsonTypeInfoResolver();
+        SubFranja.ConfigurarSerializacion(resolver);
+        FranjaOrdinaria.ConfigurarSerializacion(resolver);
+        return new JsonSerializerOptions { TypeInfoResolver = resolver };
+    }
+
+    [Fact]
+    public void Deserializar_ReconstruyeEvento_CuandoOrdinariaConDescansoYExtra()
+    {
+        var descanso = (new TimeOnly(10, 0), new TimeOnly(10, 15));
+        var extra = (new TimeOnly(6, 0), new TimeOnly(8, 0));
+        var comando = new CrearTurno(
+            TurnoId, "Turno Completo",
+            [new CrearTurno.Franja(
+                new TimeOnly(6, 0), new TimeOnly(16, 0),
+                [descanso], [extra])]);
+
+        var evento = TurnoCreado.Crear(comando);
+        var opciones = CrearOpciones();
+        var json = JsonSerializer.Serialize(evento, opciones);
+        var deserializado = JsonSerializer.Deserialize<TurnoCreado>(json, opciones);
+
+        deserializado.Should().NotBeNull();
+        deserializado!.TurnoId.Should().Be(TurnoId);
+        deserializado.Nombre.Should().Be("Turno Completo");
+        deserializado.FranjasOrdinarias.Should().HaveCount(1);
+        deserializado.FranjasOrdinarias[0].ToString()
+            .Should().Be("(06:00-16:00)[Descansos:(10:00-10:15)][Extras:(06:00-08:00)]");
+    }
+}


### PR DESCRIPTION
## Summary

- Marten/STJ no podia deserializar `TurnoCreado` porque ambos constructores eran privados, causando **500 InternalServerError** en `SolicitarProgramacionTurno` al reconstruir `CatalogoTurnos` desde el event store
- Agregar `[JsonConstructor]` al constructor privado con parametros de `TurnoCreado`
- Hacer publicos `ConfigurarSerializacion` en `FranjaOrdinaria` y `SubFranja` para que los dominios puedan configurar la serializacion de VOs compartidos
- Test de roundtrip completo: `TurnoCreado` con `FranjaOrdinaria` conteniendo descanso y extra

## Test plan

- [x] Test unitario de roundtrip serializar/deserializar TurnoCreado con FranjaOrdinaria completa
- [x] 115 tests unitarios pasando (42 Programacion + 73 Contracts)
- [ ] Smoke tests en CI (requiere deploy del fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)