### PR TITLE
Estandarizar fixtures de smoke tests para Service Bus y Postgres

### DIFF
--- a/.github/workflows/deploy-control-horas.yml
+++ b/.github/workflows/deploy-control-horas.yml
@@ -88,3 +88,6 @@ jobs:
     with:
       base_url: https://func-asist-dev-control-horas.azurewebsites.net
       test_project: tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/
+    secrets:
+      SERVICEBUS_CONNECTION_STRING: ${{ secrets.SERVICEBUS_CONNECTION_STRING }}
+      POSTGRES_CONNECTION_STRING: ${{ secrets.POSTGRES_CONNECTION_STRING }}

--- a/.github/workflows/deploy-programacion.yml
+++ b/.github/workflows/deploy-programacion.yml
@@ -87,3 +87,5 @@ jobs:
     uses: ./.github/workflows/smoke-tests.yml
     with:
       test_project: tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/
+    secrets:
+      SERVICEBUS_CONNECTION_STRING: ${{ secrets.SERVICEBUS_CONNECTION_STRING }}

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -21,6 +21,11 @@ on:
         type: string
         required: false
         default: 'tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/'
+    secrets:
+      SERVICEBUS_CONNECTION_STRING:
+        required: false
+      POSTGRES_CONNECTION_STRING:
+        required: false
 
 jobs:
   smoke-tests:
@@ -35,4 +40,6 @@ jobs:
       - name: Smoke tests
         env:
           Api__BaseUrl: ${{ inputs.base_url }}
+          ServiceBus__ConnectionString: ${{ secrets.SERVICEBUS_CONNECTION_STRING }}
+          Postgres__ConnectionString: ${{ secrets.POSTGRES_CONNECTION_STRING }}
         run: dotnet test --project ${{ inputs.test_project }} --configuration Release

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/AsignarTurnoViaSbSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/AsignarTurnoViaSbSmokeTests.cs
@@ -19,7 +19,7 @@ public class AsignarTurnoViaSbSmokeTests(ServiceBusFixture serviceBus, PostgresF
         Assert.SkipWhen(!serviceBus.IsConfigured,
             "ServiceBus no configurado. Usa appsettings.local.json o variable ServiceBus__ConnectionString.");
         Assert.SkipWhen(!postgres.IsConfigured,
-            "Postgres no configurado. Usa appsettings.local.json o variable Postgres__ConnectionString.");
+            postgres.SkipReason ?? "Postgres no disponible.");
 
         // Arrange
         var correlationId = Guid.CreateVersion7().ToString();

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/AsignarTurnoViaSbSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/AsignarTurnoViaSbSmokeTests.cs
@@ -16,6 +16,11 @@ public class AsignarTurnoViaSbSmokeTests(ServiceBusFixture serviceBus, PostgresF
     [Trait("Category", "Smoke")]
     public async Task DebeAsignarTurnoDiario_CuandoSeBusPublicaProgramacionTurnoDiarioSolicitada()
     {
+        Assert.SkipWhen(!serviceBus.IsConfigured,
+            "ServiceBus no configurado. Usa appsettings.local.json o variable ServiceBus__ConnectionString.");
+        Assert.SkipWhen(!postgres.IsConfigured,
+            "Postgres no configurado. Usa appsettings.local.json o variable Postgres__ConnectionString.");
+
         // Arrange
         var correlationId = Guid.CreateVersion7().ToString();
         var solicitudId = Guid.CreateVersion7();

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/Fixtures/Polling.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/Fixtures/Polling.cs
@@ -9,12 +9,20 @@ public static class Polling
     {
         var delay = interval ?? TimeSpan.FromSeconds(1);
         var deadline = DateTime.UtcNow + timeout;
+        Exception? lastException = null;
 
         while (DateTime.UtcNow < deadline)
         {
-            var result = await probe();
-            if (result is not null)
-                return result;
+            try
+            {
+                var result = await probe();
+                if (result is not null)
+                    return result;
+            }
+            catch (Exception ex)
+            {
+                lastException = ex;
+            }
 
             var remaining = deadline - DateTime.UtcNow;
             if (remaining <= TimeSpan.Zero)
@@ -27,6 +35,11 @@ public static class Polling
                 delay = TimeSpan.FromMilliseconds(delay.TotalMilliseconds * 1.5);
         }
 
+        if (lastException is not null)
+            throw new TimeoutException(
+                $"Polling agoto el timeout de {timeout.TotalSeconds}s. Ultima excepcion: {lastException.Message}",
+                lastException);
+
         throw new TimeoutException(
             $"Polling agoto el timeout de {timeout.TotalSeconds}s sin obtener resultado.");
     }
@@ -38,11 +51,19 @@ public static class Polling
     {
         var delay = interval ?? TimeSpan.FromSeconds(1);
         var deadline = DateTime.UtcNow + timeout;
+        Exception? lastException = null;
 
         while (DateTime.UtcNow < deadline)
         {
-            if (await condition())
-                return true;
+            try
+            {
+                if (await condition())
+                    return true;
+            }
+            catch (Exception ex)
+            {
+                lastException = ex;
+            }
 
             var remaining = deadline - DateTime.UtcNow;
             if (remaining <= TimeSpan.Zero)
@@ -53,6 +74,11 @@ public static class Polling
             if (delay < TimeSpan.FromSeconds(5))
                 delay = TimeSpan.FromMilliseconds(delay.TotalMilliseconds * 1.5);
         }
+
+        if (lastException is not null)
+            throw new TimeoutException(
+                $"Polling agoto el timeout de {timeout.TotalSeconds}s. Ultima excepcion: {lastException.Message}",
+                lastException);
 
         return false;
     }

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/Fixtures/PostgresFixture.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/Fixtures/PostgresFixture.cs
@@ -1,3 +1,4 @@
+using System.Net.Sockets;
 using System.Text.Json;
 using Microsoft.Extensions.Configuration;
 using Npgsql;
@@ -9,6 +10,8 @@ public class PostgresFixture : IAsyncLifetime
     private string _connectionString = null!;
 
     public bool IsConfigured { get; private set; }
+
+    public string? SkipReason { get; private set; }
 
     public async ValueTask InitializeAsync()
     {
@@ -23,15 +26,24 @@ public class PostgresFixture : IAsyncLifetime
         if (string.IsNullOrWhiteSpace(connectionString))
         {
             IsConfigured = false;
+            SkipReason = "Postgres no configurado. Usa appsettings.local.json o variable Postgres__ConnectionString.";
+            return;
+        }
+
+        try
+        {
+            await using var conn = new NpgsqlConnection(connectionString);
+            await conn.OpenAsync();
+        }
+        catch (NpgsqlException ex) when (ex.InnerException is SocketException or TimeoutException)
+        {
+            IsConfigured = false;
+            SkipReason = $"No se pudo conectar a Postgres. Verifica que tu IP este en el firewall de Azure (psql-asist-dev). Detalle: {ex.InnerException.Message}";
             return;
         }
 
         IsConfigured = true;
         _connectionString = connectionString;
-
-        // Verificar conectividad
-        await using var conn = new NpgsqlConnection(_connectionString);
-        await conn.OpenAsync();
     }
 
     public Task<bool> ExisteEventoAsync(

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/Fixtures/PostgresFixture.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/Fixtures/PostgresFixture.cs
@@ -8,6 +8,8 @@ public class PostgresFixture : IAsyncLifetime
 {
     private string _connectionString = null!;
 
+    public bool IsConfigured { get; private set; }
+
     public async ValueTask InitializeAsync()
     {
         var configuration = new ConfigurationBuilder()
@@ -17,9 +19,15 @@ public class PostgresFixture : IAsyncLifetime
             .AddEnvironmentVariables()
             .Build();
 
-        _connectionString = configuration["Postgres:ConnectionString"]
-            ?? throw new InvalidOperationException(
-                "Postgres:ConnectionString no esta configurado. Usa appsettings.json, appsettings.local.json o la variable de entorno Postgres__ConnectionString.");
+        var connectionString = configuration["Postgres:ConnectionString"];
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            IsConfigured = false;
+            return;
+        }
+
+        IsConfigured = true;
+        _connectionString = connectionString;
 
         // Verificar conectividad
         await using var conn = new NpgsqlConnection(_connectionString);

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/Fixtures/ServiceBusFixture.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/Fixtures/ServiceBusFixture.cs
@@ -8,6 +8,8 @@ public class ServiceBusFixture : IAsyncLifetime
 {
     private ServiceBusClient? _client;
 
+    public bool IsConfigured { get; private set; }
+
     public ValueTask InitializeAsync()
     {
         var configuration = new ConfigurationBuilder()
@@ -17,10 +19,14 @@ public class ServiceBusFixture : IAsyncLifetime
             .AddEnvironmentVariables()
             .Build();
 
-        var connectionString = configuration["ServiceBus:ConnectionString"]
-            ?? throw new InvalidOperationException(
-                "ServiceBus:ConnectionString no esta configurado. Usa appsettings.json, appsettings.local.json o la variable de entorno ServiceBus__ConnectionString.");
+        var connectionString = configuration["ServiceBus:ConnectionString"];
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            IsConfigured = false;
+            return ValueTask.CompletedTask;
+        }
 
+        IsConfigured = true;
         _client = new ServiceBusClient(connectionString);
 
         return ValueTask.CompletedTask;

--- a/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/Bitakora.ControlAsistencia.Programacion.SmokeTests.csproj
+++ b/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/Bitakora.ControlAsistencia.Programacion.SmokeTests.csproj
@@ -10,9 +10,14 @@
 
   <ItemGroup>
     <PackageReference Include="AwesomeAssertions" Version="*" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.*" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.*" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.*" />
     <PackageReference Include="xunit.v3.mtp-v2" Version="3.*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Bitakora.ControlAsistencia.Contracts\Bitakora.ControlAsistencia.Contracts.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/Fixtures/AssemblyFixture.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/Fixtures/AssemblyFixture.cs
@@ -1,3 +1,4 @@
 using Bitakora.ControlAsistencia.Programacion.SmokeTests.Fixtures;
 
 [assembly: AssemblyFixture(typeof(ApiFixture))]
+[assembly: AssemblyFixture(typeof(ServiceBusFixture))]

--- a/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/Fixtures/Polling.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/Fixtures/Polling.cs
@@ -9,12 +9,20 @@ public static class Polling
     {
         var delay = interval ?? TimeSpan.FromSeconds(1);
         var deadline = DateTime.UtcNow + timeout;
+        Exception? lastException = null;
 
         while (DateTime.UtcNow < deadline)
         {
-            var result = await probe();
-            if (result is not null)
-                return result;
+            try
+            {
+                var result = await probe();
+                if (result is not null)
+                    return result;
+            }
+            catch (Exception ex)
+            {
+                lastException = ex;
+            }
 
             var remaining = deadline - DateTime.UtcNow;
             if (remaining <= TimeSpan.Zero)
@@ -27,6 +35,11 @@ public static class Polling
                 delay = TimeSpan.FromMilliseconds(delay.TotalMilliseconds * 1.5);
         }
 
+        if (lastException is not null)
+            throw new TimeoutException(
+                $"Polling agoto el timeout de {timeout.TotalSeconds}s. Ultima excepcion: {lastException.Message}",
+                lastException);
+
         throw new TimeoutException(
             $"Polling agoto el timeout de {timeout.TotalSeconds}s sin obtener resultado.");
     }
@@ -38,11 +51,19 @@ public static class Polling
     {
         var delay = interval ?? TimeSpan.FromSeconds(1);
         var deadline = DateTime.UtcNow + timeout;
+        Exception? lastException = null;
 
         while (DateTime.UtcNow < deadline)
         {
-            if (await condition())
-                return true;
+            try
+            {
+                if (await condition())
+                    return true;
+            }
+            catch (Exception ex)
+            {
+                lastException = ex;
+            }
 
             var remaining = deadline - DateTime.UtcNow;
             if (remaining <= TimeSpan.Zero)
@@ -53,6 +74,11 @@ public static class Polling
             if (delay < TimeSpan.FromSeconds(5))
                 delay = TimeSpan.FromMilliseconds(delay.TotalMilliseconds * 1.5);
         }
+
+        if (lastException is not null)
+            throw new TimeoutException(
+                $"Polling agoto el timeout de {timeout.TotalSeconds}s. Ultima excepcion: {lastException.Message}",
+                lastException);
 
         return false;
     }

--- a/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/Fixtures/Polling.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/Fixtures/Polling.cs
@@ -1,0 +1,59 @@
+namespace Bitakora.ControlAsistencia.Programacion.SmokeTests.Fixtures;
+
+public static class Polling
+{
+    public static async Task<T> WaitUntilAsync<T>(
+        Func<Task<T?>> probe,
+        TimeSpan timeout,
+        TimeSpan? interval = null) where T : class
+    {
+        var delay = interval ?? TimeSpan.FromSeconds(1);
+        var deadline = DateTime.UtcNow + timeout;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            var result = await probe();
+            if (result is not null)
+                return result;
+
+            var remaining = deadline - DateTime.UtcNow;
+            if (remaining <= TimeSpan.Zero)
+                break;
+
+            await Task.Delay(remaining < delay ? remaining : delay);
+
+            // Backoff simple: incrementar 50% hasta max 5s
+            if (delay < TimeSpan.FromSeconds(5))
+                delay = TimeSpan.FromMilliseconds(delay.TotalMilliseconds * 1.5);
+        }
+
+        throw new TimeoutException(
+            $"Polling agoto el timeout de {timeout.TotalSeconds}s sin obtener resultado.");
+    }
+
+    public static async Task<bool> WaitUntilTrueAsync(
+        Func<Task<bool>> condition,
+        TimeSpan timeout,
+        TimeSpan? interval = null)
+    {
+        var delay = interval ?? TimeSpan.FromSeconds(1);
+        var deadline = DateTime.UtcNow + timeout;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            if (await condition())
+                return true;
+
+            var remaining = deadline - DateTime.UtcNow;
+            if (remaining <= TimeSpan.Zero)
+                break;
+
+            await Task.Delay(remaining < delay ? remaining : delay);
+
+            if (delay < TimeSpan.FromSeconds(5))
+                delay = TimeSpan.FromMilliseconds(delay.TotalMilliseconds * 1.5);
+        }
+
+        return false;
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/Fixtures/ServiceBusFixture.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/Fixtures/ServiceBusFixture.cs
@@ -29,9 +29,10 @@ public class ServiceBusFixture : IAsyncLifetime
     public async Task<T?> WaitForMessageAsync<T>(
         string topicName,
         string subscriptionName,
-        string correlationId,
+        Func<T, bool> match,
         TimeSpan timeout)
     {
+        var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
         await using var receiver = _client!.CreateReceiver(topicName, subscriptionName);
 
         var deadline = DateTime.UtcNow + timeout;
@@ -48,13 +49,21 @@ public class ServiceBusFixture : IAsyncLifetime
             if (received is null)
                 continue;
 
-            if (received.CorrelationId == correlationId)
+            try
             {
-                await receiver.CompleteMessageAsync(received);
-                return JsonSerializer.Deserialize<T>(received.Body.ToString());
+                var deserialized = JsonSerializer.Deserialize<T>(received.Body.ToString(), options);
+                if (deserialized is not null && match(deserialized))
+                {
+                    await receiver.CompleteMessageAsync(received);
+                    return deserialized;
+                }
+            }
+            catch (JsonException)
+            {
+                // Mensaje con formato incompatible, ignorar
             }
 
-            // Mensaje de otro test, abandonar para que vuelva a la cola
+            // Mensaje de otro test o formato distinto, abandonar para que vuelva a la cola
             await receiver.AbandonMessageAsync(received);
         }
 

--- a/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/Fixtures/ServiceBusFixture.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/Fixtures/ServiceBusFixture.cs
@@ -8,6 +8,8 @@ public class ServiceBusFixture : IAsyncLifetime
 {
     private ServiceBusClient? _client;
 
+    public bool IsConfigured { get; private set; }
+
     public ValueTask InitializeAsync()
     {
         var configuration = new ConfigurationBuilder()
@@ -17,10 +19,14 @@ public class ServiceBusFixture : IAsyncLifetime
             .AddEnvironmentVariables()
             .Build();
 
-        var connectionString = configuration["ServiceBus:ConnectionString"]
-            ?? throw new InvalidOperationException(
-                "ServiceBus:ConnectionString no esta configurado. Usa appsettings.json, appsettings.local.json o la variable de entorno ServiceBus__ConnectionString.");
+        var connectionString = configuration["ServiceBus:ConnectionString"];
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            IsConfigured = false;
+            return ValueTask.CompletedTask;
+        }
 
+        IsConfigured = true;
         _client = new ServiceBusClient(connectionString);
 
         return ValueTask.CompletedTask;

--- a/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/Fixtures/ServiceBusFixture.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/Fixtures/ServiceBusFixture.cs
@@ -1,0 +1,69 @@
+using System.Text.Json;
+using Azure.Messaging.ServiceBus;
+using Microsoft.Extensions.Configuration;
+
+namespace Bitakora.ControlAsistencia.Programacion.SmokeTests.Fixtures;
+
+public class ServiceBusFixture : IAsyncLifetime
+{
+    private ServiceBusClient? _client;
+
+    public ValueTask InitializeAsync()
+    {
+        var configuration = new ConfigurationBuilder()
+            .SetBasePath(AppContext.BaseDirectory)
+            .AddJsonFile("appsettings.json", optional: false)
+            .AddJsonFile("appsettings.local.json", optional: true)
+            .AddEnvironmentVariables()
+            .Build();
+
+        var connectionString = configuration["ServiceBus:ConnectionString"]
+            ?? throw new InvalidOperationException(
+                "ServiceBus:ConnectionString no esta configurado. Usa appsettings.json, appsettings.local.json o la variable de entorno ServiceBus__ConnectionString.");
+
+        _client = new ServiceBusClient(connectionString);
+
+        return ValueTask.CompletedTask;
+    }
+
+    public async Task<T?> WaitForMessageAsync<T>(
+        string topicName,
+        string subscriptionName,
+        string correlationId,
+        TimeSpan timeout)
+    {
+        await using var receiver = _client!.CreateReceiver(topicName, subscriptionName);
+
+        var deadline = DateTime.UtcNow + timeout;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            var remaining = deadline - DateTime.UtcNow;
+            if (remaining <= TimeSpan.Zero)
+                break;
+
+            var maxWait = remaining < TimeSpan.FromSeconds(5) ? remaining : TimeSpan.FromSeconds(5);
+            var received = await receiver.ReceiveMessageAsync(maxWait);
+
+            if (received is null)
+                continue;
+
+            if (received.CorrelationId == correlationId)
+            {
+                await receiver.CompleteMessageAsync(received);
+                return JsonSerializer.Deserialize<T>(received.Body.ToString());
+            }
+
+            // Mensaje de otro test, abandonar para que vuelva a la cola
+            await receiver.AbandonMessageAsync(received);
+        }
+
+        return default;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_client is not null)
+            await _client.DisposeAsync();
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoSbSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoSbSmokeTests.cs
@@ -1,0 +1,87 @@
+using System.Net;
+using System.Net.Http.Json;
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Contracts.Empleados.ValueObjects;
+using Bitakora.ControlAsistencia.Contracts.Programacion.Eventos;
+using Bitakora.ControlAsistencia.Contracts.Programacion.ValueObjects;
+using Bitakora.ControlAsistencia.Programacion.SmokeTests.Fixtures;
+
+namespace Bitakora.ControlAsistencia.Programacion.SmokeTests.SolicitarProgramacionTurnoFunction;
+
+public class SolicitarProgramacionTurnoSbSmokeTests(ApiFixture api, ServiceBusFixture serviceBus)
+{
+    private readonly HttpClient _client = api.Client;
+
+    private const string TopicSalida = "programacion-turno-diario-solicitada";
+    private const string Suscripcion = "smoke-tests";
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task DebePublicarProgramacionTurnoDiarioSolicitada_CuandoSolicitudEsAceptada()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        // Arrange: crear turno en catalogo
+        var turnoId = Guid.CreateVersion7();
+        var turnoPayload = new
+        {
+            turnoId,
+            nombre = "[TEST] Turno Smoke SB",
+            ordinarias = new[]
+            {
+                new
+                {
+                    inicio = "08:00:00",
+                    fin = "16:00:00",
+                    descansos = Array.Empty<object>(),
+                    extras = Array.Empty<object>()
+                }
+            }
+        };
+        var crearTurnoResponse = await _client.PostAsJsonAsync("/api/programacion/turnos", turnoPayload, ct);
+        crearTurnoResponse.StatusCode.Should().Be(HttpStatusCode.Accepted);
+
+        // Arrange: preparar solicitud con una sola fecha para simplificar verificacion
+        var solicitudId = Guid.CreateVersion7();
+        var correlationId = solicitudId.ToString();
+        var empleadoId = Guid.CreateVersion7().ToString();
+        var fecha = "2026-04-15";
+        var payload = new
+        {
+            id = solicitudId,
+            turnoId,
+            empleado = new
+            {
+                empleadoId,
+                tipoIdentificacion = "CC",
+                numeroIdentificacion = "555666777",
+                nombres = "[TEST] Smoke ServiceBus",
+                apellidos = "[TEST] Publicacion"
+            },
+            fechas = new[] { fecha }
+        };
+
+        // Act: enviar solicitud via HTTP
+        var response = await _client.PostAsJsonAsync("/api/programacion/solicitudes", payload, ct);
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+
+        // Assert: consumir el evento publicado desde la suscripcion smoke-tests
+        var eventoRecibido = await serviceBus.WaitForMessageAsync<ProgramacionTurnoDiarioSolicitada>(
+            TopicSalida, Suscripcion, correlationId, Timeout);
+
+        eventoRecibido.Should().NotBeNull(
+            "la Function App deberia publicar ProgramacionTurnoDiarioSolicitada al topic de Service Bus");
+
+        eventoRecibido!.SolicitudId.Should().Be(solicitudId);
+        eventoRecibido.Fecha.Should().Be(DateOnly.Parse(fecha));
+
+        var empleadoEsperado = new InformacionEmpleado(
+            empleadoId, "CC", "555666777", "[TEST] Smoke ServiceBus", "[TEST] Publicacion");
+        eventoRecibido.Empleado.Should().Be(empleadoEsperado);
+
+        eventoRecibido.DetalleTurno.Should().NotBeNull();
+        eventoRecibido.DetalleTurno.Nombre.Should().Be("[TEST] Turno Smoke SB");
+        eventoRecibido.DetalleTurno.FranjasOrdinarias.Should().HaveCount(1);
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoSbSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoSbSmokeTests.cs
@@ -20,6 +20,9 @@ public class SolicitarProgramacionTurnoSbSmokeTests(ApiFixture api, ServiceBusFi
     [Trait("Category", "Smoke")]
     public async Task DebePublicarProgramacionTurnoDiarioSolicitada_CuandoSolicitudEsAceptada()
     {
+        Assert.SkipWhen(!serviceBus.IsConfigured,
+            "ServiceBus no configurado. Usa appsettings.local.json o variable ServiceBus__ConnectionString.");
+
         var ct = TestContext.Current.CancellationToken;
 
         // Arrange: crear turno en catalogo

--- a/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoSbSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoSbSmokeTests.cs
@@ -44,7 +44,6 @@ public class SolicitarProgramacionTurnoSbSmokeTests(ApiFixture api, ServiceBusFi
 
         // Arrange: preparar solicitud con una sola fecha para simplificar verificacion
         var solicitudId = Guid.CreateVersion7();
-        var correlationId = solicitudId.ToString();
         var empleadoId = Guid.CreateVersion7().ToString();
         var fecha = "2026-04-15";
         var payload = new
@@ -67,8 +66,10 @@ public class SolicitarProgramacionTurnoSbSmokeTests(ApiFixture api, ServiceBusFi
         response.StatusCode.Should().Be(HttpStatusCode.Accepted);
 
         // Assert: consumir el evento publicado desde la suscripcion smoke-tests
+        // La FA publica via Wolverine, que no establece CorrelationId.
+        // Matching por contenido (SolicitudId) para aislar el mensaje de este test.
         var eventoRecibido = await serviceBus.WaitForMessageAsync<ProgramacionTurnoDiarioSolicitada>(
-            TopicSalida, Suscripcion, correlationId, Timeout);
+            TopicSalida, Suscripcion, e => e.SolicitudId == solicitudId, Timeout);
 
         eventoRecibido.Should().NotBeNull(
             "la Function App deberia publicar ProgramacionTurnoDiarioSolicitada al topic de Service Bus");

--- a/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/appsettings.json
+++ b/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/appsettings.json
@@ -1,5 +1,8 @@
 {
   "Api": {
     "BaseUrl": "https://func-asist-dev-programacion.azurewebsites.net"
+  },
+  "ServiceBus": {
+    "ConnectionString": ""
   }
 }


### PR DESCRIPTION
## Summary

- Agrega `ServiceBusFixture` y `Polling` a Programacion.SmokeTests para verificar eventos publicados al topic de Service Bus
- Agrega smoke test end-to-end que envía solicitud HTTP y verifica el evento `ProgramacionTurnoDiarioSolicitada` en la suscripción `smoke-tests`
- Hace todos los fixtures resilientes ante ausencia de secretos: `IsConfigured` + `Assert.SkipWhen` para skip limpio
- `PostgresFixture` detecta fallos de conexión por firewall y genera `SkipReason` descriptivo
- `Polling` ahora atrapa excepciones transitorias y reintenta hasta el timeout en vez de explotar al primer error
- Workflows de CI pasan secrets opcionales (`SERVICEBUS_CONNECTION_STRING`, `POSTGRES_CONNECTION_STRING`) a smoke tests

## Test plan

- [x] `dotnet test` pasa 123/123 con `appsettings.local.json` configurado (smoke tests corren end-to-end)
- [x] `dotnet test` sin secretos: smoke tests de SB/Postgres se skipean, el resto pasa
- [ ] Verificar que CI corre sin errores (smoke tests se skipearán hasta configurar GitHub secrets)

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)