### PR TITLE
Agregar comando KQL ad-hoc con guardrails al script de queries

### DIFF
--- a/.claude/agents/bug-investigator.md
+++ b/.claude/agents/bug-investigator.md
@@ -64,7 +64,14 @@ Con los datos de App Insights en mano:
 2. **Mapea el flujo**: identifica que funcion, comando o evento esta involucrado
 3. **Investiga errores desconocidos**: si el error es de una libreria, framework o servicio externo, usa WebSearch y WebFetch para buscar la causa conocida. Cita las fuentes.
 4. **Revisa cambios recientes**: consulta el historial git para ver si hay commits recientes en los archivos afectados
-5. **Revisa configuracion de messaging**: si el problema involucra Service Bus, lee el `host.json` del dominio afectado para verificar `prefetchCount`, `maxConcurrentCalls`, `lockDuration` (leccion de Bug #47/#48)
+5. **Query ad-hoc (si las predefinidas no alcanzan)**: si las queries del Stage 1 no contienen la informacion necesaria para correlacionar, puedes usar el comando `custom` con una query KQL minima. Principios: filtrar agresivamente con `where`, usar `take 10`, preferir `summarize` sobre `project`. Maximo 3 queries custom por sesion de investigacion.
+
+```bash
+# Ejemplo: contar eventos procesados de un tipo especifico
+./scripts/appinsights-query.sh custom "customEvents | where name == 'ProgramacionTurnoDiarioSolicitada' | summarize count() by bin(timestamp, 10m)"
+```
+
+6. **Revisa configuracion de messaging**: si el problema involucra Service Bus, lee el `host.json` del dominio afectado para verificar `prefetchCount`, `maxConcurrentCalls`, `lockDuration` (leccion de Bug #47/#48)
 
 ```bash
 # Ejemplo: ver commits recientes en un archivo sospechoso

--- a/.gitignore
+++ b/.gitignore
@@ -489,6 +489,9 @@ $RECYCLE.BIN/
 # Pipeline TDD
 .claude/pipeline/
 
+# KQL audit log (queries ad-hoc del bug-investigator)
+scripts/.kql-audit.log
+
 # Terraform
 **/.terraform/
 *.tfstate

--- a/docs/adr/0019-kql-ad-hoc-con-guardrails.md
+++ b/docs/adr/0019-kql-ad-hoc-con-guardrails.md
@@ -1,0 +1,62 @@
+# ADR-0019: KQL ad-hoc con guardrails
+
+**Fecha**: 2026-04-13
+**Estado**: Aceptado
+
+---
+
+## Contexto
+
+ADR-0009 establecio un daily cap de 0.5GB en App Insights y restringio las consultas a 5 queries
+KQL predefinidas en `scripts/appinsights-query.sh`. Esto fue una reaccion correcta al incidente
+de $350 USD en 3 dias por logging excesivo.
+
+Sin embargo, la experiencia con el agente `bug-investigator` ha mostrado que en ~10% de
+investigaciones las queries predefinidas no contienen la informacion necesaria. El agente queda
+ciego ante preguntas especificas (ej: "cuantos eventos ProgramacionTurnoDiarioSolicitada se
+procesaron en la ultima hora?"). Esta limitacion degrada la capacidad diagnostica sin un beneficio
+proporcional en control de costos -- una query ad-hoc con `take 20` y ventana de 1h tiene impacto
+marginal vs el daily cap de 0.5GB.
+
+Las 4 capas defensivas de ADR-0009 (log levels, sampling, daily cap, alertas) siguen intactas.
+Esta decision solo relaja la restriccion de "solo queries predefinidas".
+
+## Decision
+
+Se permite KQL ad-hoc a traves de un nuevo comando `custom` en `scripts/appinsights-query.sh`,
+con guardrails automaticos inyectados por el script:
+
+1. **Take forzado**: si la query no contiene `take` (case-insensitive), se inyecta `| take 20`
+   al final. Esto limita el volumen de resultados devueltos.
+
+2. **Ventana temporal forzada**: si la query no contiene `ago(`, se inyecta
+   `| where timestamp > ago(1h)` como filtro. Las queries predefinidas usan 24h; la ventana
+   reducida de 1h limita el volumen de datos escaneados.
+
+3. **Warning visible**: se imprime `ADVERTENCIA: query ad-hoc. Daily cap: 0.5GB. Ver ADR-0009.`
+   en stderr antes de ejecutar. Esto es visible tanto para humanos como para agentes.
+
+4. **Audit log**: cada ejecucion se registra en `scripts/.kql-audit.log` con timestamp y query
+   final (con guardrails aplicados). El archivo esta en `.gitignore`.
+
+El agente `bug-investigator` puede usar hasta 3 queries custom por sesion, solo en Stage 2
+(Correlacion), cuando las queries predefinidas del Stage 1 no contengan la informacion necesaria.
+
+## Consecuencias
+
+**Positivas**
+
+- El agente `bug-investigator` gana flexibilidad diagnostica en el ~10% de casos donde las
+  queries predefinidas son insuficientes.
+- Los guardrails automaticos evitan queries costosas sin depender de la disciplina del invocador.
+- El audit log permite detectar patrones de uso excesivo o abuso.
+- Las 4 capas defensivas de ADR-0009 permanecen intactas.
+
+**Negativas**
+
+- Riesgo marginal de costo: una query con `take 20` y ventana de 1h escanea mas datos que cero,
+  pero el impacto es despreciable frente al daily cap de 0.5GB.
+- La inyeccion de `where timestamp > ago(1h)` es heuristica: si la query ya filtra por otro
+  campo temporal, el filtro adicional es redundante pero no danino.
+- El limite de 3 queries por sesion depende de la disciplina del agente (no esta enforceado
+  por el script).

--- a/scripts/appinsights-query.sh
+++ b/scripts/appinsights-query.sh
@@ -65,6 +65,10 @@ if [ -z "$COMMAND" ]; then
     echo "  traces             Traces (usar con --filter para filtrar)"
     echo "  health-summary     Vista rapida: excepciones + requests fallidas + disponibilidad"
     echo ""
+    echo "Comandos ad-hoc:"
+    echo "  custom \"QUERY\"    Query KQL ad-hoc con guardrails (take 20, ventana 1h)"
+    echo "                     Ej: custom \"exceptions | where type has 'NullRef' | take 5\""
+    echo ""
     echo "Comandos Azure Resource Manager:"
     echo "  servicebus-dlq     Conteo de dead letters por subscription en Service Bus"
     echo "  servicebus-dlq-peek  Peek a mensajes en DLQ sin consumirlos (max 5)"
@@ -77,6 +81,13 @@ if [ -z "$COMMAND" ]; then
 fi
 
 shift
+
+# Capturar argumento posicional para el comando custom
+CUSTOM_ARG=""
+if [ "$COMMAND" = "custom" ] && [[ $# -gt 0 ]] && [[ "$1" != --* ]]; then
+    CUSTOM_ARG="$1"
+    shift
+fi
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -393,6 +404,34 @@ for f in funcs:
         done
 
         success "Consulta de estado de Functions completada"
+        ;;
+
+    custom)
+        CUSTOM_QUERY="$CUSTOM_ARG"
+        if [ -z "$CUSTOM_QUERY" ]; then
+            error "El comando 'custom' requiere una query KQL como argumento"
+            echo "  Ejemplo: ./scripts/appinsights-query.sh custom \"exceptions | where type has 'NullRef' | take 5\""
+            exit 1
+        fi
+
+        # Advertencia de daily cap en stderr
+        echo -e "${YELLOW}ADVERTENCIA: query ad-hoc. Daily cap: 0.5GB. Ver ADR-0009.${NC}" >&2
+
+        # Guardrail: inyectar ventana temporal si no contiene ago(
+        if ! echo "$CUSTOM_QUERY" | grep -qi 'ago('; then
+            CUSTOM_QUERY=$(echo "$CUSTOM_QUERY" | sed 's/|/| where timestamp > ago(1h) |/' )
+        fi
+
+        # Guardrail: inyectar take si no contiene take
+        if ! echo "$CUSTOM_QUERY" | grep -qi 'take'; then
+            CUSTOM_QUERY="$CUSTOM_QUERY | take 20"
+        fi
+
+        # Audit log
+        AUDIT_LOG="$SCRIPT_DIR/.kql-audit.log"
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] QUERY: $CUSTOM_QUERY" >> "$AUDIT_LOG"
+
+        run_query "$CUSTOM_QUERY" "Query ad-hoc"
         ;;
 
     *)

--- a/scripts/appinsights-query.sh
+++ b/scripts/appinsights-query.sh
@@ -419,7 +419,13 @@ for f in funcs:
 
         # Guardrail: inyectar ventana temporal si no contiene ago(
         if ! echo "$CUSTOM_QUERY" | grep -qi 'ago('; then
-            CUSTOM_QUERY=$(echo "$CUSTOM_QUERY" | sed 's/|/| where timestamp > ago(1h) |/' )
+            if echo "$CUSTOM_QUERY" | grep -q '|'; then
+                # Insertar despues del primer pipe: "tabla | where timestamp > ago(1h) | resto"
+                CUSTOM_QUERY=$(echo "$CUSTOM_QUERY" | sed 's/|/| where timestamp > ago(1h) |/')
+            else
+                # Query sin pipes (ej: "exceptions"): agregar filtro al final
+                CUSTOM_QUERY="$CUSTOM_QUERY | where timestamp > ago(1h)"
+            fi
         fi
 
         # Guardrail: inyectar take si no contiene take
@@ -431,6 +437,7 @@ for f in funcs:
         AUDIT_LOG="$SCRIPT_DIR/.kql-audit.log"
         echo "[$(date '+%Y-%m-%d %H:%M:%S')] QUERY: $CUSTOM_QUERY" >> "$AUDIT_LOG"
 
+        HOURS=1  # Reflejar la ventana real en el log de run_query
         run_query "$CUSTOM_QUERY" "Query ad-hoc"
         ;;
 


### PR DESCRIPTION
## Resumen

Pipeline tooling completado:
- Writer: implementacion de la tarea
- Reviewer: revision de calidad

## Decisiones del pipeline

<details>
<summary>Writer -- 4m 41s</summary>

_(El agente no genero resumen)_

</details>

<details>
<summary>Reviewer -- 2m 19s</summary>

# Stage 2 - Reviewer Summary

**Issue**: #64 - Agregar comando KQL ad-hoc con guardrails
**Fecha**: 2026-04-13

## Verificacion de criterios de aceptacion

| CA | Estado | Nota |
|----|--------|------|
| CA-1 | OK | El comando custom delega a run_query existente |
| CA-2 | OK | Inyeccion de take 20 cuando no existe (case-insensitive) |
| CA-3 | OK (corregido) | Inyeccion de ago(1h) - faltaba manejar queries sin pipes |
| CA-4 | OK | Audit log en scripts/.kql-audit.log con formato correcto |
| CA-5 | OK | Warning en stderr con colores |
| CA-6 | OK | Seccion Comandos ad-hoc en la ayuda |
| CA-7 | OK | Punto 5 en Stage 2 del bug-investigator con limite de 3 queries |
| CA-8 | OK | ADR-0019 completo con referencia a ADR-0009 |

## Bugs corregidos

### 1. Guardrail de ventana temporal falla sin pipes (critico)

Problema: sed no hace nada si la query no tiene pipes (ej: custom "exceptions").
El guardrail de ventana temporal falla silenciosamente.

Fix: Bifurcar: si hay pipes, usar sed; si no hay pipes, append directo de where timestamp > ago(1h).

### 2. Log enganoso en run_query (menor)

Problema: run_query imprime "ultimas 24h" pero la ventana real es ago(1h).

Fix: Asignar HOURS=1 antes de llamar a run_query.

## Calidad general

- Reutilizacion: el comando custom reutiliza run_query correctamente.
- ADR-0019: bien estructurado, referencia ADR-0009.
- bug-investigator.md: instruccion bien posicionada en Stage 2.
- .gitignore: entrada correcta para el audit log.
- Naming y estilo: consistente con el resto del script.

</details>

## Commits

6954307 Corregir guardrail de ventana temporal para queries sin pipes y log engañoso
7f2ec96 Agregar comando KQL ad-hoc con guardrails al script de queries

Closes #64