### PR TITLE
Adicionar marcación a ControlDiario cuando marcación registrada

### DIFF
--- a/src/Bitakora.ControlAsistencia.ControlHoras/AdicionarMarcacionCuandoMarcacionRegistrada/CommandHandler/AdicionarMarcacionCuandoMarcacionRegistradaCommandHandler.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/AdicionarMarcacionCuandoMarcacionRegistrada/CommandHandler/AdicionarMarcacionCuandoMarcacionRegistradaCommandHandler.cs
@@ -1,0 +1,29 @@
+using Bitakora.ControlAsistencia.ControlHoras.Entities;
+using Bitakora.ControlAsistencia.ControlHoras.RegistrarMarcacionFunction.Eventos;
+using Cosmos.EventSourcing.Abstractions;
+using Cosmos.EventSourcing.Abstractions.Commands;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.AdicionarMarcacionCuandoMarcacionRegistrada.CommandHandler;
+
+// HU-106: Handler de Wolverine que adiciona una marcacion al ControlDiario correspondiente
+// Trigger: evento local MarcacionRegistrada publicado via WolverinePrivateEventSender (#105)
+// Patron crear-o-actualizar: ExistsAsync -> si no existe StartStream, si existe GetAggregateRootAsync
+// CA-9: ventana de traslape nocturno con corte a las 04:00 como constante del handler
+// ADR-0015: partial class para soportar clase Mensajes en archivo separado si se requiere
+public partial class AdicionarMarcacionCuandoMarcacionRegistradaCommandHandler
+    : ICommandHandlerAsync<MarcacionRegistrada>
+{
+    private readonly IEventStore _eventStore;
+
+    // CA-9: constante del handler - no del aggregate. Cuando sea configurable por empresa
+    // vendra de un servicio externo, no de aqui.
+    internal static readonly TimeOnly HoraCorteTraslapeNocturno = new TimeOnly(4, 0);
+
+    public AdicionarMarcacionCuandoMarcacionRegistradaCommandHandler(IEventStore eventStore)
+    {
+        _eventStore = eventStore;
+    }
+
+    public Task HandleAsync(MarcacionRegistrada command, CancellationToken ct = default)
+        => throw new NotImplementedException();
+}

--- a/src/Bitakora.ControlAsistencia.ControlHoras/AdicionarMarcacionCuandoMarcacionRegistrada/CommandHandler/AdicionarMarcacionCuandoMarcacionRegistradaCommandHandler.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/AdicionarMarcacionCuandoMarcacionRegistrada/CommandHandler/AdicionarMarcacionCuandoMarcacionRegistradaCommandHandler.cs
@@ -1,6 +1,6 @@
+using Bitakora.ControlAsistencia.ControlHoras.AdicionarMarcacionCuandoMarcacionRegistrada.Eventos;
 using Bitakora.ControlAsistencia.ControlHoras.Entities;
 using Bitakora.ControlAsistencia.ControlHoras.RegistrarMarcacionFunction.Eventos;
-using Cosmos.EventSourcing.Abstractions;
 using Cosmos.EventSourcing.Abstractions.Commands;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.AdicionarMarcacionCuandoMarcacionRegistrada.CommandHandler;
@@ -24,6 +24,49 @@ public partial class AdicionarMarcacionCuandoMarcacionRegistradaCommandHandler
         _eventStore = eventStore;
     }
 
-    public Task HandleAsync(MarcacionRegistrada command, CancellationToken ct = default)
-        => throw new NotImplementedException();
+    public async Task HandleAsync(MarcacionRegistrada command, CancellationToken ct = default)
+    {
+        var fechaCalendario = DateOnly.FromDateTime(command.TimestampNormalizado);
+        var horaDelDia = TimeOnly.FromDateTime(command.TimestampNormalizado);
+
+        // CA-1: fuera de la ventana nocturna la marcacion va solo al dia calendario
+        // CA-2 / CA-9: dentro de la ventana [00:00, 04:00) se agrega tambien al dia anterior
+        //              para cubrir turnos nocturnos que cruzan medianoche
+        var fechasDestino = horaDelDia < HoraCorteTraslapeNocturno
+            ? new[] { fechaCalendario, fechaCalendario.AddDays(-1) }
+            : new[] { fechaCalendario };
+
+        foreach (var fecha in fechasDestino)
+        {
+            await AdicionarAControlDiarioAsync(command, fecha, ct);
+        }
+    }
+
+    // Patron crear-o-actualizar con stream ID computado (EmpleadoId + Fecha).
+    // CA-5: si el ControlDiario no existe se crea con Iniciar(MarcacionAdicionada).
+    // CA-4: si existe, el aggregate se encarga de ignorar duplicados por minuto.
+    private async Task AdicionarAControlDiarioAsync(
+        MarcacionRegistrada command, DateOnly fecha, CancellationToken ct)
+    {
+        var streamId = ControlDiarioAggregateRoot.ComputarStreamId(command.EmpleadoId, fecha);
+        var evento = new MarcacionAdicionada(
+            streamId,
+            command.EmpleadoId,
+            command.TimestampNormalizado,
+            command.TipoMarcacion,
+            command.DispositivoId);
+
+        var existe = await _eventStore.ExistsAsync<ControlDiarioAggregateRoot>(streamId, ct);
+
+        if (!existe)
+        {
+            var control = ControlDiarioAggregateRoot.Iniciar(evento);
+            _eventStore.StartStream(control);
+        }
+        else
+        {
+            var control = await _eventStore.GetAggregateRootAsync<ControlDiarioAggregateRoot>(streamId, ct);
+            control!.AdicionarMarcacion(evento);
+        }
+    }
 }

--- a/src/Bitakora.ControlAsistencia.ControlHoras/AdicionarMarcacionCuandoMarcacionRegistrada/Eventos/MarcacionAdicionada.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/AdicionarMarcacionCuandoMarcacionRegistrada/Eventos/MarcacionAdicionada.cs
@@ -1,0 +1,65 @@
+using System.Reflection;
+using System.Text.Json.Serialization.Metadata;
+using Cosmos.EventDriven.Abstractions;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.AdicionarMarcacionCuandoMarcacionRegistrada.Eventos;
+
+// HU-106: Evento privado que registra la adicion de una marcacion al ControlDiario
+// Se persiste en el stream de ControlDiarioAggregateRoot (Id = stream ID compuesto)
+// Publicado localmente via Wolverine; consumido por #107 para depuracion
+public sealed class MarcacionAdicionada : IPrivateEvent
+{
+    // CA-7: Id es el stream ID del ControlDiario: "{EmpleadoId}:{Fecha:yyyy-MM-dd}"
+    public string Id { get; private set; } = null!;
+    public string EmpleadoId { get; private set; } = null!;
+
+    // TimestampNormalizado viene ya truncado al minuto desde RegistrarMarcacion (#105)
+    public DateTime TimestampNormalizado { get; private set; }
+
+    // CA-3: TipoMarcacion y DispositivoId son opcionales
+    public string? TipoMarcacion { get; private set; }
+    public string? DispositivoId { get; private set; }
+
+    public MarcacionAdicionada(
+        string id,
+        string empleadoId,
+        DateTime timestampNormalizado,
+        string? tipoMarcacion,
+        string? dispositivoId)
+    {
+        Id = id;
+        EmpleadoId = empleadoId;
+        TimestampNormalizado = timestampNormalizado;
+        TipoMarcacion = tipoMarcacion;
+        DispositivoId = dispositivoId;
+    }
+
+    // Constructor privado para Marten/serializacion
+    private MarcacionAdicionada() { }
+
+    // Configuracion de serializacion STJ/Marten: permite deserializar con constructor privado
+    // y propiedades con private set. Ver ADR-0013 y MarcacionAdicionadaSerializacionTests.
+    public static void ConfigurarSerializacion(DefaultJsonTypeInfoResolver resolver)
+    {
+        var ctor = typeof(MarcacionAdicionada)
+            .GetConstructor(BindingFlags.NonPublic | BindingFlags.Instance, Type.EmptyTypes)!;
+
+        resolver.Modifiers.Add(typeInfo =>
+        {
+            if (typeInfo.Type != typeof(MarcacionAdicionada)) return;
+            if (typeInfo.Kind != JsonTypeInfoKind.Object) return;
+
+            typeInfo.CreateObject = () => (MarcacionAdicionada)ctor.Invoke(null);
+
+            foreach (var prop in typeInfo.Properties)
+            {
+                if (prop.Set is not null) continue;
+                var backingField = typeof(MarcacionAdicionada).GetField(
+                    $"<{prop.Name}>k__BackingField",
+                    BindingFlags.NonPublic | BindingFlags.Instance);
+                if (backingField is not null)
+                    prop.Set = (obj, val) => backingField.SetValue(obj, val);
+            }
+        });
+    }
+}

--- a/src/Bitakora.ControlAsistencia.ControlHoras/Entities/ControlDiarioAggregateRoot.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Entities/ControlDiarioAggregateRoot.cs
@@ -57,18 +57,35 @@ public partial class ControlDiarioAggregateRoot : AggregateRoot
     }
 
     // HU-106: Apply que agrega la marcacion a la lista
-    // CA-4: idempotencia nivel 2 - si el minuto ya existe, no se agrega
+    // Apply solo proyecta estado; la deteccion de duplicado vive en AdicionarMarcacion (CA-4).
+    // Cuando el aggregate nace desde Iniciar(MarcacionAdicionada), este Apply asigna el Id del stream.
     // public: requerido para que TestStore.ApplyEvent lo encuentre via GetMethods()
-    public void Apply(MarcacionAdicionada e) => throw new NotImplementedException();
+    public void Apply(MarcacionAdicionada e)
+    {
+        Id = e.Id;
+        Marcaciones.Add(new MarcacionNormalizada(e.TimestampNormalizado, e.TipoMarcacion));
+    }
 
     // HU-106: segundo camino de creacion del ControlDiario, sin turno asignado
     // CA-5: si no existe ControlDiario para la fecha, se crea con este factory
     // CA-6: InformacionEmpleado y DetalleTurno quedan null
     internal static ControlDiarioAggregateRoot Iniciar(MarcacionAdicionada evento)
-        => throw new NotImplementedException();
+    {
+        var control = new ControlDiarioAggregateRoot();
+        control._uncommittedEvents.Add(evento);
+        control.Apply(evento);
+        return control;
+    }
 
     // HU-106: agrega una marcacion al aggregate existente
-    // CA-4: el aggregate detecta el duplicado por minuto y lo ignora silenciosamente
+    // CA-4: idempotencia nivel 2 - si ya existe una marcacion con el mismo minuto
+    //        normalizado, se ignora silenciosamente sin emitir evento ni excepcion
     internal void AdicionarMarcacion(MarcacionAdicionada evento)
-        => throw new NotImplementedException();
+    {
+        var yaExiste = Marcaciones.Any(m => m.TimestampNormalizado == evento.TimestampNormalizado);
+        if (yaExiste) return;
+
+        _uncommittedEvents.Add(evento);
+        Apply(evento);
+    }
 }

--- a/src/Bitakora.ControlAsistencia.ControlHoras/Entities/ControlDiarioAggregateRoot.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Entities/ControlDiarioAggregateRoot.cs
@@ -1,5 +1,6 @@
 using Bitakora.ControlAsistencia.Contracts.Empleados.ValueObjects;
 using Bitakora.ControlAsistencia.Contracts.Programacion.ValueObjects;
+using Bitakora.ControlAsistencia.ControlHoras.AdicionarMarcacionCuandoMarcacionRegistrada.Eventos;
 using Bitakora.ControlAsistencia.ControlHoras.AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction.Eventos;
 using Cosmos.EventSourcing.Abstractions;
 
@@ -17,6 +18,11 @@ public partial class ControlDiarioAggregateRoot : AggregateRoot
 
     // Trazabilidad: id de la ultima solicitud que asigno un turno (CA-5)
     public Guid UltimaSolicitudId { get; private set; }
+
+    // HU-106: lista de marcaciones adicionadas al control diario
+    // CA-3: crece al adicionar una marcacion nueva
+    // CA-4: idempotencia nivel 2 - duplicado por minuto normalizado se ignora
+    public List<MarcacionNormalizada> Marcaciones { get; private set; } = [];
 
     // CA-7: stream ID determinista: "{EmpleadoId}:{Fecha:yyyy-MM-dd}"
     // CA-8: dos mensajes con mismo EmpleadoId+Fecha comparten el mismo stream
@@ -49,4 +55,20 @@ public partial class ControlDiarioAggregateRoot : AggregateRoot
         _uncommittedEvents.Add(evento);
         Apply(evento);
     }
+
+    // HU-106: Apply que agrega la marcacion a la lista
+    // CA-4: idempotencia nivel 2 - si el minuto ya existe, no se agrega
+    // public: requerido para que TestStore.ApplyEvent lo encuentre via GetMethods()
+    public void Apply(MarcacionAdicionada e) => throw new NotImplementedException();
+
+    // HU-106: segundo camino de creacion del ControlDiario, sin turno asignado
+    // CA-5: si no existe ControlDiario para la fecha, se crea con este factory
+    // CA-6: InformacionEmpleado y DetalleTurno quedan null
+    internal static ControlDiarioAggregateRoot Iniciar(MarcacionAdicionada evento)
+        => throw new NotImplementedException();
+
+    // HU-106: agrega una marcacion al aggregate existente
+    // CA-4: el aggregate detecta el duplicado por minuto y lo ignora silenciosamente
+    internal void AdicionarMarcacion(MarcacionAdicionada evento)
+        => throw new NotImplementedException();
 }

--- a/src/Bitakora.ControlAsistencia.ControlHoras/Entities/ControlDiarioAggregateRoot.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Entities/ControlDiarioAggregateRoot.cs
@@ -22,7 +22,10 @@ public partial class ControlDiarioAggregateRoot : AggregateRoot
     // HU-106: lista de marcaciones adicionadas al control diario
     // CA-3: crece al adicionar una marcacion nueva
     // CA-4: idempotencia nivel 2 - duplicado por minuto normalizado se ignora
-    public List<MarcacionNormalizada> Marcaciones { get; private set; } = [];
+    // Expuesta como IReadOnlyList para evitar mutaciones externas; el aggregate
+    // es el unico que puede agregar marcaciones via Apply.
+    public IReadOnlyList<MarcacionNormalizada> Marcaciones => _marcaciones;
+    private readonly List<MarcacionNormalizada> _marcaciones = [];
 
     // CA-7: stream ID determinista: "{EmpleadoId}:{Fecha:yyyy-MM-dd}"
     // CA-8: dos mensajes con mismo EmpleadoId+Fecha comparten el mismo stream
@@ -63,7 +66,7 @@ public partial class ControlDiarioAggregateRoot : AggregateRoot
     public void Apply(MarcacionAdicionada e)
     {
         Id = e.Id;
-        Marcaciones.Add(new MarcacionNormalizada(e.TimestampNormalizado, e.TipoMarcacion));
+        _marcaciones.Add(new MarcacionNormalizada(e.TimestampNormalizado, e.TipoMarcacion));
     }
 
     // HU-106: segundo camino de creacion del ControlDiario, sin turno asignado
@@ -82,7 +85,7 @@ public partial class ControlDiarioAggregateRoot : AggregateRoot
     //        normalizado, se ignora silenciosamente sin emitir evento ni excepcion
     internal void AdicionarMarcacion(MarcacionAdicionada evento)
     {
-        var yaExiste = Marcaciones.Any(m => m.TimestampNormalizado == evento.TimestampNormalizado);
+        var yaExiste = _marcaciones.Any(m => m.TimestampNormalizado == evento.TimestampNormalizado);
         if (yaExiste) return;
 
         _uncommittedEvents.Add(evento);

--- a/src/Bitakora.ControlAsistencia.ControlHoras/Entities/MarcacionNormalizada.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Entities/MarcacionNormalizada.cs
@@ -1,0 +1,6 @@
+namespace Bitakora.ControlAsistencia.ControlHoras.Entities;
+
+// HU-106: Value object que representa una marcacion normalizada dentro del ControlDiario
+// TimestampNormalizado ya viene truncado al minuto desde RegistrarMarcacion (#105)
+// TipoMarcacion es opcional (ENTRADA, SALIDA o null cuando el dispositivo no reporta tipo)
+public record MarcacionNormalizada(DateTime TimestampNormalizado, string? TipoMarcacion);

--- a/src/Bitakora.ControlAsistencia.ControlHoras/Infraestructura/ConfiguracionSerializacionControlHoras.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Infraestructura/ConfiguracionSerializacionControlHoras.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
+using Bitakora.ControlAsistencia.ControlHoras.AdicionarMarcacionCuandoMarcacionRegistrada.Eventos;
 using Bitakora.ControlAsistencia.ControlHoras.AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction.Eventos;
 using Bitakora.ControlAsistencia.ControlHoras.RegistrarMarcacionFunction.Eventos;
 
@@ -22,5 +23,6 @@ public static class ConfiguracionSerializacionControlHoras
     {
         TurnoDiarioAsignado.ConfigurarSerializacion(resolver);
         MarcacionRegistrada.ConfigurarSerializacion(resolver);
+        MarcacionAdicionada.ConfigurarSerializacion(resolver);
     }
 }

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoMarcacionRegistrada/AdicionarMarcacionCuandoMarcacionRegistradaCommandHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoMarcacionRegistrada/AdicionarMarcacionCuandoMarcacionRegistradaCommandHandlerTests.cs
@@ -1,0 +1,126 @@
+// HU-106: Adicionar marcacion a ControlDiario cuando marcacion registrada
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Contracts.Empleados.ValueObjects;
+using Bitakora.ControlAsistencia.Contracts.Programacion.ValueObjects;
+using Bitakora.ControlAsistencia.ControlHoras.AdicionarMarcacionCuandoMarcacionRegistrada.CommandHandler;
+using Bitakora.ControlAsistencia.ControlHoras.AdicionarMarcacionCuandoMarcacionRegistrada.Eventos;
+using Bitakora.ControlAsistencia.ControlHoras.Entities;
+using Bitakora.ControlAsistencia.ControlHoras.RegistrarMarcacionFunction.Eventos;
+using Cosmos.EventSourcing.Abstractions.Commands;
+using Cosmos.EventSourcing.Testing.Utilities;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Tests.AdicionarMarcacionCuandoMarcacionRegistrada;
+
+public class AdicionarMarcacionCuandoMarcacionRegistradaCommandHandlerTests
+    : CommandHandlerAsyncTest<MarcacionRegistrada>
+{
+    // Datos de prueba fijos
+    private const string EmpleadoId = "EMP-001";
+
+    // CA-1: hora fuera de ventana nocturna (>= 04:00) - solo dia calendario
+    private static readonly DateTime TimestampFueraDeVentana = new DateTime(2026, 3, 15, 8, 15, 0);
+
+    // CA-2: hora dentro de ventana nocturna (< 04:00) - dia calendario + dia anterior
+    private static readonly DateTime TimestampDentroDeVentana = new DateTime(2026, 3, 15, 2, 30, 0);
+
+    // CA-7, CA-8: stream IDs computados desde TimestampNormalizado
+    private static readonly string StreamIdDia15 = $"{EmpleadoId}:2026-03-15";
+    private static readonly string StreamIdDia14 = $"{EmpleadoId}:2026-03-14";
+
+    protected override ICommandHandlerAsync<MarcacionRegistrada> Handler =>
+        new AdicionarMarcacionCuandoMarcacionRegistradaCommandHandler(EventStore);
+
+    // Factory para MarcacionRegistrada con hora fuera de ventana
+    private static MarcacionRegistrada CrearMarcacionRegistrada(
+        DateTime timestampNormalizado,
+        string? tipoMarcacion = "ENTRADA",
+        string? dispositivoId = "DEV-001") =>
+        new(EmpleadoId, timestampNormalizado, tipoMarcacion, dispositivoId);
+
+    // Factory para MarcacionAdicionada (evento emitido al stream del ControlDiario)
+    private static MarcacionAdicionada CrearMarcacionAdicionada(
+        string streamId,
+        DateTime timestampNormalizado,
+        string? tipoMarcacion = "ENTRADA",
+        string? dispositivoId = "DEV-001") =>
+        new(streamId, EmpleadoId, timestampNormalizado, tipoMarcacion, dispositivoId);
+
+    // CA-1: hora fuera de ventana nocturna (08:15) -> un solo ControlDiario para dia calendario
+    // CA-5: si no existe ControlDiario, se crea con Iniciar(MarcacionAdicionada)
+    // CA-6: ControlDiario creado solo por marcacion tiene InformacionEmpleado y DetalleTurno nulos
+    // CA-7: stream ID es "{EmpleadoId}:{Fecha:yyyy-MM-dd}"
+    // CA-8: la fecha se extrae del TimestampNormalizado del evento
+    [Fact]
+    public async Task DebeCrearControlDiarioConMarcacion_CuandoNoExisteYHoraFueraDeVentanaNocturna()
+    {
+        // Sin Given - el stream no existe para EMP-001:2026-03-15
+        await WhenAsync(CrearMarcacionRegistrada(TimestampFueraDeVentana));
+
+        Then(StreamIdDia15, CrearMarcacionAdicionada(StreamIdDia15, TimestampFueraDeVentana));
+        And<ControlDiarioAggregateRoot, InformacionEmpleado?>(
+            StreamIdDia15, c => c.InformacionEmpleado, null);
+        And<ControlDiarioAggregateRoot, DetalleTurno?>(
+            StreamIdDia15, c => c.DetalleTurno, null);
+        And<ControlDiarioAggregateRoot, int>(
+            StreamIdDia15, c => c.Marcaciones.Count, 1);
+    }
+
+    // CA-2: hora dentro de ventana nocturna (02:30) -> dos ControlDiarios
+    //   - dia calendario (2026-03-15) y dia anterior (2026-03-14)
+    // CA-9: la ventana de traslape tiene corte a las 04:00 AM (constante del handler)
+    [Fact]
+    public async Task DebeCrearDosControlDiarios_CuandoHoraEstaEnVentanaNocturna()
+    {
+        // Sin Given - ninguno de los dos streams existe
+        await WhenAsync(CrearMarcacionRegistrada(TimestampDentroDeVentana));
+
+        // Dia calendario: 2026-03-15
+        Then(StreamIdDia15, CrearMarcacionAdicionada(StreamIdDia15, TimestampDentroDeVentana));
+        And<ControlDiarioAggregateRoot, int>(
+            StreamIdDia15, c => c.Marcaciones.Count, 1);
+
+        // Dia anterior: 2026-03-14 (traslape nocturno)
+        Then(StreamIdDia14, CrearMarcacionAdicionada(StreamIdDia14, TimestampDentroDeVentana));
+        And<ControlDiarioAggregateRoot, int>(
+            StreamIdDia14, c => c.Marcaciones.Count, 1);
+    }
+
+    // CA-3: lista de marcaciones crece al adicionar una marcacion nueva
+    //        ControlDiario ya existe con una marcacion previa (distinto minuto)
+    [Fact]
+    public async Task DebeCrecerListaMarcaciones_CuandoControlDiarioYaExisteConMarcacionPrevia()
+    {
+        // Timestamp diferente: 07:00 ya existia
+        var marcacionPrevia = CrearMarcacionAdicionada(
+            StreamIdDia15, new DateTime(2026, 3, 15, 7, 0, 0));
+
+        Given(StreamIdDia15, marcacionPrevia);
+
+        // Nueva marcacion a las 08:15 (distinto minuto)
+        await WhenAsync(CrearMarcacionRegistrada(TimestampFueraDeVentana));
+
+        Then(StreamIdDia15, CrearMarcacionAdicionada(StreamIdDia15, TimestampFueraDeVentana));
+        And<ControlDiarioAggregateRoot, int>(
+            StreamIdDia15, c => c.Marcaciones.Count, 2);
+    }
+
+    // CA-4: marcacion duplicada por minuto normalizado se ignora
+    //        el aggregate no produce nuevo evento ni lanza excepcion
+    [Fact]
+    public async Task DebeIgnorarMarcacion_CuandoExisteDuplicadoPorMinutoNormalizado()
+    {
+        // Mismo minuto normalizado: 08:15:00 ya existia (ENTRADA desde DEV-001)
+        var marcacionExistente = CrearMarcacionAdicionada(StreamIdDia15, TimestampFueraDeVentana);
+        Given(StreamIdDia15, marcacionExistente);
+
+        // Llega otra marcacion con el mismo minuto pero distinto tipo y dispositivo
+        await WhenAsync(CrearMarcacionRegistrada(TimestampFueraDeVentana, "SALIDA", "DEV-002"));
+
+        // Sin nuevos eventos - duplicado ignorado silenciosamente
+        Then(StreamIdDia15);
+        And<ControlDiarioAggregateRoot, int>(
+            StreamIdDia15, c => c.Marcaciones.Count, 1);
+    }
+
+}

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoMarcacionRegistrada/AdicionarMarcacionCuandoMarcacionRegistradaCommandHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoMarcacionRegistrada/AdicionarMarcacionCuandoMarcacionRegistradaCommandHandlerTests.cs
@@ -1,6 +1,5 @@
 // HU-106: Adicionar marcacion a ControlDiario cuando marcacion registrada
 
-using AwesomeAssertions;
 using Bitakora.ControlAsistencia.Contracts.Empleados.ValueObjects;
 using Bitakora.ControlAsistencia.Contracts.Programacion.ValueObjects;
 using Bitakora.ControlAsistencia.ControlHoras.AdicionarMarcacionCuandoMarcacionRegistrada.CommandHandler;
@@ -31,7 +30,7 @@ public class AdicionarMarcacionCuandoMarcacionRegistradaCommandHandlerTests
     protected override ICommandHandlerAsync<MarcacionRegistrada> Handler =>
         new AdicionarMarcacionCuandoMarcacionRegistradaCommandHandler(EventStore);
 
-    // Factory para MarcacionRegistrada con hora fuera de ventana
+    // Factory para MarcacionRegistrada; el timestamp decide si cae en la ventana nocturna.
     private static MarcacionRegistrada CrearMarcacionRegistrada(
         DateTime timestampNormalizado,
         string? tipoMarcacion = "ENTRADA",
@@ -105,6 +104,24 @@ public class AdicionarMarcacionCuandoMarcacionRegistradaCommandHandlerTests
             StreamIdDia15, c => c.Marcaciones.Count, 2);
     }
 
+    // CA-9: borde superior exclusivo de la ventana nocturna.
+    //        La hora de corte (04:00:00) ya NO esta dentro de la ventana,
+    //        por lo que la marcacion va solo al dia calendario (un stream).
+    [Fact]
+    public async Task DebeCrearUnSoloControlDiario_CuandoHoraEsIgualALaHoraDeCorte()
+    {
+        var timestampEnCorte = new DateTime(2026, 3, 15, 4, 0, 0);
+
+        await WhenAsync(CrearMarcacionRegistrada(timestampEnCorte));
+
+        Then(StreamIdDia15, CrearMarcacionAdicionada(StreamIdDia15, timestampEnCorte));
+        And<ControlDiarioAggregateRoot, int>(
+            StreamIdDia15, c => c.Marcaciones.Count, 1);
+
+        // El dia anterior no se toca: no hay eventos emitidos para StreamIdDia14
+        Then(StreamIdDia14);
+    }
+
     // CA-4: marcacion duplicada por minuto normalizado se ignora
     //        el aggregate no produce nuevo evento ni lanza excepcion
     [Fact]
@@ -122,5 +139,4 @@ public class AdicionarMarcacionCuandoMarcacionRegistradaCommandHandlerTests
         And<ControlDiarioAggregateRoot, int>(
             StreamIdDia15, c => c.Marcaciones.Count, 1);
     }
-
 }

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoMarcacionRegistrada/Eventos/MarcacionAdicionadaSerializacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoMarcacionRegistrada/Eventos/MarcacionAdicionadaSerializacionTests.cs
@@ -1,0 +1,59 @@
+// HU-106: Test de serializacion roundtrip para MarcacionAdicionada
+// Requerido por regla 16: todo evento persistido en Marten debe sobrevivir Serialize -> Deserialize
+
+using System.Text.Json;
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.ControlHoras.AdicionarMarcacionCuandoMarcacionRegistrada.Eventos;
+using Bitakora.ControlAsistencia.ControlHoras.Infraestructura;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Tests.AdicionarMarcacionCuandoMarcacionRegistrada.Eventos;
+
+/// <summary>
+/// Verifica que MarcacionAdicionada sobrevive un roundtrip de serializacion STJ.
+/// Requerido porque Marten usa STJ con PropertyNamingPolicy=null (PascalCase)
+/// y el evento tiene constructor privado y propiedades con private set.
+/// Ver ADR-0013 y patron canonico en TurnoCreadoSerializacionTests (Programacion).
+/// </summary>
+public class MarcacionAdicionadaSerializacionTests
+{
+    private static readonly string StreamId = "EMP-001:2026-03-15";
+    private static readonly string EmpleadoId = "EMP-001";
+    private static readonly DateTime Timestamp = new DateTime(2026, 3, 15, 8, 15, 0);
+
+    // Regla 16: usa CrearOpcionesMarten() que registra ConfigurarSerializacion de todos los tipos
+    // MarcacionAdicionada se registra en ConfiguracionSerializacionControlHoras.ConfigurarResolver
+    [Fact]
+    public void Deserializar_ReconstruyeEvento_ConTodosLosCampos()
+    {
+        var evento = new MarcacionAdicionada(StreamId, EmpleadoId, Timestamp, "ENTRADA", "DEV-001");
+        var opciones = ConfiguracionSerializacionControlHoras.CrearOpcionesMarten();
+
+        var json = JsonSerializer.Serialize(evento, opciones);
+        var deserializado = JsonSerializer.Deserialize<MarcacionAdicionada>(json, opciones);
+
+        deserializado.Should().NotBeNull();
+        deserializado!.Id.Should().Be(StreamId);
+        deserializado.EmpleadoId.Should().Be(EmpleadoId);
+        deserializado.TimestampNormalizado.Should().Be(Timestamp);
+        deserializado.TipoMarcacion.Should().Be("ENTRADA");
+        deserializado.DispositivoId.Should().Be("DEV-001");
+    }
+
+    // Verifica que los campos opcionales null se preservan correctamente en el roundtrip
+    [Fact]
+    public void Deserializar_ReconstruyeEvento_CuandoCamposOpcionalesSonNulos()
+    {
+        var evento = new MarcacionAdicionada(StreamId, EmpleadoId, Timestamp, null, null);
+        var opciones = ConfiguracionSerializacionControlHoras.CrearOpcionesMarten();
+
+        var json = JsonSerializer.Serialize(evento, opciones);
+        var deserializado = JsonSerializer.Deserialize<MarcacionAdicionada>(json, opciones);
+
+        deserializado.Should().NotBeNull();
+        deserializado!.Id.Should().Be(StreamId);
+        deserializado.EmpleadoId.Should().Be(EmpleadoId);
+        deserializado.TimestampNormalizado.Should().Be(Timestamp);
+        deserializado.TipoMarcacion.Should().BeNull();
+        deserializado.DispositivoId.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Resumen

Pipeline TDD completado:
- Fase roja: tests escritos con stubs
- Fase verde: implementación completa
- Fase refactor: revisión de calidad

## Decisiones del pipeline

<details>
<summary>Test Writer (fase roja) — 9m 30s</summary>

_(El agente no generó resumen)_

</details>

<details>
<summary>Implementer (fase verde) — 7m 33s</summary>

## ES Implementer - Decisiones HU-106

### Enfoque de implementacion
Handler de Wolverine local con patron crear-o-actualizar para ControlDiarioAggregateRoot,
identidad compuesta (EmpleadoId + Fecha) calculada via `ControlDiarioAggregateRoot.ComputarStreamId`.
La ventana de traslape nocturno se resuelve antes de iterar: devuelve una o dos fechas destino,
y para cada una se reutiliza la misma rutina de crear-o-actualizar.

### Decisiones de diseno
- **Ventana nocturna como array de fechas, no como flags**: la decision se reduce a calcular
  el conjunto `fechasDestino` (1 o 2 elementos) en un solo lugar. El resto del handler itera
  sin saber si estamos en ventana o fuera. Esto mantiene una sola ruta de efectos
  (crear-o-actualizar) para ambos escenarios.
- **foreach sobre fechasDestino**: aunque la regla 8 privilegia LINQ, aqui los efectos son
  side-effectful y asincronos sobre `_eventStore` (no thread-safe y con ordenamiento semantico).
  `foreach` con `await` es el patron correcto.
- **Idempotencia nivel 2 vive en el aggregate, no en el handler**: `AdicionarMarcacion`
  consulta `Marcaciones` y decide no emitir si ya existe el minuto. El handler se mantiene
  como orquestador puro.
- **`Apply(MarcacionAdicionada)` asigna `Id`**: necesario porque el aggregate puede nacer
  unicamente desde una marcacion (sin turno). El evento ya carga su stream ID, asi que el
  `Apply` lo proyecta tanto al crear como al hidratar.
- **Factory `Iniciar(MarcacionAdicionada)` duplica el patron del existente para `TurnoDiarioAsignado`**:
  los dos factories tienen significado semantico distinto (creacion con turno vs. creacion solo
  con marcacion) y el codigo es de una linea, no justifica abstraccion.

### Infraestructura modificada
- Ninguna. `MarcacionRegistrada` ya se publicaba via `WolverinePrivateEventSender` (#105);
  Wolverine descubre el nuevo handler por assembly scanning. No hay topics nuevos ni
  subscriptions Service Bus.
- `ConfigurarResolver` ya registraba `MarcacionAdicionada.ConfigurarSerializacion` (lo hizo
  el test-writer), y `Program.cs` ya invoca `ConfiguracionSerializacionControlHoras.ConfigurarResolver`.

### Complejidad encontrada
- Ninguna significativa. El patron crear-o-actualizar con stream ID calculado ya existia
  para `TurnoDiarioAsignado`; se replico con la unica diferencia de que el handler puede
  invocarlo dos veces (una por fecha destino) para una misma marcacion.

### Resultado
- Tests pasando: 25/25 en el proyecto ControlHoras (incluyendo los 4 tests nuevos del
  handler y los 2 tests de serializacion roundtrip de MarcacionAdicionada).
- Suite completa: 145/145 correctos (6 omitidos son smoke tests por falta de infra externa).

</details>
<details>
<summary>Reviewer (fase refactor) — 9m 24s</summary>

## ES Reviewer - Revision

### Evaluacion general
- Calidad: aceptable con mejoras aplicadas
- Cambios realizados: si

### Checklist de patrones ES
| Patron | Estado | Observacion |
|---|---|---|
| Apply() sin logica condicional | ok | `Apply(MarcacionAdicionada)` solo asigna Id y agrega a la lista |
| CommandHandler orquestador puro | ok | sin logica de negocio; la deteccion de duplicado vive en el aggregate |
| Sin AppendEvents/SaveChangesAsync manual | ok | el handler solo hace `StartStream` para streams nuevos; el middleware persiste los existentes |
| ThrowExactlyAsync solo para precondiciones | n/a | HU sin casos de error - los duplicados se ignoran silenciosamente |
| Cada test con Then() + And<>() | ok | los 5 tests emiten `Then(streamId, ...)` y al menos un `And<>()` |
| Naming de eventos en pasado | ok | `MarcacionAdicionada` sigue la convencion |
| Naming de funciones Azure | n/a | no hay Azure Function - handler Wolverine local |
| Infraestructura Service Bus verificada | n/a | evento privado, no cruza Service Bus |
| Organizacion vertical (feature folders) | ok | `AdicionarMarcacionCuandoMarcacionRegistrada/{CommandHandler,Eventos}` - espejado en tests |
| Sin strings hardcodeados en mensajes | ok | no hay throws ni eventos de fallo en esta HU |
| Aggregates/handlers son partial class | ok | `ControlDiarioAggregateRoot` y el handler son partial |
| Modelado record/clase apropiado | ok | `MarcacionNormalizada` es record; `MarcacionAdicionada` es sealed class con constructor privado para Marten |
| Factory static en objetos con invariantes | n/a | no hay invariantes relevantes en esta HU |
| Sin init en objetos con invariantes | ok | `MarcacionAdicionada` usa `{ get; private set; }` |
| Tell Don't Ask (calculos en el objeto) | ok | la idempotencia por minuto se decide dentro del aggregate, no en el handler |
| Sin numeros magicos | ok | `HoraCorteTraslapeNocturno` es constante nombrada |
| Propiedades internas son protected/private | ok | `_marcaciones` es backing field privado tras refactor |
| Tests via ToString | n/a | tests de handler verifican por proyecciones del aggregate, no ToString |
| Mensajes en .resx | n/a | HU sin mensajes de error |
| Tests verifican mensaje de excepcion | n/a | no hay excepciones |
| Tests de IEquatable para value objects | n/a | `MarcacionNormalizada` es record - igualdad estructural por el compilador |
| Tests de serializacion round-trip | ok | `MarcacionAdicionadaSerializacionTests` con dos casos (todos los campos y opcionales nulos) |
| IPublicEvent solo en Contracts/Eventos/ | ok | `MarcacionAdicionada` es `IPrivateEvent`, vive dentro del dominio |
| Sin InternalsVisibleTo de Contracts a dominio | ok | sin cambios |
| Sin records duplicados | ok | `MarcacionNormalizada` es nuevo y no duplica ningun contrato |
| Sin wrappers de IEventStore en tests | ok | usan `CommandHandlerAsyncTest<T>` con `Given/WhenAsync/Then/And` |

### Elegancia del codigo
- El patron de creacion-o-actualizacion en el handler es consistente con el hermano `AsignarTurnoCuando...CommandHandler`.
- La logica de ventana nocturna se expresa con una expresion ternaria clara; `horaDelDia < HoraCorteTraslapeNocturno` es explicito sobre el borde exclusivo.
- La deteccion de duplicado con `Any(m => m.TimestampNormalizado == ...)` es O(n), aceptable para listas cortas de marcaciones por dia.
- La propiedad `Marcaciones` se refactorizo a `IReadOnlyList<>` con backing field privado (patron ya usado por `CatalogoTurnos._franjasOrdinarias`), protegiendo al aggregate de mutaciones externas.

### Criticas y hallazgos
- **Menor - warning IDE0005**: `using AwesomeAssertions;` innecesario en el archivo de tests del handler. **Corregido.**
- **Menor - encapsulacion**: `public List<MarcacionNormalizada> Marcaciones { get; private set; }` permitia mutaciones externas. **Corregido** cambiando a `IReadOnlyList<>` con backing field.
- **Cosmetico - comentario inexacto**: el factory `CrearMarcacionRegistrada` decia "con hora fuera de ventana" pero acepta cualquier timestamp. **Corregido.**
- **Cosmetico - formato**: linea en blanco extra al final de la clase de tests. **Corregido.**

### Refactorings aplicados
- **`Marcaciones` -> `IReadOnlyList`** con backing field `_marcaciones`: alinea con el patron de `CatalogoTurnos._franjasOrdinarias` y evita exposicion de mutacion externa. `Apply(MarcacionAdicionada)` y `AdicionarMarcacion` actualizados para usar el backing field.
- **Remover using innecesario** `AwesomeAssertions` en el test de handler (queda solo en el test de serializacion, donde si se usa).
- **Corregir comentario** del factory `CrearMarcacionRegistrada`.

### Cobertura de criterios de aceptacion
| Criterio | Estado | Test(s) |
|---|---|---|
| CA-1: hora fuera de ventana -> un solo ControlDiario | cubierto | `DebeCrearControlDiarioConMarcacion_CuandoNoExisteYHoraFueraDeVentanaNocturna` |
| CA-2: hora dentro de ventana -> dos ControlDiarios | cubierto | `DebeCrearDosControlDiarios_CuandoHoraEstaEnVentanaNocturna` |
| CA-3: lista de marcaciones crece | cubierto | `DebeCrecerListaMarcaciones_CuandoControlDiarioYaExisteConMarcacionPrevia` |
| CA-4: duplicado por minuto normalizado se ignora | cubierto | `DebeIgnorarMarcacion_CuandoExisteDuplicadoPorMinutoNormalizado` |
| CA-5: patron crear-o-actualizar con `Iniciar(MarcacionAdicionada)` | cubierto | rama "no existe" del test CA-1 |
| CA-6: ControlDiario sin turno tiene `InformacionEmpleado=null` y `DetalleTurno=null` | cubierto | `DebeCrearControlDiarioConMarcacion_...` (And<> sobre InformacionEmpleado y DetalleTurno) |
| CA-7: stream ID `{EmpleadoId}:{Fecha:yyyy-MM-dd}` | cubierto | implicito por stream IDs `EMP-001:2026-03-15` y `EMP-001:2026-03-14` |
| CA-8: fecha extraida de `TimestampNormalizado` | cubierto | timestamp en 2026-03-15 produce stream con esa fecha |
| CA-9: corte a las 04:00 AM como constante del handler | cubierto | test de borde `DebeCrearUnSoloControlDiario_CuandoHoraEsIgualALaHoraDeCorte` |

### Tests agregados
- **`DebeCrearUnSoloControlDiario_CuandoHoraEsIgualALaHoraDeCorte`**: test de borde exclusivo en la hora de corte (04:00:00) para fortalecer CA-9. Valida que el operador `<` es correcto (exclusivo) y no se crea el stream del dia anterior en la frontera exacta.
- No se agregaron tests de igualdad (el value object es un record, con igualdad canonica).

</details>

## Commits

cbcbf98 refactor(hu-106): encapsula Marcaciones y agrega test de borde en hora de corte
c7b0af1 feat(hu-106): adicionar marcacion a ControlDiario cuando marcacion registrada (fase verde)
91bd25c test(hu-106): tests para adicionar marcacion a ControlDiario (fase roja)

Closes #106