### PR TITLE
fix(ci): warmup /api/health en smoke tests para sobrevivir cold start

### DIFF
--- a/.claude/agents/domain-scaffolder.md
+++ b/.claude/agents/domain-scaffolder.md
@@ -1373,11 +1373,6 @@ jobs:
           app-name: func-{prefix_func}-{kebab}
           package: ./publish
 
-      - name: Esperar arranque de Function App
-        run: |
-          echo "Esperando 30s para que la Function App arranque..."
-          sleep 30
-
   smoke-tests:
     needs: deploy
     uses: ./.github/workflows/smoke-tests-dominio.yml

--- a/.github/workflows/deploy-control-horas.yml
+++ b/.github/workflows/deploy-control-horas.yml
@@ -77,11 +77,6 @@ jobs:
           app-name: func-asist-dev-control-horas
           package: ./publish
 
-      - name: Esperar arranque de Function App
-        run: |
-          echo "Esperando 30s para que la Function App arranque..."
-          sleep 30
-
   smoke-tests:
     needs: deploy
     uses: ./.github/workflows/smoke-tests-dominio.yml

--- a/.github/workflows/deploy-programacion.yml
+++ b/.github/workflows/deploy-programacion.yml
@@ -77,11 +77,6 @@ jobs:
           app-name: func-asist-dev-programacion
           package: ./publish
 
-      - name: Esperar arranque de Function App
-        run: |
-          echo "Esperando 30s para que la Function App arranque..."
-          sleep 30
-
   smoke-tests:
     needs: deploy
     uses: ./.github/workflows/smoke-tests-dominio.yml

--- a/.github/workflows/smoke-tests-dominio.yml
+++ b/.github/workflows/smoke-tests-dominio.yml
@@ -37,6 +37,21 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
+      - name: Warmup Function App
+        run: |
+          echo "Esperando health endpoint en ${{ inputs.base_url }}/api/health..."
+          for i in $(seq 1 60); do
+            code=$(curl -s -o /dev/null -w "%{http_code}" "${{ inputs.base_url }}/api/health" || echo "000")
+            if [ "$code" = "200" ]; then
+              echo "Health OK tras ${i} intento(s) (~$((i*2))s)."
+              exit 0
+            fi
+            echo "Intento ${i}: HTTP ${code}. Reintentando en 2s..."
+            sleep 2
+          done
+          echo "Timeout: health endpoint no respondio 200 en 120s"
+          exit 1
+
       - name: Smoke tests
         env:
           Api__BaseUrl: ${{ inputs.base_url }}


### PR DESCRIPTION
## Contexto

El smoke test de ControlHoras fallo en el [run 24757005410](https://github.com/augusto-romero-arango/Bitakora.ControlAsistencia/actions/runs/24757005410) porque:

- El Function App tardo ~53s de cold start + ~20s de init lazy de Marten/Wolverine (primera ejecucion del handler).
- El workflow solo dormia 30s tras el deploy antes de lanzar los smoke tests.
- El handler proceso el mensaje correctamente, pero 20s **despues** de que el polling de 30s del test ya se habia rendido.

## Solucion

Centralizar un warmup real en el reusable workflow `smoke-tests-dominio.yml` que hace polling a `/api/health` hasta 200 (max 120s). Asi beneficia a todos los dominios actuales y futuros sin duplicacion:

- `smoke-tests-dominio.yml`: nuevo step "Warmup Function App".
- `deploy-control-horas.yml` y `deploy-programacion.yml`: eliminado el `sleep 30` redundante.
- `.claude/agents/domain-scaffolder.md`: plantilla actualizada para que nuevos dominios hereden el warmup.

## Test plan

- [ ] Disparar `deploy-control-horas.yml` en esta rama con la app fria y verificar que el step "Warmup Function App" reporta tiempo de estabilizacion y que los smoke tests pasan.
- [ ] Verificar en un segundo run (app caliente) que el warmup resuelve en 1 intento, sin penalizar la ruta rapida.
- [ ] Confirmar que `deploy-programacion.yml` tambien pasa con el mismo cambio centralizado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)