### PR TITLE
Extraer depurador de marcaciones contra franjas del turno

### DIFF
--- a/src/Bitakora.ControlAsistencia.ControlHoras/Entities/ControlFranja.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Entities/ControlFranja.cs
@@ -8,5 +8,5 @@ namespace Bitakora.ControlAsistencia.ControlHoras.Entities;
 public record ControlFranja(DetalleFranjaOrdinaria Programada, DateTime? Entrada, DateTime? Salida)
 {
     // CA-9: propiedad calculada; anomala cuando falta Entrada o Salida
-    public bool EsAnomala => throw new NotImplementedException();
+    public bool EsAnomala => Entrada is null || Salida is null;
 }

--- a/src/Bitakora.ControlAsistencia.ControlHoras/Entities/ControlFranja.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Entities/ControlFranja.cs
@@ -1,0 +1,12 @@
+using Bitakora.ControlAsistencia.Contracts.Programacion.ValueObjects;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Entities;
+
+// HU-122: Value object que representa el resultado de depurar marcaciones contra una franja ordinaria.
+// No viaja entre dominios - vive en ControlHoras junto al aggregate que lo usa.
+// El DTO para cruzar fronteras (DetalleControlFranja) se crea en #108.
+public record ControlFranja(DetalleFranjaOrdinaria Programada, DateTime? Entrada, DateTime? Salida)
+{
+    // CA-9: propiedad calculada; anomala cuando falta Entrada o Salida
+    public bool EsAnomala => throw new NotImplementedException();
+}

--- a/src/Bitakora.ControlAsistencia.ControlHoras/Entities/DepuradorDeMarcaciones.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Entities/DepuradorDeMarcaciones.cs
@@ -1,0 +1,16 @@
+using Bitakora.ControlAsistencia.Contracts.Programacion.ValueObjects;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Entities;
+
+// HU-122: Clase estatica pura que ejecuta el algoritmo secuencial por rango para asignar
+// marcaciones normalizadas a franjas ordinarias del turno.
+// Sin estado propio - no necesita inyeccion ni ser instanciada.
+// Funciones auxiliares (resolver franjas a DateTime, calcular cortes) son internal/private.
+public static class DepuradorDeMarcaciones
+{
+    public static IReadOnlyList<ControlFranja> Depurar(
+        DetalleTurno? turno,
+        DateOnly fecha,
+        IReadOnlyList<MarcacionNormalizada> marcaciones)
+        => throw new NotImplementedException();
+}

--- a/src/Bitakora.ControlAsistencia.ControlHoras/Entities/DepuradorDeMarcaciones.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Entities/DepuradorDeMarcaciones.cs
@@ -12,5 +12,70 @@ public static class DepuradorDeMarcaciones
         DetalleTurno? turno,
         DateOnly fecha,
         IReadOnlyList<MarcacionNormalizada> marcaciones)
-        => throw new NotImplementedException();
+    {
+        // CA-6: sin turno no hay franjas que depurar
+        if (turno is null)
+            return [];
+
+        var franjasResueltas = turno.FranjasOrdinarias
+            .Select(franja => (Franja: franja, Rango: ResolverRango(franja, fecha)))
+            .ToList();
+
+        var rangosDeCaptura = CalcularRangosDeCaptura(franjasResueltas.Select(f => f.Rango).ToList());
+
+        var marcacionesOrdenadas = marcaciones
+            .OrderBy(m => m.TimestampNormalizado)
+            .ToList();
+
+        return franjasResueltas
+            .Select((item, indice) => ConstruirControlFranja(
+                item.Franja,
+                rangosDeCaptura[indice],
+                marcacionesOrdenadas))
+            .ToList();
+    }
+
+    // Convierte una franja (TimeOnly + DiaOffsetFin) a un rango DateTime relativo a la fecha ancla.
+    // Para franjas nocturnas con DiaOffsetFin=1 el fin cae en el dia siguiente.
+    private static (DateTime Inicio, DateTime Fin) ResolverRango(DetalleFranjaOrdinaria franja, DateOnly fecha)
+    {
+        var inicio = fecha.ToDateTime(franja.HoraInicio);
+        var fin = fecha.AddDays(franja.DiaOffsetFin).ToDateTime(franja.HoraFin);
+        return (inicio, fin);
+    }
+
+    // Calcula el rango de captura de cada franja usando puntos medios entre franjas adyacentes.
+    // Primera franja empieza en DateTime.MinValue; ultima termina en DateTime.MaxValue.
+    private static List<(DateTime Inicio, DateTime Fin)> CalcularRangosDeCaptura(
+        IReadOnlyList<(DateTime Inicio, DateTime Fin)> rangosFranja) =>
+        rangosFranja
+            .Select((_, indice) => (
+                Inicio: indice == 0
+                    ? DateTime.MinValue
+                    : PuntoMedio(rangosFranja[indice - 1].Fin, rangosFranja[indice].Inicio),
+                Fin: indice == rangosFranja.Count - 1
+                    ? DateTime.MaxValue
+                    : PuntoMedio(rangosFranja[indice].Fin, rangosFranja[indice + 1].Inicio)))
+            .ToList();
+
+    // Punto medio entre dos DateTime usando ticks para evitar perdida de precision.
+    private static DateTime PuntoMedio(DateTime a, DateTime b) =>
+        a.AddTicks((b - a).Ticks / 2);
+
+    // Construye el ControlFranja asignando primera=Entrada y ultima=Salida dentro del rango.
+    // Con cero marcaciones: ambas null. Con una: Entrada poblada, Salida null. Intermedias se descartan.
+    private static ControlFranja ConstruirControlFranja(
+        DetalleFranjaOrdinaria franja,
+        (DateTime Inicio, DateTime Fin) rango,
+        IReadOnlyList<MarcacionNormalizada> marcacionesOrdenadas)
+    {
+        var enRango = marcacionesOrdenadas
+            .Where(m => m.TimestampNormalizado >= rango.Inicio && m.TimestampNormalizado < rango.Fin)
+            .ToList();
+
+        DateTime? entrada = enRango.Count > 0 ? enRango[0].TimestampNormalizado : null;
+        DateTime? salida = enRango.Count > 1 ? enRango[^1].TimestampNormalizado : null;
+
+        return new ControlFranja(franja, entrada, salida);
+    }
 }

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/ControlFranjaTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/ControlFranjaTests.cs
@@ -1,0 +1,56 @@
+// Issue #122: Extraer depurador de marcaciones contra franjas del turno
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Contracts.Programacion.ValueObjects;
+using Bitakora.ControlAsistencia.ControlHoras.Entities;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Tests.Entities;
+
+/// <summary>
+/// Tests de ControlFranja - solo verifica el calculo de EsAnomala (CA-9).
+/// La logica de asignacion de Entrada/Salida se verifica en DepuradorDeMarcacionesTests.
+/// </summary>
+public class ControlFranjaTests
+{
+    private static readonly DetalleFranjaOrdinaria Franja06_14 = new(
+        new TimeOnly(6, 0), new TimeOnly(14, 0), 0, [], []);
+
+    private static readonly DateTime T07 = new(2026, 3, 15, 7, 0, 0);
+    private static readonly DateTime T15 = new(2026, 3, 15, 15, 0, 0);
+
+    [Fact]
+    public void EsAnomala_EsTrue_CuandoEntradaEsNull()
+    {
+        // CA-9: Entrada null con Salida poblada -> EsAnomala true
+        var franja = new ControlFranja(Franja06_14, null, T15);
+
+        franja.EsAnomala.Should().BeTrue();
+    }
+
+    [Fact]
+    public void EsAnomala_EsTrue_CuandoSalidaEsNull()
+    {
+        // CA-9: Entrada poblada con Salida null -> EsAnomala true
+        var franja = new ControlFranja(Franja06_14, T07, null);
+
+        franja.EsAnomala.Should().BeTrue();
+    }
+
+    [Fact]
+    public void EsAnomala_EsTrue_CuandoEntradaYSalidaSonNull()
+    {
+        // CA-9: Ambas null -> EsAnomala true
+        var franja = new ControlFranja(Franja06_14, null, null);
+
+        franja.EsAnomala.Should().BeTrue();
+    }
+
+    [Fact]
+    public void EsAnomala_EsFalse_CuandoEntradaYSalidaEstanPobladas()
+    {
+        // CA-9: Ambas pobladas -> EsAnomala false
+        var franja = new ControlFranja(Franja06_14, T07, T15);
+
+        franja.EsAnomala.Should().BeFalse();
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/DepuradorDeMarcacionesTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/DepuradorDeMarcacionesTests.cs
@@ -1,0 +1,181 @@
+// Issue #122: Extraer depurador de marcaciones contra franjas del turno
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Contracts.Programacion.ValueObjects;
+using Bitakora.ControlAsistencia.ControlHoras.Entities;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Tests.Entities;
+
+/// <summary>
+/// Tests de DepuradorDeMarcaciones - cubre el algoritmo secuencial por rango completo.
+/// Un Fact por criterio de aceptacion (CA-1 a CA-8 y CA-10).
+/// </summary>
+public class DepuradorDeMarcacionesTests
+{
+    // Franjas nombradas semanticamente
+    private static readonly DetalleFranjaOrdinaria Franja06_14 = new(
+        new TimeOnly(6, 0), new TimeOnly(14, 0), 0, [], []);
+
+    private static readonly DetalleFranjaOrdinaria Franja06_12 = new(
+        new TimeOnly(6, 0), new TimeOnly(12, 0), 0, [], []);
+
+    private static readonly DetalleFranjaOrdinaria Franja14_18 = new(
+        new TimeOnly(14, 0), new TimeOnly(18, 0), 0, [], []);
+
+    // DiaOffsetFin=1 porque 22:00 > 06:00 (fin al dia siguiente)
+    private static readonly DetalleFranjaOrdinaria Franja22_06_Nocturna = new(
+        new TimeOnly(22, 0), new TimeOnly(6, 0), 1, [], []);
+
+    // Fecha de referencia para todos los tests
+    private static readonly DateOnly FechaBase = new(2026, 3, 15);
+
+    // Helpers para construir timestamps con nombres semanticos
+    private static DateTime En(int h, int m) => new(2026, 3, 15, h, m, 0);
+    private static DateTime EnDiaSiguiente(int h, int m) => new(2026, 3, 16, h, m, 0);
+
+    // Constantes con nombres semanticos para marcaciones frecuentes
+    private static readonly MarcacionNormalizada Marcacion05_50 = new(En(5, 50), null);
+    private static readonly MarcacionNormalizada Marcacion12_05 = new(En(12, 5), null);
+
+    // Factory inline para marcaciones del dia base
+    private static MarcacionNormalizada M(int h, int m) => new(En(h, m), null);
+
+    // Factory inline para marcaciones del dia siguiente
+    private static MarcacionNormalizada MSig(int h, int m) => new(EnDiaSiguiente(h, m), null);
+
+    [Fact]
+    public void Depurar_ProduceEntradaYSalidaCorrectas_CuandoFranjaUnicaConDosMarcaciones()
+    {
+        // CA-1: Una franja (06:00-14:00) con dos marcaciones (07:00, 15:00)
+        // Con franja unica el rango es (-inf, +inf) -> primera=Entrada, ultima=Salida
+        var turno = new DetalleTurno("Diurno", [Franja06_14]);
+
+        var resultado = DepuradorDeMarcaciones.Depurar(turno, FechaBase, [M(7, 0), M(15, 0)]);
+
+        resultado.Should().BeEquivalentTo(
+            new[] { new ControlFranja(Franja06_14, En(7, 0), En(15, 0)) },
+            options => options.WithStrictOrdering());
+    }
+
+    [Fact]
+    public void Depurar_DistribuyeMarcacionesPorPuntoDeCorte_CuandoTurnoPartido()
+    {
+        // CA-2: Turno partido (06:00-12:00, 14:00-18:00) con 4 marcaciones (05:50, 12:05, 14:10, 18:15)
+        // Gap 12:00-14:00 -> punto de corte = 13:00 (punto medio del gap)
+        // F1 captura marcaciones antes de 13:00: 05:50 y 12:05
+        // F2 captura marcaciones desde 13:00: 14:10 y 18:15
+        var turno = new DetalleTurno("Partido", [Franja06_12, Franja14_18]);
+
+        var resultado = DepuradorDeMarcaciones.Depurar(turno, FechaBase,
+            [Marcacion05_50, Marcacion12_05, M(14, 10), M(18, 15)]);
+
+        resultado.Should().BeEquivalentTo(new[]
+        {
+            new ControlFranja(Franja06_12, En(5, 50), En(12, 5)),
+            new ControlFranja(Franja14_18, En(14, 10), En(18, 15))
+        }, options => options.WithStrictOrdering());
+    }
+
+    [Fact]
+    public void Depurar_ProduceEntradaConSalidaNull_CuandoFranjaTieneUnaSolaMarcacion()
+    {
+        // CA-3: Franja con una sola marcacion -> Entrada poblada, Salida null, EsAnomala true
+        var turno = new DetalleTurno("Diurno", [Franja06_14]);
+
+        var resultado = DepuradorDeMarcaciones.Depurar(turno, FechaBase, [M(7, 0)]);
+
+        resultado.Should().BeEquivalentTo(
+            new[] { new ControlFranja(Franja06_14, En(7, 0), null) },
+            options => options.WithStrictOrdering());
+        resultado[0].EsAnomala.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Depurar_ProduceEntradaYSalidaNull_CuandoFranjaSinMarcaciones()
+    {
+        // CA-4: Franja sin marcaciones -> Entrada null, Salida null, EsAnomala true
+        var turno = new DetalleTurno("Diurno", [Franja06_14]);
+
+        var resultado = DepuradorDeMarcaciones.Depurar(turno, FechaBase, []);
+
+        resultado.Should().BeEquivalentTo(
+            new[] { new ControlFranja(Franja06_14, null, null) },
+            options => options.WithStrictOrdering());
+        resultado[0].EsAnomala.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Depurar_DescartaMarcacionesIntermedias_CuandoHayMasDeDosMarcaciones()
+    {
+        // CA-5: Franja unica con marcaciones 07:00, 10:00, 12:00, 15:00
+        // -> Entrada=07:00, Salida=15:00; las de 10:00 y 12:00 se descartan
+        var turno = new DetalleTurno("Diurno", [Franja06_14]);
+
+        var resultado = DepuradorDeMarcaciones.Depurar(turno, FechaBase,
+            [M(7, 0), M(10, 0), M(12, 0), M(15, 0)]);
+
+        resultado.Should().BeEquivalentTo(
+            new[] { new ControlFranja(Franja06_14, En(7, 0), En(15, 0)) },
+            options => options.WithStrictOrdering());
+    }
+
+    [Fact]
+    public void Depurar_RetornaListaVacia_CuandoTurnoEsNull()
+    {
+        // CA-6: turno null -> lista vacia (Count == 0)
+        var resultado = DepuradorDeMarcaciones.Depurar(null, FechaBase, [M(7, 0)]);
+
+        resultado.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Depurar_ResuelveRangoNocturno_CuandoFranjaTieneDiaOffsetFin1()
+    {
+        // CA-7: Franja nocturna 22:00-06:00 con DiaOffsetFin=1, fecha ancla 2026-03-15
+        // Rango resuelto: 2026-03-15 22:00 -> 2026-03-16 06:00
+        // Marcacion 22:30 del 15 y 05:30 del 16 quedan en la misma franja
+        var turno = new DetalleTurno("Nocturno", [Franja22_06_Nocturna]);
+
+        var resultado = DepuradorDeMarcaciones.Depurar(turno, FechaBase, [
+            new MarcacionNormalizada(En(22, 30), null),
+            new MarcacionNormalizada(EnDiaSiguiente(5, 30), null)
+        ]);
+
+        resultado.Should().BeEquivalentTo(
+            new[] { new ControlFranja(Franja22_06_Nocturna, En(22, 30), EnDiaSiguiente(5, 30)) },
+            options => options.WithStrictOrdering());
+    }
+
+    [Fact]
+    public void Depurar_AsignaTodosMarcacionesAFranjaUnica_CuandoHayUnaSolaFranja()
+    {
+        // CA-8: Con una sola franja, el rango es (-inf, +inf) -> todas las marcaciones le pertenecen.
+        // Timestamps fuera del horario nominal de la franja para verificar que no se filtra por hora.
+        var turno = new DetalleTurno("Diurno", [Franja06_14]);
+
+        var resultado = DepuradorDeMarcaciones.Depurar(turno, FechaBase, [M(3, 0), M(20, 0)]);
+
+        resultado.Should().BeEquivalentTo(
+            new[] { new ControlFranja(Franja06_14, En(3, 0), En(20, 0)) },
+            options => options.WithStrictOrdering());
+    }
+
+    [Fact]
+    public void Depurar_SegundaFranjaEsAnomalas_CuandoSoloPrimeraFranjaTieneMarcaciones()
+    {
+        // CA-10: Turno partido donde solo la primera franja tiene marcaciones
+        // F1 (06:00-12:00): Entrada=05:50, Salida=12:05 -> EsAnomala false
+        // F2 (14:00-18:00): Entrada=null, Salida=null -> EsAnomala true
+        var turno = new DetalleTurno("Partido", [Franja06_12, Franja14_18]);
+
+        var resultado = DepuradorDeMarcaciones.Depurar(turno, FechaBase,
+            [Marcacion05_50, Marcacion12_05]);
+
+        resultado.Should().BeEquivalentTo(new[]
+        {
+            new ControlFranja(Franja06_12, En(5, 50), En(12, 5)),
+            new ControlFranja(Franja14_18, null, null)
+        }, options => options.WithStrictOrdering());
+        resultado[1].EsAnomala.Should().BeTrue();
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/DepuradorDeMarcacionesTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/DepuradorDeMarcacionesTests.cs
@@ -136,10 +136,7 @@ public class DepuradorDeMarcacionesTests
         // Marcacion 22:30 del 15 y 05:30 del 16 quedan en la misma franja
         var turno = new DetalleTurno("Nocturno", [Franja22_06_Nocturna]);
 
-        var resultado = DepuradorDeMarcaciones.Depurar(turno, FechaBase, [
-            new MarcacionNormalizada(En(22, 30), null),
-            new MarcacionNormalizada(EnDiaSiguiente(5, 30), null)
-        ]);
+        var resultado = DepuradorDeMarcaciones.Depurar(turno, FechaBase, [M(22, 30), MSig(5, 30)]);
 
         resultado.Should().BeEquivalentTo(
             new[] { new ControlFranja(Franja22_06_Nocturna, En(22, 30), EnDiaSiguiente(5, 30)) },
@@ -147,7 +144,7 @@ public class DepuradorDeMarcacionesTests
     }
 
     [Fact]
-    public void Depurar_AsignaTodosMarcacionesAFranjaUnica_CuandoHayUnaSolaFranja()
+    public void Depurar_AsignaTodasLasMarcacionesAFranjaUnica_CuandoHayUnaSolaFranja()
     {
         // CA-8: Con una sola franja, el rango es (-inf, +inf) -> todas las marcaciones le pertenecen.
         // Timestamps fuera del horario nominal de la franja para verificar que no se filtra por hora.
@@ -161,7 +158,7 @@ public class DepuradorDeMarcacionesTests
     }
 
     [Fact]
-    public void Depurar_SegundaFranjaEsAnomalas_CuandoSoloPrimeraFranjaTieneMarcaciones()
+    public void Depurar_SegundaFranjaEsAnomala_CuandoSoloPrimeraFranjaTieneMarcaciones()
     {
         // CA-10: Turno partido donde solo la primera franja tiene marcaciones
         // F1 (06:00-12:00): Entrada=05:50, Salida=12:05 -> EsAnomala false


### PR DESCRIPTION
## Resumen

Pipeline TDD completado:
- Fase roja: tests escritos con stubs
- Fase verde: implementación completa
- Fase refactor: revisión de calidad

## Decisiones del pipeline

<details>
<summary>Test Writer (fase roja) — 5m 21s</summary>

_(El agente no generó resumen)_

</details>

<details>
<summary>Implementer (fase verde) — 3m 11s</summary>

## ES Implementer - Decisiones

### Enfoque de implementacion
Implementacion de logica pura sin event sourcing: ambos tipos son value objects/helpers estaticos. `ControlFranja.EsAnomala` se resuelve con expresion logica simple. `DepuradorDeMarcaciones.Depurar` implementa el algoritmo secuencial por rango en tres pasos: (1) resolver franjas a rangos `DateTime` absolutos, (2) calcular rangos de captura usando puntos medios entre franjas adyacentes, (3) asignar marcaciones a cada rango tomando la primera como Entrada y la ultima como Salida.

### Decisiones de diseno
- Uso de tuples de C# sobre records auxiliares: los pares `(Inicio, Fin)` son detalle de calculo efimero; crear un record ValueObject solo para ellos anadiria ruido. Tuples nombrados dan legibilidad suficiente y quedan contenidos en los helpers privados.
- Intervalo semiabierto `[Inicio, Fin)` para rangos de captura: ninguna marcacion queda ambigua en el punto de corte y el limite `DateTime.MaxValue` exclusivo no genera problemas (cualquier DateTime real es `< MaxValue`).
- Punto medio con `AddTicks((b - a).Ticks / 2)`: evita perdida de precision de usar operaciones sobre minutos/segundos. El truncamiento entero en la division por 2 no importa porque no comparamos por el mismo tick exacto con ninguna marcacion.
- Cuatro helpers privados con responsabilidad unica: `ResolverRango`, `CalcularRangosDeCaptura`, `PuntoMedio`, `ConstruirControlFranja`. Cada uno tiene una sola razon para cambiar. El orquestador `Depurar` queda como pipeline LINQ declarativo.
- LINQ en todo el flujo: no hay un solo for/foreach. Los indices se resuelven con `Select((item, indice) => ...)` para preservar la relacion franja-rango.
- Uso de `DateOnly.ToDateTime(TimeOnly)` y `AddDays(DiaOffsetFin)` para resolver rangos: tratamiento uniforme de turnos diurnos (offset 0) y nocturnos (offset 1) sin ramas condicionales.
- `ControlFranja` record con constructor primario publico: no tiene invariantes propios, los componentes validos son responsabilidad del llamador. Segun el issue, tampoco requiere `ConfigurarSerializacion` porque aun no viaja en streams.

### Infraestructura modificada
Ninguna. La historia introduce logica pura sin eventos, sin handlers y sin comunicacion entre dominios.

### Complejidad encontrada
- CA-7 (turno nocturno): el punto de mirar fue confirmar que `ToDateTime` sobre `DateOnly` ajustado con `AddDays(DiaOffsetFin)` produce el instante correcto. Resuelto con `fecha.AddDays(franja.DiaOffsetFin).ToDateTime(franja.HoraFin)`.
- CA-8 (franja unica con marcaciones fuera del horario nominal): garantizado por el contrato `(MinValue, MaxValue)` del rango de captura cuando solo hay una franja. Ninguna condicion adicional necesaria.

### Resultado
- Tests pasando: 70/70 en ControlHoras.Tests (suite completa: 190 correctos, 6 omitidos por smoke tests sin servicios externos).

</details>
<details>
<summary>Reviewer (fase refactor) — 6m 2s</summary>

## ES Reviewer - Revision

### Evaluacion general
- Calidad: buena
- Cambios realizados: si (refactor menor de tests)

### Checklist de patrones ES
| Patron | Estado | Observacion |
|---|---|---|
| Apply() sin logica condicional | n/a | HU no toca aggregates |
| CommandHandler orquestador puro | n/a | HU no toca handlers |
| Sin AppendEvents/SaveChangesAsync manual | n/a | HU no toca streams |
| ThrowExactlyAsync solo para precondiciones | n/a | No hay handler |
| Cada test con Then() + And<>() | n/a | Tests puros, no DSL ES (no hay handler/aggregate) |
| Naming de eventos en pasado | n/a | No introduce eventos |
| Naming de funciones Azure | n/a | No introduce funciones Azure |
| Infraestructura Service Bus verificada | n/a | No emite ni consume eventos |
| Organizacion vertical (feature folders) | ok | `Entities/` a nivel raiz del dominio |
| Sin strings hardcodeados en mensajes | ok | No hay mensajes (logica pura sin excepciones de dominio) |
| Aggregates/handlers son partial class | n/a | |
| Modelado record/clase apropiado | ok | `ControlFranja` es record inmutable; `DepuradorDeMarcaciones` es `static` sin estado |
| Factory static en objetos con invariantes | n/a | `ControlFranja` no tiene invariantes |
| Sin init en objetos con invariantes | ok | Usa constructor primario, sin `{ get; init; }` |
| Tell Don't Ask (calculos en el objeto) | ok | `EsAnomala` vive dentro de `ControlFranja`; el algoritmo vive en `DepuradorDeMarcaciones` |
| Sin numeros magicos | ok | Usa `DiaOffsetFin` del dominio y `DateTime.MinValue/MaxValue` centinelas |
| Propiedades internas son protected/private | ok | Helpers privados (`ResolverRango`, `CalcularRangosDeCaptura`, `PuntoMedio`, `ConstruirControlFranja`) |
| Tests via ToString (no via getters internos) | n/a | No hay `ToString` relevante |
| Mensajes en .resx (excepciones Y labels ToString) | n/a | Sin excepciones ni ToString |
| Tests verifican mensaje de excepcion (.WithMessage) | n/a | Sin excepciones |
| Tests de IEquatable para value objects | n/a | `ControlFranja` es record con equality automatica; no implementa IEquatable manual |
| Tests de serializacion round-trip | n/a | Issue declara explicitamente que NO se requiere `ConfigurarSerializacion` todavia (#107-b) |
| IPublicEvent solo en Contracts/Eventos/ | n/a | No introduce eventos publicos |
| Sin InternalsVisibleTo de Contracts a dominio | ok | No se modifico |
| Sin records duplicados (command vs Contracts) | ok | `ControlFranja` reutiliza `DetalleFranjaOrdinaria` de Contracts |
| Sin wrappers de IEventStore en tests | n/a | Tests puros sin event store |

### Elegancia del codigo
- **Compacto**: `ControlFranja` (12 lineas) y `DepuradorDeMarcaciones` (81 lineas) son minimos para lo que logran. Cuatro helpers privados con responsabilidad unica y un orquestador `Depurar` como pipeline LINQ declarativo.
- **Legible**: los nombres describen intent (`rangosDeCaptura`, `PuntoMedio`, `franjasResueltas`). Comentarios didacticos enlazan cada bloque con el criterio de aceptacion.
- **Idiomatico**: uso consistente de LINQ (`Select`, `OrderBy`, `Where`), pattern matching con `is null`, lista vacia con `[]`, constructor primario del record. Cero for/foreach. Tuples nombrados en vez de records auxiliares para el detalle efimero `(Inicio, Fin)`.
- **Robusto**: guard clause temprano para `turno is null`. Intervalo semiabierto `[Inicio, Fin)` evita ambiguedad en el punto de corte. `PuntoMedio` usa `Ticks` para preservar precision.
- **Eficiente**: O(n*m) donde n=#franjas y m=#marcaciones. Para el uso esperado (1-3 franjas, 5-20 marcaciones/dia) es trivial. Simplificar a O(n+m) con una sola pasada agregaria complejidad innecesaria.
- **Limpio**: cero warnings del compilador y cero violaciones de formato en los archivos tocados.

### Criticas y hallazgos
- **Codigo muerto en tests (menor, corregido)**: el helper `MSig(int h, int m)` estaba definido pero no se usaba. CA-7 construia la marcacion del dia siguiente inline con `new MarcacionNormalizada(EnDiaSiguiente(5, 30), null)` en vez de aprovechar el helper.
- **Typos en nombres de test (cosmeticos, corregidos)**:
  - `AsignaTodosMarcaciones` -> `AsignaTodasLasMarcaciones` (concordancia de genero: "las marcaciones" es femenino plural).
  - `SegundaFranjaEsAnomalas` -> `SegundaFranjaEsAnomala` (el sujeto "SegundaFranja" es singular).
- **Warnings de formato preexistentes**: `dotnet format --verify-no-changes` reporta warnings IDE0005 en archivos del dominio Programacion (no tocados por esta HU). Fuera de scope.

### Refactorings aplicados
- Tests de CA-7 reescritos para usar los helpers `M(22, 30)` y `MSig(5, 30)` en vez de instanciar `MarcacionNormalizada` inline. Esto elimina el codigo muerto (`MSig` ya no queda sin uso) y mejora la consistencia con el resto de tests.
- Renombre de dos metodos de test para corregir typos en concordancia gramatical.

### Cobertura de criterios de aceptacion
| Criterio | Estado | Test(s) |
|---|---|---|
| CA-1: franja unica con dos marcaciones -> Entrada/Salida | cubierto | `Depurar_ProduceEntradaYSalidaCorrectas_CuandoFranjaUnicaConDosMarcaciones` |
| CA-2: turno partido con punto de corte 13:00 | cubierto | `Depurar_DistribuyeMarcacionesPorPuntoDeCorte_CuandoTurnoPartido` |
| CA-3: franja con una sola marcacion | cubierto | `Depurar_ProduceEntradaConSalidaNull_CuandoFranjaTieneUnaSolaMarcacion` |
| CA-4: franja sin marcaciones | cubierto | `Depurar_ProduceEntradaYSalidaNull_CuandoFranjaSinMarcaciones` |
| CA-5: marcaciones intermedias descartadas | cubierto | `Depurar_DescartaMarcacionesIntermedias_CuandoHayMasDeDosMarcaciones` |
| CA-6: turno null -> lista vacia | cubierto | `Depurar_RetornaListaVacia_CuandoTurnoEsNull` |
| CA-7: turno nocturno con DiaOffsetFin=1 | cubierto | `Depurar_ResuelveRangoNocturno_CuandoFranjaTieneDiaOffsetFin1` |
| CA-8: una sola franja captura todas las marcaciones | cubierto | `Depurar_AsignaTodasLasMarcacionesAFranjaUnica_CuandoHayUnaSolaFranja` |
| CA-9: EsAnomala calculada en cada acceso | cubierto | `EsAnomala_EsTrue_CuandoEntradaEsNull`, `..._CuandoSalidaEsNull`, `..._CuandoEntradaYSalidaSonNull`, `EsAnomala_EsFalse_CuandoEntradaYSalidaEstanPobladas` |
| CA-10: turno partido con solo primera franja marcada | cubierto | `Depurar_SegundaFranjaEsAnomala_CuandoSoloPrimeraFranjaTieneMarcaciones` |

### Tests agregados
- Ningun test adicional. La cobertura de los 10 CA ya era completa en la fase roja/verde. Solo se hicieron refinamientos cosmeticos.

</details>

## Cobertura

| Archivo | Cobertura | Umbral | Estado |
|---|---|---|---|
| ControlFranja.cs | - | no evaluado | - |
| DepuradorDeMarcaciones.cs | - | no evaluado | - |
## Commits

da788a5 refactor(hu-122): elimina codigo muerto y corrige typos en tests del depurador
f656daf feat(hu-122): implementa depurador secuencial por rango (fase verde)
9f811e0 test(hu-122): tests para depurador de marcaciones contra franjas del turno (fase roja)

Closes #122