### PR TITLE
Instrumentar worker de ControlHoras con OpenTelemetry hacia App Insights

### DIFF
--- a/docs/adr/0009-control-costos-application-insights.md
+++ b/docs/adr/0009-control-costos-application-insights.md
@@ -67,5 +67,34 @@ de doble ingestion si se activa sin configurar sampling.
 | Parametro | dev | staging | prod |
 |---|---|---|---|
 | `daily_data_cap_in_gb` | 0.5 | 1.0 | 2.0 |
-| `maxTelemetryItemsPerSecond` | 5 | 5 | 10 |
+| `maxTelemetryItemsPerSecond` (clasico) | 5 | 5 | 10 |
+| `TELEMETRY_SAMPLING_RATIO` (OpenTelemetry) | 0.2 | 0.2 | 0.1 |
 | Exception spike threshold | 50 | 100 | 200 |
+
+## Actualizacion (2026-06-18): Capa 2 bajo OpenTelemetry
+
+Durante la investigacion de los smoke tests rojos del PR #165 se detecto que el proceso worker
+de las Function Apps **no emitia telemetria** (tablas `requests`/`dependencies`/`exceptions` en 0):
+el pipeline OpenTelemetry registraba fuentes pero sin exporter, asi que los spans se descartaban y
+no habia desglose de latencia por capa para depurar. Se instrumento el worker de ControlHoras con
+`telemetryMode: OpenTelemetry` (host.json) + `UseFunctionsWorkerDefaults()` + `UseAzureMonitorExporter()`.
+
+Esto **cambia el mecanismo de la Capa 2**: segun la doc oficial de Microsoft, con
+`telemetryMode: OpenTelemetry` la seccion `logging.applicationInsights` de host.json (donde vivia
+`maxTelemetryItemsPerSecond`) **deja de aplicar**. El control de volumen pasa a un sampler OTel
+head-based: `ParentBased(TraceIdRatioBased(ratio))`, con el ratio configurable via la app setting
+`TELEMETRY_SAMPLING_RATIO` (default 0.2 en codigo). Para un diagnostico puntual se sube a 1.0 y se
+restaura despues.
+
+**Trade-off honesto respecto a la decision original**: el sampling head-based muestrea tambien las
+excepciones, a diferencia del sampling adaptativo clasico de Application Insights que las preservaba
+al 100%. Mitigaciones:
+- La **Capa 3 (daily cap)** sigue intacta como tope duro de costo (0.5 GB/dia dev) -- un dia de $300
+  sigue siendo estructuralmente imposible.
+- La **Capa 4 (alerta de spike de excepciones)** sigue activa, pero el sampling reduce su
+  sensibilidad: por eso el ratio no debe ser demasiado bajo.
+- La **Capa 1 (logLevel de host.json)** solo filtra logs del proceso host; los logs del worker se
+  filtran con configuracion OTel del worker (pendiente si se requiere mayor control).
+
+Capas 3 y 4 sin cambios. Esta adaptacion aplica al dominio ControlHoras; los demas dominios
+mantienen el modelo clasico hasta que se instrumenten igual.

--- a/src/Bitakora.ControlAsistencia.ControlHoras/Bitakora.ControlAsistencia.ControlHoras.csproj
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Bitakora.ControlAsistencia.ControlHoras.csproj
@@ -11,8 +11,10 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.8.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.51.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.OpenTelemetry" Version="1.2.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.*" />
     <PackageReference Include="Cosmos.EventDriven.Abstractions" Version="0.0.8" />
@@ -20,8 +22,8 @@
     <PackageReference Include="Cosmos.EventDriven.CritterStack.AzureServiceBus" Version="0.0.6" />
     <PackageReference Include="Cosmos.EventSourcing.Abstractions" Version="0.0.12" />
     <PackageReference Include="Cosmos.EventSourcing.CritterStack" Version="0.1.9" />
-    <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.4.0" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.*" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Bitakora.ControlAsistencia.ControlHoras/Program.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Program.cs
@@ -13,6 +13,7 @@ using Microsoft.Azure.Functions.Worker.Builder;
 using Microsoft.Azure.Functions.Worker.OpenTelemetry;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using OpenTelemetry.Trace;
 
 var builder = FunctionsApplication.CreateBuilder(args);
 builder.ConfigureFunctionsWebApplication();
@@ -56,8 +57,25 @@ builder.Services.ConfigureMarten(options =>
 // ni el desglose de latencia por capa. Se usa el exporter -no el distro
 // Azure.Monitor.OpenTelemetry.AspNetCore- para evitar request telemetry duplicado en el worker.
 // Guia oficial: https://learn.microsoft.com/azure/azure-functions/opentelemetry-howto?pivots=programming-language-csharp
+//
+// ADR-0009 Capa 2 (control de costos): con telemetryMode=OpenTelemetry el sampling de
+// host.json (logging.applicationInsights) deja de aplicar, asi que el volumen de trazas se
+// controla aqui con un sampler OTel. Ratio configurable via la app setting
+// TELEMETRY_SAMPLING_RATIO (default 0.2); para un diagnostico puntual se sube a 1.0 y se baja
+// despues. El daily cap (Capa 3) sigue siendo el tope duro y la alerta de spike (Capa 4) sigue
+// activa. Nota: el sampling head-based tambien muestrea excepciones (a diferencia del sampling
+// adaptativo clasico que las preservaba al 100%); el cap y la alerta de spike lo compensan.
+var samplingRatio = double.TryParse(
+    Environment.GetEnvironmentVariable("TELEMETRY_SAMPLING_RATIO"),
+    System.Globalization.NumberStyles.Float,
+    System.Globalization.CultureInfo.InvariantCulture,
+    out var ratio) && ratio is >= 0.0 and <= 1.0
+        ? ratio
+        : 0.2;
+
 builder.Services.AddOpenTelemetry()
     .WithTracing(tracing => tracing
+        .SetSampler(new ParentBasedSampler(new TraceIdRatioBasedSampler(samplingRatio)))
         .AddSource("Wolverine")
         .AddSource("Marten")
         .AddSource("Npgsql")

--- a/src/Bitakora.ControlAsistencia.ControlHoras/Program.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Program.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Azure.Monitor.OpenTelemetry.Exporter;
 using Bitakora.ControlAsistencia.Contracts.ControlHoras.Eventos;
 using Bitakora.ControlAsistencia.ControlHoras;
 using Bitakora.ControlAsistencia.ControlHoras.Infraestructura;
@@ -9,6 +10,7 @@ using Cosmos.EventSourcing.CritterStack.Commands;
 using FluentValidation;
 using Marten;
 using Microsoft.Azure.Functions.Worker.Builder;
+using Microsoft.Azure.Functions.Worker.OpenTelemetry;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
@@ -49,11 +51,19 @@ builder.Services.ConfigureMarten(options =>
     }
 });
 
+// Observabilidad: exporta las trazas del worker (Npgsql, Marten, Wolverine, handlers) a
+// Application Insights via OpenTelemetry. Sin esto el proceso worker no emite dependencies
+// ni el desglose de latencia por capa. Se usa el exporter -no el distro
+// Azure.Monitor.OpenTelemetry.AspNetCore- para evitar request telemetry duplicado en el worker.
+// Guia oficial: https://learn.microsoft.com/azure/azure-functions/opentelemetry-howto?pivots=programming-language-csharp
 builder.Services.AddOpenTelemetry()
     .WithTracing(tracing => tracing
         .AddSource("Wolverine")
         .AddSource("Marten")
-        .AddSource("Bitakora.ControlAsistencia.ControlHoras.*"));
+        .AddSource("Npgsql")
+        .AddSource("Bitakora.ControlAsistencia.ControlHoras.*"))
+    .UseFunctionsWorkerDefaults()
+    .UseAzureMonitorExporter();
 
 // Serializacion JSON global: camelCase hacia el cliente, case-insensitive en lectura
 builder.Services.Configure<JsonSerializerOptions>(options =>

--- a/src/Bitakora.ControlAsistencia.ControlHoras/host.json
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/host.json
@@ -1,5 +1,6 @@
 {
     "version": "2.0",
+    "telemetryMode": "OpenTelemetry",
     "logging": {
         "logLevel": {
             "default": "Warning",


### PR DESCRIPTION
## Contexto

Durante la investigacion de los smoke tests rojos del PR #165 descubrimos que el **proceso worker no emitia telemetria**: en App Insights, las tablas `requests`, `dependencies` y `exceptions` estaban en **0** durante 24h (solo fluian health-checks y heartbeat del host). Sin `dependencies` no hay desglose de latencia por capa, por lo que cada hipotesis de causa raiz era adivinanza.

Causa: el pipeline OpenTelemetry en `Program.cs` registraba fuentes (Wolverine, Marten) pero **no tenia exporter**, asi que los spans se descartaban. El paquete `Azure.Monitor.OpenTelemetry.AspNetCore` (el distro) estaba referenciado pero nunca activado.

## Cambio (solo observabilidad)

- `host.json`: `telemetryMode: OpenTelemetry`.
- `Program.cs`: `UseFunctionsWorkerDefaults()` + `UseAzureMonitorExporter()`; se agrega `Npgsql` como fuente para ver el span de `ConnectAsync` (la pista del stack original).
- `.csproj`: se quita el distro sin usar; se agregan `Azure.Monitor.OpenTelemetry.Exporter`, `Microsoft.Azure.Functions.Worker.OpenTelemetry`, `OpenTelemetry.Extensions.Hosting`.

Se usa el **exporter** (no el distro completo) en el worker para evitar request telemetry duplicado, segun la guia oficial: https://learn.microsoft.com/azure/azure-functions/opentelemetry-howto?pivots=programming-language-csharp

## Garantias

- **No toca logica de negocio** ni el bloque `extensions.serviceBus` de `host.json` (`maxConcurrentCalls: 1`, ADR-0017 intacto).
- Compila; 123/123 tests unitarios de ControlHoras verdes.

## Por que ahora

Es la Ronda 0 de la estrategia de diagnostico (recuperar observabilidad antes de tocar el sistema). Una vez desplegado, podremos ver por primera vez el desglose de latencia por capa de los smoke tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)