### PR TITLE
docs: setup del plugin mefisto para nuevos desarrolladores

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,21 +1,5 @@
 {
-  "extraKnownMarketplaces": {
-    "augusto-romero-arango-harness": {
-      "source": {
-        "source": "github",
-        "repo": "augusto-romero-arango/eda-evsourcing-azure-harness"
-      }
-    }
-  },
   "permissions": {
-    "deny": [
-      "Bash(git push --force*)",
-      "Bash(git push -f *)",
-      "Bash(gh repo delete*)",
-      "Bash(terraform destroy*)",
-      "Bash(terraform apply -auto-approve*)",
-      "Bash(az group delete*)"
-    ],
     "allow": [
       "Bash(dotnet *)",
       "Bash(git *)",
@@ -48,6 +32,25 @@
       "Read(.claude/pipeline/**)",
       "Read(//Users/augusto-romero-arango/.claude/plans/**)",
       "Read(//Users/augusto-romero-arango/Codigo/Personal/experimentos/**)"
+    ],
+    "deny": [
+      "Bash(git push --force*)",
+      "Bash(git push -f *)",
+      "Bash(gh repo delete*)",
+      "Bash(terraform destroy*)",
+      "Bash(terraform apply -auto-approve*)",
+      "Bash(az group delete*)"
     ]
+  },
+  "extraKnownMarketplaces": {
+    "augusto-romero-arango-harness": {
+      "source": {
+        "source": "github",
+        "repo": "augusto-romero-arango/eda-evsourcing-azure-harness"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "mefisto@augusto-romero-arango-harness": true
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,16 @@ Este proyecto consume el plugin `mefisto@augusto-romero-arango-harness` desde el
 - **Skills disponibles**: `/mefisto:implement`, `:scaffold`, `:infra`, `:tooling`, `:bug`, `:draft`, `:merge`, `:parallel`, `:sequential`, `:show-flow`, `:work-status`, `:health-check`, `:eraser-diagram`, `:fix-review`.
 - **Actualizar**: `/plugin update mefisto`.
 
+#### Setup para nuevos desarrolladores
+
+El marketplace y el plugin ya están declarados en `.claude/settings.json` (commiteado al repo), así que la instalación es prácticamente automática:
+
+1. **Acceso al repo del harness**: asegúrate de poder leer `augusto-romero-arango/eda-evsourcing-azure-harness`. Si es privado, autentica con `gh auth login` con permisos de lectura.
+2. **Abre Claude Code en el repo**: detectará el marketplace y el plugin habilitado. Si no lo instala solo, corre `/plugin` y confirma la instalación de `mefisto`.
+3. **Recarga** con `/reload-plugins` para activar skills y agentes sin reiniciar la sesión.
+
+Para verificar que quedó: corre `/mefisto:health-check` o invoca cualquier skill `/mefisto:*` desde el prompt. Para traer cambios publicados en el harness: `/plugin update mefisto`.
+
 ### Tokens del harness (resolución para agentes y skills)
 
 Estos valores los consumen los agentes/skills del harness cuando ven los placeholders `<RootNamespace>`, `<SolutionFile>`, `<ProjectDisplayName>`. La fuente operativa para scripts es `.claude/harness.config.json`.


### PR DESCRIPTION
## Summary
- Añade sección **Setup para nuevos desarrolladores** en `CLAUDE.md`, dentro de `### Harness integrado`, con los tres pasos para que un dev recién clonado tenga el plugin `mefisto` listo (acceso al repo del harness → abrir Claude Code → `/reload-plugins`).
- Deja `enabledPlugins` declarado en `.claude/settings.json`, de modo que Claude Code proponga instalar el plugin automáticamente al abrir el repo en una máquina nueva.

## Test plan
- [ ] Clonar el repo en una máquina limpia, abrir Claude Code y verificar que se propone instalar `mefisto@augusto-romero-arango-harness` sin pasos manuales adicionales.
- [ ] Correr `/mefisto:health-check` después de instalar y confirmar que el skill responde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)