### PR TITLE
Reducir prefetchCount a 0 en host.json de todos los dominios

### DIFF
--- a/src/Bitakora.ControlAsistencia.ControlHoras/host.json
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/host.json
@@ -24,7 +24,7 @@
             "maxAutoLockRenewalDuration": "00:05:00",
             "maxConcurrentCalls": 1,
             "maxConcurrentSessions": 16,
-            "prefetchCount": 10,
+            "prefetchCount": 0,
             "sessionIdleTimeout": "00:00:01"
         }
     }

--- a/src/Bitakora.ControlAsistencia.Programacion/host.json
+++ b/src/Bitakora.ControlAsistencia.Programacion/host.json
@@ -24,7 +24,7 @@
             "maxAutoLockRenewalDuration": "00:05:00",
             "maxConcurrentCalls": 1,
             "maxConcurrentSessions": 16,
-            "prefetchCount": 10,
+            "prefetchCount": 0,
             "sessionIdleTimeout": "00:00:01"
         }
     }


### PR DESCRIPTION
## Resumen

Pipeline tooling completado:
- Writer: implementacion de la tarea
- Reviewer: revision de calidad

## Decisiones del pipeline

<details>
<summary>Writer -- 1m 46s</summary>

_(El agente no genero resumen)_

</details>

<details>
<summary>Reviewer -- 3m 6s</summary>

# Stage 2 - Reviewer Summary

**Issue**: #47 - Reducir prefetchCount a 0 en host.json de todos los dominios
**Resultado**: APROBADO sin correcciones

## Verificacion

| Criterio | Estado |
|----------|--------|
| prefetchCount = 0 en ControlHoras | OK |
| prefetchCount = 0 en Programacion | OK |
| Todos los dominios con host.json cubiertos | OK (solo existen 2) |
| maxConcurrentCalls = 1 en ambos | OK (procesamiento secuencial) |
| Compilacion sin errores | OK (0 errores, 1 warning preexistente) |
| Tests existentes | Sin regresion (runner preexistente con exit code 5, mismo comportamiento en main) |

## Analisis

- Los cambios son minimos y quirurgicos: una sola linea en cada host.json.
- Ambos archivos son identicos entre si, lo cual es consistente con el patron del proyecto.
- No hay otros dominios con host.json que requieran el cambio.
- La configuracion resultante (prefetchCount: 0 + maxConcurrentCalls: 1) elimina la condicion de carrera descrita en ADR-0017 que causaba MessageLockLost.

## Correcciones aplicadas

Ninguna. El codigo del writer es correcto.

</details>

## Commits

89bfcda fix(config): reducir prefetchCount a 0 en host.json de ControlHoras y Programacion

Closes #47