### PR TITLE
Evitar que watchdogs de run_agent bloqueen el pipe del batch-pipeline

### DIFF
--- a/scripts/tdd-pipeline.sh
+++ b/scripts/tdd-pipeline.sh
@@ -357,7 +357,7 @@ else
             >"$LOG_SCAFFOLD" 2>&1) &
         SCAFFOLD_PID=$!
         (sleep $SCAFFOLD_TIMEOUT && kill -9 -$SCAFFOLD_PID 2>/dev/null && \
-            echo "[$(date +%H:%M:%S)] TIMEOUT: domain-scaffolder supero ${SCAFFOLD_TIMEOUT}s" >> "$EVENTS_LOG_ABS") &
+            echo "[$(date +%H:%M:%S)] TIMEOUT: domain-scaffolder supero ${SCAFFOLD_TIMEOUT}s" >> "$EVENTS_LOG_ABS") </dev/null >/dev/null 2>&1 &
         SCAFFOLD_WATCHDOG=$!
 
         SCAFFOLD_EXIT=0
@@ -430,7 +430,7 @@ run_agent() {
         >"$log_stage" 2>&1) &
     local CLAUDE_PID=$!
     # M3: usar SIGKILL para garantizar que el proceso muere al timeout
-    (sleep $AGENT_TIMEOUT_SECONDS && kill -9 -$CLAUDE_PID 2>/dev/null && echo "[$(date +%H:%M:%S)] TIMEOUT: $agent superó ${AGENT_TIMEOUT_SECONDS}s — eliminado con SIGKILL" >> "$EVENTS_LOG_ABS") &
+    (sleep $AGENT_TIMEOUT_SECONDS && kill -9 -$CLAUDE_PID 2>/dev/null && echo "[$(date +%H:%M:%S)] TIMEOUT: $agent superó ${AGENT_TIMEOUT_SECONDS}s — eliminado con SIGKILL" >> "$EVENTS_LOG_ABS") </dev/null >/dev/null 2>&1 &
     local WATCHDOG_PID=$!
 
     local CLAUDE_EXIT=0
@@ -1156,7 +1156,7 @@ for bn, fullpath in logic_basenames.items():
     ) &
     CG_MEASURE_PID=$!
     (sleep $CG_TIMEOUT_MEASURE && kill -9 $CG_MEASURE_PID 2>/dev/null && \
-        echo "[$(date +%H:%M:%S)] TIMEOUT: coverage measurement supero ${CG_TIMEOUT_MEASURE}s" >> "$EVENTS_LOG_ABS") &
+        echo "[$(date +%H:%M:%S)] TIMEOUT: coverage measurement supero ${CG_TIMEOUT_MEASURE}s" >> "$EVENTS_LOG_ABS") </dev/null >/dev/null 2>&1 &
     CG_MEASURE_WATCHDOG=$!
 
     CG_MEASURE_EXIT=0
@@ -1318,7 +1318,7 @@ IMPORTANTE:
             >"$LOG_CG_TW" 2>&1) &
         CG_TW_PID=$!
         (sleep $CG_REMEDIATION_TIMEOUT && kill -9 $CG_TW_PID 2>/dev/null && \
-            echo "[$(date +%H:%M:%S)] TIMEOUT: coverage test-writer supero ${CG_REMEDIATION_TIMEOUT}s" >> "$EVENTS_LOG_ABS") &
+            echo "[$(date +%H:%M:%S)] TIMEOUT: coverage test-writer supero ${CG_REMEDIATION_TIMEOUT}s" >> "$EVENTS_LOG_ABS") </dev/null >/dev/null 2>&1 &
         CG_TW_WATCHDOG=$!
 
         CG_TW_EXIT=0
@@ -1361,7 +1361,7 @@ Pista: revisa los ultimos archivos de test creados/modificados y corrige errores
                     >"$LOG_CG_IM" 2>&1) &
                 CG_IM_PID=$!
                 (sleep $CG_REMEDIATION_TIMEOUT && kill -9 $CG_IM_PID 2>/dev/null && \
-                    echo "[$(date +%H:%M:%S)] TIMEOUT: coverage implementer supero ${CG_REMEDIATION_TIMEOUT}s" >> "$EVENTS_LOG_ABS") &
+                    echo "[$(date +%H:%M:%S)] TIMEOUT: coverage implementer supero ${CG_REMEDIATION_TIMEOUT}s" >> "$EVENTS_LOG_ABS") </dev/null >/dev/null 2>&1 &
                 CG_IM_WATCHDOG=$!
 
                 CG_IM_EXIT=0
@@ -1394,7 +1394,7 @@ Pista: revisa los ultimos archivos de test creados/modificados y corrige errores
                 (measure_coverage) &
                 CG_REMEASURE_PID=$!
                 (sleep $CG_TIMEOUT_MEASURE && kill -9 $CG_REMEASURE_PID 2>/dev/null && \
-                    echo "[$(date +%H:%M:%S)] TIMEOUT: re-medicion cobertura supero ${CG_TIMEOUT_MEASURE}s" >> "$EVENTS_LOG_ABS") &
+                    echo "[$(date +%H:%M:%S)] TIMEOUT: re-medicion cobertura supero ${CG_TIMEOUT_MEASURE}s" >> "$EVENTS_LOG_ABS") </dev/null >/dev/null 2>&1 &
                 CG_REMEASURE_WATCHDOG=$!
                 CG_REMEASURE_EXIT=0
                 wait $CG_REMEASURE_PID || CG_REMEASURE_EXIT=$?

--- a/scripts/tooling-pipeline.sh
+++ b/scripts/tooling-pipeline.sh
@@ -273,7 +273,7 @@ run_agent() {
         --output-format text \
         >"$log_stage" 2>&1) &
     local CLAUDE_PID=$!
-    (sleep $AGENT_TIMEOUT_SECONDS && kill -9 -$CLAUDE_PID 2>/dev/null && echo "[$(date +%H:%M:%S)] TIMEOUT: $agent supero ${AGENT_TIMEOUT_SECONDS}s" >> "$EVENTS_LOG_ABS") &
+    (sleep $AGENT_TIMEOUT_SECONDS && kill -9 -$CLAUDE_PID 2>/dev/null && echo "[$(date +%H:%M:%S)] TIMEOUT: $agent supero ${AGENT_TIMEOUT_SECONDS}s" >> "$EVENTS_LOG_ABS") </dev/null >/dev/null 2>&1 &
     local WATCHDOG_PID=$!
 
     local CLAUDE_EXIT=0


### PR DESCRIPTION
## Resumen

Pipeline tooling completado:
- Writer: implementacion de la tarea
- Reviewer: revision de calidad

## Decisiones del pipeline

<details>
<summary>Writer -- 4m 10s</summary>

# Stage 1 - Writer - Issue #133

## Resumen

Se aplico la redireccion `</dev/null >/dev/null 2>&1` antes del `&` en los 7 watchdogs
que lanzan subshells con el patron `(sleep N && kill ...)` en los pipelines. Esto evita
que el `sleep` hijo (reparenteado a init cuando el watchdog padre muere) herede el FD 1
del pipe al `tee` del batch-pipeline y lo mantenga abierto por hasta 30 minutos,
bloqueando el avance del batch entre issues.

## Archivos modificados

### `scripts/tdd-pipeline.sh` (6 watchdogs)

1. Linea 359-360: watchdog del `domain-scaffolder` (SCAFFOLD_TIMEOUT, 1800s).
2. Linea 433: watchdog principal de `run_agent` (AGENT_TIMEOUT_SECONDS, 1800s).
3. Linea 1158-1159: watchdog de medicion de cobertura (CG_TIMEOUT_MEASURE, 600s).
4. Linea 1320-1321: watchdog de remediacion `test-writer` (CG_REMEDIATION_TIMEOUT).
5. Linea 1363-1364: watchdog de remediacion `implementer` (CG_REMEDIATION_TIMEOUT).
6. Linea 1396-1397: watchdog de re-medicion de cobertura post-remediacion.

### `scripts/tooling-pipeline.sh` (1 watchdog)

1. Linea 276: watchdog principal de `run_agent` en pipeline de tooling.

## Patron aplicado

Antes:
```bash
(sleep $TIMEOUT && kill -9 -$PID 2>/dev/null && echo "..." >> "$EVENTS_LOG_ABS") &
```

Despues:
```bash
(sleep $TIMEOUT && kill -9 -$PID 2>/dev/null && echo "..." >> "$EVENTS_LOG_ABS") </dev/null >/dev/null 2>&1 &
```

La redireccion global del subshell cubre al `sleep` hijo. El `echo ... >> "$EVENTS_LOG_ABS"`
dentro del subshell mantiene su redireccion explicita al log de eventos (redireccion explicita
gana sobre la global del subshell).

## Criterios de aceptacion

- [x] CA-1: Redireccion aplicada al watchdog de `run_agent` en `tdd-pipeline.sh` (linea 433).
- [x] CA-2: Redireccion aplicada a los 4 watchdogs de coverage remediation (1158, 1320, 1363, 1396) y al watchdog del domain-scaffolder (359).
- [x] CA-3: Redireccion aplicada al watchdog de `tooling-pipeline.sh` (linea 276).
- [x] CA-4: `bash -n scripts/tdd-pipeline.sh` y `bash -n scripts/tooling-pipeline.sh` pasan.
- [ ] CA-5: Validacion empirica con `/sequential <A> <B>` queda para verificacion manual tras el merge (no se puede reproducir dentro de este pipeline aislado).

## Por que esta alternativa y no `setsid`

La causa del bloqueo es el FD heredado, no la existencia del proceso huerfano. La redireccion
elimina la herencia del pipe en origen, sin requerir utilidades externas. `setsid` no es
POSIX uniforme en macOS.

## Alcance

Solo se modificaron los watchdogs con el patron `(sleep N && kill ...) &`. No se toca
ninguna otra parte del pipeline. Ninguna logica de dominio fue modificada.

</details>

<details>
<summary>Reviewer -- 3m 23s</summary>

# Stage 2 - Reviewer

## Issue

#133 - Evitar que watchdogs de run_agent bloqueen el pipe del batch-pipeline.

## Veredicto

Aprobado. El commit 7d2fdb8 del writer cumple los criterios CA-1 a CA-4. CA-5 solo se puede validar empiricamente en la proxima ejecucion real de /sequential.

No se introdujeron correcciones adicionales. La redireccion es minima, focalizada y consistente en todos los puntos afectados.

## Verificaciones realizadas

### CA-1: run_agent de tdd-pipeline.sh

Linea 433 aplica la redireccion antes del background operator. Verificado con grep -n 'sleep.*&&.*kill'.

### CA-2: Watchdogs de coverage remediation y domain-scaffolder

Redireccion aplicada en las lineas:
- 360 (domain-scaffolder).
- 1159 (coverage measurement).
- 1321 (coverage test-writer).
- 1364 (coverage implementer).
- 1397 (re-medicion cobertura).

### CA-3: tooling-pipeline.sh

Linea 276 (unico watchdog de agente) con la misma redireccion.

### CA-4: Sintaxis

bash -n scripts/tdd-pipeline.sh pasa sin errores.
bash -n scripts/tooling-pipeline.sh pasa sin errores.

### CA-5: Validacion empirica

Pendiente. Se validara en el proximo /sequential. Criterio de exito: lsof -p <batch-pid> | grep sleep no devuelve FD 1 apuntando al pipe del tee al terminar el issue A.

## Diseno y alcance

### Por que el fix es correcto

- </dev/null >/dev/null 2>&1 aplicado al subshell cierra los FDs heredados antes de que el sleep hijo los pueda propagar despues de quedar huerfano (PPID=1).
- El echo ... >> EVENTS_LOG_ABS dentro del subshell conserva su redireccion local, que tiene precedencia sobre la global del subshell. Los logs de TIMEOUT siguen fluyendo al log de eventos.
- No requiere setsid ni utilidades externas (importante en macOS donde setsid no esta disponible nativamente).

### Watchdogs fuera del scope

scripts/iac-pipeline.sh:293 y scripts/scaffold-pipeline.sh:238 tambien usan el patron (sleep N && kill ...) & sin redireccion. No estan en el alcance del issue porque batch-pipeline.sh solo enruta a tdd-pipeline.sh y tooling-pipeline.sh (ver resolve_pipeline en scripts/_pipeline-common.sh); ningun pipeline iac/scaffold puede bloquear el tee del batch.

Si en el futuro batch-pipeline.sh aprende a enrutar a iac o scaffold, aplicar el mismo patron ahi.

### Consideraciones

- El cambio es idempotente: los siete watchdogs quedan con la misma redireccion.
- No hay regresion en el manejo de errores del agente: kill WATCHDOG_PID + wait posteriores siguen funcionando igual.
- No se introducen dependencias nuevas.

## Archivos tocados por el writer

- scripts/tdd-pipeline.sh (+6 / -6).
- scripts/tooling-pipeline.sh (+1 / -1).

## Commits del stage 2

Ninguno. El codigo del writer es suficiente; no se introdujeron cambios adicionales en esta revision.

</details>

## Commits

7d2fdb8 fix(tooling-133): evita que watchdogs de run_agent bloqueen pipe del batch

Closes #133