### PR TITLE
Verificar ausencia de dead letters como criterio de exito en smoke tests

### DIFF
--- a/.claude/agents/domain-scaffolder.md
+++ b/.claude/agents/domain-scaffolder.md
@@ -651,6 +651,18 @@ public class ServiceBusFixture : IAsyncLifetime
         return default;
     }
 
+    public async Task<IReadOnlyList<ServiceBusReceivedMessage>> PeekDeadLetterMessagesAsync(
+        string topicName,
+        string subscriptionName,
+        int maxMessages = 10)
+    {
+        var options = new ServiceBusReceiverOptions { SubQueue = SubQueue.DeadLetter };
+        await using var receiver = _client!.CreateReceiver(topicName, subscriptionName, options);
+
+        var messages = await receiver.PeekMessagesAsync(maxMessages);
+        return messages;
+    }
+
     public async ValueTask DisposeAsync()
     {
         if (_client is not null)

--- a/.claude/agents/smoke-test-writer.md
+++ b/.claude/agents/smoke-test-writer.md
@@ -203,6 +203,7 @@ public class SolicitarProgramacionTurnoSbSmokeTests(ApiFixture api, ServiceBusFi
 
     private const string TopicSalida = "programacion-turno-diario-solicitada";
     private const string Suscripcion = "smoke-tests";
+    private const string SuscripcionConsumidor = "{consumidor}-escucha-{productor}";
     private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
 
     [Fact]
@@ -231,6 +232,17 @@ public class SolicitarProgramacionTurnoSbSmokeTests(ApiFixture api, ServiceBusFi
         var empleadoEsperado = new InformacionEmpleado(
             empleadoId, "CC", "555666777", "[TEST] Smoke", "[TEST] SB");
         evento!.Empleado.Should().Be(empleadoEsperado);
+
+        // Assert: verificar ausencia de dead letters en la suscripcion del consumidor real.
+        // Esperar a que el consumidor haya tenido tiempo de procesar el mensaje.
+        await Task.Delay(TimeSpan.FromSeconds(5), ct);
+
+        var deadLetters = await serviceBus.PeekDeadLetterMessagesAsync(
+            TopicSalida, SuscripcionConsumidor);
+
+        deadLetters.Should().BeEmpty(
+            "no deberia haber mensajes en dead letter de '{0}' - si los hay, el consumidor fallo al procesar el evento",
+            SuscripcionConsumidor);
     }
 }
 ```
@@ -241,6 +253,7 @@ public class SolicitarProgramacionTurnoSbSmokeTests(ApiFixture api, ServiceBusFi
 - El predicate `match` filtra por un campo identificador unico (ej: `SolicitudId`), **nunca por posicion**
 - Timeout estandar: `TimeSpan.FromSeconds(30)`
 - El tipo `T` del mensaje es el evento publico de `Contracts` (igualdad natural de records)
+- **Verificacion de dead letter obligatoria**: despues de consumir el evento, esperar ~5s y verificar que la suscripcion del consumidor real no tenga dead letters con `PeekDeadLetterMessagesAsync`
 
 ### Patron 2: Dominio consumidor (Service Bus -> Postgres)
 
@@ -252,6 +265,7 @@ El dominio recibe un evento de Service Bus y persiste el resultado en PostgreSQL
 public class AsignarTurnoViaSbSmokeTests(ServiceBusFixture serviceBus, PostgresFixture postgres)
 {
     private const string TopicEntrada = "programacion-turno-diario-solicitada";
+    private const string SuscripcionConsumidor = "{consumidor}-escucha-{productor}";
     private const string SchemaControlHoras = "control_horas";
     private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
 
@@ -300,6 +314,14 @@ public class AsignarTurnoViaSbSmokeTests(ServiceBusFixture serviceBus, PostgresF
         var empleadoPersistido = eventoPersistido
             .GetProperty("InformacionEmpleado").Deserialize<InformacionEmpleado>();
         empleadoPersistido.Should().Be(empleadoEsperado);
+
+        // Assert: verificar ausencia de dead letters en la suscripcion del consumidor
+        var deadLetters = await serviceBus.PeekDeadLetterMessagesAsync(
+            TopicEntrada, SuscripcionConsumidor);
+
+        deadLetters.Should().BeEmpty(
+            "no deberia haber mensajes en dead letter de '{0}' - si los hay, el consumidor fallo al procesar el evento",
+            SuscripcionConsumidor);
     }
 }
 ```
@@ -310,13 +332,14 @@ public class AsignarTurnoViaSbSmokeTests(ServiceBusFixture serviceBus, PostgresF
 - El evento se construye como objeto anonimo (no usa clases de produccion) con PascalCase (Service Bus no aplica JsonNamingPolicy)
 - `ExisteEventoAsync` y `ObtenerEventoAsync` verifican persistencia filtrando por campo unico
 - **Siempre** filtrar por campo identificador (ej: `SolicitudId`), nunca por posicion en el stream
+- **Verificacion de dead letter obligatoria**: despues de verificar persistencia, comprobar que no haya dead letters en la suscripcion del consumidor con `PeekDeadLetterMessagesAsync`
 
 ### Fixtures: cuando usar cada uno
 
 | Fixture | Cuando usarlo | Metodos principales |
 |---|---|---|
 | `ApiFixture` | Siempre que el test haga llamadas HTTP | `.Client` (HttpClient preconfigurado) |
-| `ServiceBusFixture` | Publicar eventos o consumir de suscripciones | `.PublishAsync(topic, mensaje, correlationId)`, `.WaitForMessageAsync<T>(topic, suscripcion, match, timeout)` |
+| `ServiceBusFixture` | Publicar eventos, consumir de suscripciones o verificar dead letters | `.PublishAsync(topic, mensaje, correlationId)`, `.WaitForMessageAsync<T>(topic, suscripcion, match, timeout)`, `.PeekDeadLetterMessagesAsync(topic, suscripcion, maxMessages)` |
 | `PostgresFixture` | Verificar eventos persistidos en Marten/Postgres | `.ExisteEventoAsync(schema, streamId, tipo, timeout, campoJson, valorJson)`, `.ObtenerEventoAsync<T>(schema, streamId, tipo, campo, valor, timeout)` |
 | `Polling` | Usado internamente por PostgresFixture; no lo uses directamente en tests | `.WaitUntilAsync<T>(probe, timeout)`, `.WaitUntilTrueAsync(condition, timeout)` |
 
@@ -324,7 +347,7 @@ public class AsignarTurnoViaSbSmokeTests(ServiceBusFixture serviceBus, PostgresF
 
 - **Topic**: nombre del evento en kebab-case (`programacion-turno-diario-solicitada`, `turno-diario-asignado`)
 - **Suscripcion de smoke tests**: siempre `smoke-tests` (nombre generico, una por topic)
-- **Suscripcion de produccion**: `{consumidor}-escucha-{productor}` (no usarla en smoke tests)
+- **Suscripcion de produccion**: `{consumidor}-escucha-{productor}` (usarla solo para verificar dead letters, no para consumir mensajes)
 - **Timeout estandar**: `TimeSpan.FromSeconds(30)` para esperar mensajes o persistencia
 
 ### Aserciones con Contracts

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/AsignarTurnoViaSbSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/AsignarTurnoViaSbSmokeTests.cs
@@ -9,6 +9,7 @@ namespace Bitakora.ControlAsistencia.ControlHoras.SmokeTests.AsignarTurnoCuandoP
 public class AsignarTurnoViaSbSmokeTests(ServiceBusFixture serviceBus, PostgresFixture postgres)
 {
     private const string TopicEntrada = "programacion-turno-diario-solicitada";
+    private const string SuscripcionConsumidor = "control-horas-escucha-programacion";
     private const string SchemaControlHoras = "control_horas";
     private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
 
@@ -89,5 +90,13 @@ public class AsignarTurnoViaSbSmokeTests(ServiceBusFixture serviceBus, PostgresF
         var detalleTurnoPersistido = eventoPersistido
             .GetProperty("DetalleTurno").Deserialize<DetalleTurno>();
         detalleTurnoPersistido.Should().BeEquivalentTo(detalleTurnoEsperado);
+
+        // Assert: verificar ausencia de dead letters en la suscripcion del consumidor
+        var deadLetters = await serviceBus.PeekDeadLetterMessagesAsync(
+            TopicEntrada, SuscripcionConsumidor);
+
+        deadLetters.Should().BeEmpty(
+            "no deberia haber mensajes en dead letter de '{0}' - si los hay, el consumidor fallo al procesar el evento",
+            SuscripcionConsumidor);
     }
 }

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/Fixtures/ServiceBusFixture.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/Fixtures/ServiceBusFixture.cs
@@ -83,6 +83,18 @@ public class ServiceBusFixture : IAsyncLifetime
         return default;
     }
 
+    public async Task<IReadOnlyList<ServiceBusReceivedMessage>> PeekDeadLetterMessagesAsync(
+        string topicName,
+        string subscriptionName,
+        int maxMessages = 10)
+    {
+        var options = new ServiceBusReceiverOptions { SubQueue = SubQueue.DeadLetter };
+        await using var receiver = _client!.CreateReceiver(topicName, subscriptionName, options);
+
+        var messages = await receiver.PeekMessagesAsync(maxMessages);
+        return messages;
+    }
+
     public async ValueTask DisposeAsync()
     {
         if (_client is not null)

--- a/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/Fixtures/ServiceBusFixture.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/Fixtures/ServiceBusFixture.cs
@@ -76,6 +76,18 @@ public class ServiceBusFixture : IAsyncLifetime
         return default;
     }
 
+    public async Task<IReadOnlyList<ServiceBusReceivedMessage>> PeekDeadLetterMessagesAsync(
+        string topicName,
+        string subscriptionName,
+        int maxMessages = 10)
+    {
+        var options = new ServiceBusReceiverOptions { SubQueue = SubQueue.DeadLetter };
+        await using var receiver = _client!.CreateReceiver(topicName, subscriptionName, options);
+
+        var messages = await receiver.PeekMessagesAsync(maxMessages);
+        return messages;
+    }
+
     public async ValueTask DisposeAsync()
     {
         if (_client is not null)

--- a/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoSbSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoSbSmokeTests.cs
@@ -14,6 +14,7 @@ public class SolicitarProgramacionTurnoSbSmokeTests(ApiFixture api, ServiceBusFi
 
     private const string TopicSalida = "programacion-turno-diario-solicitada";
     private const string Suscripcion = "smoke-tests";
+    private const string SuscripcionConsumidor = "control-horas-escucha-programacion";
     private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
 
     [Fact]
@@ -87,5 +88,16 @@ public class SolicitarProgramacionTurnoSbSmokeTests(ApiFixture api, ServiceBusFi
         eventoRecibido.DetalleTurno.Should().NotBeNull();
         eventoRecibido.DetalleTurno.Nombre.Should().Be("[TEST] Turno Smoke SB");
         eventoRecibido.DetalleTurno.FranjasOrdinarias.Should().HaveCount(1);
+
+        // Assert: verificar ausencia de dead letters en la suscripcion del consumidor real.
+        // Esperar a que el consumidor haya tenido tiempo de procesar el mensaje.
+        await Task.Delay(TimeSpan.FromSeconds(5), ct);
+
+        var deadLetters = await serviceBus.PeekDeadLetterMessagesAsync(
+            TopicSalida, SuscripcionConsumidor);
+
+        deadLetters.Should().BeEmpty(
+            "no deberia haber mensajes en dead letter de '{0}' - si los hay, el consumidor fallo al procesar el evento",
+            SuscripcionConsumidor);
     }
 }


### PR DESCRIPTION
## Resumen

Pipeline tooling completado:
- Writer: implementacion de la tarea
- Reviewer: revision de calidad

## Decisiones del pipeline

<details>
<summary>Writer -- 5m 17s</summary>

_(El agente no genero resumen)_

</details>

<details>
<summary>Reviewer -- 5m 48s</summary>

## Stage 2 - Reviewer

**Issue:** #30 - Verificar ausencia de dead letters como criterio de exito en smoke tests
**Resultado:** APROBADO con correcciones

### Evaluacion del writer

El writer implemento correctamente:
- `PeekDeadLetterMessagesAsync` en ambos `ServiceBusFixture` (Programacion y ControlHoras)
- Verificacion de dead letters en `SolicitarProgramacionTurnoSbSmokeTests` con delay de 5s para dar tiempo al consumidor
- Verificacion de dead letters en `AsignarTurnoViaSbSmokeTests` (sin delay necesario, el wait de Postgres ya lo cubre)
- Naming consistente: `SuscripcionConsumidor` como constante en ambos tests
- Compilacion limpia, 0 errores, 0 warnings

### Correcciones del reviewer

El writer **no actualizo las plantillas** del domain-scaffolder ni del smoke-test-writer, que es un criterio de aceptacion del issue. Correcciones realizadas:

1. **domain-scaffolder.md**: Agregado `PeekDeadLetterMessagesAsync` al template de `ServiceBusFixture.cs` que genera el scaffolder para nuevos dominios.

2. **smoke-test-writer.md**:
   - Agregado `PeekDeadLetterMessagesAsync` a la tabla de metodos de `ServiceBusFixture`
   - Actualizada la convencion de suscripciones de produccion: de "no usarla en smoke tests" a "usarla solo para verificar dead letters"
   - Agregada constante `SuscripcionConsumidor` y bloque de verificacion de dead letter al Patron 1 (publicador)
   - Agregada constante `SuscripcionConsumidor` y bloque de verificacion de dead letter al Patron 2 (consumidor)
   - Agregada clave "Verificacion de dead letter obligatoria" a ambas secciones de claves

### Criterios de aceptacion

- [x] Existe `PeekDeadLetterMessagesAsync` en `ServiceBusFixture`
- [x] `SolicitarProgramacionTurnoSbSmokeTests` verifica dead letters en `control-horas-escucha-programacion`
- [x] `AsignarTurnoViaSbSmokeTests` verifica dead letters en `control-horas-escucha-programacion`
- [x] Plantillas del smoke-test-writer incluyen dead letter como patron estandar
- [x] Plantillas del domain-scaffolder incluyen `PeekDeadLetterMessagesAsync`
- [x] Compilacion limpia: 0 errores, 0 warnings
- [x] Tests unitarios: 109 pasando (64 Contracts + 42 Programacion + 3 ControlHoras)

</details>

## Commits

5109c00 refactor(agents): incluir verificacion de dead letters en plantillas de smoke tests
3a84646 feat(smoke-tests): verificar ausencia de dead letters como criterio de exito

Closes #30