### PR TITLE
chore(ci): actualizar GitHub Actions a sus ultimas versiones major

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup .NET 10
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
 
@@ -86,6 +86,6 @@ jobs:
 
       - name: Comentar cobertura en el PR
         if: github.event_name == 'pull_request'
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@v3
         with:
           path: coverage/report/SummaryGithub.md

--- a/.github/workflows/deploy-control-horas.yml
+++ b/.github/workflows/deploy-control-horas.yml
@@ -13,9 +13,9 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
 
@@ -35,9 +35,9 @@ jobs:
     needs: build-and-test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
 
@@ -67,7 +67,7 @@ jobs:
           test -f ./publish/Bitakora.ControlAsistencia.ControlHoras.dll
 
       - name: Azure Authentication
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 

--- a/.github/workflows/deploy-programacion.yml
+++ b/.github/workflows/deploy-programacion.yml
@@ -13,9 +13,9 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
 
@@ -35,9 +35,9 @@ jobs:
     needs: build-and-test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
 
@@ -67,7 +67,7 @@ jobs:
           test -f ./publish/Bitakora.ControlAsistencia.Programacion.dll
 
       - name: Azure Authentication
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 

--- a/.github/workflows/infra-cd.yml
+++ b/.github/workflows/infra-cd.yml
@@ -27,10 +27,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
 
       - name: Terraform Init
         working-directory: infra/environments/dev

--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -26,10 +26,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
 
       - name: Terraform Init
         working-directory: infra/environments/dev
@@ -42,7 +42,7 @@ jobs:
         continue-on-error: true
 
       - name: Comentar plan en PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/smoke-tests-dominio.yml
+++ b/.github/workflows/smoke-tests-dominio.yml
@@ -31,9 +31,9 @@ jobs:
   smoke-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
 

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -9,7 +9,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - id: set-matrix
         run: echo "matrix=$(jq -c . .github/smoke-tests-dominios.json)" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
Actualiza todas las GitHub Actions usadas en los workflows a sus ultimas versiones major.

## Cambios
- actions/checkout: v4 -> v6
- actions/setup-dotnet: v4 -> v5
- actions/github-script: v7 -> v9
- azure/login: v2 -> v3
- hashicorp/setup-terraform: v3 -> v4
- marocchino/sticky-pull-request-comment: v2 -> v3

Archivos tocados: ci.yml, deploy-control-horas.yml, deploy-programacion.yml, infra-cd.yml, infra-ci.yml, smoke-tests-dominio.yml, smoke-tests.yml (solo YAML de workflows).

## Notas de verificacion
- Todos los tests unitarios pasan (ControlHoras.Tests, Contracts.Tests, Programacion.Tests) y la solucion compila.
- El pipeline de tooling local quedo en `failed` unicamente por 11 smoke tests de Programacion.SmokeTests que no alcanzaron el entorno dev (errores de socket, ADR-0016). El cambio es exclusivamente YAML y no puede afectar los tests de .NET.

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)