### PR TITLE
Corregir deserializacion de mensajes Service Bus en endpoints consumidores

### DIFF
--- a/src/Bitakora.ControlAsistencia.ControlHoras/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/FunctionEndpoint.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/FunctionEndpoint.cs
@@ -1,5 +1,6 @@
 using Azure.Messaging.ServiceBus;
 using Bitakora.ControlAsistencia.Contracts.Programacion.Eventos;
+using Bitakora.ControlAsistencia.ControlHoras.Infraestructura;
 using Cosmos.EventSourcing.Abstractions.Commands;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
@@ -24,7 +25,7 @@ public class FunctionEndpoint(ICommandRouter commandRouter, ILogger<FunctionEndp
     {
         try
         {
-            var evento = message.Body.ToObjectFromJson<ProgramacionTurnoDiarioSolicitada>()!;
+            var evento = ServiceBusDeserializador.Deserializar<ProgramacionTurnoDiarioSolicitada>(message.Body);
             await commandRouter.InvokeAsync(evento, ct);
             await messageActions.CompleteMessageAsync(message, ct);
         }

--- a/src/Bitakora.ControlAsistencia.ControlHoras/Infraestructura/ServiceBusDeserializador.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Infraestructura/ServiceBusDeserializador.cs
@@ -1,0 +1,14 @@
+using System.Text.Json;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Infraestructura;
+
+/// <summary>
+/// Helper para deserializar mensajes de Service Bus con opciones correctas.
+/// Wolverine serializa con camelCase; ToObjectFromJson sin opciones usa
+/// PascalCase (case-sensitive), lo que causa que todas las propiedades queden null.
+/// </summary>
+public static class ServiceBusDeserializador
+{
+    public static T Deserializar<T>(BinaryData body)
+        => throw new NotImplementedException();
+}

--- a/src/Bitakora.ControlAsistencia.ControlHoras/Infraestructura/ServiceBusDeserializador.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Infraestructura/ServiceBusDeserializador.cs
@@ -9,6 +9,13 @@ namespace Bitakora.ControlAsistencia.ControlHoras.Infraestructura;
 /// </summary>
 public static class ServiceBusDeserializador
 {
+    private static readonly JsonSerializerOptions Opciones = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
     public static T Deserializar<T>(BinaryData body)
-        => throw new NotImplementedException();
+        => JsonSerializer.Deserialize<T>(body.ToString(), Opciones)
+           ?? throw new InvalidOperationException(
+               $"No se pudo deserializar el mensaje como {typeof(T).Name}");
 }

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/AsignarTurnoViaSbSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/AsignarTurnoViaSbSmokeTests.cs
@@ -90,4 +90,97 @@ public class AsignarTurnoViaSbSmokeTests(ServiceBusFixture serviceBus, PostgresF
             .GetProperty("DetalleTurno").Deserialize<DetalleTurno>();
         detalleTurnoPersistido.Should().BeEquivalentTo(detalleTurnoEsperado);
     }
+
+    /// <summary>
+    /// Regression test para el bug del issue #29.
+    /// Wolverine serializa con camelCase. El endpoint consumidor usaba ToObjectFromJson
+    /// con opciones default (case-sensitive), lo que causaba que todas las propiedades
+    /// quedaran null y se lanzara NullReferenceException.
+    /// Este test verifica que ServiceBusDeserializador con PropertyNameCaseInsensitive=true
+    /// resuelve el problema en produccion.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task DebeAsignarTurnoDiario_CuandoMensajeTieneFormatoCamelCaseDeWolverine()
+    {
+        Assert.SkipWhen(!serviceBus.IsConfigured,
+            "ServiceBus no configurado. Usa appsettings.local.json o variable ServiceBus__ConnectionString.");
+        Assert.SkipWhen(!postgres.IsConfigured,
+            postgres.SkipReason ?? "Postgres no disponible.");
+
+        // Arrange: mensaje en camelCase, exactamente como lo serializa Wolverine
+        var correlationId = Guid.CreateVersion7().ToString();
+        var solicitudId = Guid.CreateVersion7();
+        var empleadoId = Guid.CreateVersion7().ToString();
+        var fecha = new DateOnly(2026, 4, 10);
+
+        // Propiedades en camelCase simulan la serializacion real de Wolverine.
+        // Antes del fix este formato causaba NullReferenceException en el handler
+        // porque ToObjectFromJson usa case-sensitive por defecto.
+        var eventoEnFormatoWolverine = new
+        {
+            solicitudId = solicitudId,
+            empleado = new
+            {
+                empleadoId = empleadoId,
+                tipoIdentificacion = "CC",
+                numeroIdentificacion = "111222333",
+                nombres = "[TEST] Smoke Wolverine",
+                apellidos = "[TEST] CamelCase Fix"
+            },
+            fecha = fecha.ToString("yyyy-MM-dd"),
+            detalleTurno = new
+            {
+                nombre = "[TEST] Turno Wolverine CamelCase",
+                franjasOrdinarias = new[]
+                {
+                    new
+                    {
+                        horaInicio = "07:00:00",
+                        horaFin = "15:00:00",
+                        diaOffsetFin = 0,
+                        descansos = Array.Empty<object>(),
+                        extras = Array.Empty<object>()
+                    }
+                }
+            }
+        };
+
+        // Act: publicar al topic en formato camelCase
+        await serviceBus.PublishAsync(TopicEntrada, eventoEnFormatoWolverine, correlationId);
+
+        // Assert: verificar persistencia en Postgres.
+        // Si la deserializacion falla (propiedades null), el handler lanza
+        // NullReferenceException, el mensaje va a dead-letter y NUNCA se persiste.
+        var streamId = $"{empleadoId}:{fecha:yyyy-MM-dd}";
+        var tipoEvento = "turno_diario_asignado";
+
+        var existe = await postgres.ExisteEventoAsync(
+            SchemaControlHoras, streamId, tipoEvento, Timeout,
+            campoJson: "SolicitudId", valorJson: solicitudId.ToString());
+
+        existe.Should().BeTrue(
+            $"el evento {tipoEvento} con SolicitudId {solicitudId} deberia existir. " +
+            $"Si falla, ServiceBusDeserializador no esta usando PropertyNameCaseInsensitive=true.");
+
+        // Assert detallado: verificar que los datos se mapearon correctamente
+        var eventoPersistido = await postgres.ObtenerEventoAsync<JsonElement>(
+            SchemaControlHoras, streamId, tipoEvento,
+            "SolicitudId", solicitudId.ToString(), TimeSpan.FromSeconds(5));
+
+        var infoEmpleadoEsperada = new InformacionEmpleado(
+            empleadoId, "CC", "111222333", "[TEST] Smoke Wolverine", "[TEST] CamelCase Fix");
+        var infoEmpleadoPersistida = eventoPersistido
+            .GetProperty("InformacionEmpleado").Deserialize<InformacionEmpleado>();
+        infoEmpleadoPersistida.Should().Be(infoEmpleadoEsperada);
+
+        var detalleTurnoEsperado = new DetalleTurno("[TEST] Turno Wolverine CamelCase", [
+            new DetalleFranjaOrdinaria(
+                new TimeOnly(7, 0), new TimeOnly(15, 0), 0,
+                Array.Empty<DetalleSubFranja>(), Array.Empty<DetalleSubFranja>())
+        ]);
+        var detalleTurnoPersistido = eventoPersistido
+            .GetProperty("DetalleTurno").Deserialize<DetalleTurno>();
+        detalleTurnoPersistido.Should().BeEquivalentTo(detalleTurnoEsperado);
+    }
 }

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/ProgramacionTurnoDiarioSolicitadaDeserializacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/ProgramacionTurnoDiarioSolicitadaDeserializacionTests.cs
@@ -1,0 +1,70 @@
+// HU-29: Corregir deserializacion de mensajes Service Bus en endpoints consumidores
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Contracts.Programacion.Eventos;
+using Bitakora.ControlAsistencia.ControlHoras.Infraestructura;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Tests.AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction;
+
+/// <summary>
+/// Verifica que ProgramacionTurnoDiarioSolicitada se deserializa correctamente
+/// desde el formato que produce Wolverine al publicar al Service Bus (camelCase JSON).
+/// Sin PropertyNameCaseInsensitive=true, todas las propiedades quedan null
+/// provocando NullReferenceException en el handler (linea: command.Empleado.EmpleadoId).
+/// </summary>
+public class ProgramacionTurnoDiarioSolicitadaDeserializacionTests
+{
+    private static readonly Guid SolicitudId =
+        Guid.Parse("019600b0-0000-7000-8000-000000000001");
+
+    // JSON en formato camelCase - exactamente como Wolverine lo serializa al publicar al Service Bus.
+    // Wolverine usa System.Text.Json con camelCase naming policy por defecto.
+    private const string JsonFormatoWolverine = """
+        {
+          "solicitudId": "019600b0-0000-7000-8000-000000000001",
+          "empleado": {
+            "empleadoId": "EMP-001",
+            "tipoIdentificacion": "CC",
+            "numeroIdentificacion": "1234567890",
+            "nombres": "Luis Augusto",
+            "apellidos": "Barreto"
+          },
+          "fecha": "2026-03-15",
+          "detalleTurno": {
+            "nombre": "Turno Manana",
+            "franjasOrdinarias": [
+              {
+                "horaInicio": "08:00:00",
+                "horaFin": "16:00:00",
+                "diaOffsetFin": 0,
+                "descansos": [],
+                "extras": []
+              }
+            ]
+          }
+        }
+        """;
+
+    // CA: Los mensajes ProgramacionTurnoDiarioSolicitada se deserializan correctamente en ControlHoras
+    // CA: Existe un test que verifica que la deserializacion funciona con el formato que produce Wolverine
+    [Fact]
+    public void Deserializar_ReconstruyeEvento_CuandoJsonEsFormatoWolverine()
+    {
+        var body = BinaryData.FromString(JsonFormatoWolverine);
+
+        var evento = ServiceBusDeserializador.Deserializar<ProgramacionTurnoDiarioSolicitada>(body);
+
+        evento.Should().NotBeNull();
+        evento.SolicitudId.Should().Be(SolicitudId);
+        evento.Empleado.Should().NotBeNull();
+        evento.Empleado.EmpleadoId.Should().Be("EMP-001");
+        evento.Empleado.TipoIdentificacion.Should().Be("CC");
+        evento.Empleado.Nombres.Should().Be("Luis Augusto");
+        evento.Fecha.Should().Be(new DateOnly(2026, 3, 15));
+        evento.DetalleTurno.Should().NotBeNull();
+        evento.DetalleTurno.Nombre.Should().Be("Turno Manana");
+        evento.DetalleTurno.FranjasOrdinarias.Should().HaveCount(1);
+        evento.DetalleTurno.FranjasOrdinarias[0].HoraInicio.Should().Be(new TimeOnly(8, 0));
+        evento.DetalleTurno.FranjasOrdinarias[0].HoraFin.Should().Be(new TimeOnly(16, 0));
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/ProgramacionTurnoDiarioSolicitadaDeserializacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/ProgramacionTurnoDiarioSolicitadaDeserializacionTests.cs
@@ -1,5 +1,6 @@
 // HU-29: Corregir deserializacion de mensajes Service Bus en endpoints consumidores
 
+using System.Text.Json;
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.Contracts.Programacion.Eventos;
 using Bitakora.ControlAsistencia.ControlHoras.Infraestructura;
@@ -59,12 +60,24 @@ public class ProgramacionTurnoDiarioSolicitadaDeserializacionTests
         evento.Empleado.Should().NotBeNull();
         evento.Empleado.EmpleadoId.Should().Be("EMP-001");
         evento.Empleado.TipoIdentificacion.Should().Be("CC");
+        evento.Empleado.NumeroIdentificacion.Should().Be("1234567890");
         evento.Empleado.Nombres.Should().Be("Luis Augusto");
+        evento.Empleado.Apellidos.Should().Be("Barreto");
         evento.Fecha.Should().Be(new DateOnly(2026, 3, 15));
         evento.DetalleTurno.Should().NotBeNull();
         evento.DetalleTurno.Nombre.Should().Be("Turno Manana");
         evento.DetalleTurno.FranjasOrdinarias.Should().HaveCount(1);
         evento.DetalleTurno.FranjasOrdinarias[0].HoraInicio.Should().Be(new TimeOnly(8, 0));
         evento.DetalleTurno.FranjasOrdinarias[0].HoraFin.Should().Be(new TimeOnly(16, 0));
+    }
+
+    [Fact]
+    public void Deserializar_LanzaExcepcion_CuandoJsonEsInvalido()
+    {
+        var body = BinaryData.FromString("esto no es json");
+
+        var act = () => ServiceBusDeserializador.Deserializar<ProgramacionTurnoDiarioSolicitada>(body);
+
+        act.Should().ThrowExactly<JsonException>();
     }
 }


### PR DESCRIPTION
## Resumen

Pipeline TDD completado:
- Fase roja: tests escritos con stubs
- Fase verde: implementación completa
- Smoke tests: escritos para endpoints detectados
- Fase refactor: revisión de calidad

## Decisiones del pipeline

<details>
<summary>Test Writer (fase roja) — 8m 11s</summary>

_(El agente no generó resumen)_

</details>

<details>
<summary>Implementer (fase verde) — 1m 42s</summary>

_(El agente no generó resumen)_

</details>
<details>
<summary>Smoke Test Writer — 4m 55s</summary>

_(El agente no generó resumen)_

</details>
<details>
<summary>Reviewer (fase refactor) — 5m 10s</summary>

_(El agente no generó resumen)_

</details>

## Commits

a49f6d5 refactor(hu-29): completar aserciones y agregar test de error en deserializacion
624a1cc test(hu-29): smoke tests para endpoints
5d098fc feat(hu-29): helper ServiceBusDeserializador con PropertyNameCaseInsensitive (fase verde)
f1f4b3e test(hu-29): tests para deserializacion de mensajes Service Bus (fase roja)

Closes #29