### PR TITLE
Alinear Microsoft.Azure.Functions.Worker a 2.52.0 (fix MissingMethodException)

### DIFF
--- a/src/Bitakora.ControlAsistencia.ControlHoras/Bitakora.ControlAsistencia.ControlHoras.csproj
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Bitakora.ControlAsistencia.ControlHoras.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.8.1" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.51.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.52.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.OpenTelemetry" Version="1.2.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />


### PR DESCRIPTION
## Problema

Tras #168, el worker de ControlHoras en dev devolvia **HTTP 500 en todo** (incluido `/api/health`):
```
System.MissingMethodException: Method not found:
'Void Microsoft.Azure.Functions.Worker.DefaultTraceContext..ctor(String, String, IReadOnlyDictionary<String,String>)'
  at Microsoft.Azure.Functions.Worker.Grpc.GrpcFunctionInvocation..ctor(InvocationRequest)
```

## Causa

Desajuste de versiones introducido en #168: `Microsoft.Azure.Functions.Worker.OpenTelemetry` 1.2.0
depende de `Worker.Core` **2.52.0**, asi que NuGet subio Core, pero `Worker` y `Worker.Grpc`
quedaron en **2.51.0**. `Core` y `Grpc` son un set acoplado; con versiones distintas, el ctor de
`DefaultTraceContext` que invoca Grpc no existe en el Core cargado.

## Fix

Subir el meta-paquete `Microsoft.Azure.Functions.Worker` 2.51.0 -> **2.52.0**. Esto realinea
`Worker`, `Worker.Core` y `Worker.Grpc` todos en 2.52.0.

## Validacion local (func start)

- Build Release OK.
- Versiones resueltas: Worker / Core / Grpc todas en 2.52.0.
- `func start`: el worker arranca, hace el handshake gRPC e indexa las 3 funciones
  (`health`, `RegistrarMarcacion`, `AsignarTurno...`) **sin ningun MissingMethodException**.
  (El unico error en la prueba es SB ConnectionRefused por usar una connection string dummy.)

Esta validacion local es la que faltó en #168 y causó la regresion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)