### PR TITLE
Aplicar resolver ADR-0015 al ServiceBusFixture de ControlHoras.SmokeTests

### DIFF
--- a/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/Fixtures/ServiceBusFixture.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/Fixtures/ServiceBusFixture.cs
@@ -1,5 +1,7 @@
 using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
 using Azure.Messaging.ServiceBus;
+using Bitakora.ControlAsistencia.Contracts.ControlHoras.ValueObjects;
 using Microsoft.Extensions.Configuration;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.SmokeTests.Fixtures;
@@ -7,11 +9,26 @@ namespace Bitakora.ControlAsistencia.ControlHoras.SmokeTests.Fixtures;
 public class ServiceBusFixture : IAsyncLifetime
 {
     private ServiceBusClient? _client;
+    private JsonSerializerOptions _jsonOptions = null!;
 
     public bool IsConfigured { get; private set; }
 
     public ValueTask InitializeAsync()
     {
+        // Issue #160: aplicar ADR-0015 al consumir eventos con VOs sealed (ctor privado).
+        // Sin este resolver, STJ falla con NotSupportedException al deserializar
+        // DiaCalculado.DesgloseHoras.RetardoTotal y los IntervaloTemporal del desglose.
+        // Solo registramos los VOs sealed que viajan en eventos consumidos por estos
+        // smoke tests; al aparecer otros, agregar la llamada ConfigurarSerializacion correspondiente.
+        var resolver = new DefaultJsonTypeInfoResolver();
+        IntervaloTemporal.ConfigurarSerializacion(resolver);
+        DetalleRetardo.ConfigurarSerializacion(resolver);
+        _jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            TypeInfoResolver = resolver
+        };
+
         var configuration = new ConfigurationBuilder()
             .SetBasePath(AppContext.BaseDirectory)
             .AddJsonFile("appsettings.json", optional: false)
@@ -69,7 +86,6 @@ public class ServiceBusFixture : IAsyncLifetime
         Func<T, bool> match,
         TimeSpan timeout)
     {
-        var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
         await using var receiver = _client!.CreateReceiver(topicName, subscriptionName);
 
         var deadline = DateTime.UtcNow + timeout;
@@ -88,7 +104,7 @@ public class ServiceBusFixture : IAsyncLifetime
 
             try
             {
-                var deserialized = JsonSerializer.Deserialize<T>(received.Body.ToString(), options);
+                var deserialized = JsonSerializer.Deserialize<T>(received.Body.ToString(), _jsonOptions);
                 if (deserialized is null)
                 {
                     await receiver.CompleteMessageAsync(received);


### PR DESCRIPTION
## Resumen

Pipeline tooling completado:
- Writer: implementacion de la tarea
- Reviewer: revision de calidad

## Decisiones del pipeline

<details>
<summary>Writer -- 3m 46s</summary>

# Stage 1 Writer - Issue #160

## Que se implemento

Fix de tooling: aplicar el resolver ADR-0015 al ServiceBusFixture del proyecto
Bitakora.ControlAsistencia.ControlHoras.SmokeTests, para que WaitForMessageAsync<T>
pueda deserializar DiaCalculado (que contiene VOs sealed con ctor privado:
DetalleRetardo y IntervaloTemporal).

## Archivo modificado

- tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/Fixtures/ServiceBusFixture.cs

### Cambios

1. Imports anadidos: System.Text.Json.Serialization.Metadata y
   Bitakora.ControlAsistencia.Contracts.ControlHoras.ValueObjects.
2. Campo nuevo private JsonSerializerOptions _jsonOptions = null!; cacheado.
3. InitializeAsync construye una sola vez el DefaultJsonTypeInfoResolver,
   llama IntervaloTemporal.ConfigurarSerializacion(resolver) y
   DetalleRetardo.ConfigurarSerializacion(resolver), y arma _jsonOptions con
   PropertyNameCaseInsensitive = true y TypeInfoResolver = resolver.
4. WaitForMessageAsync<T> deja de construir su propio JsonSerializerOptions
   local y reusa _jsonOptions.
5. PublishAsync no se toco (solo se cambia el lado consumidor).

## Criterios de aceptacion

- CA-2: cumplido. Resolver con ambos ConfigurarSerializacion aplicado al
  WaitForMessageAsync via _jsonOptions cacheado.
- CA-3: cumplido. PropertyNameCaseInsensitive = true preservado, PublishAsync
  con ContentType application/json intacto.
- CA-4: cumplido. Programacion.SmokeTests/Fixtures/ServiceBusFixture.cs sin cambios.
- CA-1: a verificar contra el workflow de smoke tests. Build local OK.

## Verificacion local

dotnet build tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests => 0 errores, 0 warnings.
No se corre dotnet test local: la validacion del fix es el smoke test
contra el entorno dev (ADR-0016).

## Decisiones de diseno respetadas

- ADR-0024 (Rule of Three): no se extrajo helper a Contracts. Solo dos sitios
  hoy duplican el registro (dominio + este fixture); se mantiene mecanico.
- ADR-0015: se reusan los ConfigurarSerializacion publicos de los VOs.
- ADR-0002: solo se usa API publica de Contracts; no se importa
  ConfiguracionSerializacionControlHoras del dominio.

## Commit

fix(smoke-tests): aplicar resolver ADR-0015 al ServiceBusFixture de ControlHoras

</details>

<details>
<summary>Reviewer -- 3m 12s</summary>

# Stage 2 - Reviewer (Issue #160)

## Veredicto

Aprobado sin correcciones. El writer entrego un fix mecanico y bien acotado.

## Verificaciones

- dotnet build solucion: correcto, 0 errores (warnings NU1902 preexistentes).
- dotnet test ControlHoras.Tests: 108/108 verde.
- dotnet test Programacion.Tests: 42/42 verde.
- Smoke tests requieren entorno dev; valida el workflow (CA-1).

## Criterios de aceptacion

- CA-1 (smoke test verde): diferido al workflow. Causa raiz del NotSupportedException atendida.
- CA-2 (resolver con ambos VOs): cumple. ServiceBusFixture.cs:23-30 registra IntervaloTemporal y DetalleRetardo.
- CA-3 (PublishAsync intacto, camelCase preservado): cumple. PropertyNameCaseInsensitive = true preservado.
- CA-4 (Programacion.SmokeTests sin cambios): cumple. git diff solo lista el fixture de ControlHoras.

## Calidad del codigo

- Reusa el patron de ConfiguracionSerializacionControlHoras.ConfigurarResolver con el subset relevante para DiaCalculado (ADR-0024 Rule of Three).
- Naming _jsonOptions con null! coherente con el estilo del archivo (mismo patron que _client).
- Comentario explica el por que (issue, ADR-0015, sintoma desgloseHoras.retardoTotal).
- Construccion una sola vez en InitializeAsync, reuso en WaitForMessageAsync (recomendacion del planner aplicada).
- Imports ordenados, sin caracteres Unicode prohibidos.

## Alineacion con ADRs

- ADR-0015: usa la API publica ConfigurarSerializacion expuesta por cada VO sellado en Contracts.
- ADR-0016: el fixture como cliente del Service Bus real necesita la misma logica de serializacion que cualquier consumidor.
- ADR-0024: duplicacion estable entre fixture y dominio mantenida; reabrir si aparece tercer sitio.

## Correcciones aplicadas

Ninguna. El diff del writer ya esta en commit 7249337 y no requiere ajustes.

## Riesgos residuales

- Nuevos VOs sealed entrando al grafo de DiaCalculado disparan el mismo bug; el patron del comentario indica como remediarlo.
- Programacion.SmokeTests/Fixtures/ServiceBusFixture.cs sigue con el bug latente, vigilancia abierta en el issue.

</details>

## Commits

7249337 fix(smoke-tests): aplicar resolver ADR-0015 al ServiceBusFixture de ControlHoras

Closes #160