### PR TITLE
Unificar DuracionEnHorasDecimales a decimal en FranjaTemporal

### DIFF
--- a/src/Bitakora.ControlAsistencia.Contracts/Programacion/ValueObjects/FranjaTemporal.cs
+++ b/src/Bitakora.ControlAsistencia.Contracts/Programacion/ValueObjects/FranjaTemporal.cs
@@ -61,7 +61,7 @@ public abstract class FranjaTemporal
     public int DuracionEnMinutos() => MinutosAbsolutoFin - MinutosAbsolutoInicio;
 
     // CA-12: conversor a horas decimales
-    public double DuracionEnHorasDecimales() => DuracionEnMinutos() / (double)MinutosPorHora;
+    public decimal DuracionEnHorasDecimales() => DuracionEnMinutos() / (decimal)MinutosPorHora;
 
     // CA-20: formato legible - "(06:00-12:00)" o "(22:00-06:00+1)" con offset
     public abstract override string ToString();

--- a/tests/Bitakora.ControlAsistencia.Contracts.Tests/ValueObjects/FranjaOrdinariaTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Contracts.Tests/ValueObjects/FranjaOrdinariaTests.cs
@@ -108,7 +108,7 @@ public class FranjaOrdinariaTests
     {
         var franja = FranjaOrdinaria.Crear(new TimeOnly(8, 0), new TimeOnly(11, 30));
 
-        franja.DuracionEnHorasDecimales().Should().Be(3.5);
+        franja.DuracionEnHorasDecimales().Should().Be(3.5m);
     }
 
     // ---------- CA-13: infiere offset +1 cuando fin < inicio ----------

--- a/tests/Bitakora.ControlAsistencia.Contracts.Tests/ValueObjects/SubFranjaTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Contracts.Tests/ValueObjects/SubFranjaTests.cs
@@ -105,7 +105,7 @@ public class SubFranjaTests
     {
         var franja = SubFranja.Crear(new TimeOnly(10, 0), new TimeOnly(10, 15));
 
-        franja.DuracionEnHorasDecimales().Should().Be(0.25);
+        franja.DuracionEnHorasDecimales().Should().Be(0.25m);
     }
 
     // ---------- CA-20, CA-21: ToString() ----------


### PR DESCRIPTION
## Resumen

Pipeline TDD completado (refactoring puro):
- Análisis: no se requieren tests nuevos
- Justificación: Issue #128 es un refactor mecanico de tipo de retorno: DuracionEnHorasDecimales() pasa de double a decimal. Los tests que cubren CA-2 (SubFranja 15min = 0.25) y CA-3 (FranjaOrdinaria 210min = 3.5) ya existen en SubFranjaTests.cs (linea 108) y FranjaOrdinariaTests.cs (linea 111). Solo se ajustan los literales de sufijo (0.25 -> 0.25m, 3.5 -> 3.5m) y el tipo de retorno en FranjaTemporal.cs. No hay comportamiento nuevo ni CAs sin cobertura.
- Baseline: 151 tests pasando
- Refactoring ejecutado manteniendo todos los tests verdes

## Decisiones del pipeline

<details>
<summary>Test Writer (fase roja) — 1m 20s</summary>

_(El agente no generó resumen)_

</details>

<details>
<summary>Reviewer (fase refactor) — 4m 11s</summary>

## ES Reviewer - Revision

### Evaluacion general
- Calidad: buena
- Cambios realizados: si (refactor mecanico aplicado tal como lo describe el issue)

### Cumplimiento de ADRs aplicables

El issue #128 NO contiene seccion `## ADRs aplicables`. Es un refactor mecanico de tipo de retorno (double -> decimal) sin efectos en serializacion, igualdad ni eventos. Aun asi, evaluo los ADRs potencialmente relevantes a un cambio en value objects:

| ADR | Cumplimiento | Observacion |
|---|---|---|
| ADR-0015: serializacion / VOs / records vs sealed class | ok | El cambio no toca constructores, campos `readonly`, ni `ConfigurarSerializacion`. `FranjaTemporal` mantiene su forma de clase abstracta con campos `protected readonly` y constructor privado. El metodo `DuracionEnHorasDecimales()` es una proyeccion calculada, no un campo serializado. |
| ADR-0007: manejo de errores ES | n/a | No hay cambios de comportamiento ni paths de error nuevos. |
| ADR-0022: naming de tests | ok | Los tests existentes (`DuracionEnHorasDecimales_Retorna0Punto25_CuandoFranja15Minutos`, `DuracionEnHorasDecimales_Retorna3Punto5_CuandoFranjaDe210Minutos`) cumplen `<Sujeto>_<LoQuePasa>_Cuando<Condicion>`. |

**Recomendacion al planner**: incluir explicitamente la seccion `## ADRs aplicables` en futuros issues, aunque sean refactors mecanicos, para mantener la trazabilidad descrita en CLAUDE.md.

### Desviaciones de ADRs

Ninguna desviacion - todos los ADRs aplicables se cumplen.

### Precedentes consultados por el implementer

No aplica: esta tarea fue ejecutada como refactor puro (sin fases roja/verde previas, sin agente implementer). El reviewer hizo el cambio directo siguiendo lo descrito en el issue.

Precedente verificado por el reviewer:
- `IntervaloTemporal.DuracionEnHorasDecimales` (en `src/Bitakora.ControlAsistencia.Contracts/ControlHoras/ValueObjects/IntervaloTemporal.cs:59`) ya retornaba `decimal`. Este es el patron canonico que ahora replica `FranjaTemporal`.

### Convenciones del pipeline (no ADRs)

| Convencion | Estado | Observacion |
|---|---|---|
| Cada test con `Then()` + `And<>()` | n/a | Los tests afectados son de value object (no command handler); usan aserciones directas con AwesomeAssertions. |
| Overloads correctos para stream IDs compuestos | n/a | No es un test de aggregate. |
| Fakes manuales (no NSubstitute) | n/a | Sin dependencias mockeadas. |
| Feature folders (produccion y tests) | ok | Estructura existente respetada. |
| Smoke tests: SkipWhen, secrets, cobertura | n/a | El cambio no afecta endpoints ni eventos. |
| Tests via ToString/comportamiento | ok | Los tests verifican el comportamiento publico (`DuracionEnHorasDecimales()`), no internos. |
| Sin numeros magicos | ok | `MinutosPorHora` permanece como constante simbolica. |
| Sin caracteres prohibidos U+2500 | ok | No se introdujo el caracter box-drawing. |

### Elegancia del codigo
- **Compacto**: el diff total es 3 lineas modificadas (1 produccion + 2 tests). Cero verbosidad anadida.
- **Idiomatico**: `(decimal)MinutosPorHora` y `0.25m`/`3.5m` son la forma canonica de C#. La convencion del proyecto (uso de `decimal` para fraccionarios) se respeta.
- **Robusto**: division decimal por una constante distinta de cero, sin nuevos paths de error.
- **Eficiente**: O(1), sin cambios de complejidad.
- **Limpio**: sin warnings nuevos del compilador. Los warnings preexistentes (`NU1902` de OpenTelemetry y `CS0414` de `CatalogoTurnos._estaActivo`) son ajenos al refactor.
- **Legible**: el comentario `// CA-12: conversor a horas decimales` sigue siendo preciso (ahora con mas razon, pues retorna `decimal`).

### Criticas y hallazgos
- Ningun hallazgo bloqueante.
- Cosmetico: el issue podria haber listado `## ADRs aplicables` aunque sea refactor mecanico. No es un defecto del refactor en si.

### Refactorings aplicados
- **Cambio mecanico (issue #128)**:
  - `FranjaTemporal.cs:64`: tipo de retorno `double` -> `decimal`, cast `(double)` -> `(decimal)`.
  - `SubFranjaTests.cs:108`: literal `0.25` -> `0.25m`.
  - `FranjaOrdinariaTests.cs:111`: literal `3.5` -> `3.5m`.
- No se aplicaron refactorings adicionales (no hay nada que mejorar en el alcance del issue).

### Cobertura de criterios de aceptacion
| Criterio | Estado | Test(s) |
|---|---|---|
| CA-1: `FranjaTemporal.DuracionEnHorasDecimales()` retorna `decimal` (no `double`) | cubierto | Verificacion estatica (la suite no compila si el tipo no coincide); ademas los literales `0.25m`/`3.5m` solo aceptan retorno `decimal`. |
| CA-2: SubFranja de 15 minutos -> `0.25m` | cubierto | `SubFranjaTests.DuracionEnHorasDecimales_Retorna0Punto25_CuandoFranja15Minutos` |
| CA-3: FranjaOrdinaria de 210 minutos -> `3.5m` | cubierto | `FranjaOrdinariaTests.DuracionEnHorasDecimales_Retorna3Punto5_CuandoFranjaDe210Minutos` |

### Tests agregados
- Ninguno. Los CAs ya estaban cubiertos por los tests existentes; el refactor solo ajusta los literales (`0.25` -> `0.25m`, `3.5` -> `3.5m`) para mantener la equivalencia tras el cambio de tipo.
- Tests de contrato (igualdad / serializacion) no aplican: el cambio no afecta `IEquatable<T>` ni `ConfigurarSerializacion` de `FranjaTemporal`.

### Verificacion final
- `dotnet build`: compila sin errores.
- `dotnet test`: 296 correctos, 0 errores, 6 omitidos (smoke tests sin Service Bus configurado, comportamiento normal).
- Commit: `9e2481f refactor(hu-128): unificar DuracionEnHorasDecimales a decimal en FranjaTemporal`.

</details>

## Commits

9e2481f refactor(hu-128): unificar DuracionEnHorasDecimales a decimal en FranjaTemporal

Closes #128