### PR TITLE
Corregir filtro de DLLs en Stage 4 que omite la instrumentacion completa

### DIFF
--- a/scripts/tdd-pipeline.sh
+++ b/scripts/tdd-pipeline.sh
@@ -1099,15 +1099,31 @@ if [ "$IS_REFACTOR" != true ] && [ "$FROM_STAGE" -le 4 ]; then
         log "Instrumentando DLLs..."
         local settings_xml="$WORKTREE_PATH/dotnet-coverage.settings.xml"
         local instrumented=0
+        local seen_dlls=0
+        local skipped_tests=0
+        local skipped_duplicates=0
+        declare -A instrumented_basenames=()
         for dll in "$WORKTREE_PATH"/tests/Bitakora.ControlAsistencia.*.Tests/bin/Debug/net10.0/Bitakora.ControlAsistencia.*.dll; do
-            [[ "$dll" == *Tests* ]] && continue
             [[ ! -f "$dll" ]] && continue
+            seen_dlls=$((seen_dlls + 1))
+            local bn
+            bn="$(basename "$dll")"
+            if [[ "$bn" == *Tests.dll ]]; then
+                skipped_tests=$((skipped_tests + 1))
+                continue
+            fi
+            if [[ -n "${instrumented_basenames[$bn]:-}" ]]; then
+                skipped_duplicates=$((skipped_duplicates + 1))
+                continue
+            fi
             if dotnet-coverage instrument "$dll" --settings "$settings_xml" >>"${LOG_FILE_ABS:-$LOG_FILE}" 2>&1; then
                 instrumented=$((instrumented + 1))
+                instrumented_basenames[$bn]=1
             else
-                warn "No se pudo instrumentar: $(basename "$dll")"
+                warn "No se pudo instrumentar: $bn"
             fi
         done
+        log "Instrumentacion: vistas=$seen_dlls, omitidas_tests=$skipped_tests, omitidas_duplicadas=$skipped_duplicates, instrumentadas=$instrumented"
 
         if [ "$instrumented" -eq 0 ]; then
             warn "No se instrumento ninguna DLL"

--- a/scripts/tdd-pipeline.sh
+++ b/scripts/tdd-pipeline.sh
@@ -1102,7 +1102,9 @@ if [ "$IS_REFACTOR" != true ] && [ "$FROM_STAGE" -le 4 ]; then
         local seen_dlls=0
         local skipped_tests=0
         local skipped_duplicates=0
-        declare -A instrumented_basenames=()
+        # Set de basenames ya instrumentados (compatible bash 3.2, sin declare -A).
+        # Cadena con espacios como delimitadores; se consulta con [[ "$set" == *" $bn "* ]].
+        local instrumented_basenames=" "
         for dll in "$WORKTREE_PATH"/tests/Bitakora.ControlAsistencia.*.Tests/bin/Debug/net10.0/Bitakora.ControlAsistencia.*.dll; do
             [[ ! -f "$dll" ]] && continue
             seen_dlls=$((seen_dlls + 1))
@@ -1112,13 +1114,13 @@ if [ "$IS_REFACTOR" != true ] && [ "$FROM_STAGE" -le 4 ]; then
                 skipped_tests=$((skipped_tests + 1))
                 continue
             fi
-            if [[ -n "${instrumented_basenames[$bn]:-}" ]]; then
+            if [[ "$instrumented_basenames" == *" $bn "* ]]; then
                 skipped_duplicates=$((skipped_duplicates + 1))
                 continue
             fi
             if dotnet-coverage instrument "$dll" --settings "$settings_xml" >>"${LOG_FILE_ABS:-$LOG_FILE}" 2>&1; then
                 instrumented=$((instrumented + 1))
-                instrumented_basenames[$bn]=1
+                instrumented_basenames+="$bn "
             else
                 warn "No se pudo instrumentar: $bn"
             fi


### PR DESCRIPTION
## Resumen

Pipeline tooling completado:
- Writer: implementacion de la tarea
- Reviewer: revision de calidad

## Decisiones del pipeline

<details>
<summary>Writer -- 3m 10s</summary>

# Stage 1 — Writer (Tooling, issue #158)

## Cambio aplicado

Archivo unico modificado: `scripts/tdd-pipeline.sh` (lineas 1099-1126, dentro de la funcion `measure_coverage`).

### Fix principal

El filtro `[[ "$dll" == *Tests* ]]` operaba contra la ruta absoluta del DLL. Como el segmento `.Tests` aparece siempre en el directorio padre (`tests/Bitakora.ControlAsistencia.X.Tests/`), el `continue` saltaba TODA iteracion y `dotnet-coverage instrument` jamas se invocaba.

Se reemplazo por un filtro sobre el basename: `[[ "$bn" == *Tests.dll ]]`. Ahora solo se omiten los `*.Tests.dll` que se copian dentro de `bin/` por `ProjectReference`, dejando pasar las DLLs de produccion que efectivamente queremos instrumentar.

### Mejoras complementarias (nice-to-have del issue)

1. **Logging granular**: una sola linea reporta `vistas=N, omitidas_tests=N, omitidas_duplicadas=N, instrumentadas=N`. Permite diagnosticar futuras degradaciones del gate sin tener que reproducir el bug a mano.
2. **Deduplicacion por basename**: `Contracts.dll` se replica en cada `tests/X.Tests/bin/` por `ProjectReference`. Ahora se instrumenta una sola vez (la primera ocurrencia gana) usando un array asociativo `instrumented_basenames`.

## Restricciones respetadas (ADR-0018)

- **No se convierte `skipped` en `failed`**: la funcion sigue retornando `1` cuando no se instrumenta nada, y el llamador sigue cayendo en la rama de skip no-bloqueante.
- **No se toca el camino `skipped` por `PR_SRC_FILES` vacio**: ese caso (PR de docs/infra/smoke tests/tooling) sigue exactamente igual.
- **No se toca el glob `*.Tests/`** del bucle (ya excluye `*.SmokeTests/` por construccion).

## Verificacion

- `bash -n scripts/tdd-pipeline.sh` -> OK (sintaxis valida con `set -euo pipefail`).
- No se modifico codigo C#, no aplica `dotnet build`.

## Commit

`890b31a` — `fix(tooling): corregir filtro de DLLs en Stage 4 del pipeline TDD` (Closes #158).

## Validacion sugerida (post-merge, no parte de Stage 1)

- Correr el pipeline TDD sobre un issue con archivos de logica reales y confirmar que `events.log` registra por primera vez "DLL(s) instrumentada(s)" y la nueva linea con el desglose `vistas/omitidas_tests/omitidas_duplicadas/instrumentadas`.
- Confirmar que un PR de solo docs/smoke tests/tooling sigue cayendo en `skipped` legitimo via el camino C (`PR_SRC_FILES` vacio), sin entrar a `measure_coverage`.

</details>

<details>
<summary>Reviewer -- 4m 2s</summary>

# Stage 2 - Reviewer (Issue #158)

## Veredicto
Cambios alineados con el issue, pero con un problema de compatibilidad **bloqueante** en macOS (bash 3.2) que ya corregi y commitee.

## Lo que hizo el writer
Modifico el bucle de instrumentacion en scripts/tdd-pipeline.sh (measure_coverage, lineas 1099-1128):

1. **Fix nuclear**: cambia el filtro [[ "$dll" == *Tests* ]] (rota porque mira la ruta completa que siempre contiene tests/X.Tests/) por un check sobre el basename [[ "$bn" == *Tests.dll ]]. Este era el bug raiz del issue #158.
2. **Logging granular** (nice-to-have): contadores seen_dlls, skipped_tests, skipped_duplicates, instrumented y linea sintetica "Instrumentacion: vistas=X, omitidas_tests=Y, omitidas_duplicadas=Z, instrumentadas=W".
3. **Deduplicacion** (nice-to-have): evita instrumentar Bitakora.ControlAsistencia.Contracts.dll repetido por ProjectReference en cada tests/*.Tests/bin/Debug/net10.0/.

Cobertura del issue: completa, incluyendo los dos nice-to-have.

## Problemas detectados

### 1. (Bloqueante) declare -A rompe en bash 3.2 - corregido
declare -A instrumented_basenames=() requiere bash 4+. macOS por default trae bash 3.2.57, y /usr/bin/env bash resuelve a /bin/bash en el PATH local del proyecto (/bin aparece antes que /opt/homebrew/bin).

Verificacion:
    $ /bin/bash -c 'declare -A x=()'
    /bin/bash: line 0: declare: -A: invalid option

Otros scripts del pipeline ya documentan esta restriccion:
- scripts/pr-sync.sh:10 - "Compatible con bash 3.2+ (macOS nativo)"
- scripts/pr-sync.sh:37 - "Status tracker (compatible bash 3.2, sin declare -A)"
- scripts/batch-pipeline.sh:18, scripts/parallel-pipeline.sh:21 - idem

Sin el fix, el bucle aborta con set -euo pipefail activo y reproduce el mismo modo de falla original (instrumentadas=0), reintroduciendo el bug que el issue queria erradicar.

**Correccion aplicada** (commit 048ca41): reemplace el array asociativo por una cadena delimitada por espacios - el mismo patron documentado en pr-sync.sh.

    local instrumented_basenames=" "
    ...
    if [[ "$instrumented_basenames" == *" $bn "* ]]; then
        skipped_duplicates=$((skipped_duplicates + 1))
        continue
    fi
    ...
    instrumented_basenames+="$bn "

Validacion con bash 3.2 (simulacion 6 DLLs, dos *.Tests.dll, dos Contracts.dll duplicadas):
    vistas=6 omitidas_tests=2 omitidas_duplicadas=1 instrumentadas=3

### 2. Sintaxis general - OK
/bin/bash -n scripts/tdd-pipeline.sh pasa sin errores tras el fix.

## Restricciones del ADR-0018 - respetadas
- El gate sigue degradando a skipped cuando instrumented==0 (lineas 1130-1132). No convierte fallas en failed.
- No se toca el camino skipped por PR_SRC_FILES vacio.
- El glob *.Tests/ no cambio: SmokeTests siguen excluidos.

## Tests existentes
No hay tests automatizados del script (tests/**/tdd-pipeline* vacio). La validacion sugerida en el issue ("correr el pipeline TDD sobre un issue con archivos de logica") solo puede hacerla el operador humano en una corrida real.

## Commits dejados por el reviewer
- 048ca41 - fix(tooling): usar set bash 3.2-compatible para deduplicar DLLs

## Recomendacion
Mergear. El fix nuclear esta correcto, los nice-to-have agregan diagnostico util, y el problema de compatibilidad bash 3.2 quedo resuelto.

</details>

## Commits

048ca41 fix(tooling): usar set bash 3.2-compatible para deduplicar DLLs
890b31a fix(tooling): corregir filtro de DLLs en Stage 4 del pipeline TDD

Closes #158