### PR TITLE
Purgar suscripción smoke-tests antes del Act y fallar ante mensajes inesperados

### DIFF
--- a/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/Bitakora.ControlAsistencia.Programacion.SmokeTests.csproj
+++ b/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/Bitakora.ControlAsistencia.Programacion.SmokeTests.csproj
@@ -27,6 +27,7 @@
   <ItemGroup>
     <Content Include="appsettings.json" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="appsettings.local.json" CopyToOutputDirectory="PreserveNewest" Condition="Exists('appsettings.local.json')" />
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>

--- a/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/Fixtures/ServiceBusFixture.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/Fixtures/ServiceBusFixture.cs
@@ -73,19 +73,22 @@ public class ServiceBusFixture : IAsyncLifetime
             try
             {
                 var deserialized = JsonSerializer.Deserialize<T>(received.Body.ToString(), options);
-                if (deserialized is not null && match(deserialized))
+                if (deserialized is null)
+                {
+                    await receiver.CompleteMessageAsync(received);
+                    continue;
+                }
+
+                if (match(deserialized))
                 {
                     await receiver.CompleteMessageAsync(received);
                     return deserialized;
                 }
 
-                if (deserialized is not null)
-                {
-                    await receiver.CompleteMessageAsync(received);
-                    throw new InvalidOperationException(
-                        $"Llego mensaje de tipo {typeof(T).Name} pero no cumplio el predicado. " +
-                        $"Contenido: {received.Body}");
-                }
+                await receiver.CompleteMessageAsync(received);
+                throw new InvalidOperationException(
+                    $"Llego mensaje de tipo {typeof(T).Name} pero no cumplio el predicado. " +
+                    $"Contenido: {received.Body}");
             }
             catch (JsonException)
             {

--- a/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/Fixtures/ServiceBusFixture.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/Fixtures/ServiceBusFixture.cs
@@ -32,7 +32,22 @@ public class ServiceBusFixture : IAsyncLifetime
         return ValueTask.CompletedTask;
     }
 
-    public async Task<T?> WaitForMessageAsync<T>(
+    public async Task PurgeAsync(string topicName, string subscriptionName)
+    {
+        await using var receiver = _client!.CreateReceiver(topicName, subscriptionName);
+        var maxWait = TimeSpan.FromSeconds(2);
+
+        while (true)
+        {
+            var message = await receiver.ReceiveMessageAsync(maxWait);
+            if (message is null)
+                break;
+
+            await receiver.CompleteMessageAsync(message);
+        }
+    }
+
+    public async Task<T> WaitForMessageAsync<T>(
         string topicName,
         string subscriptionName,
         Func<T, bool> match,
@@ -63,17 +78,25 @@ public class ServiceBusFixture : IAsyncLifetime
                     await receiver.CompleteMessageAsync(received);
                     return deserialized;
                 }
+
+                if (deserialized is not null)
+                {
+                    await receiver.CompleteMessageAsync(received);
+                    throw new InvalidOperationException(
+                        $"Llego mensaje de tipo {typeof(T).Name} pero no cumplio el predicado. " +
+                        $"Contenido: {received.Body}");
+                }
             }
             catch (JsonException)
             {
-                // Mensaje con formato incompatible, ignorar
+                await receiver.CompleteMessageAsync(received);
+                continue;
             }
-
-            // Mensaje de otro test o formato distinto, abandonar para que vuelva a la cola
-            await receiver.AbandonMessageAsync(received);
         }
 
-        return default;
+        throw new TimeoutException(
+            $"No se recibio ningun mensaje en la suscripcion {subscriptionName} " +
+            $"del topic {topicName} en {timeout.TotalSeconds}s");
     }
 
     public async Task<IReadOnlyList<ServiceBusReceivedMessage>> PeekDeadLetterMessagesAsync(

--- a/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoSbSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoSbSmokeTests.cs
@@ -26,6 +26,9 @@ public class SolicitarProgramacionTurnoSbSmokeTests(ApiFixture api, ServiceBusFi
 
         var ct = TestContext.Current.CancellationToken;
 
+        // Arrange: purgar mensajes preexistentes de ejecuciones anteriores
+        await serviceBus.PurgeAsync(TopicSalida, Suscripcion);
+
         // Arrange: crear turno en catalogo
         var turnoId = Guid.CreateVersion7();
         var turnoPayload = new
@@ -75,10 +78,7 @@ public class SolicitarProgramacionTurnoSbSmokeTests(ApiFixture api, ServiceBusFi
         var eventoRecibido = await serviceBus.WaitForMessageAsync<ProgramacionTurnoDiarioSolicitada>(
             TopicSalida, Suscripcion, e => e.SolicitudId == solicitudId, Timeout);
 
-        eventoRecibido.Should().NotBeNull(
-            "la Function App deberia publicar ProgramacionTurnoDiarioSolicitada al topic de Service Bus");
-
-        eventoRecibido!.SolicitudId.Should().Be(solicitudId);
+        eventoRecibido.SolicitudId.Should().Be(solicitudId);
         eventoRecibido.Fecha.Should().Be(DateOnly.Parse(fecha));
 
         var empleadoEsperado = new InformacionEmpleado(

--- a/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/xunit.runner.json
+++ b/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/xunit.runner.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "parallelizeAssembly": false,
+  "parallelizeTestCollections": false
+}


### PR DESCRIPTION
## Resumen

Pipeline tooling completado:
- Writer: implementacion de la tarea
- Reviewer: revision de calidad

## Decisiones del pipeline

<details>
<summary>Writer -- 4m 6s</summary>

# Stage 1 - Writer Summary (Issue #93)

## Cambios realizados

### ServiceBusFixture.cs
- PurgeAsync: nuevo metodo que recibe+completa mensajes preexistentes (maxWait 2s, CompleteMessageAsync)
- WaitForMessageAsync refactorizado: retorna T, lanza excepciones, elimina AbandonMessageAsync

### xunit.runner.json (nuevo)
- Deshabilita paralelismo

### SolicitarProgramacionTurnoSbSmokeTests.cs
- Agrega PurgeAsync en Arrange antes del Act HTTP

## Criterios de aceptacion: CA-1 a CA-8 implementados
## Verificacion: dotnet build exitoso

</details>

<details>
<summary>Reviewer -- 2m 40s</summary>

# Stage 2 - Reviewer

## Veredicto: APROBADO con una correccion

## Cumplimiento de criterios de aceptacion

| CA | Estado | Nota |
|----|--------|------|
| CA-1 | OK | xunit.runner.json desactiva paralelismo de assembly y collections |
| CA-2 | OK | PurgeAsync recibe+completa con maxWait 2s |
| CA-3 | OK | Diagnostico con tipo y contenido JSON al no cumplir predicado |
| CA-4 | OK | JsonException -> CompleteMessageAsync + continue |
| CA-5 | OK | TimeoutException con suscripcion, topic y segundos |
| CA-6 | OK | Cero llamadas a AbandonMessageAsync en el proyecto |
| CA-7 | OK | PurgeAsync en Arrange antes del Act HTTP |
| CA-8 | OK | Compila sin errores, logica de verificacion intacta |

## Correccion aplicada

Bug: mensaje deserializado null quedaba sin completar.
Cuando JsonSerializer.Deserialize retornaba null (JSON valido pero resultado nulo), el flujo no entraba en ninguna rama con CompleteMessageAsync. El mensaje quedaba abandonado al disponer el receiver. Corregido agregando una rama explicita para deserialized is null que completa y continua, igual que el caso de JsonException.

Commit: 3046ccd

## Compilacion

dotnet build exitoso sin errores ni advertencias. Los tests unitarios no se pudieron ejecutar por SDKs de workload faltantes en el entorno (no relacionado con los cambios).

</details>

## Commits

3046ccd Corregir mensaje deserializado null que quedaba sin completar en WaitForMessageAsync
3ff6760 Purgar suscripcion smoke-tests antes del Act y fallar ante mensajes inesperados

Closes #93