### PR TITLE
Separar label bug de la faceta tipo: en el esquema de labels

### DIFF
--- a/.claude/agents/bug-investigator.md
+++ b/.claude/agents/bug-investigator.md
@@ -100,11 +100,15 @@ NO avances al Stage 4 sin confirmacion del usuario.
 
 Con el diagnostico validado, propone acciones concretas:
 
-1. **Crear issues**: para cada fix necesario, propone un issue con titulo, descripcion y labels siguiendo las convenciones del proyecto (`tipo:bug`, `dom:X`, `estado:listo`)
+1. **Crear issues**: para cada fix necesario, propone un issue con titulo, descripcion y labels siguiendo las convenciones del proyecto. Usa el label `bug` como origen y agrega el `tipo:` segun la naturaleza del fix:
+   - `tipo:refactor` — si el fix reestructura logica existente (default para la mayoria de bugs)
+   - `tipo:feature` — si el fix requiere comportamiento nuevo
+   - `tipo:tooling` — si el fix es en scripts, agentes o configuracion
+   - `tipo:infra` — si el fix es en infraestructura Azure/Terraform
 
 ```bash
 # Solo con confirmacion del usuario
-gh issue create --title "Corregir [descripcion]" --body "..." --label "tipo:bug,dom:X,estado:listo"
+gh issue create --title "Corregir [descripcion]" --body "..." --label "bug,tipo:refactor,dom:X,estado:listo"
 ```
 
 2. **Workarounds inmediatos**: si hay una accion urgente (reiniciar funcion, purgar cola), describela pero NO la ejecutes sin confirmacion explicita

--- a/.claude/agents/planner.md
+++ b/.claude/agents/planner.md
@@ -321,7 +321,7 @@ Cuando una idea esté lista para convertirse en issue, confirma con el usuario e
 ```bash
 gh issue create \
   --title "[verbo infinitivo] [que cosa]" \
-  --label "tipo:[feature|refactor|bug|tooling]" \
+  --label "tipo:[feature|refactor|tooling]" \
   --label "dom:[programacion|contracts|asistencia]" \
   --label "estado:listo" \
   --body "$(cat <<'ISSUEEOF'
@@ -383,6 +383,8 @@ La sección **Interfaz pública** es obligatoria para issues que crean value obj
 Si el issue depende de otro no cerrado, agrega también `--label "bloqueado"`.
 
 Si el dominio no aplica (tooling, cross-cutting), omite el label `dom:`.
+
+Si el issue corrige un defecto (bug), agrega `--label "bug"` ademas del `tipo:` que corresponda. El label `bug` indica origen (el issue existe porque se descubrio un defecto), mientras que `tipo:` indica el pipeline de implementacion. Ejemplo: `--label "bug" --label "tipo:refactor"`.
 
 ### Template para issues de infraestructura
 

--- a/.claude/commands/draft.md
+++ b/.claude/commands/draft.md
@@ -12,7 +12,8 @@ El texto de la idea esta en: $ARGUMENTS
 
 2. Infiere:
    - **Titulo**: usa el formato `[verbo infinitivo] [que cosa]`. Maximo 70 caracteres.
-   - **Tipo probable**: `tipo:feature` (default), `tipo:infra`, `tipo:refactor`, `tipo:bug`, o `tipo:tooling`
+   - **Tipo probable**: `tipo:feature` (default), `tipo:infra`, `tipo:refactor`, o `tipo:tooling`
+   - **Es un defecto?**: si la idea describe un bug o defecto, agregar tambien el label `bug` (ademas del `tipo:` que corresponda; default `tipo:refactor` para bugs)
    - **Dominio probable**: `dom:programacion`, `dom:contracts`, `dom:asistencia`. Si no queda claro, omite el label de dominio.
 
 3. Crea el issue:

--- a/docs/adr/0010-gestion-proyecto-github-issues.md
+++ b/docs/adr/0010-gestion-proyecto-github-issues.md
@@ -15,7 +15,7 @@ El proyecto es de un solo desarrollador en fase de exploracion y aprendizaje. La
 
 ## Decision
 
-### 1. Labels dimensionales (3 ejes, 14 labels)
+### 1. Labels dimensionales (4 ejes + especiales)
 
 Reemplazar los 9 labels default de GitHub con un esquema por facetas:
 

--- a/docs/adr/0010-gestion-proyecto-github-issues.md
+++ b/docs/adr/0010-gestion-proyecto-github-issues.md
@@ -19,10 +19,13 @@ El proyecto es de un solo desarrollador en fase de exploracion y aprendizaje. La
 
 Reemplazar los 9 labels default de GitHub con un esquema por facetas:
 
-- **Tipo** (`tipo:feature`, `tipo:infra`, `tipo:refactor`, `tipo:bug`, `tipo:tooling`)
+- **Tipo** — indica el pipeline de implementacion (`tipo:feature`, `tipo:infra`, `tipo:refactor`, `tipo:tooling`)
+- **Origen** — indica por que existe el issue (`bug`)
 - **Dominio** (`dom:programacion`, `dom:contracts`, `dom:asistencia`, + nuevos conforme crecen)
 - **Estado** (`estado:borrador`, `estado:listo`)
 - **Especiales** (`bloqueado`, `epic`)
+
+El label `bug` es ortogonal al `tipo:`: un issue de bug siempre lleva un `tipo:` que indica que pipeline lo implementa (ej: `bug` + `tipo:refactor` + `dom:asistencia`).
 
 ### 2. Convencion de titulos sin prefijos
 

--- a/docs/adr/0014-definition-of-ready.md
+++ b/docs/adr/0014-definition-of-ready.md
@@ -23,21 +23,23 @@ Establecer un **Definition of Ready (DoR)** que define los criterios minimos que
 
 ### Tabla DoR por tipo de issue
 
-| Seccion | `feature` | `refactor` | `bug` | `infra` | `tooling` |
-|---|---|---|---|---|---|
-| Titulo: `[verbo infinitivo] [que cosa]` | Obligatorio | Obligatorio | Obligatorio | Obligatorio | Obligatorio |
-| Label `tipo:X` | Obligatorio | Obligatorio | Obligatorio | Obligatorio | Obligatorio |
-| Label `dom:X` | Obligatorio | Obligatorio | Obligatorio | Opcional | Opcional |
-| Label `estado:listo` | Obligatorio | Obligatorio | Obligatorio | Obligatorio | Obligatorio |
-| `## Contexto` | Obligatorio | Obligatorio | Obligatorio | Obligatorio | Obligatorio |
-| `## Dependencias` | Obligatorio | Obligatorio | Obligatorio | Obligatorio | Obligatorio |
-| `## Modelo de eventos` | **Critico** | No aplica | Condicional* | No aplica | No aplica |
-| `## Criterios de aceptacion` | **Critico** | **Critico** | **Critico** | **Critico** | **Critico** |
-| `## Notas tecnicas` | Recomendado | Recomendado | Obligatorio | Recomendado | Recomendado |
-| `## Impacto en archivos` | Recomendado | Obligatorio | Recomendado | Obligatorio | Recomendado |
-| `## Ambiente` | No aplica | No aplica | No aplica | Obligatorio | No aplica |
+| Seccion | `feature` | `refactor` | `infra` | `tooling` |
+|---|---|---|---|---|
+| Titulo: `[verbo infinitivo] [que cosa]` | Obligatorio | Obligatorio | Obligatorio | Obligatorio |
+| Label `tipo:X` | Obligatorio | Obligatorio | Obligatorio | Obligatorio |
+| Label `dom:X` | Obligatorio | Obligatorio | Opcional | Opcional |
+| Label `estado:listo` | Obligatorio | Obligatorio | Obligatorio | Obligatorio |
+| `## Contexto` | Obligatorio | Obligatorio | Obligatorio | Obligatorio |
+| `## Dependencias` | Obligatorio | Obligatorio | Obligatorio | Obligatorio |
+| `## Modelo de eventos` | **Critico** | No aplica | No aplica | No aplica |
+| `## Criterios de aceptacion` | **Critico** | **Critico** | **Critico** | **Critico** |
+| `## Notas tecnicas` | Recomendado | Recomendado | Recomendado | Recomendado |
+| `## Impacto en archivos` | Recomendado | Obligatorio | Obligatorio | Recomendado |
+| `## Ambiente` | No aplica | No aplica | Obligatorio | No aplica |
 
-*Condicional: obligatorio si el bug involucra comportamiento del aggregate.
+**Nota sobre bugs**: un issue con label `bug` siempre lleva un `tipo:` valido (`feature`, `refactor`, `tooling` o `infra`). Los criterios DoR se aplican segun ese `tipo:`, no segun el label `bug`. Si el bug involucra comportamiento del aggregate, el `## Modelo de eventos` es obligatorio (esto aplica cuando el tipo es `feature`).
+
+Los issues con label `bug` aplican los criterios de la columna correspondiente a su `tipo:`.
 
 ### Por que cada campo critico
 
@@ -61,7 +63,7 @@ El skill valida programaticamente un subconjunto del DoR antes de lanzar el pipe
 
 1. Label `estado:listo` presente
 2. Label `tipo:X` presente
-3. Label `dom:X` presente (si tipo es `feature`, `refactor` o `bug`)
+3. Label `dom:X` presente (si tipo es `feature` o `refactor`)
 4. Body contiene `## Criterios de aceptaci` (prefijo, tolera tildes)
 5. Body contiene `## Modelo de eventos` (solo si tipo es `feature`)
 

--- a/scripts/_pipeline-common.sh
+++ b/scripts/_pipeline-common.sh
@@ -35,7 +35,7 @@ resolve_pipeline() {
 # Funcion interna: determina el pipeline a partir de texto de labels (una por linea).
 _resolve_from_labels() {
     local labels="$1"
-    if echo "$labels" | grep -qE '^tipo:(feature|refactor|bug)$'; then
+    if echo "$labels" | grep -qE '^tipo:(feature|refactor)$'; then
         echo "./scripts/tdd-pipeline.sh"
     elif echo "$labels" | grep -q '^tipo:tooling$'; then
         echo "./scripts/tooling-pipeline.sh"

--- a/scripts/batch-pipeline.sh
+++ b/scripts/batch-pipeline.sh
@@ -8,7 +8,7 @@
 #   ./scripts/batch-pipeline.sh 42 43 --stop-on-error             # abortar en primer fallo
 #
 # Enrutamiento automatico: sin --pipeline, cada issue se enruta segun su label tipo:*
-#   tipo:feature|refactor|bug  -> tdd-pipeline.sh
+#   tipo:feature|refactor       -> tdd-pipeline.sh
 #   tipo:tooling               -> tooling-pipeline.sh
 #   tipo:infra                 -> SKIP (warning, no aborta)
 #   sin label tipo:*           -> SKIP (warning, no aborta)

--- a/scripts/parallel-pipeline.sh
+++ b/scripts/parallel-pipeline.sh
@@ -10,7 +10,7 @@
 #   ./scripts/parallel-pipeline.sh 42 43 44 --keep-status               # no borrar status files al terminar
 #
 # Enrutamiento automatico: sin --pipeline, cada issue se enruta segun su label tipo:*
-#   tipo:feature|refactor|bug  -> tdd-pipeline.sh
+#   tipo:feature|refactor       -> tdd-pipeline.sh
 #   tipo:tooling               -> tooling-pipeline.sh
 #   tipo:infra                 -> SKIP (warning, no aborta)
 #   sin label tipo:*           -> SKIP (warning, no aborta)

--- a/scripts/setup-github-labels.sh
+++ b/scripts/setup-github-labels.sh
@@ -21,7 +21,7 @@ gh label create "tipo:tooling"   --color "0052CC" --description "Mejoras a pipel
 
 echo ""
 echo "Creando labels de origen (naranja)..."
-gh label create "bug"            --color "D93F0B" --description "Correccion de defecto — siempre acompanado de un tipo: que indica el pipeline"
+gh label create "bug"            --color "D93F0B" --description "Correccion de defecto — siempre acompanado de un tipo: que indica el pipeline" --force
 
 echo ""
 echo "Creando labels de dominio (verde)..."

--- a/scripts/setup-github-labels.sh
+++ b/scripts/setup-github-labels.sh
@@ -8,7 +8,7 @@
 set -e
 
 echo "Eliminando labels default de GitHub..."
-for label in "bug" "documentation" "duplicate" "enhancement" "good first issue" "help wanted" "invalid" "question" "wontfix"; do
+for label in "documentation" "duplicate" "enhancement" "good first issue" "help wanted" "invalid" "question" "wontfix"; do
   gh label delete "$label" --yes 2>/dev/null && echo "  - eliminado: $label" || echo "  - no encontrado (ok): $label"
 done
 
@@ -17,8 +17,11 @@ echo "Creando labels de tipo (azul)..."
 gh label create "tipo:feature"   --color "0052CC" --description "Funcionalidad nueva de dominio"
 gh label create "tipo:infra"     --color "0052CC" --description "Infraestructura Azure / Terraform"
 gh label create "tipo:refactor"  --color "0052CC" --description "Reestructuracion sin comportamiento nuevo"
-gh label create "tipo:bug"       --color "0052CC" --description "Correccion de defecto"
 gh label create "tipo:tooling"   --color "0052CC" --description "Mejoras a pipeline, agentes o scripts"
+
+echo ""
+echo "Creando labels de origen (naranja)..."
+gh label create "bug"            --color "D93F0B" --description "Correccion de defecto — siempre acompanado de un tipo: que indica el pipeline"
 
 echo ""
 echo "Creando labels de dominio (verde)..."

--- a/scripts/tmux-pipeline.sh
+++ b/scripts/tmux-pipeline.sh
@@ -432,7 +432,7 @@ ${BOLD}Uso:${NC}
 
 ${BOLD}Enrutamiento automatico:${NC}
   Sin --pipeline ni --tooling/--infra, el pipeline se determina por el label tipo:* del issue:
-    tipo:feature|refactor|bug  -> tdd-pipeline.sh
+    tipo:feature|refactor       -> tdd-pipeline.sh
     tipo:tooling               -> tooling-pipeline.sh
     tipo:infra                 -> SKIP (usar --infra explicitamente)
 


### PR DESCRIPTION
## Resumen

Pipeline tooling completado:
- Writer: implementacion de la tarea
- Reviewer: revision de calidad

## Decisiones del pipeline

<details>
<summary>Writer -- 7m 45s</summary>

# Stage 1 - Writer Summary (Issue #86)

## Que se hizo

Se separo el label tipo:bug de la faceta tipo: en el esquema de labels del proyecto. El label bug ahora es un label de **origen** (indica que el issue existe porque se descubrio un defecto), mientras que tipo: sigue indicando el **pipeline** de implementacion.

## Archivos modificados (10)

| Archivo | Cambio |
|---|---|
| scripts/setup-github-labels.sh | Quitar bug de labels default a eliminar; quitar tipo:bug de seccion tipo; agregar seccion labels de origen con bug (color D93F0B) |
| scripts/_pipeline-common.sh | Regex de enrutamiento sin bug |
| .claude/agents/bug-investigator.md | Stage 4: tipo:bug -> bug + tipo: inferido segun naturaleza del fix |
| .claude/commands/draft.md | Quitar tipo:bug de lista; agregar regla para detectar defectos |
| .claude/agents/planner.md | Quitar bug de tipo:[...]; agregar nota sobre label bug como origen |
| docs/adr/0010-gestion-proyecto-github-issues.md | Quitar tipo:bug de faceta Tipo; agregar faceta Origen con bug |
| docs/adr/0014-definition-of-ready.md | Eliminar columna bug de tabla DoR; agregar nota; actualizar validacion dom:X |
| scripts/parallel-pipeline.sh | Comentario de enrutamiento actualizado |
| scripts/batch-pipeline.sh | Comentario de enrutamiento actualizado |
| scripts/tmux-pipeline.sh | Comentario de enrutamiento actualizado |

## Acciones en GitHub

- Label tipo:bug renombrado a bug via gh label edit
- Issue #84 actualizado: se le agrego tipo:tooling (ya tenia bug por el rename automatico)

## Criterios de aceptacion

- [x] CA-1 a CA-9: todos cumplidos

</details>

<details>
<summary>Reviewer -- 3m 26s</summary>

# Stage 2: Reviewer -- Issue #86

## Veredicto: APROBADO con correcciones menores

## Criterios de aceptacion

| CA | Estado | Nota |
|----|--------|------|
| CA-1: Renombrar label tipo:bug a bug | OK | Verificado con gh label list |
| CA-2: setup-github-labels.sh | OK + fix | Se agrego --force |
| CA-3: _pipeline-common.sh regex | OK | sin bug en regex |
| CA-4: bug-investigator.md | OK | Labels y guia correctos |
| CA-5: draft.md | OK | Instruccion de defecto presente |
| CA-6: ADR-0010 | OK + fix | Encabezado corregido |
| CA-7: ADR-0014 DoR | OK | Tabla y notas correctas |
| CA-8: planner.md | OK | Template y nota correctos |
| CA-9: Issue #84 | OK | Tiene bug + tipo:tooling |

## Correcciones aplicadas

1. setup-github-labels.sh: Agregado --force al gh label create bug.
   Sin esto, el script falla en repos nuevos donde el label default bug ya existe.

2. ADR-0010: Corregido encabezado de "3 ejes, 14 labels" a "4 ejes + especiales".
   Con la nueva faceta Origen el conteo anterior era incorrecto.

## Archivos bonus actualizados por el writer

batch-pipeline.sh, parallel-pipeline.sh, tmux-pipeline.sh: comentarios de enrutamiento.

## Observaciones sin accion

- Referencia residual a tipo:bug en docs/bitacora/2026-04-12.md es registro historico.

</details>

## Commits

32bc966 corregir revision: --force en label bug y actualizar conteo de ejes en ADR-0010
8dd7fae separar label bug de la faceta tipo: en el esquema de labels

Closes #86