### PR TITLE
Filtrar cobertura de CI para incluir solo assemblies del proyecto

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
           reports: 'coverage/coverage.cobertura.xml'
           targetdir: 'coverage/report'
           reporttypes: 'MarkdownSummaryGithub'
+          assemblyfilters: '+Bitakora.ControlAsistencia.*;-*.Tests'
 
       - name: Publicar resumen en Job Summary
         run: cat coverage/report/SummaryGithub.md >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Resumen

Pipeline tooling completado:
- Writer: implementacion de la tarea
- Reviewer: revision de calidad

## Decisiones del pipeline

<details>
<summary>Writer -- 1m 21s</summary>

_(El agente no genero resumen)_

</details>

<details>
<summary>Reviewer -- 1m 21s</summary>

_(El agente no genero resumen)_

</details>

## Commits

408ccad fix(ci): filtrar cobertura para incluir solo assemblies del proyecto

Closes #52