### PR TITLE
Integrar depurador al ControlDiario de forma reactiva

### DIFF
--- a/src/Bitakora.ControlAsistencia.ControlHoras/Entities/ControlDiarioAggregateRoot.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Entities/ControlDiarioAggregateRoot.cs
@@ -27,6 +27,16 @@ public partial class ControlDiarioAggregateRoot : AggregateRoot
     public IReadOnlyList<MarcacionNormalizada> Marcaciones => _marcaciones;
     private readonly List<MarcacionNormalizada> _marcaciones = [];
 
+    // HU-123: resultado del depurador de marcaciones aplicado reactivamente en cada Apply.
+    // Se recalcula completo en cada Apply(MarcacionAdicionada) y Apply(TurnoDiarioAsignado).
+    // Expuesta como IReadOnlyList para que los handlers y tests externos puedan consultar.
+    public IReadOnlyList<ControlFranja> ControlesDeFranja => _controlesDeFranja;
+    private readonly List<ControlFranja> _controlesDeFranja = [];
+
+    // HU-123: recalculo reactivo invocado al final de cada Apply
+    // Reemplaza completamente el contenido de _controlesDeFranja con el resultado del depurador
+    private void Depurar() => throw new NotImplementedException();
+
     // CA-7: stream ID determinista: "{EmpleadoId}:{Fecha:yyyy-MM-dd}"
     // CA-8: dos mensajes con mismo EmpleadoId+Fecha comparten el mismo stream
     public static string ComputarStreamId(string empleadoId, DateOnly fecha) =>

--- a/src/Bitakora.ControlAsistencia.ControlHoras/Entities/ControlDiarioAggregateRoot.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Entities/ControlDiarioAggregateRoot.cs
@@ -34,8 +34,14 @@ public partial class ControlDiarioAggregateRoot : AggregateRoot
     private readonly List<ControlFranja> _controlesDeFranja = [];
 
     // HU-123: recalculo reactivo invocado al final de cada Apply
-    // Reemplaza completamente el contenido de _controlesDeFranja con el resultado del depurador
-    private void Depurar() => throw new NotImplementedException();
+    // Reemplaza completamente el contenido de _controlesDeFranja con el resultado del depurador.
+    // Si DetalleTurno es null (marcacion llego antes que el turno), el depurador retorna lista vacia.
+    private void Depurar()
+    {
+        _controlesDeFranja.Clear();
+        var resultado = DepuradorDeMarcaciones.Depurar(DetalleTurno, Fecha, _marcaciones);
+        _controlesDeFranja.AddRange(resultado);
+    }
 
     // CA-7: stream ID determinista: "{EmpleadoId}:{Fecha:yyyy-MM-dd}"
     // CA-8: dos mensajes con mismo EmpleadoId+Fecha comparten el mismo stream
@@ -51,6 +57,7 @@ public partial class ControlDiarioAggregateRoot : AggregateRoot
         Fecha = e.Fecha;
         DetalleTurno = e.DetalleTurno;
         UltimaSolicitudId = e.SolicitudId;
+        Depurar();
     }
 
     // Factory: crea el aggregate con el evento en _uncommittedEvents para StartStream
@@ -77,6 +84,7 @@ public partial class ControlDiarioAggregateRoot : AggregateRoot
     {
         Id = e.Id;
         _marcaciones.Add(new MarcacionNormalizada(e.TimestampNormalizado, e.TipoMarcacion));
+        Depurar();
     }
 
     // HU-106: segundo camino de creacion del ControlDiario, sin turno asignado

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoMarcacionRegistrada/DepurarAlAdicionarMarcacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoMarcacionRegistrada/DepurarAlAdicionarMarcacionTests.cs
@@ -1,0 +1,115 @@
+// HU-123: Integrar depurador al ControlDiario de forma reactiva
+// Familia 1: verifica que Apply(MarcacionAdicionada) dispara el recalculo de ControlesDeFranja
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Contracts.Empleados.ValueObjects;
+using Bitakora.ControlAsistencia.Contracts.Programacion.ValueObjects;
+using Bitakora.ControlAsistencia.ControlHoras.AdicionarMarcacionCuandoMarcacionRegistrada.CommandHandler;
+using Bitakora.ControlAsistencia.ControlHoras.AdicionarMarcacionCuandoMarcacionRegistrada.Eventos;
+using Bitakora.ControlAsistencia.ControlHoras.AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction.Eventos;
+using Bitakora.ControlAsistencia.ControlHoras.Entities;
+using Bitakora.ControlAsistencia.ControlHoras.RegistrarMarcacionFunction.Eventos;
+using Cosmos.EventSourcing.Abstractions.Commands;
+using Cosmos.EventSourcing.Testing.Utilities;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Tests.AdicionarMarcacionCuandoMarcacionRegistrada;
+
+public class DepurarAlAdicionarMarcacionTests : CommandHandlerAsyncTest<MarcacionRegistrada>
+{
+    // Datos de prueba fijos - misma ancla de fecha que los tests del handler
+    private const string EmpleadoId = "EMP-001";
+    private static readonly DateOnly Fecha = new(2026, 3, 15);
+    private static readonly string StreamId = $"{EmpleadoId}:{Fecha:yyyy-MM-dd}";
+
+    // Empleado para construir TurnoDiarioAsignado en Given
+    private static readonly InformacionEmpleado Empleado = new(
+        EmpleadoId, "CC", "1234567890", "Luis Augusto", "Barreto");
+    private static readonly Guid SolicitudId = Guid.Parse("019600c0-0000-7000-8000-000000000001");
+
+    // CA-1: franja unica 06:00-14:00
+    private static readonly DetalleFranjaOrdinaria Franja06_14 =
+        new(new TimeOnly(6, 0), new TimeOnly(14, 0), 0, [], []);
+
+    // CA-3: turno partido con dos franjas
+    private static readonly DetalleFranjaOrdinaria Franja06_12 =
+        new(new TimeOnly(6, 0), new TimeOnly(12, 0), 0, [], []);
+    private static readonly DetalleFranjaOrdinaria Franja14_18 =
+        new(new TimeOnly(14, 0), new TimeOnly(18, 0), 0, [], []);
+
+    // Timestamps de marcaciones (fuera de ventana nocturna: >= 04:00)
+    private static readonly DateTime Timestamp07_00 = new(2026, 3, 15, 7, 0, 0);
+    private static readonly DateTime Timestamp05_50 = new(2026, 3, 15, 5, 50, 0);
+    private static readonly DateTime Timestamp12_05 = new(2026, 3, 15, 12, 5, 0);
+    private static readonly DateTime Timestamp14_10 = new(2026, 3, 15, 14, 10, 0);
+
+    protected override ICommandHandlerAsync<MarcacionRegistrada> Handler =>
+        new AdicionarMarcacionCuandoMarcacionRegistradaCommandHandler(EventStore);
+
+    private static MarcacionRegistrada CrearMarcacionRegistrada(DateTime timestamp) =>
+        new(EmpleadoId, timestamp, "ENTRADA", "DEV-001");
+
+    private static MarcacionAdicionada CrearMarcacionAdicionada(DateTime timestamp) =>
+        new(StreamId, EmpleadoId, timestamp, "ENTRADA", "DEV-001");
+
+    private static TurnoDiarioAsignado CrearTurnoDiarioAsignado(DetalleTurno detalleTurno) =>
+        new(StreamId, Empleado, Fecha, detalleTurno, SolicitudId);
+
+    // CA-1: con TurnoDiarioAsignado (franja unica 06:00-14:00) previo y MarcacionRegistrada a las 07:00,
+    //        ControlesDeFranja debe quedar con un ControlFranja(Franja06_14, Entrada=07:00, Salida=null).
+    //        Verifica que el hook reactivo se dispara desde Apply(MarcacionAdicionada).
+    [Fact]
+    public async Task DebeCalcularControlFranja_CuandoHayTurnoYLlegaMarcacion()
+    {
+        var turnoUnico = new DetalleTurno("Turno Manana", [Franja06_14]);
+        Given(StreamId, CrearTurnoDiarioAsignado(turnoUnico));
+
+        await WhenAsync(CrearMarcacionRegistrada(Timestamp07_00));
+
+        Then(StreamId, CrearMarcacionAdicionada(Timestamp07_00));
+        And<ControlDiarioAggregateRoot, IReadOnlyList<ControlFranja>>(
+            StreamId,
+            c => c.ControlesDeFranja,
+            new ControlFranja[] { new(Franja06_14, Timestamp07_00, null) });
+    }
+
+    // CA-2: sin turno previo, la marcacion crea el aggregate sin DetalleTurno.
+    //        Depurar() retorna lista vacia porque DepuradorDeMarcaciones.Depurar(null,...) -> [].
+    //        Verifica el caso "marcacion llega antes del turno" donde el aggregate
+    //        se inicia solo con marcacion y no hay nada que depurar.
+    [Fact]
+    public async Task DebeDejarControlesDeFranjaVacios_CuandoNoHayTurnoPrevio()
+    {
+        // Sin Given - el aggregate se crea solo con la marcacion (DetalleTurno queda null)
+        await WhenAsync(CrearMarcacionRegistrada(Timestamp07_00));
+
+        Then(StreamId, CrearMarcacionAdicionada(Timestamp07_00));
+        And<ControlDiarioAggregateRoot, int>(
+            StreamId, c => c.ControlesDeFranja.Count, 0);
+    }
+
+    // CA-3: con turno partido (06:00-12:00 y 14:00-18:00) y 2 MarcacionAdicionada previas
+    //        (05:50 y 12:05), la nueva MarcacionRegistrada a las 14:10 dispara el recalculo
+    //        completo: F1(Entrada=05:50, Salida=12:05) + F2(Entrada=14:10, Salida=null).
+    //        Verifica comportamiento idem-potente: no acumula sobre resultado anterior.
+    [Fact]
+    public async Task DebeRecalcularControlesDeFranjaCompletos_CuandoHayTurnoPartidoYMarcacionesAcumuladas()
+    {
+        var turnoPartido = new DetalleTurno("Turno Partido", [Franja06_12, Franja14_18]);
+        Given(StreamId,
+            CrearTurnoDiarioAsignado(turnoPartido),
+            CrearMarcacionAdicionada(Timestamp05_50),
+            CrearMarcacionAdicionada(Timestamp12_05));
+
+        await WhenAsync(CrearMarcacionRegistrada(Timestamp14_10));
+
+        Then(StreamId, CrearMarcacionAdicionada(Timestamp14_10));
+        And<ControlDiarioAggregateRoot, IReadOnlyList<ControlFranja>>(
+            StreamId,
+            c => c.ControlesDeFranja,
+            new ControlFranja[]
+            {
+                new(Franja06_12, Timestamp05_50, Timestamp12_05),
+                new(Franja14_18, Timestamp14_10, null)
+            });
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoMarcacionRegistrada/DepurarAlAdicionarMarcacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoMarcacionRegistrada/DepurarAlAdicionarMarcacionTests.cs
@@ -1,7 +1,6 @@
 // HU-123: Integrar depurador al ControlDiario de forma reactiva
 // Familia 1: verifica que Apply(MarcacionAdicionada) dispara el recalculo de ControlesDeFranja
 
-using AwesomeAssertions;
 using Bitakora.ControlAsistencia.Contracts.Empleados.ValueObjects;
 using Bitakora.ControlAsistencia.Contracts.Programacion.ValueObjects;
 using Bitakora.ControlAsistencia.ControlHoras.AdicionarMarcacionCuandoMarcacionRegistrada.CommandHandler;

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/DepurarAlAsignarTurnoTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/DepurarAlAsignarTurnoTests.cs
@@ -1,0 +1,71 @@
+// HU-123: Integrar depurador al ControlDiario de forma reactiva
+// Familia 2: verifica que Apply(TurnoDiarioAsignado) dispara el recalculo de ControlesDeFranja
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Contracts.Empleados.ValueObjects;
+using Bitakora.ControlAsistencia.Contracts.Programacion.Eventos;
+using Bitakora.ControlAsistencia.Contracts.Programacion.ValueObjects;
+using Bitakora.ControlAsistencia.ControlHoras.AdicionarMarcacionCuandoMarcacionRegistrada.Eventos;
+using Bitakora.ControlAsistencia.ControlHoras.AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction.CommandHandler;
+using Bitakora.ControlAsistencia.ControlHoras.AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction.Eventos;
+using Bitakora.ControlAsistencia.ControlHoras.Entities;
+using Cosmos.EventSourcing.Abstractions.Commands;
+using Cosmos.EventSourcing.Testing.Utilities;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Tests.AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction;
+
+public class DepurarAlAsignarTurnoTests
+    : CommandHandlerAsyncTest<ProgramacionTurnoDiarioSolicitada>
+{
+    // Datos de prueba fijos - el stream ID es determinista a partir de EmpleadoId+Fecha
+    private static readonly Guid SolicitudId =
+        Guid.Parse("019600c0-0000-7000-8000-000000000002");
+
+    private static readonly InformacionEmpleado Empleado = new(
+        "EMP-001", "CC", "1234567890", "Luis Augusto", "Barreto");
+
+    private static readonly DateOnly Fecha = new(2026, 3, 15);
+    private static readonly string StreamId = $"{Empleado.EmpleadoId}:{Fecha:yyyy-MM-dd}";
+
+    // CA-4: franja unica 06:00-14:00 para el turno asignado
+    private static readonly DetalleFranjaOrdinaria Franja06_14 =
+        new(new TimeOnly(6, 0), new TimeOnly(14, 0), 0, [], []);
+
+    // Timestamps de las marcaciones que llegan antes que el turno
+    private static readonly DateTime Timestamp07_00 = new(2026, 3, 15, 7, 0, 0);
+    private static readonly DateTime Timestamp15_00 = new(2026, 3, 15, 15, 0, 0);
+
+    protected override ICommandHandlerAsync<ProgramacionTurnoDiarioSolicitada> Handler =>
+        new AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaCommandHandler(EventStore);
+
+    private static ProgramacionTurnoDiarioSolicitada CrearEvento(DetalleTurno detalleTurno) =>
+        new(SolicitudId, Empleado, Fecha, detalleTurno);
+
+    private static TurnoDiarioAsignado CrearTurnoDiarioAsignado(DetalleTurno detalleTurno) =>
+        new(StreamId, Empleado, Fecha, detalleTurno, SolicitudId);
+
+    private static MarcacionAdicionada CrearMarcacionAdicionada(DateTime timestamp) =>
+        new(StreamId, Empleado.EmpleadoId, timestamp, "ENTRADA", "DEV-001");
+
+    // CA-4: con 2 MarcacionAdicionada previas (07:00, 15:00) sin turno,
+    //        al procesar ProgramacionTurnoDiarioSolicitada con franja 06:00-14:00,
+    //        el Apply(TurnoDiarioAsignado) dispara Depurar() y ControlesDeFranja
+    //        queda con ControlFranja(Franja06_14, Entrada=07:00, Salida=15:00).
+    //        Verifica el caso "marcaciones llegaron antes que el turno".
+    [Fact]
+    public async Task DebeCalcularControlFranja_CuandoMarcacionesLlegaronAntesQueTurno()
+    {
+        var turnoConFranjaUnica = new DetalleTurno("Turno Manana", [Franja06_14]);
+        Given(StreamId,
+            CrearMarcacionAdicionada(Timestamp07_00),
+            CrearMarcacionAdicionada(Timestamp15_00));
+
+        await WhenAsync(CrearEvento(turnoConFranjaUnica));
+
+        Then(StreamId, CrearTurnoDiarioAsignado(turnoConFranjaUnica));
+        And<ControlDiarioAggregateRoot, IReadOnlyList<ControlFranja>>(
+            StreamId,
+            c => c.ControlesDeFranja,
+            new ControlFranja[] { new(Franja06_14, Timestamp07_00, Timestamp15_00) });
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/DepurarAlAsignarTurnoTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/DepurarAlAsignarTurnoTests.cs
@@ -1,7 +1,6 @@
 // HU-123: Integrar depurador al ControlDiario de forma reactiva
 // Familia 2: verifica que Apply(TurnoDiarioAsignado) dispara el recalculo de ControlesDeFranja
 
-using AwesomeAssertions;
 using Bitakora.ControlAsistencia.Contracts.Empleados.ValueObjects;
 using Bitakora.ControlAsistencia.Contracts.Programacion.Eventos;
 using Bitakora.ControlAsistencia.Contracts.Programacion.ValueObjects;


### PR DESCRIPTION
## Resumen

Pipeline TDD completado:
- Fase roja: tests escritos con stubs
- Fase verde: implementación completa
- Fase refactor: revisión de calidad

## Decisiones del pipeline

<details>
<summary>Test Writer (fase roja) — 9m 43s</summary>

_(El agente no generó resumen)_

</details>

<details>
<summary>Implementer (fase verde) — 4m 10s</summary>

## ES Implementer - Decisiones

### Enfoque de implementacion
Se implemento el hook reactivo `Depurar()` dentro de `ControlDiarioAggregateRoot` siguiendo exactamente el patron descrito en la HU-123 y ya esbozado por el test-writer en el scaffolding del aggregate. El cambio es minimo: tres puntos de edicion sobre un unico archivo de produccion.

1. Implementacion del cuerpo de `Depurar()` (antes throw NotImplementedException).
2. Llamada a `Depurar()` como ultima instruccion de `Apply(TurnoDiarioAsignado)`.
3. Llamada a `Depurar()` como ultima instruccion de `Apply(MarcacionAdicionada)`.

### Decisiones de diseno
- **Reemplazo completo, no incremento**: `Depurar()` empieza con `_controlesDeFranja.Clear()` y luego reemplaza con el resultado del depurador. Es la unica forma de garantizar idempotencia (CA-3) frente a multiples Apply que podrian acumular resultados residuales.
- **Hook al final del Apply**: se invoca despues de proyectar el estado (asignar DetalleTurno, agregar la marcacion, etc.) porque el depurador consume DetalleTurno y _marcaciones ya actualizados. Invertir el orden produciria calculos sobre estado stale.
- **DetalleTurno null es un caso valido**: cuando el aggregate nace con Iniciar(MarcacionAdicionada) sin turno previo, DetalleTurno es null y DepuradorDeMarcaciones.Depurar(null, ...) retorna lista vacia. No hay condicional adicional en el hook porque el depurador ya encapsula esa decision.
- **Apply sigue siendo proyeccion pura**: Depurar() no lanza excepciones ni muta estado de dominio mas alla de recomputar una lista derivada de estado ya proyectado. Mantiene la regla de que Apply nunca aborta ni bloquea eventos compensatorios.
- **No se agregaron eventos nuevos**: la HU explicita que el recalculo es efecto lateral del Apply, no una decision de negocio que merezca evento propio. Esto queda reservado para #108 (DiaCalculado).

### Infraestructura modificada
Ninguna. No se publican eventos publicos nuevos ni se agregan topics/subscriptions.

### Complejidad encontrada
Ninguna. Los tests del test-writer ya traian todos los datos fijos (timestamps, franjas, turnos) y el depurador de #122 ya tenia implementada toda la logica del algoritmo secuencial por rango. Este issue es puro pegamento reactivo.

### Resultado
- Tests pasando: 194/194 (6 smoke tests omitidos por dependencias de infraestructura no configurada localmente, ningun fallo).
- Tests del dominio ControlHoras: 74/74 correctos.

</details>
<details>
<summary>Reviewer (fase refactor) — 6m 58s</summary>

## ES Reviewer - Revision

### Evaluacion general
- Calidad: buena
- Cambios realizados: si (cleanup menor)

### Checklist de patrones ES
| Patron | Estado | Observacion |
|---|---|---|
| Apply() sin logica condicional | ok | Apply(TurnoDiarioAsignado) y Apply(MarcacionAdicionada) solo asignan estado y llaman al hook Depurar(); sin if/throw. Depurar() mismo es proyeccion pura: Clear + AddRange del resultado deterministico de DepuradorDeMarcaciones |
| CommandHandler orquestador puro | ok | Ambos handlers no fueron tocados; siguen como orquestador puro |
| Sin AppendEvents/SaveChangesAsync manual | ok | Solo StartStream para streams nuevos; el middleware persiste los existentes |
| ThrowExactlyAsync solo para precondiciones | n/a | No hay escenarios de excepcion en esta HU |
| Cada test con Then() + And<>() | ok | Los 4 tests tienen Then(streamId, evento) + al menos un And<>() sobre ControlesDeFranja |
| Naming de eventos en pasado | n/a | No se introducen eventos nuevos |
| Naming de funciones Azure | n/a | No se agregan funciones |
| Infraestructura Service Bus verificada | n/a | No hay topics/subs nuevos |
| Organizacion vertical (feature folders) | ok | Tests en las carpetas de sus handlers |
| Sin strings hardcodeados en mensajes | ok | No se emiten eventos de fallo ni mensajes de excepcion en esta HU |
| Aggregates/handlers son partial class | ok | ControlDiarioAggregateRoot ya era partial class |
| Modelado record/clase apropiado | ok | ControlFranja es record (no muta); _controlesDeFranja es List mutable encapsulada dentro del aggregate |
| Factory static en objetos con invariantes | n/a | Sin objetos nuevos con invariantes |
| Sin init en objetos con invariantes | n/a | No aplica |
| Tell Don't Ask (calculos en el objeto) | ok | El aggregate computa ControlesDeFranja internamente via Depurar(); no hay codigo externo calculando la lista |
| Sin numeros magicos | ok | Los timestamps y franjas en tests usan constantes con nombre descriptivo |
| Propiedades internas son protected/private | ok | _controlesDeFranja es private readonly; expuesto via ControlesDeFranja IReadOnlyList |
| Tests via ToString (no via getters internos) | n/a | Los tests verifican ControlesDeFranja que es interfaz publica del aggregate |
| Mensajes en .resx (excepciones Y labels ToString) | n/a | No hay excepciones nuevas ni ToString() |
| Tests verifican mensaje de excepcion (.WithMessage) | n/a | Sin escenarios de excepcion |
| Tests de IEquatable para value objects | n/a | No se introdujo value object nuevo; ControlFranja ya fue cubierto en #122 |
| Tests de serializacion round-trip | n/a | ControlFranja ya fue cubierto en #122; eventos no cambian |
| IPublicEvent solo en Contracts/Eventos/ | n/a | Sin eventos publicos nuevos |
| Sin InternalsVisibleTo de Contracts a dominio | ok | No se introduce |
| Sin records duplicados (command vs Contracts) | n/a | Sin cambio de estructura |
| Sin wrappers de IEventStore en tests | ok | Los tests usan el harness estandar CommandHandlerAsyncTest<T>, sin wrappers |

### Elegancia del codigo
- **Compacto**: Depurar() es un metodo privado de 4 lineas con comentario claro de 3 lineas. La variable local `resultado` mantiene la linea corta y legible.
- **Legible**: los comentarios de HU y CA son precisos y ayudan a navegar el codigo. Los nombres de constantes en tests (Timestamp07_00, Franja06_14, Franja06_12, Franja14_18) revelan intencion y codifican el escenario en el nombre.
- **Idiomatico**: hook reactivo al final del Apply; DSL Given/WhenAsync/Then/And completamente empleado en los tests.
- **Robusto**: el caso DetalleTurno is null esta encapsulado en DepuradorDeMarcaciones.Depurar (de #122); el aggregate no necesita condicional y CA-2 lo verifica.
- **Eficiente**: Clear + AddRange en cada Apply es O(n) sobre una lista chica (al sumo una decena de franjas). Adecuado.
- **Limpio**: unico hallazgo fue `using AwesomeAssertions;` sin uso en los dos archivos de test nuevos (corregido).

### Criticas y hallazgos
- **Cosmetico - Corregido**: los dos archivos de test nuevos importaban `AwesomeAssertions` sin usar `.Should()`. Los tests existentes del mismo dominio no lo importan. Se eliminaron ambos imports.
- **Sin hallazgos adicionales** de logica, patrones ES o organizacion.

### Refactorings aplicados
- Eliminar import innecesario `using AwesomeAssertions;` en:
  - `tests/.../AdicionarMarcacionCuandoMarcacionRegistrada/DepurarAlAdicionarMarcacionTests.cs`
  - `tests/.../AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/DepurarAlAsignarTurnoTests.cs`

  Justificacion: ningun test nuevo usa `.Should()` directamente; toda la verificacion pasa por el DSL `Then/And<>` del harness.

### Cobertura de criterios de aceptacion
| Criterio | Estado | Test(s) |
|---|---|---|
| CA-1: con turno + MarcacionRegistrada, ControlesDeFranja refleja Entrada=07:00, Salida=null | cubierto | `DebeCalcularControlFranja_CuandoHayTurnoYLlegaMarcacion` |
| CA-2: sin turno + MarcacionRegistrada, ControlesDeFranja queda vacio | cubierto | `DebeDejarControlesDeFranjaVacios_CuandoNoHayTurnoPrevio` |
| CA-3: turno partido + 2 marcaciones previas + nueva, recalculo idempotente completo | cubierto | `DebeRecalcularControlesDeFranjaCompletos_CuandoHayTurnoPartidoYMarcacionesAcumuladas` |
| CA-4: marcaciones previas + ProgramacionTurnoDiarioSolicitada, Apply(TurnoDiarioAsignado) dispara el hook | cubierto | `DebeCalcularControlFranja_CuandoMarcacionesLlegaronAntesQueTurno` |

### Tests agregados
- Ninguno. Los 4 tests del test-writer cubren exactamente los 4 CA y los dos disparadores del hook.

</details>

## Commits

7814a49 refactor(hu-123): elimina import AwesomeAssertions sin uso en tests de Depurar
513f246 feat(hu-123): recalculo reactivo de ControlesDeFranja en cada Apply (fase verde)
2b07b13 test(hu-123): tests de recalculo reactivo de ControlesDeFranja (fase roja)

Closes #123