### PR TITLE
Automatizar gestion del label bloqueado en issues

### DIFF
--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -30,7 +30,34 @@ Determina el tipo del issue buscando el label `tipo:X`. Luego verifica los 5 cri
 
 Si **uno o mas criterios fallan**: muestra la lista completa de lo que falta, sugiere `claude --agent planner` en modo `refinar` para completarlos, y **detente**.
 
-Si **todos los criterios pasan**: continua al paso 2.
+Si **todos los criterios pasan**: continua al paso 1.6.
+
+### 1.6. Verificar label bloqueado
+
+Si el issue tiene el label `bloqueado`, lee la seccion `## Dependencias` del body y extrae todos los numeros de issue/PR referenciados (patron `#NNN`).
+
+Para cada referencia, consulta su estado:
+
+```bash
+gh issue view <num> --json state -q '.state'
+gh pr view <num> --json state -q '.state'
+```
+
+- Si **todas** las dependencias estan cerradas (`CLOSED`) o mergeadas (`MERGED`): quita el label y continua:
+
+```bash
+gh issue edit $ARGUMENTS --remove-label "bloqueado"
+```
+
+- Si **alguna** dependencia sigue abierta: muestra cuales y **detente**:
+
+```
+El issue #$ARGUMENTS esta bloqueado. Dependencias abiertas:
+  - #42: [titulo] (OPEN)
+  - #55: [titulo] (OPEN)
+
+Resuelve estas dependencias antes de lanzar el pipeline.
+```
 
 ### 2. Detectar dominio
 

--- a/.claude/commands/tooling.md
+++ b/.claude/commands/tooling.md
@@ -32,6 +32,33 @@ Si es logica de dominio, usa /implement en su lugar.
 ¿Continuar de todos modos? (s/n)
 ```
 
+### 2.5. Verificar label bloqueado
+
+Si el issue tiene el label `bloqueado`, lee la seccion `## Dependencias` del body y extrae todos los numeros de issue/PR referenciados (patron `#NNN`).
+
+Para cada referencia, consulta su estado:
+
+```bash
+gh issue view <num> --json state -q '.state'
+gh pr view <num> --json state -q '.state'
+```
+
+- Si **todas** las dependencias estan cerradas (`CLOSED`) o mergeadas (`MERGED`): quita el label y continua:
+
+```bash
+gh issue edit $ARGUMENTS --remove-label "bloqueado"
+```
+
+- Si **alguna** dependencia sigue abierta: muestra cuales y **detente**:
+
+```
+El issue #$ARGUMENTS esta bloqueado. Dependencias abiertas:
+  - #42: [titulo] (OPEN)
+  - #55: [titulo] (OPEN)
+
+Resuelve estas dependencias antes de lanzar el pipeline.
+```
+
 ### 3. Mostrar info y lanzar
 
 Muestra una linea con el issue:

--- a/scripts/pr-sync.sh
+++ b/scripts/pr-sync.sh
@@ -290,6 +290,115 @@ merge_pr_with_retry() {
     return 1
 }
 
+# ─── Función: desbloquear issues dependientes tras merge ─────────────────
+desbloquear_issues_dependientes() {
+    local pr_num="$1"
+
+    # Obtener body del PR para extraer "Closes #N"
+    local pr_body
+    pr_body=$(gh pr view "$pr_num" --json body -q '.body' 2>/dev/null || echo "")
+    if [ -z "$pr_body" ]; then
+        return 0
+    fi
+
+    # Extraer todos los issue numbers cerrados por este PR
+    local closed_issues=()
+    local match
+    while IFS= read -r match; do
+        [ -n "$match" ] && closed_issues+=("$match")
+    done < <(echo "$pr_body" | grep -ioE 'Closes #[0-9]+' | grep -oE '[0-9]+')
+
+    if [ ${#closed_issues[@]} -eq 0 ]; then
+        return 0
+    fi
+
+    log "PR #$pr_num cierra issue(s): ${closed_issues[*]}. Buscando issues bloqueados dependientes..."
+
+    # Obtener todos los issues abiertos con label "bloqueado"
+    local bloqueados_json
+    bloqueados_json=$(gh issue list --state open --label "bloqueado" --json number,body,title 2>/dev/null || echo "[]")
+
+    if [ "$bloqueados_json" = "[]" ] || [ -z "$bloqueados_json" ]; then
+        log "No hay issues con label 'bloqueado'."
+        return 0
+    fi
+
+    # Para cada issue bloqueado, verificar si depende de alguno de los issues cerrados
+    local bloqueado_count
+    bloqueado_count=$(echo "$bloqueados_json" | jq 'length')
+
+    local idx=0
+    while [ "$idx" -lt "$bloqueado_count" ]; do
+        local bloqueado_num
+        bloqueado_num=$(echo "$bloqueados_json" | jq -r ".[$idx].number")
+        local bloqueado_body
+        bloqueado_body=$(echo "$bloqueados_json" | jq -r ".[$idx].body // \"\"")
+        local bloqueado_title
+        bloqueado_title=$(echo "$bloqueados_json" | jq -r ".[$idx].title // \"\"")
+
+        # Extraer seccion ## Dependencias del body
+        local deps_section
+        deps_section=$(echo "$bloqueado_body" | sed -n '/^## Dependencias/,/^## /p' | head -n -1)
+        if [ -z "$deps_section" ]; then
+            # Intentar sin trailing section
+            deps_section=$(echo "$bloqueado_body" | sed -n '/^## Dependencias/,$p')
+        fi
+
+        # Verificar si este issue bloqueado referencia alguno de los issues cerrados
+        local referencia_cerrado=false
+        local closed_num
+        for closed_num in "${closed_issues[@]}"; do
+            if echo "$deps_section" | grep -qE "#${closed_num}([^0-9]|$)"; then
+                referencia_cerrado=true
+                break
+            fi
+        done
+
+        if [ "$referencia_cerrado" = true ]; then
+            # Extraer TODAS las dependencias del issue bloqueado
+            local all_deps=()
+            local dep_num
+            while IFS= read -r dep_num; do
+                [ -n "$dep_num" ] && all_deps+=("$dep_num")
+            done < <(echo "$deps_section" | grep -oE '#[0-9]+' | grep -oE '[0-9]+' | sort -u)
+
+            # Verificar si TODAS las dependencias estan cerradas/mergeadas
+            local todas_cerradas=true
+            local dep_abierta=""
+            for dep_num in "${all_deps[@]}"; do
+                local dep_state
+                # Intentar como issue primero
+                dep_state=$(gh issue view "$dep_num" --json state -q '.state' 2>/dev/null || echo "")
+                if [ "$dep_state" = "CLOSED" ]; then
+                    continue
+                fi
+                # Intentar como PR
+                dep_state=$(gh pr view "$dep_num" --json state -q '.state' 2>/dev/null || echo "")
+                if [ "$dep_state" = "MERGED" ] || [ "$dep_state" = "CLOSED" ]; then
+                    continue
+                fi
+                # Si llegamos aqui, la dependencia sigue abierta
+                todas_cerradas=false
+                dep_abierta="$dep_num"
+                break
+            done
+
+            if [ "$todas_cerradas" = true ]; then
+                log "Desbloqueando issue #$bloqueado_num: $bloqueado_title"
+                if gh issue edit "$bloqueado_num" --remove-label "bloqueado" >>"$LOG_FILE_ABS" 2>&1; then
+                    success "Issue #$bloqueado_num desbloqueado: $bloqueado_title"
+                else
+                    warn "No se pudo quitar el label 'bloqueado' del issue #$bloqueado_num"
+                fi
+            else
+                log "Issue #$bloqueado_num sigue bloqueado (dependencia #$dep_abierta aun abierta)"
+            fi
+        fi
+
+        idx=$((idx + 1))
+    done
+}
+
 # ─── Loop principal ───────────────────────────────────────────────────────────
 for PR_NUM in "${PR_NUMS[@]}"; do
     header "PR #$PR_NUM"
@@ -332,6 +441,7 @@ for PR_NUM in "${PR_NUMS[@]}"; do
             if merge_pr_with_retry "$PR_NUM"; then
                 success "PR #$PR_NUM mergeado a main"
                 set_status "$PR_NUM" "mergeado"
+                desbloquear_issues_dependientes "$PR_NUM"
                 git fetch origin main >>"$LOG_FILE_ABS" 2>&1 || true
             else
                 fail_pr "$PR_NUM" "No se pudo mergear después de reintentos"
@@ -462,6 +572,7 @@ Cuando termines, haz commit de los cambios."
         if merge_pr_with_retry "$PR_NUM"; then
             success "PR #$PR_NUM mergeado a main"
             set_status "$PR_NUM" "mergeado"
+            desbloquear_issues_dependientes "$PR_NUM"
             git fetch origin main >>"$LOG_FILE_ABS" 2>&1 || true
         else
             fail_pr "$PR_NUM" "No se pudo mergear después de reintentos"

--- a/scripts/pr-sync.sh
+++ b/scripts/pr-sync.sh
@@ -337,12 +337,9 @@ desbloquear_issues_dependientes() {
         bloqueado_title=$(echo "$bloqueados_json" | jq -r ".[$idx].title // \"\"")
 
         # Extraer seccion ## Dependencias del body
+        # Usa awk para compatibilidad con macOS (head -n -1 no funciona en BSD)
         local deps_section
-        deps_section=$(echo "$bloqueado_body" | sed -n '/^## Dependencias/,/^## /p' | head -n -1)
-        if [ -z "$deps_section" ]; then
-            # Intentar sin trailing section
-            deps_section=$(echo "$bloqueado_body" | sed -n '/^## Dependencias/,$p')
-        fi
+        deps_section=$(echo "$bloqueado_body" | awk '/^## Dependencias/{found=1; next} /^## /{found=0} found{print}')
 
         # Verificar si este issue bloqueado referencia alguno de los issues cerrados
         local referencia_cerrado=false


### PR DESCRIPTION
## Resumen

Pipeline tooling completado:
- Writer: implementacion de la tarea
- Reviewer: revision de calidad

## Decisiones del pipeline

<details>
<summary>Writer -- 4m 5s</summary>

_(El agente no genero resumen)_

</details>

<details>
<summary>Reviewer -- 6m 22s</summary>

# Stage 2 - Reviewer: Issue #71

## Veredicto: APROBADO con correcciones

## Problemas encontrados y corregidos

### 1. Bug: head -n -1 incompatible con macOS (critico)

Archivo: scripts/pr-sync.sh:341
Problema: BSD head en macOS no soporta conteos negativos. El script falla al extraer la seccion Dependencias.
Correccion: Reemplazado por awk compatible con ambas plataformas.

### 2. CA-4/5/6/7 no implementados (critico)

Archivos: .claude/commands/implement.md, .claude/commands/tooling.md
Problema: El writer solo implemento la parte proactiva (pr-sync.sh) pero no la defensiva en los skills.
Correccion: Agregado paso 1.6 en implement y paso 2.5 en tooling con verificacion de bloqueado.

## Cobertura de criterios de aceptacion

- CA-1: OK - pr-sync detecta Closes y desbloquea
- CA-2: OK - log y success con numero y titulo
- CA-3: OK - break temprano si alguna dep abierta
- CA-4: OK (corregido) - paso 1.6 en implement
- CA-5: OK (corregido) - quita label si todas cerradas
- CA-6: OK (corregido) - detiene con lista de abiertas
- CA-7: OK (corregido) - paso 2.5 en tooling
- CA-8: OK - regex cubre todos los formatos

</details>

## Commits

5821a3d review(#71): corregir compatibilidad macOS y agregar verificacion bloqueado en skills
c5fcc87 tooling(#71): implementacion

Closes #71