### PR TITLE
fix(infra): transicion segura del Service Plan por dominio (Fase 1 de #172)

### DIFF
--- a/infra/environments/dev/main.tf
+++ b/infra/environments/dev/main.tf
@@ -26,6 +26,20 @@ module "service_plan_control_horas" {
   tags                = local.tags
 }
 
+# TRANSITORIO (Fase 1 de #172): el plan compartido se reintroduce para que este
+# apply solo REASIGNE las apps a sus planes nuevos sin destruirlo. Azure rechaza
+# (409) destruir un Service Plan con apps aun asociadas, y Terraform no garantiza
+# detach-antes-de-destroy al quitar el modulo. Este modulo se ELIMINA en la Fase 2,
+# cuando el plan ya tenga 0 apps. No referenciar desde ninguna function app.
+module "service_plan" {
+  source              = "../../modules/service-plan"
+  name                = "asp-${local.prefix}"
+  resource_group_name = module.resource_group.name
+  location            = module.resource_group.location
+  sku_name            = "B1"
+  tags                = local.tags
+}
+
 module "monitoring" {
   source              = "../../modules/monitoring"
   name                = local.prefix


### PR DESCRIPTION
## Contexto (incidente)

El merge de #172 (PR #173) dejó en `main` un Terraform que **no aplica**. El `terraform apply` destruye el plan compartido `asp-controlasistencias-dev` mientras todavía tiene asociadas las dos Function Apps, y Azure responde **409 Conflict** (`Server farm ... cannot be deleted because it has web app(s) ... assigned`). Terraform no garantiza el detach-antes-de-destroy al quitar el módulo.

Resultado: la **Infra CD de `main` quedó en rojo** ([run fallido](https://github.com/augusto-romero-arango/Bitakora.ControlAsistencia/actions/runs/27799876170/job/82267680160)) y el cambio de #172 **no se aplicó** en Azure (las apps siguen en el plan viejo; los 2 planes nuevos existen vacíos).

## Esta PR (Fase 1 de 2)

Reintroduce el `module "service_plan"` compartido de forma **transitoria**, sin que ninguna Function App lo referencie. Así este apply **solo reasigna** las apps a sus planes nuevos (`asp-asist-dev-control-horas`, `asp-asist-dev-programacion`) **sin destruir** el viejo, que queda retenido con 0 apps.

**`terraform plan` esperado (gate de `infra-ci`):**
```
Plan: 0 to add, 2 to change, 0 to destroy.
```
Las 2 `change` son el `service_plan_id` de cada `azurerm_linux_function_app` (in-place, no replace).

> [!WARNING]
> Si el plan de CI muestra el plan compartido como **`to create`** o **cualquier `destroy`**, NO mergear: significa que `asp-controlasistencias-dev` no quedó en el state de Terraform (el destroy fallido debería haberlo conservado) y haría falta `terraform import` antes. El plan de CI es el gate.

## Fase 2 (PR siguiente, tras mergear esta y verificar CD verde)

Quitar de nuevo el `module "service_plan"`. Ya con 0 apps, su destroy procede limpio → estado objetivo de #172 alcanzado.

## Notas

- No cierra #172 (ya cerrado por #173); es un fix-forward del regression.
- Suscripción target del deploy: **"Augusto"** (`50fc1901…`), no el default `az` local ("Azure Cosmos").
- Bugs colaterales detectados, fuera de scope de esta PR: (1) el `infra-applier` del iac-pipeline reportó el apply como exitoso pese al 409 (falso positivo); (2) `infra/environments/dev/tfplan` está versionado y no debería.

🤖 Generated with [Claude Code](https://claude.com/claude-code)