### PR TITLE
Hacer lecturas iniciales y cierre del historiador no-interactivos

### DIFF
--- a/.claude/agents/historiador.md
+++ b/.claude/agents/historiador.md
@@ -11,7 +11,7 @@ La bitacora no es un changelog. Es la narrativa de como se construyo este proyec
 
 ## Al iniciar la sesion
 
-Recopila automaticamente todas las fuentes del dia (o de la fecha que el usuario especifique). Si el usuario te pasa una fecha como argumento, usala. Si no, usa hoy.
+Ejecuta **toda la recopilacion sin pedir confirmacion al usuario**. Las fuentes siempre son las mismas — no hay razon para interrumpir. Ejecuta todos los comandos de golpe, lee las field notes completas, lee los ultimos 2 dias de bitacora, y luego presenta el resumen.
 
 ```bash
 # Fecha de trabajo
@@ -99,11 +99,37 @@ El archivo destino es `docs/bitacora/YYYY-MM-DD.md`. Sigue el formato establecid
 
 ## Al terminar
 
-Despues de escribir la entrada, pregunta:
-- "Quieres que mueva las field notes de hoy a `docs/bitacora/field-notes/procesadas/`?"
-- "Hago el commit?"
+Despues de que el usuario aprueba el borrador de la entrada, ejecuta el **cierre atomico**. Antes de empezar, muestra un unico mensaje de confirmacion:
 
-Si el usuario confirma el commit:
+> "Voy a escribir la entrada de bitacora, mover las field notes a `procesadas/` y hacer commit + push. Listo?"
+
+Espera la confirmacion del usuario. Una vez confirmado, ejecuta toda la secuencia **sin interrupciones adicionales**:
+
+### 1. Escribir la entrada de bitacora
+
+Escribe el archivo `docs/bitacora/YYYY-MM-DD.md` con el contenido aprobado.
+
+### 2. Mover field notes a procesadas
+
+Usa `git mv` para que las eliminaciones y adiciones queden stageadas en una sola operacion:
+
+```bash
+mkdir -p docs/bitacora/field-notes/procesadas
+git mv docs/bitacora/field-notes/${FECHA}-*.md docs/bitacora/field-notes/procesadas/
+```
+
+Si `git mv` con glob falla, usa la alternativa: `mv` seguido de `git add` de **ambas rutas** (origen y destino):
+
+```bash
+mkdir -p docs/bitacora/field-notes/procesadas
+mv docs/bitacora/field-notes/${FECHA}-*.md docs/bitacora/field-notes/procesadas/
+git add docs/bitacora/field-notes/ docs/bitacora/field-notes/procesadas/
+```
+
+### 3. Commit con todos los cambios
+
+Un solo commit que incluya la entrada de bitacora y los movimientos de field notes:
+
 ```bash
 git add docs/bitacora/YYYY-MM-DD.md
 git commit -m "docs(bitacora): entrada del YYYY-MM-DD — [titulo]
@@ -111,10 +137,10 @@ git commit -m "docs(bitacora): entrada del YYYY-MM-DD — [titulo]
 Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
 ```
 
-Si mueve las field notes:
+### 4. Push a la rama actual
+
 ```bash
-mkdir -p docs/bitacora/field-notes/procesadas
-mv docs/bitacora/field-notes/YYYY-MM-DD-*.md docs/bitacora/field-notes/procesadas/
+git push
 ```
 
-Y agrega esos movimientos al mismo commit si el usuario lo prefiere.
+Push simple a la rama actual (main), sin force.


### PR DESCRIPTION
## Resumen

Pipeline tooling completado:
- Writer: implementacion de la tarea
- Reviewer: revision de calidad

## Decisiones del pipeline

<details>
<summary>Writer -- 2m 50s</summary>

# Stage 1 - Writer: Issue #69

## Archivo modificado
- `.claude/agents/historiador.md`

## Cambios realizados

### Seccion "Al iniciar la sesion" (CA-1)
- Reemplazado texto generico por instruccion explicita: **"Ejecuta toda la recopilacion sin pedir confirmacion al usuario"**
- Los comandos de recopilacion no cambiaron — solo se agrego la directiva de ejecutarlos sin interrumpir

### Seccion "Al terminar" (CA-2, CA-3, CA-4, CA-5)
- Eliminadas las preguntas separadas ("Quieres mover?", "Hago commit?")
- Reemplazadas por un **cierre atomico** con una sola confirmacion previa
- Secuencia post-confirmacion: escribir entrada -> git mv field notes -> commit unico -> push
- Usa `git mv` para stagear eliminaciones y adiciones atomicamente (CA-4)
- Incluye fallback a `mv` + `git add` de ambas rutas si git mv con glob falla
- Push simple sin force a la rama actual (CA-5)

## Criterios de aceptacion
- [x] CA-1: Recopilacion sin pedir confirmacion
- [x] CA-2: Secuencia atomica de cierre
- [x] CA-3: Unica pregunta de confirmacion previa
- [x] CA-4: Commit unico con entrada + movimientos de field notes
- [x] CA-5: Push sin force a rama actual

</details>

<details>
<summary>Reviewer -- 1m 52s</summary>

# Stage 2 - Reviewer Summary

## Issue: #69 - Hacer lecturas iniciales y cierre del historiador no-interactivos

## Veredicto: APROBADO sin correcciones

## Criterios de aceptacion

| CA | Estado | Detalle |
|----|--------|---------|
| CA-1 | ok | Linea 14: instruccion explicita de ejecutar recopilacion sin pedir confirmacion |
| CA-2 | ok | Seccion Al terminar reestructurada como secuencia atomica de 4 pasos |
| CA-3 | ok | Mensaje unico de confirmacion en linea 104 antes de ejecutar el cierre |
| CA-4 | ok | Usa git mv (stagea eliminaciones+adiciones); fallback con mv + git add de ambas rutas |
| CA-5 | ok | git push simple sin force a rama actual |

## Revision de calidad

- Consistencia de rutas: docs/bitacora/field-notes/procesadas/ consistente con CLAUDE.md y bitacora existente
- Patron de glob: FECHA-*.md coincide con nombres reales de field notes
- Modelo del agente: se mantiene sonnet
- Co-Authored-By: usa Claude Sonnet 4.6
- Fallback robusto: alternativa mv + git add de ambas rutas si git mv con glob falla

## Correcciones aplicadas

Ninguna. El codigo del writer cumple todos los criterios y es consistente con los patrones del proyecto.

</details>

## Commits

b7a4bcb hacer lecturas iniciales y cierre del historiador no-interactivos

Closes #69