### PR TITLE
Agregar ServiceBusEndpointBase y ServiceBusDeserializador al domain-scaffolder

### DIFF
--- a/.claude/agents/domain-scaffolder.md
+++ b/.claude/agents/domain-scaffolder.md
@@ -341,7 +341,7 @@ public static class ServiceBusDeserializador
     public static T Deserializar<T>(BinaryData body)
         => JsonSerializer.Deserialize<T>(body.ToString(), Opciones)
            ?? throw new InvalidOperationException(
-               \$"No se pudo deserializar el mensaje como {typeof(T).Name}");
+               $"No se pudo deserializar el mensaje como {typeof(T).Name}");
 }
 ```
 

--- a/.claude/agents/domain-scaffolder.md
+++ b/.claude/agents/domain-scaffolder.md
@@ -319,6 +319,76 @@ public class RequestValidator(IServiceProvider serviceProvider) : IRequestValida
 }
 ```
 
+**11b. Crear el `ServiceBusDeserializador.cs` en `Infraestructura/`:**
+
+```csharp
+using System.Text.Json;
+
+namespace Bitakora.ControlAsistencia.{PascalCase}.Infraestructura;
+
+/// <summary>
+/// Helper para deserializar mensajes de Service Bus con opciones correctas.
+/// Wolverine serializa con camelCase; ToObjectFromJson sin opciones usa
+/// PascalCase (case-sensitive), lo que causa que todas las propiedades queden null.
+/// </summary>
+public static class ServiceBusDeserializador
+{
+    private static readonly JsonSerializerOptions Opciones = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    public static T Deserializar<T>(BinaryData body)
+        => JsonSerializer.Deserialize<T>(body.ToString(), Opciones)
+           ?? throw new InvalidOperationException(
+               \$"No se pudo deserializar el mensaje como {typeof(T).Name}");
+}
+```
+
+**11c. Crear el `ServiceBusEndpointBase.cs` en `Infraestructura/`:**
+
+```csharp
+using Azure.Messaging.ServiceBus;
+using Cosmos.EventSourcing.Abstractions.Commands;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+
+namespace Bitakora.ControlAsistencia.{PascalCase}.Infraestructura;
+
+/// <summary>
+/// Clase base para FunctionEndpoints de ServiceBus.
+/// Encapsula la orquestacion: deserializar -> despachar al command router -> complete/lock-lost/dead-letter.
+/// Cada endpoint concreto hereda, define [Function] + [ServiceBusTrigger] y delega a <see cref="ProcesarMensaje"/>.
+/// </summary>
+public abstract class ServiceBusEndpointBase<TEvento>(ICommandRouter commandRouter, ILogger logger)
+    where TEvento : class
+{
+    protected async Task ProcesarMensaje(
+        ServiceBusReceivedMessage message,
+        ServiceBusMessageActions messageActions,
+        CancellationToken ct)
+    {
+        try
+        {
+            var evento = ServiceBusDeserializador.Deserializar<TEvento>(message.Body);
+            await commandRouter.InvokeAsync(evento, ct);
+            await messageActions.CompleteMessageAsync(message, ct);
+        }
+        catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.MessageLockLost)
+        {
+            logger.LogWarning(ex,
+                "Lock perdido para mensaje {MessageId} - Service Bus lo re-entregara automaticamente",
+                message.MessageId);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error procesando mensaje {MessageId}", message.MessageId);
+            await messageActions.DeadLetterMessageAsync(message, cancellationToken: ct);
+        }
+    }
+}
+```
+
 **12. Crear el HealthCheck en `HealthCheck.cs` (raiz del proyecto):**
 
 ```csharp
@@ -405,6 +475,190 @@ Y agregar en su lugar (en el mismo `<ItemGroup>` o en uno nuevo):
   <Using Include="Xunit" />
 </ItemGroup>
 ```
+
+**6. Crear `Infraestructura/ServiceBusEndpointBaseTests.cs`:**
+
+Tests de la orquestacion generica de `ServiceBusEndpointBase`. Cubren los 4 escenarios: camino feliz, lock perdido, error generico y JSON invalido.
+
+```bash
+mkdir -p "$REPO_ROOT/tests/Bitakora.ControlAsistencia.{PascalCase}.Tests/Infraestructura"
+```
+
+```csharp
+using AwesomeAssertions;
+using Azure.Messaging.ServiceBus;
+using Bitakora.ControlAsistencia.{PascalCase}.Infraestructura;
+using Cosmos.EventSourcing.Abstractions.Commands;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+
+namespace Bitakora.ControlAsistencia.{PascalCase}.Tests.Infraestructura;
+
+public class ServiceBusEndpointBaseTests
+{
+    private const string JsonValido = """{"nombre": "test"}""";
+
+    private static ServiceBusReceivedMessage CrearMensaje(string json = JsonValido)
+        => ServiceBusModelFactory.ServiceBusReceivedMessage(body: BinaryData.FromString(json));
+
+    // Camino feliz: deserializa, despacha al command router, completa el mensaje
+    [Fact]
+    public async Task DebeCompletarMensaje_CuandoProcesamientoEsExitoso()
+    {
+        var router = new FakeCommandRouter();
+        var actions = new FakeServiceBusMessageActions();
+        var endpoint = new StubEndpoint(router, new FakeLogger());
+
+        await endpoint.Procesar(CrearMensaje(), actions, CancellationToken.None);
+
+        actions.MensajeCompletado.Should().BeTrue();
+        actions.MensajeEnDeadLetter.Should().BeFalse();
+    }
+
+    // Lock perdido -> log warning, NO dead-letter
+    [Fact]
+    public async Task DebeLoguearWarning_CuandoSePierdeLock()
+    {
+        var lockLost = new ServiceBusException(
+            "Lock expirado", ServiceBusFailureReason.MessageLockLost);
+        var router = new FakeCommandRouter();
+        var actions = new FakeServiceBusMessageActions(excepcionAlCompletar: lockLost);
+        var logger = new FakeLogger();
+        var endpoint = new StubEndpoint(router, logger);
+
+        await endpoint.Procesar(CrearMensaje(), actions, CancellationToken.None);
+
+        actions.MensajeEnDeadLetter.Should().BeFalse("el lock ya no es valido, no se puede dead-letter");
+        logger.WarningLogueado.Should().BeTrue();
+    }
+
+    // Error generico -> dead-letter el mensaje
+    [Fact]
+    public async Task DebeEnviarADeadLetter_CuandoOcurreErrorGenerico()
+    {
+        var router = new FakeCommandRouter(
+            excepcion: new InvalidOperationException("Error inesperado"));
+        var actions = new FakeServiceBusMessageActions();
+        var endpoint = new StubEndpoint(router, new FakeLogger());
+
+        await endpoint.Procesar(CrearMensaje(), actions, CancellationToken.None);
+
+        actions.MensajeEnDeadLetter.Should().BeTrue();
+        actions.MensajeCompletado.Should().BeFalse();
+    }
+
+    // JSON invalido -> dead-letter (error de deserializacion)
+    [Fact]
+    public async Task DebeEnviarADeadLetter_CuandoJsonEsInvalido()
+    {
+        var router = new FakeCommandRouter();
+        var actions = new FakeServiceBusMessageActions();
+        var endpoint = new StubEndpoint(router, new FakeLogger());
+
+        await endpoint.Procesar(CrearMensaje("no-es-json"), actions, CancellationToken.None);
+
+        actions.MensajeEnDeadLetter.Should().BeTrue();
+        actions.MensajeCompletado.Should().BeFalse();
+    }
+}
+
+// ---- Stub concreto minimo para testear la clase base ----
+
+internal record EventoStub(string? Nombre);
+
+internal class StubEndpoint(ICommandRouter commandRouter, ILogger logger)
+    : ServiceBusEndpointBase<EventoStub>(commandRouter, logger)
+{
+    public Task Procesar(
+        ServiceBusReceivedMessage message,
+        ServiceBusMessageActions actions,
+        CancellationToken ct)
+        => ProcesarMensaje(message, actions, ct);
+}
+
+// ---- Fakes manuales - NO NSubstitute ----
+
+internal class FakeCommandRouter : ICommandRouter
+{
+    private readonly Exception? _excepcion;
+
+    public FakeCommandRouter(Exception? excepcion = null) => _excepcion = excepcion;
+
+    public Task InvokeAsync<TCommand>(TCommand command, CancellationToken ct = default)
+        where TCommand : class
+    {
+        if (_excepcion is not null) throw _excepcion;
+        return Task.CompletedTask;
+    }
+
+    public Task<TResult> InvokeAsync<TCommand, TResult>(TCommand command, CancellationToken ct = default)
+        where TCommand : class
+        => throw new NotImplementedException();
+}
+
+internal class FakeServiceBusMessageActions : ServiceBusMessageActions
+{
+    private readonly Exception? _excepcionAlCompletar;
+
+    public bool MensajeCompletado { get; private set; }
+    public bool MensajeEnDeadLetter { get; private set; }
+
+    public FakeServiceBusMessageActions(Exception? excepcionAlCompletar = null)
+        => _excepcionAlCompletar = excepcionAlCompletar;
+
+    public override Task CompleteMessageAsync(
+        ServiceBusReceivedMessage message, CancellationToken cancellationToken = default)
+    {
+        if (_excepcionAlCompletar is not null) throw _excepcionAlCompletar;
+        MensajeCompletado = true;
+        return Task.CompletedTask;
+    }
+
+    public override Task DeadLetterMessageAsync(
+        ServiceBusReceivedMessage message,
+        Dictionary<string, object>? propertiesToModify = null,
+        string? deadLetterReason = null,
+        string? deadLetterErrorDescription = null,
+        CancellationToken cancellationToken = default)
+    {
+        MensajeEnDeadLetter = true;
+        return Task.CompletedTask;
+    }
+
+    public override Task AbandonMessageAsync(
+        ServiceBusReceivedMessage message,
+        IDictionary<string, object>? propertiesToModify = null,
+        CancellationToken cancellationToken = default)
+        => throw new NotImplementedException();
+
+    public override Task DeferMessageAsync(
+        ServiceBusReceivedMessage message,
+        IDictionary<string, object>? propertiesToModify = null,
+        CancellationToken cancellationToken = default)
+        => throw new NotImplementedException();
+
+    public override Task RenewMessageLockAsync(
+        ServiceBusReceivedMessage message,
+        CancellationToken cancellationToken = default)
+        => throw new NotImplementedException();
+}
+
+internal class FakeLogger : ILogger
+{
+    public bool WarningLogueado { get; private set; }
+
+    public void Log<TState>(
+        LogLevel logLevel, EventId eventId, TState state,
+        Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        if (logLevel == LogLevel.Warning) WarningLogueado = true;
+    }
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+}
+```
+
 
 ---
 
@@ -1228,9 +1482,12 @@ Scaffold completado para el dominio "{kebab}":
     Program.cs                             - JSON global, IRequestValidator, FluentValidation
     HealthCheck.cs                         - Trigger HTTP de health check (raiz del proyecto)
     Infraestructura/RequestValidator.cs    - IRequestValidator + implementacion
+    Infraestructura/ServiceBusDeserializador.cs - Helper de deserializacion case-insensitive
+    Infraestructura/ServiceBusEndpointBase.cs   - Clase base para endpoints de ServiceBus
     Entities/                              - AggregateRoots y eventos del dominio (siempre raiz)
 
   tests/Bitakora.ControlAsistencia.{PascalCase}.Tests/
+    Infraestructura/ServiceBusEndpointBaseTests.cs - Tests de orquestacion (feliz, lock-lost, dead-letter, JSON invalido)
                                            - Proyecto de tests unitarios (xUnit v3 + AwesomeAssertions)
 
   tests/Bitakora.ControlAsistencia.{PascalCase}.SmokeTests/


### PR DESCRIPTION
## Resumen

Pipeline tooling completado:
- Writer: implementacion de la tarea
- Reviewer: revision de calidad

## Decisiones del pipeline

<details>
<summary>Writer -- 3m 34s</summary>

# Stage 1 - Writer Summary

## Issue: #70 - Agregar ServiceBusEndpointBase y ServiceBusDeserializador al domain-scaffolder

## Archivo modificado

- `.claude/agents/domain-scaffolder.md`

## Cambios realizados

### Paso 11b - ServiceBusDeserializador.cs
Template para generar Infraestructura/ServiceBusDeserializador.cs en cada dominio nuevo.

### Paso 11c - ServiceBusEndpointBase.cs
Template para generar Infraestructura/ServiceBusEndpointBase.cs.

### Paso 2.6 - ServiceBusEndpointBaseTests.cs
Template con 4 tests + StubEndpoint + fakes manuales. Sin comentario HU-67.

### Seccion Resultado final
Lista los 3 archivos nuevos.

## Criterios de aceptacion
- [x] CA-1: ServiceBusDeserializador.cs con namespace correcto
- [x] CA-2: ServiceBusEndpointBase.cs con namespace correcto
- [x] CA-3: ServiceBusEndpointBaseTests.cs con 4 tests y fakes
- [x] CA-4: Seccion Resultado final actualizada

</details>

<details>
<summary>Reviewer -- 2m 54s</summary>

# Stage 2 - Reviewer: Issue #70

## Veredicto: APROBADO con 1 correccion

## Criterios de aceptacion

- [x] CA-1: El scaffolder genera ServiceBusDeserializador.cs con namespace {PascalCase} correcto
- [x] CA-2: El scaffolder genera ServiceBusEndpointBase.cs con namespace {PascalCase} correcto
- [x] CA-3: El scaffolder genera ServiceBusEndpointBaseTests.cs con 4 tests y fakes, namespaces correctos
- [x] CA-4: La seccion Resultado final lista los 3 archivos nuevos

## Revision de calidad

### Fidelidad con archivos de referencia
- ServiceBusDeserializador.cs: coincide exactamente con la fuente en ControlHoras (solo namespace cambiado)
- ServiceBusEndpointBase.cs: coincide exactamente con la fuente en ControlHoras
- ServiceBusEndpointBaseTests.cs: coincide con la fuente, correctamente omite // HU-67: y (regresion issue #48)

### Ubicacion de los pasos
- Paso 11b y 11c: correctamente despues de paso 11 (RequestValidator), antes de paso 12 (HealthCheck)
- Paso 6 de tests: dentro de la seccion de proyecto de tests, incluye mkdir -p
- Seccion Resultado final: actualizada con los 3 archivos nuevos

### Naming y patrones
- Sigue el patron existente de copiar infraestructura por dominio (consistente con RequestValidator)
- Naming en espanol consistente con el resto del proyecto
- Fakes manuales sin NSubstitute (consistente con ControlHoras.Tests)

## Correccion aplicada

1. Dollar sign escapado (domain-scaffolder.md:344): el writer introdujo backslash-dollar en la string interpolation del template de ServiceBusDeserializador. Corregido a dollar sin escape.

## Compilacion y tests

- Build: 0 errores, 1 warning pre-existente (CS0414 en Programacion)
- Tests: 133 total, 130 correctos, 3 omitidos, 0 errores

</details>

## Commits

d75f496 fix(scaffolder): corregir dollar sign escapado en template de ServiceBusDeserializador
f45a169 agregar ServiceBusEndpointBase y ServiceBusDeserializador al domain-scaffolder

Closes #70