### PR TITLE
Actualizar template ServiceBusFixture del domain-scaffolder con patrón de purga

### DIFF
--- a/.claude/agents/domain-scaffolder.md
+++ b/.claude/agents/domain-scaffolder.md
@@ -775,7 +775,9 @@ public class ApiFixture : IAsyncLifetime
 
 **4. Crear `Fixtures/ServiceBusFixture.cs`:**
 
-El fixture incluye ambas variantes de interaccion con Service Bus: `PublishAsync` (para enviar comandos/eventos) y `WaitForMessageAsync` con dos overloads (por `correlationId` y por predicado `Func<T, bool>`). Usa el patron `IsConfigured` para skip graceful.
+El fixture incluye: `PurgeAsync` (para limpiar mensajes residuales antes de cada test), `PublishAsync` (para enviar comandos/eventos) y `WaitForMessageAsync` (por predicado `Func<T, bool>`). Usa el patron `IsConfigured` para skip graceful.
+
+> **Importante**: Se usa `CompleteMessageAsync` en todas las ramas (match, no-match, JsonException) en vez de `AbandonMessageAsync`. Abandonar mensajes los devuelve a la suscripcion y, tras agotar los reintentos, los envia a dead letters, acumulando basura en la suscripcion `smoke-tests`. Completar siempre evita este problema.
 
 ```csharp
 using System.Text.Json;
@@ -812,6 +814,21 @@ public class ServiceBusFixture : IAsyncLifetime
         return ValueTask.CompletedTask;
     }
 
+    public async Task PurgeAsync(string topicName, string subscriptionName)
+    {
+        await using var receiver = _client!.CreateReceiver(topicName, subscriptionName);
+        var maxWait = TimeSpan.FromSeconds(2);
+
+        while (true)
+        {
+            var message = await receiver.ReceiveMessageAsync(maxWait);
+            if (message is null)
+                break;
+
+            await receiver.CompleteMessageAsync(message);
+        }
+    }
+
     public async Task PublishAsync<T>(string topicName, T message, string? correlationId = null)
     {
         await using var sender = _client!.CreateSender(topicName);
@@ -828,41 +845,10 @@ public class ServiceBusFixture : IAsyncLifetime
         await sender.SendMessageAsync(sbMessage);
     }
 
-    public async Task<T?> WaitForMessageAsync<T>(
-        string topicName,
-        string subscriptionName,
-        string correlationId,
-        TimeSpan timeout)
-    {
-        await using var receiver = _client!.CreateReceiver(topicName, subscriptionName);
-
-        var deadline = DateTime.UtcNow + timeout;
-
-        while (DateTime.UtcNow < deadline)
-        {
-            var remaining = deadline - DateTime.UtcNow;
-            if (remaining <= TimeSpan.Zero)
-                break;
-
-            var maxWait = remaining < TimeSpan.FromSeconds(5) ? remaining : TimeSpan.FromSeconds(5);
-            var received = await receiver.ReceiveMessageAsync(maxWait);
-
-            if (received is null)
-                continue;
-
-            if (received.CorrelationId == correlationId)
-            {
-                await receiver.CompleteMessageAsync(received);
-                return JsonSerializer.Deserialize<T>(received.Body.ToString());
-            }
-
-            await receiver.AbandonMessageAsync(received);
-        }
-
-        return default;
-    }
-
-    public async Task<T?> WaitForMessageAsync<T>(
+    // Se usa CompleteMessageAsync en todas las ramas para evitar acumulacion
+    // de dead letters en la suscripcion smoke-tests. AbandonMessageAsync devuelve
+    // el mensaje a la cola y, tras agotar reintentos, lo envia a dead letters.
+    public async Task<T> WaitForMessageAsync<T>(
         string topicName,
         string subscriptionName,
         Func<T, bool> match,
@@ -888,21 +874,33 @@ public class ServiceBusFixture : IAsyncLifetime
             try
             {
                 var deserialized = JsonSerializer.Deserialize<T>(received.Body.ToString(), options);
-                if (deserialized is not null && match(deserialized))
+                if (deserialized is null)
+                {
+                    await receiver.CompleteMessageAsync(received);
+                    continue;
+                }
+
+                if (match(deserialized))
                 {
                     await receiver.CompleteMessageAsync(received);
                     return deserialized;
                 }
+
+                await receiver.CompleteMessageAsync(received);
+                throw new InvalidOperationException(
+                    $"Llego mensaje de tipo {typeof(T).Name} pero no cumplio el predicado. " +
+                    $"Contenido: {received.Body}");
             }
             catch (JsonException)
             {
-                // Mensaje con formato incompatible, ignorar
+                await receiver.CompleteMessageAsync(received);
+                continue;
             }
-
-            await receiver.AbandonMessageAsync(received);
         }
 
-        return default;
+        throw new TimeoutException(
+            $"No se recibio ningun mensaje en la suscripcion {subscriptionName} " +
+            $"del topic {topicName} en {timeout.TotalSeconds}s");
     }
 
     public async Task<IReadOnlyList<ServiceBusReceivedMessage>> PeekDeadLetterMessagesAsync(
@@ -1153,6 +1151,7 @@ public static class Polling
 ```csharp
 using Bitakora.ControlAsistencia.{PascalCase}.SmokeTests.Fixtures;
 
+[assembly: CollectionBehavior(DisableTestParallelization = true)]
 [assembly: AssemblyFixture(typeof(ApiFixture))]
 [assembly: AssemblyFixture(typeof(ServiceBusFixture))]
 [assembly: AssemblyFixture(typeof(PostgresFixture))]
@@ -1492,7 +1491,7 @@ Scaffold completado para el dominio "{kebab}":
 
   tests/Bitakora.ControlAsistencia.{PascalCase}.SmokeTests/
     Fixtures/ApiFixture.cs                 - HttpClient + config + health check fail-fast
-    Fixtures/ServiceBusFixture.cs          - PublishAsync + WaitForMessageAsync (correlationId y predicado)
+    Fixtures/ServiceBusFixture.cs          - PurgeAsync + PublishAsync + WaitForMessageAsync (predicado)
     Fixtures/PostgresFixture.cs            - IsConfigured + SkipReason + firewall catch + consulta Marten
     Fixtures/Polling.cs                    - Polling tolerante a excepciones con backoff
     Fixtures/AssemblyFixture.cs            - Registra ApiFixture, ServiceBusFixture, PostgresFixture


### PR DESCRIPTION
## Resumen

Pipeline tooling completado:
- Writer: implementacion de la tarea
- Reviewer: revision de calidad

## Decisiones del pipeline

<details>
<summary>Writer -- 5m 8s</summary>

# Stage 1 - Writer Summary (Issue #95)

## Que se hizo

Se actualizo el template de ServiceBusFixture en .claude/agents/domain-scaffolder.md para alinearlo con el patron de purga y diagnostico establecido en los issues #93 y #94.

## Cambios realizados

### Archivo modificado: .claude/agents/domain-scaffolder.md

1. **Agregado PurgeAsync** (CA-1): Nuevo metodo que recibe y completa todos los mensajes residuales de una suscripcion antes de cada test.

2. **CompleteMessageAsync en todas las ramas** (CA-2): Se reemplazo AbandonMessageAsync por CompleteMessageAsync en las ramas de no-match y JsonException. Se elimino el overload por correlationId que tambien usaba AbandonMessageAsync.

3. **Diagnostico cuando no cumple predicado** (CA-3): Cuando un mensaje deserializa correctamente pero no cumple el predicado, se lanza InvalidOperationException con el tipo y contenido del mensaje. El metodo ahora retorna Task<T> (no-nullable) y lanza TimeoutException si no llega ningun mensaje.

4. **DisableTestParallelization en AssemblyFixture** (CA-4): Se agrego [assembly: CollectionBehavior(DisableTestParallelization = true)] al template de AssemblyFixture.cs.

5. **Documentacion del patron** (CA-5): Se agrego nota explicativa y comentarios en el codigo explicando por que se usa CompleteMessageAsync en vez de AbandonMessageAsync (evitar acumulacion de dead letters).

6. **Checklist actualizado**: Se actualizo la linea del checklist final para reflejar los metodos disponibles (PurgeAsync + PublishAsync + WaitForMessageAsync (predicado)).

## Verificaciones

- No hay llamadas a AbandonMessageAsync en el template de ServiceBusFixture (las 3 menciones restantes son en FakeServiceBusReceiver y en comentarios explicativos)
- El template replica fielmente el patron de tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/Fixtures/ServiceBusFixture.cs
- No se modifico codigo C# compilable, solo templates en markdown

</details>

<details>
<summary>Reviewer -- 2m 5s</summary>

_(El agente no genero resumen)_

</details>

## Commits

0e0c7b6 Actualizar template ServiceBusFixture del domain-scaffolder con patron de purga y diagnostico

Closes #95