### PR TITLE
Crear estructuras agregadas DesgloseFranja y DesgloseHoras

### DIFF
--- a/src/Bitakora.ControlAsistencia.Contracts/ControlHoras/ValueObjects/DesgloseFranja.cs
+++ b/src/Bitakora.ControlAsistencia.Contracts/ControlHoras/ValueObjects/DesgloseFranja.cs
@@ -1,0 +1,17 @@
+using Bitakora.ControlAsistencia.Contracts.Programacion.ValueObjects;
+
+namespace Bitakora.ControlAsistencia.Contracts.ControlHoras.ValueObjects;
+
+// Issue #129: Estructura agregada del desglose de una sola franja.
+// Record con constructor primario publico - STJ lo serializa nativamente sin ConfigurarSerializacion (ADR-0015).
+// Las propiedades calculadas se recalculan en cada acceso desde los parametros del ctor.
+public record DesgloseFranja(
+    DetalleFranjaOrdinaria Programada,
+    IReadOnlyList<IntervaloClasificado> Intervalos,
+    DetalleRetardo Retardo)
+{
+    // CA-1, CA-2: agrupa Intervalos por Concepto y suma DuracionEnMinutos.
+    // Los conceptos que no aparecen en Intervalos no figuran en el diccionario.
+    public IReadOnlyDictionary<Concepto, int> MinutosPorConcepto =>
+        throw new NotImplementedException();
+}

--- a/src/Bitakora.ControlAsistencia.Contracts/ControlHoras/ValueObjects/DesgloseFranja.cs
+++ b/src/Bitakora.ControlAsistencia.Contracts/ControlHoras/ValueObjects/DesgloseFranja.cs
@@ -13,5 +13,7 @@ public record DesgloseFranja(
     // CA-1, CA-2: agrupa Intervalos por Concepto y suma DuracionEnMinutos.
     // Los conceptos que no aparecen en Intervalos no figuran en el diccionario.
     public IReadOnlyDictionary<Concepto, int> MinutosPorConcepto =>
-        throw new NotImplementedException();
+        Intervalos
+            .GroupBy(i => i.Concepto)
+            .ToDictionary(g => g.Key, g => g.Sum(i => i.DuracionEnMinutos));
 }

--- a/src/Bitakora.ControlAsistencia.Contracts/ControlHoras/ValueObjects/DesgloseHoras.cs
+++ b/src/Bitakora.ControlAsistencia.Contracts/ControlHoras/ValueObjects/DesgloseHoras.cs
@@ -1,0 +1,20 @@
+namespace Bitakora.ControlAsistencia.Contracts.ControlHoras.ValueObjects;
+
+// Issue #129: Estructura agregada del desglose del dia completo.
+// Record con constructor primario publico - STJ lo serializa nativamente sin ConfigurarSerializacion (ADR-0015).
+// FranjasAnomalas: franjas excluidas por falta de entrada o salida.
+// RetardoTotal: consolidado del dia; lo calcula #116 con compensacion cruzada.
+public record DesgloseHoras(
+    IReadOnlyList<DesgloseFranja> DesglosePorFranja,
+    DetalleRetardo RetardoTotal,
+    int FranjasAnomalas)
+{
+    // CA-3: suma elemento a elemento de MinutosPorConcepto de cada DesgloseFranja.
+    public IReadOnlyDictionary<Concepto, int> TotalMinutosPorConcepto =>
+        throw new NotImplementedException();
+
+    // CA-4: lista vacia, RetardoTotal = DetalleRetardo.Vacio, FranjasAnomalas = 0.
+    // Usado cuando no hay turno o todas las franjas son anomalas.
+    public static DesgloseHoras Vacio =>
+        throw new NotImplementedException();
+}

--- a/src/Bitakora.ControlAsistencia.Contracts/ControlHoras/ValueObjects/DesgloseHoras.cs
+++ b/src/Bitakora.ControlAsistencia.Contracts/ControlHoras/ValueObjects/DesgloseHoras.cs
@@ -11,10 +11,12 @@ public record DesgloseHoras(
 {
     // CA-3: suma elemento a elemento de MinutosPorConcepto de cada DesgloseFranja.
     public IReadOnlyDictionary<Concepto, int> TotalMinutosPorConcepto =>
-        throw new NotImplementedException();
+        DesglosePorFranja
+            .SelectMany(f => f.MinutosPorConcepto)
+            .GroupBy(kv => kv.Key)
+            .ToDictionary(g => g.Key, g => g.Sum(kv => kv.Value));
 
     // CA-4: lista vacia, RetardoTotal = DetalleRetardo.Vacio, FranjasAnomalas = 0.
     // Usado cuando no hay turno o todas las franjas son anomalas.
-    public static DesgloseHoras Vacio =>
-        throw new NotImplementedException();
+    public static readonly DesgloseHoras Vacio = new([], DetalleRetardo.Vacio, 0);
 }

--- a/src/Bitakora.ControlAsistencia.Contracts/Programacion/ValueObjects/DetalleFranjaOrdinaria.cs
+++ b/src/Bitakora.ControlAsistencia.Contracts/Programacion/ValueObjects/DetalleFranjaOrdinaria.cs
@@ -3,9 +3,38 @@ namespace Bitakora.ControlAsistencia.Contracts.Programacion.ValueObjects;
 /// <summary>
 /// Representacion plana de una franja ordinaria que viaja en eventos entre dominios.
 /// </summary>
+/// <remarks>
+/// Issue #129: override de Equals/GetHashCode para comparar Descansos y Extras con SequenceEqual.
+/// El record por defecto compara colecciones por referencia (ADR-0015 advierte sobre records con
+/// IReadOnlyList que prometen igualdad por valor que no cumplen). Esta intervencion preserva la
+/// forma de record (constructor primario publico, properties get-only) y corrige el bug.
+/// </remarks>
 public record DetalleFranjaOrdinaria(
     TimeOnly HoraInicio,
     TimeOnly HoraFin,
     int DiaOffsetFin,
     IReadOnlyList<DetalleSubFranja> Descansos,
-    IReadOnlyList<DetalleSubFranja> Extras);
+    IReadOnlyList<DetalleSubFranja> Extras)
+{
+    public virtual bool Equals(DetalleFranjaOrdinaria? other)
+    {
+        if (other is null) return false;
+        if (ReferenceEquals(this, other)) return true;
+        return HoraInicio == other.HoraInicio
+            && HoraFin == other.HoraFin
+            && DiaOffsetFin == other.DiaOffsetFin
+            && Descansos.SequenceEqual(other.Descansos)
+            && Extras.SequenceEqual(other.Extras);
+    }
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(HoraInicio);
+        hash.Add(HoraFin);
+        hash.Add(DiaOffsetFin);
+        foreach (var d in Descansos) hash.Add(d);
+        foreach (var e in Extras) hash.Add(e);
+        return hash.ToHashCode();
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Contracts.Tests/ValueObjects/ControlHoras/DesgloseFranjaTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Contracts.Tests/ValueObjects/ControlHoras/DesgloseFranjaTests.cs
@@ -1,0 +1,118 @@
+// HU-129: Crear estructuras agregadas DesgloseFranja y DesgloseHoras
+// CA-1: MinutosPorConcepto agrupa intervalos por concepto y suma sus duraciones correctamente
+// CA-2: MinutosPorConcepto omite los conceptos que no aparecen en Intervalos
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Contracts.ControlHoras.ValueObjects;
+using Bitakora.ControlAsistencia.Contracts.Programacion.ValueObjects;
+
+namespace Bitakora.ControlAsistencia.Contracts.Tests.ValueObjects.ControlHoras;
+
+/// <summary>
+/// Tests de DesgloseFranja - estructura agregada del desglose de una sola franja.
+/// Interfaz publica: constructor primario (Programada, Intervalos, Retardo), MinutosPorConcepto.
+/// </summary>
+public class DesgloseFranjaTests
+{
+    private static IntervaloTemporal CrearIntervalo(TimeOnly inicio, TimeOnly fin) =>
+        IntervaloTemporal.Crear(new MomentoDelDia(inicio), new MomentoDelDia(fin));
+
+    private static DetalleFranjaOrdinaria CrearFranjaProgramada() =>
+        new DetalleFranjaOrdinaria(new TimeOnly(8, 0), new TimeOnly(17, 0), 0, [], []);
+
+    // ---------- CA-1: agrupa por concepto y suma duraciones ----------
+
+    [Fact]
+    public void MinutosPorConcepto_AgrupaPorConceptoYSuma_CuandoMismoConceptoEnVariosIntervalos()
+    {
+        // Dos intervalos de OrdinariaDiurna: 240 min + 240 min = 480 min
+        var intervalos = new List<IntervaloClasificado>
+        {
+            new(CrearIntervalo(new TimeOnly(8, 0), new TimeOnly(12, 0)), Concepto.OrdinariaDiurna),
+            new(CrearIntervalo(new TimeOnly(13, 0), new TimeOnly(17, 0)), Concepto.OrdinariaDiurna)
+        };
+        var franja = new DesgloseFranja(CrearFranjaProgramada(), intervalos, DetalleRetardo.Vacio);
+
+        var resultado = franja.MinutosPorConcepto;
+
+        resultado.Should().ContainKey(Concepto.OrdinariaDiurna);
+        resultado[Concepto.OrdinariaDiurna].Should().Be(480);
+    }
+
+    [Fact]
+    public void MinutosPorConcepto_DistingueConceptosEnElDiccionario_CuandoIntervalosDeConceptosDiferentes()
+    {
+        // 120 min nocturno + 540 min diurno
+        var intervalos = new List<IntervaloClasificado>
+        {
+            new(CrearIntervalo(new TimeOnly(6, 0), new TimeOnly(8, 0)), Concepto.OrdinariaNocturna),
+            new(CrearIntervalo(new TimeOnly(8, 0), new TimeOnly(17, 0)), Concepto.OrdinariaDiurna)
+        };
+        var franja = new DesgloseFranja(CrearFranjaProgramada(), intervalos, DetalleRetardo.Vacio);
+
+        var resultado = franja.MinutosPorConcepto;
+
+        resultado[Concepto.OrdinariaNocturna].Should().Be(120);
+        resultado[Concepto.OrdinariaDiurna].Should().Be(540);
+    }
+
+    [Fact]
+    public void MinutosPorConcepto_SumaConceptosExtra_CuandoIntervaloDiurnoYExtraDiurnaPresentes()
+    {
+        // 480 min ordinaria diurna + 60 min extra diurna
+        var intervalos = new List<IntervaloClasificado>
+        {
+            new(CrearIntervalo(new TimeOnly(8, 0), new TimeOnly(16, 0)), Concepto.OrdinariaDiurna),
+            new(CrearIntervalo(new TimeOnly(16, 0), new TimeOnly(17, 0)), Concepto.ExtraDiurna)
+        };
+        var franja = new DesgloseFranja(CrearFranjaProgramada(), intervalos, DetalleRetardo.Vacio);
+
+        var resultado = franja.MinutosPorConcepto;
+
+        resultado[Concepto.OrdinariaDiurna].Should().Be(480);
+        resultado[Concepto.ExtraDiurna].Should().Be(60);
+    }
+
+    [Fact]
+    public void MinutosPorConcepto_ContieneSoloLosConceptosPresentes_CuandoUnSoloIntervalo()
+    {
+        var intervalos = new List<IntervaloClasificado>
+        {
+            new(CrearIntervalo(new TimeOnly(8, 0), new TimeOnly(17, 0)), Concepto.OrdinariaDiurna)
+        };
+        var franja = new DesgloseFranja(CrearFranjaProgramada(), intervalos, DetalleRetardo.Vacio);
+
+        var resultado = franja.MinutosPorConcepto;
+
+        resultado.Should().HaveCount(1);
+        resultado[Concepto.OrdinariaDiurna].Should().Be(540);
+    }
+
+    // ---------- CA-2: omite conceptos ausentes ----------
+
+    [Fact]
+    public void MinutosPorConcepto_OmiteConceptos_CuandoNoApareceEnIntervalos()
+    {
+        // Solo OrdinariaDiurna en los intervalos; el resto de conceptos no deben figurar
+        var intervalos = new List<IntervaloClasificado>
+        {
+            new(CrearIntervalo(new TimeOnly(8, 0), new TimeOnly(17, 0)), Concepto.OrdinariaDiurna)
+        };
+        var franja = new DesgloseFranja(CrearFranjaProgramada(), intervalos, DetalleRetardo.Vacio);
+
+        var resultado = franja.MinutosPorConcepto;
+
+        resultado.Should().NotContainKey(Concepto.ExtraDiurna);
+        resultado.Should().NotContainKey(Concepto.OrdinariaNocturna);
+        resultado.Should().NotContainKey(Concepto.ExtraNocturna);
+        resultado.Should().NotContainKey(Concepto.Descanso);
+        resultado.Should().NotContainKey(Concepto.DominicalFestivaDiurna);
+    }
+
+    [Fact]
+    public void MinutosPorConcepto_EstaVacio_CuandoSinIntervalos()
+    {
+        var franja = new DesgloseFranja(CrearFranjaProgramada(), [], DetalleRetardo.Vacio);
+
+        franja.MinutosPorConcepto.Should().BeEmpty();
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Contracts.Tests/ValueObjects/ControlHoras/DesgloseHorasTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Contracts.Tests/ValueObjects/ControlHoras/DesgloseHorasTests.cs
@@ -1,0 +1,108 @@
+// HU-129: Crear estructuras agregadas DesgloseFranja y DesgloseHoras
+// CA-3: TotalMinutosPorConcepto es la suma elemento a elemento de MinutosPorConcepto de cada franja
+// CA-4: Vacio tiene DesglosePorFranja vacio, RetardoTotal=DetalleRetardo.Vacio, FranjasAnomalas=0
+//       y TotalMinutosPorConcepto vacio
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Contracts.ControlHoras.ValueObjects;
+using Bitakora.ControlAsistencia.Contracts.Programacion.ValueObjects;
+
+namespace Bitakora.ControlAsistencia.Contracts.Tests.ValueObjects.ControlHoras;
+
+/// <summary>
+/// Tests de DesgloseHoras - estructura agregada del desglose del dia completo.
+/// Interfaz publica: constructor primario (DesglosePorFranja, RetardoTotal, FranjasAnomalas),
+/// TotalMinutosPorConcepto, Vacio.
+/// </summary>
+public class DesgloseHorasTests
+{
+    private static IntervaloTemporal CrearIntervalo(TimeOnly inicio, TimeOnly fin) =>
+        IntervaloTemporal.Crear(new MomentoDelDia(inicio), new MomentoDelDia(fin));
+
+    private static DetalleFranjaOrdinaria CrearFranjaProgramada() =>
+        new DetalleFranjaOrdinaria(new TimeOnly(8, 0), new TimeOnly(17, 0), 0, [], []);
+
+    private static DesgloseFranja CrearFranjaConIntervalos(
+        params (TimeOnly inicio, TimeOnly fin, Concepto concepto)[] datos)
+    {
+        var intervalos = datos
+            .Select(d => new IntervaloClasificado(CrearIntervalo(d.inicio, d.fin), d.concepto))
+            .ToList<IntervaloClasificado>();
+        return new DesgloseFranja(CrearFranjaProgramada(), intervalos, DetalleRetardo.Vacio);
+    }
+
+    // ---------- CA-3: TotalMinutosPorConcepto suma elemento a elemento ----------
+
+    [Fact]
+    public void TotalMinutosPorConcepto_EsLaSumaDeTodasLasFranjas_CuandoMismoConcepto()
+    {
+        // franja1: 240 min OrdinariaDiurna, franja2: 240 min OrdinariaDiurna => total 480
+        var franja1 = CrearFranjaConIntervalos(
+            (new TimeOnly(8, 0), new TimeOnly(12, 0), Concepto.OrdinariaDiurna));
+        var franja2 = CrearFranjaConIntervalos(
+            (new TimeOnly(13, 0), new TimeOnly(17, 0), Concepto.OrdinariaDiurna));
+        var desglose = new DesgloseHoras([franja1, franja2], DetalleRetardo.Vacio, 0);
+
+        desglose.TotalMinutosPorConcepto[Concepto.OrdinariaDiurna].Should().Be(480);
+    }
+
+    [Fact]
+    public void TotalMinutosPorConcepto_SumaConceptosParciales_CuandoConceptoApareceEnSolgunasFranjas()
+    {
+        // franja1: 120 min nocturno + 240 min diurno; franja2: 240 min diurno
+        // Esperado: nocturno=120, diurno=480
+        var franja1 = CrearFranjaConIntervalos(
+            (new TimeOnly(6, 0), new TimeOnly(8, 0), Concepto.OrdinariaNocturna),
+            (new TimeOnly(8, 0), new TimeOnly(12, 0), Concepto.OrdinariaDiurna));
+        var franja2 = CrearFranjaConIntervalos(
+            (new TimeOnly(13, 0), new TimeOnly(17, 0), Concepto.OrdinariaDiurna));
+        var desglose = new DesgloseHoras([franja1, franja2], DetalleRetardo.Vacio, 0);
+
+        desglose.TotalMinutosPorConcepto[Concepto.OrdinariaNocturna].Should().Be(120);
+        desglose.TotalMinutosPorConcepto[Concepto.OrdinariaDiurna].Should().Be(480);
+    }
+
+    [Fact]
+    public void TotalMinutosPorConcepto_OmiteConceptoAusenteEnTodasLasFranjas_CuandoSoloHayDiurna()
+    {
+        var franja1 = CrearFranjaConIntervalos(
+            (new TimeOnly(8, 0), new TimeOnly(17, 0), Concepto.OrdinariaDiurna));
+        var desglose = new DesgloseHoras([franja1], DetalleRetardo.Vacio, 0);
+
+        desglose.TotalMinutosPorConcepto.Should().NotContainKey(Concepto.ExtraDiurna);
+        desglose.TotalMinutosPorConcepto.Should().NotContainKey(Concepto.OrdinariaNocturna);
+    }
+
+    [Fact]
+    public void TotalMinutosPorConcepto_EstaVacio_CuandoSinFranjas()
+    {
+        var desglose = new DesgloseHoras([], DetalleRetardo.Vacio, 0);
+
+        desglose.TotalMinutosPorConcepto.Should().BeEmpty();
+    }
+
+    // ---------- CA-4: Vacio ----------
+
+    [Fact]
+    public void Vacio_TieneDesglosePorFranjaVacio()
+    {
+        DesgloseHoras.Vacio.DesglosePorFranja.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Vacio_TieneRetardoTotalIgualADetalleRetardoVacio()
+    {
+        DesgloseHoras.Vacio.RetardoTotal.Should().Be(DetalleRetardo.Vacio);
+    }
+
+    [Fact]
+    public void Vacio_TieneFranjasAnomalasEnCero()
+    {
+        DesgloseHoras.Vacio.FranjasAnomalas.Should().Be(0);
+    }
+
+    [Fact]
+    public void Vacio_TieneTotalMinutosPorConceptoVacio()
+    {
+        DesgloseHoras.Vacio.TotalMinutosPorConcepto.Should().BeEmpty();
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Contracts.Tests/ValueObjects/ControlHoras/DesgloseHorasTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Contracts.Tests/ValueObjects/ControlHoras/DesgloseHorasTests.cs
@@ -46,7 +46,7 @@ public class DesgloseHorasTests
     }
 
     [Fact]
-    public void TotalMinutosPorConcepto_SumaConceptosParciales_CuandoConceptoApareceEnSolgunasFranjas()
+    public void TotalMinutosPorConcepto_SumaConceptosParciales_CuandoConceptoApareceEnAlgunasFranjas()
     {
         // franja1: 120 min nocturno + 240 min diurno; franja2: 240 min diurno
         // Esperado: nocturno=120, diurno=480

--- a/tests/Bitakora.ControlAsistencia.Contracts.Tests/ValueObjects/DetalleFranjaOrdinariaIgualdadTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Contracts.Tests/ValueObjects/DetalleFranjaOrdinariaIgualdadTests.cs
@@ -1,0 +1,65 @@
+// Issue #129: Tests de contrato IEquatable para DetalleFranjaOrdinaria.
+// DetalleFranjaOrdinaria es record con override manual de Equals/GetHashCode que compara
+// las colecciones Descansos y Extras con SequenceEqual (en lugar de la igualdad por
+// referencia que el record genera por defecto - ADR-0015).
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Contracts.Programacion.ValueObjects;
+
+namespace Bitakora.ControlAsistencia.Contracts.Tests.ValueObjects;
+
+public class DetalleFranjaOrdinariaIgualdadTests : IgualdadTestBase<DetalleFranjaOrdinaria>
+{
+    private static DetalleSubFranja Descanso() =>
+        new(new TimeOnly(12, 0), new TimeOnly(13, 0), 0, 0);
+
+    private static DetalleSubFranja Extra() =>
+        new(new TimeOnly(17, 0), new TimeOnly(19, 0), 0, 0);
+
+    protected override DetalleFranjaOrdinaria CrearInstancia() =>
+        new(new TimeOnly(8, 0), new TimeOnly(17, 0), 0, [Descanso()], [Extra()]);
+
+    protected override DetalleFranjaOrdinaria CrearInstanciaCopia() =>
+        new(new TimeOnly(8, 0), new TimeOnly(17, 0), 0, [Descanso()], [Extra()]);
+
+    protected override IEnumerable<(string, DetalleFranjaOrdinaria)> CrearInstanciasDiferentes()
+    {
+        yield return ("HoraInicio",
+            new DetalleFranjaOrdinaria(new TimeOnly(7, 0), new TimeOnly(17, 0), 0, [Descanso()], [Extra()]));
+        yield return ("HoraFin",
+            new DetalleFranjaOrdinaria(new TimeOnly(8, 0), new TimeOnly(18, 0), 0, [Descanso()], [Extra()]));
+        yield return ("DiaOffsetFin",
+            new DetalleFranjaOrdinaria(new TimeOnly(8, 0), new TimeOnly(17, 0), 1, [Descanso()], [Extra()]));
+        yield return ("Descansos",
+            new DetalleFranjaOrdinaria(new TimeOnly(8, 0), new TimeOnly(17, 0), 0, [], [Extra()]));
+        yield return ("Extras",
+            new DetalleFranjaOrdinaria(new TimeOnly(8, 0), new TimeOnly(17, 0), 0, [Descanso()], []));
+    }
+
+    // Cobertura especifica del override: las listas se comparan por valor, no por referencia.
+
+    [Fact]
+    public void Equals_RetornaTrue_CuandoListasSonInstanciasDiferentesConMismoContenido()
+    {
+        var a = new DetalleFranjaOrdinaria(new TimeOnly(8, 0), new TimeOnly(17, 0), 0,
+            [new DetalleSubFranja(new TimeOnly(12, 0), new TimeOnly(13, 0), 0, 0)],
+            [new DetalleSubFranja(new TimeOnly(17, 0), new TimeOnly(19, 0), 0, 0)]);
+        var b = new DetalleFranjaOrdinaria(new TimeOnly(8, 0), new TimeOnly(17, 0), 0,
+            [new DetalleSubFranja(new TimeOnly(12, 0), new TimeOnly(13, 0), 0, 0)],
+            [new DetalleSubFranja(new TimeOnly(17, 0), new TimeOnly(19, 0), 0, 0)]);
+
+        a.Equals(b).Should().BeTrue();
+    }
+
+    [Fact]
+    public void GetHashCode_RetornaMismoHash_CuandoListasSonInstanciasDiferentesConMismoContenido()
+    {
+        var a = new DetalleFranjaOrdinaria(new TimeOnly(8, 0), new TimeOnly(17, 0), 0,
+            [new DetalleSubFranja(new TimeOnly(12, 0), new TimeOnly(13, 0), 0, 0)],
+            []);
+        var b = new DetalleFranjaOrdinaria(new TimeOnly(8, 0), new TimeOnly(17, 0), 0,
+            [new DetalleSubFranja(new TimeOnly(12, 0), new TimeOnly(13, 0), 0, 0)],
+            []);
+
+        a.GetHashCode().Should().Be(b.GetHashCode());
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/DesgloseFranjaSerializacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/DesgloseFranjaSerializacionTests.cs
@@ -1,0 +1,147 @@
+// HU-129: Crear estructuras agregadas DesgloseFranja y DesgloseHoras
+// CA-5: DesgloseFranja sobrevive round-trip JSON con ConfiguracionSerializacionControlHoras.CrearOpcionesMarten()
+//       preservando Programada, Intervalos, Retardo y recalculando MinutosPorConcepto con los mismos valores.
+// Barrera anti-regresion: sin el registro de DetalleRetardo en el resolver, la deserializacion falla.
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Contracts.ControlHoras.ValueObjects;
+using Bitakora.ControlAsistencia.Contracts.Programacion.ValueObjects;
+using Bitakora.ControlAsistencia.ControlHoras.Infraestructura;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Tests.Infraestructura;
+
+public class DesgloseFranjaSerializacionTests
+{
+    private static JsonSerializerOptions CrearOpciones() =>
+        ConfiguracionSerializacionControlHoras.CrearOpcionesMarten();
+
+    private static IntervaloTemporal CrearIntervalo(TimeOnly inicio, TimeOnly fin) =>
+        IntervaloTemporal.Crear(new MomentoDelDia(inicio), new MomentoDelDia(fin));
+
+    private static DetalleFranjaOrdinaria CrearFranjaProgramadaConDescanso() =>
+        new DetalleFranjaOrdinaria(
+            new TimeOnly(8, 0), new TimeOnly(17, 0), 0,
+            [new DetalleSubFranja(new TimeOnly(12, 0), new TimeOnly(13, 0), 0, 0)],
+            []);
+
+    private static DetalleFranjaOrdinaria CrearFranjaProgramadaSimple() =>
+        new DetalleFranjaOrdinaria(new TimeOnly(8, 0), new TimeOnly(17, 0), 0, [], []);
+
+    [Fact]
+    public void RoundTrip_PreservaProgramada_CuandoFranjaConDescanso()
+    {
+        var programada = CrearFranjaProgramadaConDescanso();
+        var original = new DesgloseFranja(
+            programada,
+            [new IntervaloClasificado(CrearIntervalo(new TimeOnly(8, 0), new TimeOnly(12, 0)), Concepto.OrdinariaDiurna)],
+            DetalleRetardo.Vacio);
+        var opciones = CrearOpciones();
+
+        var json = JsonSerializer.Serialize(original, opciones);
+        var restaurado = JsonSerializer.Deserialize<DesgloseFranja>(json, opciones);
+
+        restaurado.Should().NotBeNull();
+        restaurado!.Programada.Should().Be(programada);
+    }
+
+    [Fact]
+    public void RoundTrip_PreservaIntervalos_CuandoVariosConceptos()
+    {
+        var intervalos = new List<IntervaloClasificado>
+        {
+            new(CrearIntervalo(new TimeOnly(6, 0), new TimeOnly(8, 0)), Concepto.OrdinariaNocturna),
+            new(CrearIntervalo(new TimeOnly(8, 0), new TimeOnly(17, 0)), Concepto.OrdinariaDiurna)
+        };
+        var original = new DesgloseFranja(CrearFranjaProgramadaSimple(), intervalos, DetalleRetardo.Vacio);
+        var opciones = CrearOpciones();
+
+        var json = JsonSerializer.Serialize(original, opciones);
+        var restaurado = JsonSerializer.Deserialize<DesgloseFranja>(json, opciones);
+
+        restaurado.Should().NotBeNull();
+        restaurado!.Intervalos.Should().HaveCount(2);
+        restaurado.Intervalos[0].Concepto.Should().Be(Concepto.OrdinariaNocturna);
+        restaurado.Intervalos[1].Concepto.Should().Be(Concepto.OrdinariaDiurna);
+    }
+
+    [Fact]
+    public void RoundTrip_PreservaRetardo_CuandoConCompensacionParcial()
+    {
+        // 30 min retardados - 20 min compensados = 10 min neto
+        var retardo = DetalleRetardo.Crear(
+            [CrearIntervalo(new TimeOnly(8, 0), new TimeOnly(8, 30))],
+            [CrearIntervalo(new TimeOnly(12, 0), new TimeOnly(12, 20))]);
+        var original = new DesgloseFranja(
+            CrearFranjaProgramadaSimple(),
+            [new IntervaloClasificado(CrearIntervalo(new TimeOnly(8, 30), new TimeOnly(17, 0)), Concepto.OrdinariaDiurna)],
+            retardo);
+        var opciones = CrearOpciones();
+
+        var json = JsonSerializer.Serialize(original, opciones);
+        var restaurado = JsonSerializer.Deserialize<DesgloseFranja>(json, opciones);
+
+        restaurado.Should().NotBeNull();
+        restaurado!.Retardo.Should().Be(retardo);
+        restaurado.Retardo.RetardoNeto.Should().Be(10);
+    }
+
+    [Fact]
+    public void RoundTrip_PreservaRetardoVacio_CuandoSinRetardo()
+    {
+        var original = new DesgloseFranja(
+            CrearFranjaProgramadaSimple(),
+            [new IntervaloClasificado(CrearIntervalo(new TimeOnly(8, 0), new TimeOnly(17, 0)), Concepto.OrdinariaDiurna)],
+            DetalleRetardo.Vacio);
+        var opciones = CrearOpciones();
+
+        var json = JsonSerializer.Serialize(original, opciones);
+        var restaurado = JsonSerializer.Deserialize<DesgloseFranja>(json, opciones);
+
+        restaurado.Should().NotBeNull();
+        restaurado!.Retardo.Should().Be(DetalleRetardo.Vacio);
+        restaurado.Retardo.RetardoNeto.Should().Be(0);
+    }
+
+    [Fact]
+    public void RoundTrip_RecalculaMinutosPorConcepto_TrasDeserializar()
+    {
+        // 240 + 240 min OrdinariaDiurna: MinutosPorConcepto debe devolver 480 tras deserializar
+        var intervalos = new List<IntervaloClasificado>
+        {
+            new(CrearIntervalo(new TimeOnly(8, 0), new TimeOnly(12, 0)), Concepto.OrdinariaDiurna),
+            new(CrearIntervalo(new TimeOnly(13, 0), new TimeOnly(17, 0)), Concepto.OrdinariaDiurna)
+        };
+        var original = new DesgloseFranja(CrearFranjaProgramadaSimple(), intervalos, DetalleRetardo.Vacio);
+        var opciones = CrearOpciones();
+
+        var json = JsonSerializer.Serialize(original, opciones);
+        var restaurado = JsonSerializer.Deserialize<DesgloseFranja>(json, opciones);
+
+        restaurado.Should().NotBeNull();
+        restaurado!.MinutosPorConcepto[Concepto.OrdinariaDiurna].Should().Be(480);
+    }
+
+    // Barrera anti-regresion: DesgloseFranja.Retardo (DetalleRetardo) no sobrevive sin
+    // ConfigurarSerializacion registrado. Si alguien borra DetalleRetardo.ConfigurarSerializacion(resolver)
+    // de ConfigurarResolver, este test falla.
+    [Fact]
+    public void Deserializar_Falla_CuandoResolverNoTieneRegistroDeDetalleRetardo()
+    {
+        var original = new DesgloseFranja(
+            CrearFranjaProgramadaSimple(),
+            [new IntervaloClasificado(CrearIntervalo(new TimeOnly(8, 0), new TimeOnly(12, 0)), Concepto.OrdinariaDiurna)],
+            DetalleRetardo.Crear(
+                [CrearIntervalo(new TimeOnly(8, 0), new TimeOnly(8, 30))],
+                []));
+        var opcionesCompletas = CrearOpciones();
+        var json = JsonSerializer.Serialize(original, opcionesCompletas);
+
+        var resolverVacio = new DefaultJsonTypeInfoResolver();
+        var opcionesVacias = new JsonSerializerOptions { TypeInfoResolver = resolverVacio };
+
+        var act = () => JsonSerializer.Deserialize<DesgloseFranja>(json, opcionesVacias);
+
+        act.Should().Throw<NotSupportedException>();
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/DesgloseHorasSerializacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/DesgloseHorasSerializacionTests.cs
@@ -1,0 +1,161 @@
+// HU-129: Crear estructuras agregadas DesgloseFranja y DesgloseHoras
+// CA-6: DesgloseHoras sobrevive round-trip JSON con ConfiguracionSerializacionControlHoras.CrearOpcionesMarten()
+//       preservando DesglosePorFranja, RetardoTotal, FranjasAnomalas y recalculando TotalMinutosPorConcepto.
+// Barrera anti-regresion: sin el registro de DetalleRetardo en el resolver, la deserializacion falla.
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Contracts.ControlHoras.ValueObjects;
+using Bitakora.ControlAsistencia.Contracts.Programacion.ValueObjects;
+using Bitakora.ControlAsistencia.ControlHoras.Infraestructura;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Tests.Infraestructura;
+
+public class DesgloseHorasSerializacionTests
+{
+    private static JsonSerializerOptions CrearOpciones() =>
+        ConfiguracionSerializacionControlHoras.CrearOpcionesMarten();
+
+    private static IntervaloTemporal CrearIntervalo(TimeOnly inicio, TimeOnly fin) =>
+        IntervaloTemporal.Crear(new MomentoDelDia(inicio), new MomentoDelDia(fin));
+
+    private static DetalleFranjaOrdinaria CrearFranjaProgramadaSimple() =>
+        new DetalleFranjaOrdinaria(new TimeOnly(8, 0), new TimeOnly(17, 0), 0, [], []);
+
+    private static DesgloseFranja CrearFranjaDiurna() =>
+        new DesgloseFranja(
+            CrearFranjaProgramadaSimple(),
+            [new IntervaloClasificado(CrearIntervalo(new TimeOnly(8, 0), new TimeOnly(17, 0)), Concepto.OrdinariaDiurna)],
+            DetalleRetardo.Vacio);
+
+    private static DesgloseFranja CrearFranjaConRetardo() =>
+        new DesgloseFranja(
+            CrearFranjaProgramadaSimple(),
+            [new IntervaloClasificado(CrearIntervalo(new TimeOnly(8, 30), new TimeOnly(17, 0)), Concepto.OrdinariaDiurna)],
+            DetalleRetardo.Crear(
+                [CrearIntervalo(new TimeOnly(8, 0), new TimeOnly(8, 30))],
+                []));
+
+    [Fact]
+    public void RoundTrip_PreservaDesglosePorFranja_CuandoVariasFranjas()
+    {
+        var original = new DesgloseHoras(
+            [CrearFranjaDiurna(), CrearFranjaDiurna()],
+            DetalleRetardo.Vacio,
+            0);
+        var opciones = CrearOpciones();
+
+        var json = JsonSerializer.Serialize(original, opciones);
+        var restaurado = JsonSerializer.Deserialize<DesgloseHoras>(json, opciones);
+
+        restaurado.Should().NotBeNull();
+        restaurado!.DesglosePorFranja.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void RoundTrip_PreservaRetardoTotal_CuandoConRetardo()
+    {
+        var retardoTotal = DetalleRetardo.Crear(
+            [CrearIntervalo(new TimeOnly(8, 0), new TimeOnly(8, 30))],
+            []);
+        var original = new DesgloseHoras(
+            [CrearFranjaDiurna()],
+            retardoTotal,
+            0);
+        var opciones = CrearOpciones();
+
+        var json = JsonSerializer.Serialize(original, opciones);
+        var restaurado = JsonSerializer.Deserialize<DesgloseHoras>(json, opciones);
+
+        restaurado.Should().NotBeNull();
+        restaurado!.RetardoTotal.Should().Be(retardoTotal);
+        restaurado.RetardoTotal.RetardoNeto.Should().Be(30);
+    }
+
+    [Fact]
+    public void RoundTrip_PreservaFranjasAnomalas_CuandoConAnomalas()
+    {
+        var original = new DesgloseHoras(
+            [CrearFranjaDiurna()],
+            DetalleRetardo.Vacio,
+            FranjasAnomalas: 2);
+        var opciones = CrearOpciones();
+
+        var json = JsonSerializer.Serialize(original, opciones);
+        var restaurado = JsonSerializer.Deserialize<DesgloseHoras>(json, opciones);
+
+        restaurado.Should().NotBeNull();
+        restaurado!.FranjasAnomalas.Should().Be(2);
+    }
+
+    [Fact]
+    public void RoundTrip_PreservaFranjasAnomalasEnCero_CuandoSinAnomalas()
+    {
+        var original = new DesgloseHoras(
+            [CrearFranjaDiurna()],
+            DetalleRetardo.Vacio,
+            0);
+        var opciones = CrearOpciones();
+
+        var json = JsonSerializer.Serialize(original, opciones);
+        var restaurado = JsonSerializer.Deserialize<DesgloseHoras>(json, opciones);
+
+        restaurado.Should().NotBeNull();
+        restaurado!.FranjasAnomalas.Should().Be(0);
+    }
+
+    [Fact]
+    public void RoundTrip_RecalculaTotalMinutosPorConcepto_TrasDeserializar()
+    {
+        // Dos franjas diurnas de 540 min cada una: total 1080 min OrdinariaDiurna
+        var original = new DesgloseHoras(
+            [CrearFranjaDiurna(), CrearFranjaDiurna()],
+            DetalleRetardo.Vacio,
+            0);
+        var opciones = CrearOpciones();
+
+        var json = JsonSerializer.Serialize(original, opciones);
+        var restaurado = JsonSerializer.Deserialize<DesgloseHoras>(json, opciones);
+
+        restaurado.Should().NotBeNull();
+        restaurado!.TotalMinutosPorConcepto[Concepto.OrdinariaDiurna].Should().Be(1080);
+    }
+
+    [Fact]
+    public void RoundTrip_PreservaIntervalosDetenidos_CuandoFranjaConRetardoEnDesglose()
+    {
+        // Verifica que los intervalos dentro de cada DesgloseFranja se preservan correctamente
+        var franja = CrearFranjaConRetardo();
+        var original = new DesgloseHoras([franja], DetalleRetardo.Vacio, 0);
+        var opciones = CrearOpciones();
+
+        var json = JsonSerializer.Serialize(original, opciones);
+        var restaurado = JsonSerializer.Deserialize<DesgloseHoras>(json, opciones);
+
+        restaurado.Should().NotBeNull();
+        restaurado!.DesglosePorFranja[0].Retardo.RetardoNeto.Should().Be(30);
+    }
+
+    // Barrera anti-regresion: DesgloseHoras.RetardoTotal (DetalleRetardo) no sobrevive sin
+    // ConfigurarSerializacion registrado. Si alguien borra DetalleRetardo.ConfigurarSerializacion(resolver)
+    // de ConfigurarResolver, este test falla.
+    [Fact]
+    public void Deserializar_Falla_CuandoResolverNoTieneRegistroDeDetalleRetardo()
+    {
+        var original = new DesgloseHoras(
+            [CrearFranjaDiurna()],
+            DetalleRetardo.Crear(
+                [CrearIntervalo(new TimeOnly(8, 0), new TimeOnly(8, 30))],
+                []),
+            0);
+        var opcionesCompletas = CrearOpciones();
+        var json = JsonSerializer.Serialize(original, opcionesCompletas);
+
+        var resolverVacio = new DefaultJsonTypeInfoResolver();
+        var opcionesVacias = new JsonSerializerOptions { TypeInfoResolver = resolverVacio };
+
+        var act = () => JsonSerializer.Deserialize<DesgloseHoras>(json, opcionesVacias);
+
+        act.Should().Throw<NotSupportedException>();
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/DesgloseHorasSerializacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/DesgloseHorasSerializacionTests.cs
@@ -122,9 +122,10 @@ public class DesgloseHorasSerializacionTests
     }
 
     [Fact]
-    public void RoundTrip_PreservaIntervalosDetenidos_CuandoFranjaConRetardoEnDesglose()
+    public void RoundTrip_PreservaRetardoDeFranjaInterna_CuandoDesgloseTieneFranjaConRetardo()
     {
-        // Verifica que los intervalos dentro de cada DesgloseFranja se preservan correctamente
+        // Verifica que el Retardo dentro de cada DesgloseFranja se preserva correctamente
+        // tras anidar DesgloseFranja > DesgloseHoras y atravesar dos niveles de serializacion.
         var franja = CrearFranjaConRetardo();
         var original = new DesgloseHoras([franja], DetalleRetardo.Vacio, 0);
         var opciones = CrearOpciones();


### PR DESCRIPTION
## Resumen

Pipeline TDD completado:
- Fase roja: tests escritos con stubs
- Fase verde: implementación completa
- Fase refactor: revisión de calidad

## Decisiones del pipeline

<details>
<summary>Test Writer (fase roja) — 9m 9s</summary>

_(El agente no generó resumen)_

</details>

<details>
<summary>Implementer (fase verde) — 13m 20s</summary>

## ES Implementer - Decisiones

### Enfoque de implementacion

Implementacion directa de las dos estructuras agregadas como records con
constructor primario publico (segun lo especificado en el issue). Las
propiedades calculadas se exponen como `IReadOnlyDictionary<Concepto, int>`
y se recalculan en cada acceso via LINQ (`GroupBy` + `ToDictionary`).

`DesgloseHoras.Vacio` se declaro como `static readonly` field (singleton
alocado una vez), siguiendo el patron de `DetalleRetardo.Vacio`. El stub
del test-writer proponia property `=>` (instancia nueva por acceso), pero
para un objeto inmutable de conveniencia el field es mas eficiente y mas
idiomatico en el codebase. Cualquier opcion satisface los tests.

### Decisiones de diseno

- `MinutosPorConcepto`: `Intervalos.GroupBy(Concepto).ToDictionary(suma)`.
  Conceptos ausentes en `Intervalos` no aparecen en el diccionario (CA-2)
  porque `GroupBy` solo emite grupos para keys observadas.
- `TotalMinutosPorConcepto`: `SelectMany` aplana los pares (Concepto,int)
  de cada franja, luego `GroupBy` + `Sum` los agrega. Mismo principio:
  conceptos ausentes en todas las franjas no aparecen.
- `Vacio = new([], DetalleRetardo.Vacio, 0)`: literal de coleccion vacia
  para `IReadOnlyList<DesgloseFranja>` y delegacion a `DetalleRetardo.Vacio`
  ya existente.

### ADRs consultados

- ADR-0015 (estilo modelado de objetos de dominio): heuristica record vs
  sealed class, advertencia explicita sobre records con `IReadOnlyList`
  que prometen igualdad por valor que no cumplen.
- ADR-0007 (manejo de errores event sourcing): no aplica directamente
  aqui porque son value objects sin invariantes ni eventos de fallo.

### Desviaciones de ADRs

Ninguna desviacion de ADRs - todos los ADRs aplicados al pie de la letra
(records con ctor primario publico para tipos sin invariantes, segun
ADR-0015 tabla de heuristicas).

### Desviaciones del plan del planner

#### Desviacion: "Impacto en archivos - Modifica: ninguno"

- **Sugerencia del issue**: el bloque "Impacto en archivos" declara
  `**Modifica**: ninguno`. Solo se debian crear `DesgloseFranja.cs`,
  `DesgloseHoras.cs` y los dos test files.
- **Desviacion aplicada**: modifico tambien
  `src/Bitakora.ControlAsistencia.Contracts/Programacion/ValueObjects/DetalleFranjaOrdinaria.cs`
  agregando override de `Equals(DetalleFranjaOrdinaria?)` y `GetHashCode()`
  que comparan `Descansos` y `Extras` con `SequenceEqual` en vez de
  igualdad por referencia.
- **Razon tecnica**: el test
  `DesgloseFranjaSerializacionTests.RoundTrip_PreservaProgramada_CuandoFranjaConDescanso`
  hace `restaurado.Programada.Should().Be(programada)`. `Should().Be(...)`
  llama `Equals`. `DetalleFranjaOrdinaria` es un `record` con dos campos
  `IReadOnlyList<DetalleSubFranja>`, y los records de C# generan `Equals`
  que compara colecciones por referencia (no por valor). Verifique con un
  programa minimo: dos `DetalleFranjaOrdinaria` con el mismo contenido y
  listas distintas dan `Equals = false`. El test sigue siendo correcto en
  intencion (CA-5 exige preservar `Programada` tras round-trip), pero
  expone un bug pre-existente en `DetalleFranjaOrdinaria` que ADR-0015
  advierte explicitamente: "Usar `record` para eventos con colecciones
  (ej: `IReadOnlyList<T>`) promete igualdad por valor que no cumple".
- **Por que esta intervencion y no otra**:
  - Refactorizar a `sealed class` con factory + `IEquatable` cambia la
    forma del tipo y obligaria a actualizar todos los call-sites.
  - Override solo de `Equals`/`GetHashCode` es la fix minima: preserva
    el constructor primario publico, las properties get-only, y la
    serializacion native con STJ. Solo agrega 2 metodos.
- **Consecuencia conocida**:
  - Riesgo de cambio de comportamiento para consumidores que dependieran
    del comportamiento por-referencia de Equals: verifique con grep que
    ningun test ni codigo de produccion compara `DetalleFranjaOrdinaria`
    con `==` o `.Equals(...)` directamente. Solo este test nuevo lo hace.
  - Ahora `GetHashCode()` itera todos los elementos, costo O(n+m) por
    invocacion - aceptable para VOs pequenos como detalles de franjas.
  - Queda pendiente decidir si extender la misma fix a `DetalleTurno`
    (que contiene `IReadOnlyList<DetalleFranjaOrdinaria>`); no era
    necesario para los tests actuales y no lo toque.
- **Status**: pendiente de evaluacion del usuario / reviewer. Si el
  reviewer prefiere el camino largo (refactorizar `DetalleFranjaOrdinaria`
  a `sealed class` con factory completo, alineado con ADR-0015 estricto),
  esa es una decision arquitectonica que excede la fase verde.

### Precedentes consultados

- `DetalleRetardo.Vacio` (alineado con ADR-0015): patron de `static readonly`
  field para singleton de conveniencia. Replicado en `DesgloseHoras.Vacio`.
- `DetalleRetardo.Equals` (alineado con ADR-0015): patron de `SequenceEqual`
  para comparar colecciones internas. Inspiro la fix de `DetalleFranjaOrdinaria`.
- `IntervaloTemporal` y `DetalleRetardo` `ConfigurarSerializacion` (alineados
  con ADR-0015 y registrados en `ConfiguracionSerializacionControlHoras`):
  no se replico aqui porque `DesgloseFranja` y `DesgloseHoras` son records
  con ctor publico, manejados nativamente por STJ.

### Infraestructura modificada

Ninguna. No se publican eventos publicos en este issue.

### Complejidad encontrada

- Igualdad estructural en records con `IReadOnlyList`: documentada arriba.
- Los SmokeTests (`Programacion.SmokeTests`, `ControlHoras.SmokeTests`)
  fallan por timeout HTTP a un endpoint dev no disponible localmente.
  No relacionado con el cambio.

### Resultado

- Tests pasando: 309/309 unitarios
  - `Bitakora.ControlAsistencia.Contracts.Tests`: 165/165
  - `Bitakora.ControlAsistencia.Programacion.Tests`: 42/42
  - `Bitakora.ControlAsistencia.ControlHoras.Tests`: 102/102
- SmokeTests: 0/20 (todos fallan por API dev inaccesible, no relacionado)

</details>
<details>
<summary>Reviewer (fase refactor) — 11m 6s</summary>

## ES Reviewer - Revision

### Evaluacion general
- Calidad: buena con observacion arquitectonica documentada
- Cambios realizados: si (refactor de nombres + tests de igualdad para DetalleFranjaOrdinaria)

### Cumplimiento de ADRs aplicables

| ADR | Cumplimiento | Observacion |
|---|---|---|
| ADR-0015: Estilo modelado de objetos de dominio | desviacion declarada (DetalleFranjaOrdinaria) + desviacion NO declarada parcial (DesgloseFranja, DesgloseHoras) | Ver "Desviaciones de ADRs" |
| ADR-0007: Manejo de errores event sourcing | n/a | No hay aggregates ni eventos en este issue |
| ADR-0002: Contracts | ok | Tipos viven en `Contracts/ControlHoras/ValueObjects/` (correcto, viajan en evento publico DiaCalculado) |

El issue no tenia seccion `## ADRs aplicables` explicita - escalar al planner para futuros issues. El implementer identifico ADR-0015 correctamente en su resumen.

### Desviaciones de ADRs

**Desviaciones declaradas por el implementer** (copiadas de `stage-2-implementer.md`):

#### Desviacion: ADR-0015 - Equals/GetHashCode override en DetalleFranjaOrdinaria
- **Regla del ADR**: "Usar `record` para eventos con colecciones (ej: `IReadOnlyList<T>`) promete igualdad por valor que no cumple - `sealed class` no hace esa promesa."
- **Desviacion aplicada**: el implementer mantuvo `DetalleFranjaOrdinaria` como `record` pero agrego override de `Equals`/`GetHashCode` que comparan `Descansos` y `Extras` con `SequenceEqual`. Esto NO es estrictamente lo que el ADR prescribe (el ADR sugeriria migrar a `sealed class` con factory).
- **Razon del implementer**: el test `RoundTrip_PreservaProgramada_CuandoFranjaConDescanso` invoca `restaurado.Programada.Should().Be(programada)`, lo que rompe sin igualdad por valor de las listas. Migrar a `sealed class` cambia la API publica y requiere actualizar todos los call-sites del proyecto. El override es el "fix minimo" que cumple ADR-0015 en el comportamiento (igualdad por valor) sin tocar la forma del tipo.
- **Consecuencia conocida**: `GetHashCode()` ahora itera todos los elementos (O(n+m)). Aceptable para VOs pequenos. Queda pendiente decidir si extender la fix a `DetalleTurno` (contiene `IReadOnlyList<DetalleFranjaOrdinaria>`).
- **Evaluacion del reviewer**: **aceptable**. La razon es tecnica legitima: el camino largo (refactor a sealed class) tendria scope mucho mayor que este issue. El override preserva el comportamiento publico y agrega la igualdad por valor que ADR-0015 esperaria. Se agrego cobertura de tests dedicada para el override (DetalleFranjaOrdinariaIgualdadTests) durante la revision.
- **Status**: pendiente de evaluacion del usuario

**Desviaciones detectadas por el reviewer (NO declaradas por el implementer)**:

#### Desviacion: ADR-0015 - DesgloseFranja y DesgloseHoras tienen el mismo riesgo no mitigado
- **Regla del ADR**: igual que arriba - records con `IReadOnlyList` prometen igualdad por valor que no cumplen.
- **Desviacion encontrada en el diff**:
  - `src/Bitakora.ControlAsistencia.Contracts/ControlHoras/ValueObjects/DesgloseFranja.cs:8-19`: record con `IReadOnlyList<IntervaloClasificado> Intervalos`. Sin override de Equals - dos `DesgloseFranja` con listas distintas pero contenido identico devolverian `Equals = false`.
  - `src/Bitakora.ControlAsistencia.Contracts/ControlHoras/ValueObjects/DesgloseHoras.cs:7-22`: record con `IReadOnlyList<DesgloseFranja> DesglosePorFranja`. Mismo problema.
- **Por que el implementer no lo declaro**: solo aplico el fix donde un test fallo (DetalleFranjaOrdinaria, expuesto por CA-5). Para los nuevos tipos no hay test que invoque `Should().Be(...)` directamente sobre un `DesgloseFranja` o `DesgloseHoras`, asi que el bug no se expresa en este issue.
- **Accion tomada**: NO se aplico la fix proactiva. Razones:
  1. El issue (planner) eligio explicitamente `record` para estos tipos a sabiendas de ADR-0015.
  2. Los tests actuales no requieren igualdad por valor de los nuevos tipos.
  3. Aplicar el fix por anticipacion expandiria el scope del issue mas alla del plan.
  4. Cuando #115/#116 (calculadora) o consumidores futuros del evento `DiaCalculado` necesiten comparar dos `DesgloseHoras` por valor, la fix sera necesaria y sera parte del scope de ese issue.
- **Status**: documentado para futura mitigacion. El bug es latente (no hay test fallando hoy), pero ADR-0015 lo describe explicitamente. Recomiendo escalarlo al planner para que el issue #115 o #116 incluya la fix.

### Precedentes consultados por el implementer

| Precedente | ADR aplicable | Veredicto |
|---|---|---|
| `DetalleRetardo.Vacio` (static readonly field) | ADR-0015 | alineado: patron de singleton de conveniencia |
| `DetalleRetardo.Equals` (SequenceEqual sobre listas internas) | ADR-0015 | alineado: ejemplo canonico de igualdad por valor en sealed class con colecciones |
| `IntervaloTemporal`/`DetalleRetardo.ConfigurarSerializacion` | ADR-0015 | alineado: precedente de Contract Model resolver |

### Convenciones del pipeline (no ADRs)

| Convencion | Estado | Observacion |
|---|---|---|
| Cada test con `Then()` + `And<>()` | n/a | No es un command handler test |
| Overloads correctos para stream IDs compuestos | n/a | No hay aggregates en este issue |
| Fakes manuales (no NSubstitute) | n/a | No hay handlers ni dependencias |
| Feature folders (produccion y tests) | ok | `Contracts/ControlHoras/ValueObjects/` y mirroring en tests |
| Smoke tests: SkipWhen, secrets, cobertura | n/a | No aplica para value objects |
| Tests via comportamiento publico | ok | Tests verifican propiedades calculadas y round-trip |
| Sin numeros magicos | ok | Constantes obvias del dominio (8:00, 17:00 horas) sin oscurecer intent |
| Naming de tests segun ADR-0022 | ok (con typo corregido durante revision) | Sujeto_LoQuePasa_CuandoCondicion en todos |

### Elegancia del codigo

- **Compacto**: las propiedades calculadas son LINQ idiomatico de una linea cada una. Sin verbosidad.
- **Legible**: comentarios mapean explicitamente a CAs (CA-1, CA-2, CA-3, CA-4). Bien.
- **Idiomatico**: uso correcto de `record` con constructor primario, expresiones LINQ, literal de coleccion `[]`.
- **Robusto**: sin guard clauses faltantes (no hay boundaries del sistema en este codigo). El override de Equals tiene el patron correcto (null check, ReferenceEquals, comparacion estructural).
- **Eficiente**: O(n+m) en GetHashCode/Equals, O(n) en propiedades calculadas. Aceptable. El issue ya documenta que si el profiling lo requiere, se migra a calculo eager en otro issue.
- **Limpio**: sin warnings de compilador en codigo nuevo, sin debug cruft, sin imports innecesarios. Solo el typo "Solgunas" que se corrigio.

### Criticas y hallazgos

1. **Typo en nombre de test (cosmetico, corregido)**: `TotalMinutosPorConcepto_SumaConceptosParciales_CuandoConceptoApareceEnSolgunasFranjas` -> `EnAlgunasFranjas`.
2. **Naming poco claro (cosmetico, corregido)**: `RoundTrip_PreservaIntervalosDetenidos_CuandoFranjaConRetardoEnDesglose` no comunicaba la intencion. Renombrado a `RoundTrip_PreservaRetardoDeFranjaInterna_CuandoDesgloseTieneFranjaConRetardo` que refleja que el test verifica el Retardo anidado (no "intervalos detenidos").
3. **Cobertura faltante de igualdad para DetalleFranjaOrdinaria (mayor, corregido)**: el implementer agrego override de Equals/GetHashCode sin tests dedicados. Solo el test de round-trip cubre indirectamente el contrato. Se agrego `DetalleFranjaOrdinariaIgualdadTests` (8 tests via IgualdadTestBase + 2 tests adicionales para listas con instancias distintas).
4. **Riesgo de igualdad latente en DesgloseFranja/DesgloseHoras (mayor, documentado)**: ver "Desviaciones de ADRs" arriba.

### Refactorings aplicados

1. Renombrar test con typo (`Solgunas` -> `Algunas`).
2. Renombrar test con naming confuso (`PreservaIntervalosDetenidos` -> `PreservaRetardoDeFranjaInterna`).
3. Crear `tests/Bitakora.ControlAsistencia.Contracts.Tests/ValueObjects/DetalleFranjaOrdinariaIgualdadTests.cs` heredando de `IgualdadTestBase<DetalleFranjaOrdinaria>` con 5 atributos diferenciadores y 2 tests adicionales para listas equivalentes en instancias separadas.

### Cobertura de criterios de aceptacion

| Criterio | Estado | Test(s) |
|---|---|---|
| CA-1: `MinutosPorConcepto` agrupa intervalos por concepto y suma duraciones | cubierto | `MinutosPorConcepto_AgrupaPorConceptoYSuma_*`, `MinutosPorConcepto_DistingueConceptos_*`, `MinutosPorConcepto_SumaConceptosExtra_*`, `MinutosPorConcepto_ContieneSoloLosConceptosPresentes_*` |
| CA-2: `MinutosPorConcepto` omite conceptos ausentes | cubierto | `MinutosPorConcepto_OmiteConceptos_CuandoNoApareceEnIntervalos`, `MinutosPorConcepto_EstaVacio_CuandoSinIntervalos` |
| CA-3: `TotalMinutosPorConcepto` suma elemento a elemento por franja | cubierto | `TotalMinutosPorConcepto_EsLaSumaDeTodasLasFranjas_*`, `TotalMinutosPorConcepto_SumaConceptosParciales_*`, `TotalMinutosPorConcepto_OmiteConceptoAusenteEnTodasLasFranjas_*`, `TotalMinutosPorConcepto_EstaVacio_*` |
| CA-4: `Vacio` con DesglosePorFranja vacio, RetardoTotal=DetalleRetardo.Vacio, FranjasAnomalas=0 | cubierto | `Vacio_TieneDesglosePorFranjaVacio`, `Vacio_TieneRetardoTotalIgualADetalleRetardoVacio`, `Vacio_TieneFranjasAnomalasEnCero`, `Vacio_TieneTotalMinutosPorConceptoVacio` |
| CA-5: DesgloseFranja round-trip JSON Marten preserva todo | cubierto | `RoundTrip_PreservaProgramada_*`, `RoundTrip_PreservaIntervalos_*`, `RoundTrip_PreservaRetardo_*`, `RoundTrip_PreservaRetardoVacio_*`, `RoundTrip_RecalculaMinutosPorConcepto_*`, `Deserializar_Falla_CuandoResolverNoTieneRegistroDeDetalleRetardo` |
| CA-6: DesgloseHoras round-trip JSON Marten preserva todo | cubierto | `RoundTrip_PreservaDesglosePorFranja_*`, `RoundTrip_PreservaRetardoTotal_*`, `RoundTrip_PreservaFranjasAnomalas_*`, `RoundTrip_PreservaFranjasAnomalasEnCero_*`, `RoundTrip_RecalculaTotalMinutosPorConcepto_*`, `RoundTrip_PreservaRetardoDeFranjaInterna_*`, `Deserializar_Falla_CuandoResolverNoTieneRegistroDeDetalleRetardo` |

### Tests agregados

- **DetalleFranjaOrdinariaIgualdadTests** (10 tests): cubre el override de `Equals`/`GetHashCode` que el implementer agrego como desviacion declarada del plan. Sin estos tests, una regresion futura del override podria pasar desapercibida (el test de round-trip solo cubre un caso indirecto).
  - 8 tests heredados de `IgualdadTestBase<T>` (Equals true/false, EqualsObject, GetHashCode iguales/diferentes, null checks, tipo distinto)
  - 2 tests adicionales: `Equals` y `GetHashCode` con listas en instancias distintas pero contenido identico (la razon de ser del override)
- No se agregaron tests de igualdad para `DesgloseFranja` y `DesgloseHoras` porque NO tienen override de Equals - agregar tests de igualdad implicaria cambiar tambien el codigo de produccion, lo cual va mas alla del scope del issue (ver desviacion no declarada arriba).

### Resultado final

- Tests: 333 correctos / 6 omitidos (smoke tests sin config local) / 0 errores
- Cobertura de los 6 CAs: completa
- Sin warnings nuevos de compilacion
- Formato verificado

</details>

## Cobertura

| Archivo | Cobertura | Umbral | Estado |
|---|---|---|---|
| DesgloseFranja.cs | - | no evaluado | - |
| DesgloseHoras.cs | - | no evaluado | - |
| DetalleFranjaOrdinaria.cs | - | no evaluado | - |
## Commits

825cc49 refactor(hu-129): tests de igualdad para DetalleFranjaOrdinaria y nombres mas claros
3d5bf7a feat(hu-129): implementacion de DesgloseFranja y DesgloseHoras (fase verde)
b089b91 test(hu-129): tests para DesgloseFranja y DesgloseHoras con stubs de compilacion (fase roja)

Closes #129