### PR TITLE
Refactorizar agentes y skills para que consulten ADRs en vez de duplicar sus reglas

### DIFF
--- a/.claude/agents/implementer.md
+++ b/.claude/agents/implementer.md
@@ -320,16 +320,11 @@ builder.Services.AddValidatorsFromAssemblyContaining<I{Dominio}AssemblyMarker>()
 
 ## Modelado de objetos de dominio
 
-Las reglas de forma (`record` vs `sealed class`), constructor (publico vs privado + vacio), serializacion (`ConfigurarSerializacion`, proscripcion de `[JsonConstructor]`) y registro en infraestructura viven **en ADR-0015**. No las duplico aqui — leelo antes de crear un value object, un evento o cualquier tipo persistido.
+Las reglas de forma (`record` vs `sealed class`), constructor, serializacion (`ConfigurarSerializacion`, proscripcion de `[JsonConstructor]`) y registro en infraestructura viven **en ADR-0015**. Este agente **no las duplica** — leelo completo antes de crear un value object, un evento o cualquier tipo persistido.
 
-Puntos donde fallan tipicamente los agentes (detectados en reviews anteriores):
+Aviso de "precedente ≠ autoridad" (didactico, no reglas enumeradas): reviews pasados (PR 142, PR 144) replicaron violaciones de ADR-0015 (`[JsonConstructor]` en ctor privado, `record` con `IReadOnlyList<T>`, `ConfigurarSerializacion` sin registro) porque el implementer uso el precedente como justificacion. Si tu patron parece resolverlo pero el ADR dice otra cosa, **gana el ADR**. Reportalo como bug del precedente en tu resumen.
 
-- **Value Object / evento con invariantes**: es `sealed class`, no `record`. La distincion clave del ADR es **invariantes**, no mutabilidad. Un `record` con `IReadOnlyList<T>` promete igualdad por valor que no cumple (compara por referencia via `EqualityComparer<T>.Default`).
-- **[JsonConstructor] en ctor privado**: no funciona con Marten (ADR-0015, "Serializacion sin atributos"). El patron canonico es ctor vacio privado + campos `private readonly` + `ConfigurarSerializacion` con `typeInfo.CreateObject` + `FieldInfo.SetValue`.
-- **`ConfigurarSerializacion` sin registro**: si agregas el metodo, agrega la linea `{Tipo}.ConfigurarSerializacion(resolver)` al `ConfigurarResolver` del dominio (clase `ConfiguracionSerializacion{Dominio}`). Sin registro, el metodo es codigo muerto (ADR-0015, "Sin este registro...").
-- **`IEquatable<T>` manual en `sealed class`**: si el tipo tiene colecciones, `Equals` debe usar `SequenceEqual` y `GetHashCode` debe combinar cada elemento con `HashCode.Add`.
-
-Referencias canonicas en el codigo: `SubFranja` (VO con `sealed class` + `ConfigurarSerializacion` + `IEquatable` manual); `TurnoDiarioAsignado` (evento con precondiciones + `ConfigurarSerializacion`).
+Referencias canonicas en el codigo (alineadas con ADR-0015): `SubFranja` (VO con `sealed class` + `ConfigurarSerializacion` + `IEquatable` manual); `TurnoDiarioAsignado` (evento con precondiciones + `ConfigurarSerializacion`). Antes de usarlas como plantilla, verifica que siguen alineadas — el ADR es la autoridad, no el archivo.
 
 ### Encapsulamiento: propiedades internas
 

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -130,13 +130,7 @@ Esta fase reemplaza el antiguo "checklist de patrones ES" (que duplicaba reglas 
    - Si NO lo declaro, es una desviacion no reportada: intenta corregir el codigo (siguiendo las reglas estandar: `dotnet test` despues de cada cambio, revertir si rompe). Si no es trivial corregir, documentalo como hallazgo bloqueante.
 5. **Verifica precedentes citados por el implementer**: si cito algun archivo/PR del proyecto como referencia, valida que el precedente realmente cumple el ADR. Si el precedente viola el ADR (como paso con PR 142 vs ADR-0015), reporta el bug del precedente en tus hallazgos — pero NO lo uses para justificar replicar la violacion.
 
-**Violaciones de ADR-0015 a detectar activamente** (patrones reales detectados en reviews previos que los agentes suelen desestimar):
-
-- `[JsonConstructor]` en ctor privado de VO/evento — **bloqueante** (no funciona con Marten, ADR-0015 l.227-230). Si el diff lo introduce: fallar, pedir migracion al patron canonico (ctor vacio privado + campos `private readonly` + `ConfigurarSerializacion`).
-- `record` con `IReadOnlyList<T>` / `List<T>` / `T[]` — **bloqueante** (ADR-0015 l.43-45). `EqualityComparer<IReadOnlyList<T>>.Default` usa igualdad de referencia; el `record` promete valor equality que no cumple. Migrar a `sealed class` con `IEquatable<T>` manual + `SequenceEqual`. **No desestimes este hallazgo con "el issue no pide tests de IEquatable"**: la regla del ADR aplica al **tipo**, no a los tests.
-- `ConfigurarSerializacion` sin registro en `ConfiguracionSerializacion{Dominio}.ConfigurarResolver` — **bloqueante** (ADR-0015 l.253-254). Grep `ConfigurarSerializacion` en el diff; para cada uno, verifica que hay una linea correspondiente en `ConfigurarResolver`. Sin registro es codigo muerto.
-- Tests de round-trip con `JsonSerializer.Serialize(obj)` sin opciones — **bloqueante**. Los tests pasan con STJ vanilla aunque el registro en el dominio no exista. Reemplazar por `ConfiguracionSerializacion{Dominio}.CrearOpcionesMarten()`. Si el test vive en un proyecto que no puede depender del dominio (ej `Contracts.Tests`), moverlo a `{Dominio}.Tests/Infraestructura/`.
-- Falta de test "sin registro falla" — **sugerencia**. Para cada tipo con `ConfigurarSerializacion`, debe existir un test que verifique `NotSupportedException` al deserializar con resolver vacio. Es la barrera que protege contra que alguien borre la linea de registro en `ConfigurarResolver`.
+**Memoria de gaps pasados (no son reglas enumeradas — son recordatorios de "precedente ≠ autoridad")**: PR 142 y PR 144 pasaron el review con violaciones a ADR-0015 porque se asumio que el precedente era suficiente. Si dudas sobre un patron de serializacion o igualdad de VOs, **relee ADR-0015** antes de aceptar o rechazar el diff — no busques el patron en el codigo ya mergeado como autoridad. Incidentes documentados en `docs/bitacora/field-notes/review-pr-144.md`.
 
 **Convenciones del pipeline que NO estan en ADRs** (revisa tambien):
 


### PR DESCRIPTION
## Resumen

Pipeline tooling completado:
- Writer: implementacion de la tarea
- Reviewer: revision de calidad

## Decisiones del pipeline

<details>
<summary>Writer -- 11m 49s</summary>

## Tooling Writer - Resumen (issue #145)

### Contexto

El issue #145 ya fue implementado en gran parte por el commit `60e0e75` en `main`
("docs(agentes): consolidar ADRs como fuente unica de verdad arquitectonica"),
gestado en la sesion del planner documentada en
`docs/bitacora/field-notes/review-pr-144.md`.

Mi trabajo en esta rama fue:

1. Auditar los 20 criterios de aceptacion (CA-1 a CA-20) contra el estado actual
   de los 4 archivos afectados (CLAUDE.md, planner.md, implementer.md, reviewer.md).
2. Tensar los dos lugares donde aun quedaba enumeracion de reglas derivadas de
   ADR-0015 — lo que violaba el espiritu de CA-10, CA-13 y CA-16.

### Cambios aplicados

Commit `ddca746`:

| Archivo | Cambio |
|---|---|
| `.claude/agents/reviewer.md` | Paso 3: elimino la subseccion "Violaciones de ADR-0015 a detectar activamente" (5 bullets con proscripciones copiadas del ADR, numeros de linea, severidades) y la reemplazo por un parrafo breve de "memoria de gaps pasados" que apunta a PR 142/144 como recordatorio de "precedente != autoridad" sin duplicar las reglas. |
| `.claude/agents/implementer.md` | Seccion "Modelado de objetos de dominio": elimino los 4 bullets que enumeraban proscripciones de ADR-0015 como patron canonico y los reemplazo por un aviso didactico de "precedente != autoridad". |

No modifique CLAUDE.md ni planner.md — su estado actual ya satisface CA-1 a CA-6.
Tampoco toque implementer.md secciones 1b, 9 ni reglas absolutas (CA-7 a CA-11 ya
estaban satisfechos), ni reviewer.md secciones 1b, 3-restante ni reporte (CA-12 a
CA-18 ya estaban satisfechos).

### Verificacion contra los 20 CAs

**CLAUDE.md**
- CA-1 (indice tematico >=10 temas): 11 entradas en la tabla, ok
- CA-2 (declaracion explicita de ADRs como fuente unica): linea 105, ok

**planner.md**
- CA-3 (seccion "ADRs aplicables" en template de dominio, antes de "Interfaz publica"): lineas 434-443, antes de 445, ok
- CA-4 (seccion "ADRs aplicables" en template de infra, antes de "Criterios de aceptacion"): lineas 505-510, ok
- CA-5 (paso del modo refinar que exige enumerar ADRs): paso 7, linea 259, ok
- CA-6 (item de checklist pre-listo): linea 373, ok

**implementer.md**
- CA-7 (paso 1b "Leer los ADRs aplicables" con stop-and-report): lineas 581-590, ok
- CA-8 (Precedente != autoridad en 1b y reglas absolutas): linea 590 + regla 9 (linea 765), ok
- CA-9 (paso 9 con "ADRs consultados" / "Desviaciones" / "Precedentes"): lineas 721-738, ok
- CA-10 (reglas 4,5,11,12,13,14,15,17 del set pre-refactor eliminadas): verificado contra `git show 60e0e75^:.claude/agents/implementer.md`, ok
- CA-11 (header "reglas arquitectonicas viven en ADRs"): linea 755, ok

**reviewer.md**
- CA-12 (paso 1b leer ADRs + resumen del implementer): lineas 58-71, ok
- CA-13 (paso 3 reescrito; checklist ADR-derivado reducido a convenciones no-ADR del pipeline): lineas 121-147 tras el tensado, ok
- CA-14 (template de stage-3 con secciones nuevas): lineas 288-370, ok
- CA-15 (Precedente != autoridad en reglas absolutas): regla 11 (linea 390), ok
- CA-16 (reglas 8,9,10,11,14,15,16,17,18,19,20,21 del set pre-refactor eliminadas): verificado contra `git show 60e0e75^:.claude/agents/reviewer.md`, ok

**Desviaciones trazables**
- CA-17 (formato estandar "ADR / Regla / Desviacion / Razon / Consecuencia / Status" en implementer): implementer.md lineas 727-733, ok
- CA-18 (reviewer agrega seccion "NO declarada por el implementer"): reviewer.md lineas 319-325, ok

**Verificacion manual**
- CA-19 (grep "JsonConstructor|record para value objects|ConfigurarSerializacion" bajo): implementer=5, reviewer=2 (baseline pre-refactor: 4 y 2; tras 60e0e75: 6 y 5; tras este commit: 5 y 2), ok
- CA-20 (grep "ADR-" mayor que baseline pre-refactor):
  - CLAUDE.md: 11 vs 0 baseline, ok
  - planner.md: 8 vs 3 baseline, ok
  - implementer.md: 9 vs 4 baseline, ok
  - reviewer.md: 7 vs 3 baseline, ok

### Decisiones de diseno

- **No reescribi las secciones "Convenciones de nombramiento" e "Infraestructura" de implementer.md** aunque solapan con ADR-0005, ADR-0008 y ADR-0004. El issue acota la eliminacion al bloque de reglas absolutas y a las subsecciones tabulares/checklist derivadas de ADRs (CA-10, CA-13, CA-16). Las secciones de patrones de codigo de produccion quedan como ejemplos didacticos del pipeline.
- **Mantuve la regla 4 del implementer** ("NUNCA try-catch de excepciones de dominio en el CommandHandler"). Aunque el racional viene de ADR-0007, es una convencion procedimental del endpoint HTTP + CommandHandler, no una regla de negocio del aggregate. El issue no la lista en CA-10.
- **Mantuve las referencias canonicas a `SubFranja` y `TurnoDiarioAsignado`** con aviso explicito ("verifica que siguen alineadas — el ADR es la autoridad, no el archivo"). Son plantillas utiles mientras el agente no use el precedente como autoridad.

### Precedentes consultados

- `docs/bitacora/field-notes/review-pr-144.md` — driver del issue #145, listo las 4 lecciones del review del PR 144.
- Commit `60e0e75` (main) — base del refactor. Mis cambios son un tensado marginal sobre lo que ese commit dejo.

### Resultado

- Los 20 CAs verificados.
- Compilacion del proyecto no aplicable (no se toco C#).
- Commit `ddca746` creado con las correcciones.

</details>

<details>
<summary>Reviewer -- 8m 42s</summary>

## Tooling Reviewer - Revision (issue #145)

### Evaluacion general

- Calidad: **buena**.
- Cambios realizados por el reviewer: **no**. El diff del writer cumple los 20 CAs sin refactors adicionales.
- Naturaleza del issue: meta-trabajo sobre agentes del pipeline (solo archivos `.md` en `.claude/agents/` y `CLAUDE.md`). No hay codigo C# tocado, no hay tests que correr.

### Alcance del cambio bajo review

Dos commits relevantes en esta rama:

| Commit | Autor | Archivos | Sintesis |
|---|---|---|---|
| `60e0e75` (ya en `main`) | sesion previa | CLAUDE.md, planner.md, implementer.md, reviewer.md, test-writer.md | Instalo la arquitectura del issue (indice tematico, seccion "ADRs aplicables" en templates, pasos 1b, formato de desviaciones). |
| `ddca746` (solo en esta rama) | writer | implementer.md, reviewer.md | Tensado: eliminacion del ultimo residuo que enumeraba reglas derivadas de ADR-0015 (el bloque "Violaciones de ADR-0015 a detectar activamente" en reviewer paso 3; los 4 bullets de "Puntos donde fallan tipicamente los agentes" en implementer). |

La base del trabajo vino antes de esta rama. El writer solo cerro los gaps que aun violaban el espiritu de CA-10, CA-13 y CA-16.

### Cumplimiento de los 20 criterios de aceptacion

Verificados uno por uno contra los archivos del HEAD actual (`ddca746`):

**CLAUDE.md**
- CA-1: indice tematico con **11 filas** (umbral >=10). ok — lineas 107-123.
- CA-2: declaracion explicita "Los ADRs son la unica fuente de verdad..." en linea 105. ok.

**planner.md**
- CA-3: seccion `## ADRs aplicables` en template de dominio (linea 434), antes de `## Interfaz publica` (linea 445). ok.
- CA-4: seccion `## ADRs aplicables` en template de infra (linea 505), antes de `## Criterios de aceptacion` (linea 512). ok.
- CA-5: paso 7 del modo `refinar` (linea 259) exige enumerar ADRs antes de `estado:listo`. ok.
- CA-6: item final del checklist pre-listo (linea 373). ok.

**implementer.md**
- CA-7: paso 1b "Leer los ADRs aplicables del issue" (lineas 576-585), con stop-and-report si falta la seccion. ok.
- CA-8: "Precedente != autoridad" en paso 1b (linea 585) y como regla absoluta 9 (linea 760). ok.
- CA-9: paso 9 con "ADRs consultados" / "Desviaciones de ADRs" (formato estandar) / "Precedentes consultados" (lineas 716-733). ok.
- CA-10: reglas absolutas 4, 5, 11, 12, 13, 14, 15, 17 del set pre-refactor eliminadas. Verificado contra `git show 9bbe71c:.claude/agents/implementer.md`. El set actual (11 reglas) es estrictamente procedimental + governance de ADRs. ok.
- CA-11: header explicito "Las reglas arquitectonicas viven exclusivamente en los ADRs del proyecto" en linea 750. ok.

**reviewer.md**
- CA-12: paso 1b "Leer los ADRs aplicables del issue y el resumen del implementer" (lineas 58-71). ok.
- CA-13: paso 3 reescrito como "Verificar cumplimiento de los ADRs aplicables" (linea 121). El checklist reducido a convenciones no-ADR del pipeline (Then+And, fakes manuales, feature folders, smoke tests) en lineas 135-145. ok.
- CA-14: template de `stage-3-reviewer.md` con secciones "Cumplimiento de ADRs aplicables", "Desviaciones de ADRs (declaradas + NO declaradas)" y "Precedentes consultados por el implementer" (lineas 282-363). ok.
- CA-15: "Precedente != autoridad" como regla absoluta 11 (linea 384). ok.
- CA-16: reglas absolutas 8, 9, 10, 11, 14, 15, 16, 17, 18, 19, 20, 21 del set pre-refactor eliminadas. Verificado contra `git show 9bbe71c:.claude/agents/reviewer.md`. El set actual (12 reglas) es procedimental + governance. ok.

**Desviaciones trazables**
- CA-17: formato estandar "ADR / Regla / Desviacion aplicada / Razon / Consecuencia conocida / Status" en implementer.md lineas 722-728. ok.
- CA-18: reviewer.md tiene bloque "Desviaciones detectadas por el reviewer (NO declaradas por el implementer)" (lineas 313-319). ok.

**Verificacion manual**
- CA-19: counts bajos y todas las menciones didacticas — ok.
- CA-20: ADR- counts superan baseline en los 4 archivos (CLAUDE 11 vs 0, planner 8 vs 3, implementer 9 vs 4, reviewer 7 vs 3). ok.

### Cumplimiento de ADRs aplicables

Issue declara "Ninguno". El diff no toca ADRs ni patrones de dominio.

### Desviaciones de ADRs

Ninguna desviacion — no aplican ADRs al issue.

### Precedentes consultados por el implementer

| Precedente | ADR aplicable | Veredicto |
|---|---|---|
| Commit `60e0e75` (ya en main) | n/a | alineado — base del refactor |
| `docs/bitacora/field-notes/review-pr-144.md` | n/a | alineado — driver del issue |
| PR 142, PR 144 (citados como gap pasado) | ADR-0015 | VIOLARON el ADR (es el gap que motiva el issue) — citados como memoria didactica, no como autoridad |

### Convenciones del pipeline (no ADRs)

| Convencion | Estado | Observacion |
|---|---|---|
| Commits descriptivos en espanol | ok | `tooling(#145): tensar reviewer e implementer...` |
| Archivos `.md` solamente (sin C#) | ok | scope coincide con lo declarado |
| Referencias a archivos que existen | ok | `docs/bitacora/field-notes/review-pr-144.md` existe |

### Elegancia del diff

- **Compacto**: reemplaza dos bloques enumerativos por parrafos didacticos breves con apuntador al ADR.
- **Legible**: el marcador "didactico, no reglas enumeradas" comunica explicitamente el nuevo contrato.
- **Idiomatico**: usa la terminologia "precedente != autoridad" alineada con el issue y la bitacora.
- **Limpio**: sin ruido, sin referencias a reglas borradas.

### Criticas y hallazgos

- **Menor (no bloqueante)**: implementer.md mantiene secciones de patrones de codigo (AggregateRoot, CommandHandler, endpoints, nombramiento, infraestructura) que solapan parcialmente con ADR-0007, ADR-0008 y ADR-0004. El issue no las incluye en CA-10 porque son ejemplos didacticos del pipeline.
- **Menor**: la regla absoluta 4 de implementer ("NUNCA try-catch de excepciones de dominio en el CommandHandler") podria argumentarse que duplica ADR-0007. El issue no la lista en CA-10.
- **Ninguno mayor**.

### Refactorings aplicados

Ninguno. El diff ya entrega el estado deseado.

### Cobertura de criterios de aceptacion

Los 20 CAs verificados arriba en la seccion de cumplimiento — todos cubiertos.

### Tests agregados

Ninguno. No hay codigo C# en el scope.

### Resultado

- 20/20 CAs verificados.
- 0 desviaciones de ADRs.
- 0 refactors aplicados por el reviewer.
- Listo para crear PR.

</details>

## Commits

ddca746 tooling(#145): tensar reviewer e implementer para no enumerar reglas de ADR-0015

Closes #145