### PR TITLE
Agregar fuentes de Service Bus y Azure Functions al bug-investigator

### DIFF
--- a/.claude/agents/bug-investigator.md
+++ b/.claude/agents/bug-investigator.md
@@ -37,6 +37,19 @@ Ejecuta queries predefinidas contra App Insights usando el script del proyecto:
 
 # Filtrar por el sintoma reportado
 ./scripts/appinsights-query.sh traces --filter "SINTOMA_AQUI"
+
+# Estado de Service Bus - dead letters en todas las subscriptions
+./scripts/appinsights-query.sh servicebus-dlq
+
+# Estado de Azure Functions - running/stopped
+./scripts/appinsights-query.sh function-status
+```
+
+**Heuristica DLQ**: si el sintoma menciona "dead letter", "mensaje perdido", "cola" o "DLQ", ejecuta tambien:
+
+```bash
+# Peek al contenido de dead letters (sin consumir)
+./scripts/appinsights-query.sh servicebus-dlq-peek
 ```
 
 Ajusta el rango temporal con `--hours N` si el usuario reporta que el error fue hace mas de 24h.
@@ -51,6 +64,7 @@ Con los datos de App Insights en mano:
 2. **Mapea el flujo**: identifica que funcion, comando o evento esta involucrado
 3. **Investiga errores desconocidos**: si el error es de una libreria, framework o servicio externo, usa WebSearch y WebFetch para buscar la causa conocida. Cita las fuentes.
 4. **Revisa cambios recientes**: consulta el historial git para ver si hay commits recientes en los archivos afectados
+5. **Revisa configuracion de messaging**: si el problema involucra Service Bus, lee el `host.json` del dominio afectado para verificar `prefetchCount`, `maxConcurrentCalls`, `lockDuration` (leccion de Bug #47/#48)
 
 ```bash
 # Ejemplo: ver commits recientes en un archivo sospechoso

--- a/scripts/.env.template
+++ b/scripts/.env.template
@@ -12,3 +12,12 @@ APPINSIGHTS_APP=
 
 # Resource group donde esta App Insights (patron: rg-${prefix})
 APPINSIGHTS_RG=
+
+# Service Bus namespace (patron: ${prefix}-sbns)
+SERVICEBUS_NAMESPACE=
+
+# Resource group donde esta Service Bus (patron: rg-${prefix})
+SERVICEBUS_RG=
+
+# Nombres de Function Apps separados por coma (patron: ${prefix}-func-{dominio})
+FUNCTIONAPP_NAMES=

--- a/scripts/appinsights-query.sh
+++ b/scripts/appinsights-query.sh
@@ -68,16 +68,21 @@ MAX_ROWS=50
 if [ -z "$COMMAND" ]; then
     echo -e "${CYAN}${BOLD}appinsights-query.sh${NC} - Consultas KQL contra App Insights"
     echo ""
-    echo "Comandos disponibles:"
-    echo "  exceptions       Top 20 excepciones agrupadas por tipo y mensaje"
-    echo "  dead-letters     Mensajes dead-lettered en traces"
-    echo "  function-errors  Funciones con requests fallidas"
-    echo "  traces           Traces (usar con --filter para filtrar)"
-    echo "  health-summary   Vista rapida: excepciones + requests fallidas + disponibilidad"
+    echo "Comandos KQL (App Insights):"
+    echo "  exceptions         Top 20 excepciones agrupadas por tipo y mensaje"
+    echo "  dead-letters       Mensajes dead-lettered en traces"
+    echo "  function-errors    Funciones con requests fallidas"
+    echo "  traces             Traces (usar con --filter para filtrar)"
+    echo "  health-summary     Vista rapida: excepciones + requests fallidas + disponibilidad"
+    echo ""
+    echo "Comandos Azure Resource Manager:"
+    echo "  servicebus-dlq     Conteo de dead letters por subscription en Service Bus"
+    echo "  servicebus-dlq-peek  Peek a mensajes en DLQ sin consumirlos (max 5)"
+    echo "  function-status    Estado y funciones registradas de cada Function App"
     echo ""
     echo "Opciones:"
-    echo "  --hours N        Ventana temporal en horas (default: 24)"
-    echo "  --filter TEXT    Filtrar por texto (solo para 'traces')"
+    echo "  --hours N          Ventana temporal en horas (default: 24, solo KQL)"
+    echo "  --filter TEXT      Filtrar por texto (solo para 'traces')"
     exit 1
 fi
 
@@ -188,6 +193,202 @@ case "$COMMAND" in
             "Top 5 tipos de error"
 
         success "Health summary completado"
+        ;;
+
+    servicebus-dlq)
+        if [ -z "${SERVICEBUS_NAMESPACE:-}" ]; then
+            error "Variable SERVICEBUS_NAMESPACE no definida en $ENV_FILE"
+            echo "  Agrega SERVICEBUS_NAMESPACE al archivo $ENV_FILE (ver .env.template)"
+            exit 1
+        fi
+        if [ -z "${SERVICEBUS_RG:-}" ]; then
+            error "Variable SERVICEBUS_RG no definida en $ENV_FILE"
+            echo "  Agrega SERVICEBUS_RG al archivo $ENV_FILE (ver .env.template)"
+            exit 1
+        fi
+
+        log "Conteo de dead letters en Service Bus namespace: $SERVICEBUS_NAMESPACE"
+
+        topics=$(az servicebus topic list \
+            --namespace-name "$SERVICEBUS_NAMESPACE" \
+            --resource-group "$SERVICEBUS_RG" \
+            --query "[].name" -o tsv 2>&1) || {
+            error "Fallo al listar topics de Service Bus"
+            echo "$topics" >&2
+            exit 1
+        }
+
+        if [ -z "$topics" ]; then
+            warn "No se encontraron topics en el namespace $SERVICEBUS_NAMESPACE"
+        else
+            for topic in $topics; do
+                subs=$(az servicebus topic subscription list \
+                    --namespace-name "$SERVICEBUS_NAMESPACE" \
+                    --resource-group "$SERVICEBUS_RG" \
+                    --topic-name "$topic" \
+                    --query "[].name" -o tsv 2>&1) || {
+                    warn "Fallo al listar subscriptions del topic $topic"
+                    continue
+                }
+
+                for sub in $subs; do
+                    dlq_count=$(az servicebus topic subscription show \
+                        --namespace-name "$SERVICEBUS_NAMESPACE" \
+                        --resource-group "$SERVICEBUS_RG" \
+                        --topic-name "$topic" \
+                        --name "$sub" \
+                        --query "countDetails.deadLetterMessageCount" -o tsv 2>&1) || {
+                        warn "Fallo al consultar subscription $topic/$sub"
+                        continue
+                    }
+
+                    if [ "${dlq_count:-0}" -gt 0 ] 2>/dev/null; then
+                        echo -e "${RED}${BOLD}DLQ${NC} $topic/$sub: ${RED}$dlq_count${NC} mensajes"
+                    else
+                        echo -e "${GREEN}ok${NC}  $topic/$sub: $dlq_count mensajes"
+                    fi
+                done
+            done
+        fi
+
+        success "Consulta de dead letters completada"
+        ;;
+
+    servicebus-dlq-peek)
+        if [ -z "${SERVICEBUS_NAMESPACE:-}" ]; then
+            error "Variable SERVICEBUS_NAMESPACE no definida en $ENV_FILE"
+            echo "  Agrega SERVICEBUS_NAMESPACE al archivo $ENV_FILE (ver .env.template)"
+            exit 1
+        fi
+        if [ -z "${SERVICEBUS_RG:-}" ]; then
+            error "Variable SERVICEBUS_RG no definida en $ENV_FILE"
+            echo "  Agrega SERVICEBUS_RG al archivo $ENV_FILE (ver .env.template)"
+            exit 1
+        fi
+
+        log "Peek a dead letters en Service Bus namespace: $SERVICEBUS_NAMESPACE"
+
+        topics=$(az servicebus topic list \
+            --namespace-name "$SERVICEBUS_NAMESPACE" \
+            --resource-group "$SERVICEBUS_RG" \
+            --query "[].name" -o tsv 2>&1) || {
+            error "Fallo al listar topics de Service Bus"
+            echo "$topics" >&2
+            exit 1
+        }
+
+        if [ -z "$topics" ]; then
+            warn "No se encontraron topics en el namespace $SERVICEBUS_NAMESPACE"
+        else
+            for topic in $topics; do
+                subs=$(az servicebus topic subscription list \
+                    --namespace-name "$SERVICEBUS_NAMESPACE" \
+                    --resource-group "$SERVICEBUS_RG" \
+                    --topic-name "$topic" \
+                    --query "[].name" -o tsv 2>&1) || {
+                    warn "Fallo al listar subscriptions del topic $topic"
+                    continue
+                }
+
+                for sub in $subs; do
+                    echo -e "\n${CYAN}${BOLD}--- $topic/$sub/\$deadletterqueue ---${NC}"
+                    messages=$(az servicebus topic subscription receive \
+                        --namespace-name "$SERVICEBUS_NAMESPACE" \
+                        --resource-group "$SERVICEBUS_RG" \
+                        --topic-name "$topic" \
+                        --subscription-name "$sub" \
+                        --is-dead-letter-queue true \
+                        --peek-lock \
+                        --max-messages 5 \
+                        --output json 2>&1) || {
+                        warn "Fallo al hacer peek en $topic/$sub DLQ"
+                        continue
+                    }
+
+                    msg_count=$(echo "$messages" | python3 -c "import sys,json; print(len(json.load(sys.stdin)))" 2>/dev/null || echo "0")
+                    if [ "$msg_count" = "0" ]; then
+                        echo "  (vacio)"
+                    else
+                        echo "$messages" | python3 -c "
+import sys, json
+msgs = json.load(sys.stdin)
+for i, m in enumerate(msgs):
+    body = m.get('body', '(sin body)')
+    props = m.get('applicationProperties', {})
+    reason = m.get('deadLetterReason', '(sin razon)')
+    print(f'  [{i+1}] reason={reason}')
+    if props:
+        print(f'      props={json.dumps(props, ensure_ascii=False)}')
+    body_str = body if isinstance(body, str) else json.dumps(body, ensure_ascii=False)
+    if len(body_str) > 200:
+        body_str = body_str[:200] + '...'
+    print(f'      body={body_str}')
+" 2>/dev/null || echo "$messages"
+                    fi
+                done
+            done
+        fi
+
+        success "Peek de dead letters completado"
+        ;;
+
+    function-status)
+        if [ -z "${FUNCTIONAPP_NAMES:-}" ]; then
+            error "Variable FUNCTIONAPP_NAMES no definida en $ENV_FILE"
+            echo "  Agrega FUNCTIONAPP_NAMES al archivo $ENV_FILE (ver .env.template)"
+            exit 1
+        fi
+
+        log "Estado de Azure Functions"
+
+        IFS=',' read -ra APPS <<< "$FUNCTIONAPP_NAMES"
+        for app_name in "${APPS[@]}"; do
+            app_name=$(echo "$app_name" | xargs)  # trim whitespace
+            echo -e "\n${CYAN}${BOLD}--- $app_name ---${NC}"
+
+            status=$(az functionapp show \
+                --name "$app_name" \
+                --resource-group "${APPINSIGHTS_RG}" \
+                --query "{state:state, defaultHostName:defaultHostName, kind:kind}" \
+                --output json 2>&1) || {
+                warn "Fallo al consultar Function App $app_name"
+                echo "$status" >&2
+                continue
+            }
+
+            state=$(echo "$status" | python3 -c "import sys,json; print(json.load(sys.stdin).get('state','unknown'))" 2>/dev/null || echo "unknown")
+            if [ "$state" = "Running" ]; then
+                echo -e "  Estado: ${GREEN}${BOLD}$state${NC}"
+            else
+                echo -e "  Estado: ${RED}${BOLD}$state${NC}"
+            fi
+
+            functions=$(az functionapp function list \
+                --name "$app_name" \
+                --resource-group "${APPINSIGHTS_RG}" \
+                --query "[].{name:name, isDisabled:isDisabled}" \
+                --output json 2>&1) || {
+                warn "Fallo al listar funciones de $app_name"
+                continue
+            }
+
+            func_count=$(echo "$functions" | python3 -c "import sys,json; print(len(json.load(sys.stdin)))" 2>/dev/null || echo "0")
+            echo "  Funciones registradas: $func_count"
+
+            if [ "$func_count" != "0" ]; then
+                echo "$functions" | python3 -c "
+import sys, json
+funcs = json.load(sys.stdin)
+for f in funcs:
+    name = f.get('name', '?').split('/')[-1]
+    disabled = f.get('isDisabled', False)
+    status = 'DISABLED' if disabled else 'ok'
+    print(f'    - {name} ({status})')
+" 2>/dev/null || echo "$functions"
+            fi
+        done
+
+        success "Consulta de estado de Functions completada"
         ;;
 
     *)

--- a/scripts/appinsights-query.sh
+++ b/scripts/appinsights-query.sh
@@ -43,16 +43,6 @@ else
     exit 1
 fi
 
-if [ -z "${APPINSIGHTS_APP:-}" ]; then
-    error "Variable APPINSIGHTS_APP no definida en $ENV_FILE"
-    exit 1
-fi
-
-if [ -z "${APPINSIGHTS_RG:-}" ]; then
-    error "Variable APPINSIGHTS_RG no definida en $ENV_FILE"
-    exit 1
-fi
-
 # --- Verificar az login ------------------------------------------------------
 if ! az account show &>/dev/null; then
     error "No hay sesion activa de Azure CLI. Ejecuta 'az login' primero."
@@ -117,6 +107,15 @@ done
 run_query() {
     local query="$1"
     local description="$2"
+
+    if [ -z "${APPINSIGHTS_APP:-}" ]; then
+        error "Variable APPINSIGHTS_APP no definida en $ENV_FILE"
+        exit 1
+    fi
+    if [ -z "${APPINSIGHTS_RG:-}" ]; then
+        error "Variable APPINSIGHTS_RG no definida en $ENV_FILE"
+        exit 1
+    fi
 
     log "$description (ultimas ${HOURS}h)"
 
@@ -336,6 +335,11 @@ for i, m in enumerate(msgs):
         if [ -z "${FUNCTIONAPP_NAMES:-}" ]; then
             error "Variable FUNCTIONAPP_NAMES no definida en $ENV_FILE"
             echo "  Agrega FUNCTIONAPP_NAMES al archivo $ENV_FILE (ver .env.template)"
+            exit 1
+        fi
+        if [ -z "${APPINSIGHTS_RG:-}" ]; then
+            error "Variable APPINSIGHTS_RG no definida en $ENV_FILE (usada como resource group de las Function Apps)"
+            echo "  Agrega APPINSIGHTS_RG al archivo $ENV_FILE (ver .env.template)"
             exit 1
         fi
 


### PR DESCRIPTION
## Resumen

Pipeline tooling completado:
- Writer: implementacion de la tarea
- Reviewer: revision de calidad

## Decisiones del pipeline

<details>
<summary>Writer -- 1m 16s</summary>

_(El agente no genero resumen)_

</details>

<details>
<summary>Reviewer -- 7m 6s</summary>

# Stage 2 - Reviewer Summary (Issue #62)

## Veredicto: APROBADO con correcciones

## Problemas encontrados y corregidos

### 1. Bug: validacion global de APPINSIGHTS_APP/RG bloqueaba comandos ARM (severidad: alta)

La validacion de APPINSIGHTS_APP y APPINSIGHTS_RG (lineas 46-54) se ejecutaba incondicionalmente antes del case, haciendo que los nuevos comandos ARM (servicebus-dlq, servicebus-dlq-peek, function-status) fallaran si App Insights no estaba configurado. El issue dice explicitamente: solo se validan cuando se ejecuta un comando que las necesita.

**Fix**: mover la validacion dentro de run_query() (solo la usan los 5 comandos KQL). Agregar validacion propia de APPINSIGHTS_RG en function-status.

### 2. bug-investigator.md no fue modificado (severidad: alta)

El writer no toco el agente. Faltaban CA-7, CA-8 y CA-9:
- Stage 1: servicebus-dlq y function-status como queries estandar
- Stage 1: heuristica para servicebus-dlq-peek cuando el sintoma menciona dead letters
- Stage 2: paso 5 de revision de host.json para config de messaging

**Fix**: aplicar los 3 cambios al agente.

### 3. function-status depende de APPINSIGHTS_RG sin validacion propia (severidad: media)

function-status usa APPINSIGHTS_RG como resource group de las Function Apps (pragmatico dado que comparten RG), pero no lo validaba por si mismo -- dependia de la validacion global que movimos.

**Fix**: agregar validacion local con mensaje descriptivo.

## Criterios de aceptacion

| CA | Estado | Nota |
|----|--------|------|
| CA-1 | OK | servicebus-dlq valida sus vars y ejecuta az CLI |
| CA-2 | OK | function-status valida FUNCTIONAPP_NAMES + APPINSIGHTS_RG |
| CA-3 | OK | servicebus-dlq-peek usa --peek-lock, max 5 mensajes |
| CA-4 | OK (corregido) | La validacion global bloqueaba ARM; ahora cada comando valida lo suyo |
| CA-5 | OK | Bloque de ayuda lista 8 comandos (5 KQL + 3 ARM) |
| CA-6 | OK | .env.template tiene las 3 nuevas variables |
| CA-7 | OK (corregido) | Agregado servicebus-dlq y function-status a Stage 1 |
| CA-8 | OK (corregido) | Agregada heuristica DLQ peek |
| CA-9 | OK (corregido) | Agregado paso 5 en Stage 2 sobre host.json |

## Lo que esta bien del writer

- Los 3 comandos ARM siguen el patron existente del script (colores, funciones log/error/warn/success)
- La iteracion topics -> subscriptions es correcta para servicebus-dlq
- servicebus-dlq-peek formatea bien los mensajes con python3 (trunca body a 200 chars)
- Las validaciones de variables son consistentes con el patron existente
- El .env.template tiene comentarios descriptivos con patrones de naming

## Tests

- Compilacion: 0 errores, 1 warning pre-existente
- Tests unitarios (Contracts): 64/64 pasan
- Smoke tests: 15 fallan (pre-existente, requieren entorno desplegado)

</details>

## Commits

1dcf765 review(#62): corregir validacion global y completar bug-investigator
ff3e49f tooling(#62): implementacion

Closes #62