### PR TITLE
Manejar MessageLockLost en FunctionEndpoint sin intentar dead-letter

### DIFF
--- a/src/Bitakora.ControlAsistencia.ControlHoras/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/FunctionEndpoint.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/FunctionEndpoint.cs
@@ -29,6 +29,12 @@ public class FunctionEndpoint(ICommandRouter commandRouter, ILogger<FunctionEndp
             await commandRouter.InvokeAsync(evento, ct);
             await messageActions.CompleteMessageAsync(message, ct);
         }
+        catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.MessageLockLost)
+        {
+            logger.LogWarning(ex,
+                "Lock perdido para mensaje {MessageId} - Service Bus lo re-entregara automaticamente",
+                message.MessageId);
+        }
         catch (Exception ex)
         {
             logger.LogError(ex, "Error procesando mensaje {MessageId}", message.MessageId);


### PR DESCRIPTION
## Resumen

Pipeline tooling completado:
- Writer: implementacion de la tarea
- Reviewer: revision de calidad

## Decisiones del pipeline

<details>
<summary>Writer -- 2m 1s</summary>

_(El agente no genero resumen)_

</details>

<details>
<summary>Reviewer -- 1m 45s</summary>

_(El agente no genero resumen)_

</details>

## Commits

a16fb72 fix(#48): manejar MessageLockLost sin intentar dead-letter

Closes #48