### PR TITLE
ci: ejecutar CI solo en pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: CI
 on:
   pull_request:
     branches: [main]
-  push:
-    branches: [main]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Qué

Elimina el trigger `push: branches: [main]` de `ci.yml`, dejándolo únicamente en `pull_request`.

## Por qué

Hoy, al mergear un PR que toca un dominio, la suite de tests se compila y corre **tres veces** sobre el mismo código:

1. En el PR (`ci.yml`).
2. En el push a main (`ci.yml` otra vez).
3. En el push a main (`build-and-test` del workflow de deploy del dominio).

La pasada redundante es la #2: `ci.yml` en `push` a main **no gatea nada** (corre en paralelo al deploy, no lo bloquea) y solo reejecuta lo que el PR ya validó.

El job `build-and-test` de los workflows `deploy-*` **se mantiene**: es la compuerta real previa a publicar en Azure. Como `ci.yml` y los `deploy-*` son workflows independientes disparados por el mismo `push` y **sin orden garantizado** entre sí, ese job es lo que impide desplegar con tests rojos.

Con este cambio: **PR →** valida `ci.yml` (build + test + cobertura + comentario). **Merge →** corre solo el deploy del dominio afectado con su `build-and-test` como compuerta. De 3 ejecuciones por merge se pasa a 2.

## A tener en cuenta

- **Branch protection**: el required status check de CI sigue generándose en el PR. Verificar que la regla apunte al check del evento `pull_request`.
- **Cobertura en main**: ya no se publica el reporte sobre los push a main (sigue disponible en cada PR).