### PR TITLE
Crear script appinsights-query.sh para consultas KQL predefinidas

### DIFF
--- a/scripts/.env.template
+++ b/scripts/.env.template
@@ -1,0 +1,14 @@
+# scripts/.env.template - Variables de configuracion para appinsights-query.sh
+#
+# Copiar a scripts/.env y completar con valores reales:
+#   cp scripts/.env.template scripts/.env
+#
+# Valores para el entorno dev (ver infra/environments/dev/):
+#   APPINSIGHTS_APP=controlasistencias-dev-ai
+#   APPINSIGHTS_RG=rg-controlasistencias-dev
+
+# Nombre del recurso Application Insights (patron: ${prefix}-ai)
+APPINSIGHTS_APP=
+
+# Resource group donde esta App Insights (patron: rg-${prefix})
+APPINSIGHTS_RG=

--- a/scripts/appinsights-query.sh
+++ b/scripts/appinsights-query.sh
@@ -14,7 +14,7 @@
 
 set -euo pipefail
 
-# --- Colores ----------------------------------------------------------------
+# --- Colores -----------------------------------------------------------------
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
@@ -86,10 +86,18 @@ shift
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --hours)
+            if [[ -z "${2:-}" ]]; then
+                error "--hours requiere un valor numerico"
+                exit 1
+            fi
             HOURS="$2"
             shift 2
             ;;
         --filter)
+            if [[ -z "${2:-}" ]]; then
+                error "--filter requiere un valor de texto"
+                exit 1
+            fi
             FILTER="$2"
             shift 2
             ;;
@@ -123,6 +131,12 @@ run_query() {
 }
 
 # --- Queries KQL predefinidas ------------------------------------------------
+
+# Sanitizar filtro para uso seguro en KQL (escapar comillas simples)
+sanitize_kql_filter() {
+    echo "${1//\'/\\\'}"
+}
+
 case "$COMMAND" in
     exceptions)
         run_query \
@@ -144,8 +158,9 @@ case "$COMMAND" in
 
     traces)
         if [ -n "$FILTER" ]; then
+            SAFE_FILTER=$(sanitize_kql_filter "$FILTER")
             run_query \
-                "traces | where timestamp > ago(${HOURS}h) | where message has '${FILTER}' | project timestamp, message, severityLevel, operation_Name | order by timestamp desc | take ${MAX_ROWS}" \
+                "traces | where timestamp > ago(${HOURS}h) | where message has '${SAFE_FILTER}' | project timestamp, message, severityLevel, operation_Name | order by timestamp desc | take ${MAX_ROWS}" \
                 "Traces filtradas por '${FILTER}'"
         else
             run_query \
@@ -158,25 +173,19 @@ case "$COMMAND" in
         log "Health summary (ultimas ${HOURS}h)"
 
         echo -e "\n${CYAN}${BOLD}--- Excepciones ---${NC}"
-        az monitor app-insights query \
-            --app "$APPINSIGHTS_APP" \
-            --resource-group "$APPINSIGHTS_RG" \
-            --analytics-query "exceptions | where timestamp > ago(${HOURS}h) | summarize totalExceptions=count(), distinctTypes=dcount(type) | project totalExceptions, distinctTypes" \
-            --output table 2>&1 || true
+        run_query \
+            "exceptions | where timestamp > ago(${HOURS}h) | summarize totalExceptions=count(), distinctTypes=dcount(type) | project totalExceptions, distinctTypes" \
+            "Resumen de excepciones"
 
         echo -e "\n${CYAN}${BOLD}--- Requests fallidas ---${NC}"
-        az monitor app-insights query \
-            --app "$APPINSIGHTS_APP" \
-            --resource-group "$APPINSIGHTS_RG" \
-            --analytics-query "requests | where timestamp > ago(${HOURS}h) | summarize totalRequests=count(), failedRequests=countif(success == false), availabilityPct=round(100.0 * countif(success == true) / count(), 2)" \
-            --output table 2>&1 || true
+        run_query \
+            "requests | where timestamp > ago(${HOURS}h) | summarize totalRequests=count(), failedRequests=countif(success == false), availabilityPct=round(100.0 * countif(success == true) / count(), 2)" \
+            "Resumen de requests"
 
         echo -e "\n${CYAN}${BOLD}--- Top 5 errores ---${NC}"
-        az monitor app-insights query \
-            --app "$APPINSIGHTS_APP" \
-            --resource-group "$APPINSIGHTS_RG" \
-            --analytics-query "exceptions | where timestamp > ago(${HOURS}h) | summarize count() by type | order by count_ desc | take 5" \
-            --output table 2>&1 || true
+        run_query \
+            "exceptions | where timestamp > ago(${HOURS}h) | summarize count() by type | order by count_ desc | take 5" \
+            "Top 5 tipos de error"
 
         success "Health summary completado"
         ;;

--- a/scripts/appinsights-query.sh
+++ b/scripts/appinsights-query.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# appinsights-query.sh - Consultas KQL predefinidas contra Application Insights
+#
+# Uso:
+#   ./scripts/appinsights-query.sh exceptions
+#   ./scripts/appinsights-query.sh dead-letters
+#   ./scripts/appinsights-query.sh function-errors
+#   ./scripts/appinsights-query.sh traces --filter "NullReferenceException"
+#   ./scripts/appinsights-query.sh health-summary
+#   ./scripts/appinsights-query.sh exceptions --hours 48
+#
+# Requiere: az cli con sesion activa (az login)
+# Configuracion: scripts/.env (ver scripts/.env.template)
+
+set -euo pipefail
+
+# --- Colores ----------------------------------------------------------------
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+# --- Logging -----------------------------------------------------------------
+log()     { echo -e "${BLUE}[$(date +%H:%M:%S)]${NC} $1"; }
+success() { echo -e "${GREEN}${BOLD}ok${NC} $1"; }
+warn()    { echo -e "${YELLOW}!${NC} $1"; }
+error()   { echo -e "${RED}${BOLD}ERROR:${NC} $1" >&2; }
+
+# --- Configuracion -----------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="$SCRIPT_DIR/.env"
+
+if [ -f "$ENV_FILE" ]; then
+    # shellcheck source=/dev/null
+    source "$ENV_FILE"
+else
+    error "No se encontro $ENV_FILE"
+    echo "  Copia el template y completa los valores:"
+    echo "    cp scripts/.env.template scripts/.env"
+    exit 1
+fi
+
+if [ -z "${APPINSIGHTS_APP:-}" ]; then
+    error "Variable APPINSIGHTS_APP no definida en $ENV_FILE"
+    exit 1
+fi
+
+if [ -z "${APPINSIGHTS_RG:-}" ]; then
+    error "Variable APPINSIGHTS_RG no definida en $ENV_FILE"
+    exit 1
+fi
+
+# --- Verificar az login ------------------------------------------------------
+if ! az account show &>/dev/null; then
+    error "No hay sesion activa de Azure CLI. Ejecuta 'az login' primero."
+    exit 1
+fi
+
+# --- Parametros --------------------------------------------------------------
+COMMAND="${1:-}"
+HOURS=24
+FILTER=""
+MAX_ROWS=50
+
+if [ -z "$COMMAND" ]; then
+    echo -e "${CYAN}${BOLD}appinsights-query.sh${NC} - Consultas KQL contra App Insights"
+    echo ""
+    echo "Comandos disponibles:"
+    echo "  exceptions       Top 20 excepciones agrupadas por tipo y mensaje"
+    echo "  dead-letters     Mensajes dead-lettered en traces"
+    echo "  function-errors  Funciones con requests fallidas"
+    echo "  traces           Traces (usar con --filter para filtrar)"
+    echo "  health-summary   Vista rapida: excepciones + requests fallidas + disponibilidad"
+    echo ""
+    echo "Opciones:"
+    echo "  --hours N        Ventana temporal en horas (default: 24)"
+    echo "  --filter TEXT    Filtrar por texto (solo para 'traces')"
+    exit 1
+fi
+
+shift
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --hours)
+            HOURS="$2"
+            shift 2
+            ;;
+        --filter)
+            FILTER="$2"
+            shift 2
+            ;;
+        *)
+            error "Opcion desconocida: $1"
+            exit 1
+            ;;
+    esac
+done
+
+# --- Ejecutar query ----------------------------------------------------------
+run_query() {
+    local query="$1"
+    local description="$2"
+
+    log "$description (ultimas ${HOURS}h)"
+
+    local result
+    if ! result=$(az monitor app-insights query \
+        --app "$APPINSIGHTS_APP" \
+        --resource-group "$APPINSIGHTS_RG" \
+        --analytics-query "$query" \
+        --output table 2>&1); then
+        error "Fallo la consulta KQL"
+        echo "$result" >&2
+        exit 1
+    fi
+
+    echo "$result"
+    success "Consulta completada"
+}
+
+# --- Queries KQL predefinidas ------------------------------------------------
+case "$COMMAND" in
+    exceptions)
+        run_query \
+            "exceptions | where timestamp > ago(${HOURS}h) | summarize count() by type, outerMessage | order by count_ desc | take 20" \
+            "Top 20 excepciones agrupadas por tipo y mensaje"
+        ;;
+
+    dead-letters)
+        run_query \
+            "traces | where timestamp > ago(${HOURS}h) | where message has 'dead' or message has 'deadletter' or message has 'Dead' | project timestamp, message, operation_Name | order by timestamp desc | take ${MAX_ROWS}" \
+            "Mensajes dead-lettered en traces"
+        ;;
+
+    function-errors)
+        run_query \
+            "requests | where timestamp > ago(${HOURS}h) | where success == false | summarize failedCount=count() by name, resultCode | order by failedCount desc | take ${MAX_ROWS}" \
+            "Funciones con requests fallidas"
+        ;;
+
+    traces)
+        if [ -n "$FILTER" ]; then
+            run_query \
+                "traces | where timestamp > ago(${HOURS}h) | where message has '${FILTER}' | project timestamp, message, severityLevel, operation_Name | order by timestamp desc | take ${MAX_ROWS}" \
+                "Traces filtradas por '${FILTER}'"
+        else
+            run_query \
+                "traces | where timestamp > ago(${HOURS}h) | project timestamp, message, severityLevel, operation_Name | order by timestamp desc | take ${MAX_ROWS}" \
+                "Todas las traces"
+        fi
+        ;;
+
+    health-summary)
+        log "Health summary (ultimas ${HOURS}h)"
+
+        echo -e "\n${CYAN}${BOLD}--- Excepciones ---${NC}"
+        az monitor app-insights query \
+            --app "$APPINSIGHTS_APP" \
+            --resource-group "$APPINSIGHTS_RG" \
+            --analytics-query "exceptions | where timestamp > ago(${HOURS}h) | summarize totalExceptions=count(), distinctTypes=dcount(type) | project totalExceptions, distinctTypes" \
+            --output table 2>&1 || true
+
+        echo -e "\n${CYAN}${BOLD}--- Requests fallidas ---${NC}"
+        az monitor app-insights query \
+            --app "$APPINSIGHTS_APP" \
+            --resource-group "$APPINSIGHTS_RG" \
+            --analytics-query "requests | where timestamp > ago(${HOURS}h) | summarize totalRequests=count(), failedRequests=countif(success == false), availabilityPct=round(100.0 * countif(success == true) / count(), 2)" \
+            --output table 2>&1 || true
+
+        echo -e "\n${CYAN}${BOLD}--- Top 5 errores ---${NC}"
+        az monitor app-insights query \
+            --app "$APPINSIGHTS_APP" \
+            --resource-group "$APPINSIGHTS_RG" \
+            --analytics-query "exceptions | where timestamp > ago(${HOURS}h) | summarize count() by type | order by count_ desc | take 5" \
+            --output table 2>&1 || true
+
+        success "Health summary completado"
+        ;;
+
+    *)
+        error "Comando desconocido: $COMMAND"
+        echo "Ejecuta sin argumentos para ver los comandos disponibles."
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Resumen

Pipeline tooling completado:
- Writer: implementacion de la tarea
- Reviewer: revision de calidad

## Decisiones del pipeline

<details>
<summary>Writer -- 2m 50s</summary>

_(El agente no genero resumen)_

</details>

<details>
<summary>Reviewer -- 3m 13s</summary>

# Stage 2 - Reviewer: appinsights-query.sh (#33)

## Veredicto: APROBADO con correcciones

## Criterios de aceptacion

| CA | Estado | Nota |
|----|--------|------|
| CA-1 | ok | `exceptions` ejecuta query KQL con top 20 agrupadas por tipo y mensaje |
| CA-2 | ok | `dead-letters` busca mensajes dead-lettered en traces |
| CA-3 | ok | `function-errors` muestra requests fallidas por funcion |
| CA-4 | ok | `traces --filter` filtra por termino con sanitizacion KQL |
| CA-5 | ok | `health-summary` muestra excepciones + requests fallidas + disponibilidad |
| CA-6 | ok | Todas las queries usan `take N` (max 50) y `ago(Xh)` (default 24h) |
| CA-7 | ok | `--hours N` ajusta ventana temporal en todos los comandos |
| CA-8 | ok | Valida `az login`, `.env` y variables requeridas con exit != 0 |
| CA-9 | ok | `scripts/.env.template` con variables documentadas |
| CA-10 | ok | `.gitignore` linea 7 ya incluye `.env` |

## Correcciones aplicadas

1. **Sanitizacion KQL en --filter**: el valor de `--filter` se interpolaba directamente en la query KQL sin escapar comillas simples. Agregada funcion `sanitize_kql_filter` que escapa `'` a `\'`.

2. **Reutilizacion de run_query en health-summary**: las 3 queries del health-summary duplicaban la logica de invocacion de `az monitor app-insights query` en vez de reutilizar `run_query`. Refactorizado para usar `run_query` consistentemente, ganando manejo de errores uniforme.

3. **Validacion de argumentos en --hours y --filter**: si el usuario pasaba `--hours` o `--filter` sin valor, el `shift 2` fallaba con error criptico. Agregada validacion explicita antes del shift.

## Verificaciones

- Sintaxis bash: `bash -n` pasa
- Permisos: ejecutable (755)
- Build del proyecto: compila sin errores
- Tests: 121 correctos, 0 errores
- Caracteres prohibidos (U+2500): no encontrados

</details>

## Commits

ffcef26 fix(tooling): corregir sanitizacion KQL, reutilizar run_query en health-summary y validar args
b0d3d9a feat(tooling): crear script appinsights-query.sh para consultas KQL predefinidas

Closes #33