### PR TITLE
fix(infra): eliminar plan compartido ya vacio (Fase 2 de #172)

### DIFF
--- a/infra/environments/dev/main.tf
+++ b/infra/environments/dev/main.tf
@@ -26,20 +26,6 @@ module "service_plan_control_horas" {
   tags                = local.tags
 }
 
-# TRANSITORIO (Fase 1 de #172): el plan compartido se reintroduce para que este
-# apply solo REASIGNE las apps a sus planes nuevos sin destruirlo. Azure rechaza
-# (409) destruir un Service Plan con apps aun asociadas, y Terraform no garantiza
-# detach-antes-de-destroy al quitar el modulo. Este modulo se ELIMINA en la Fase 2,
-# cuando el plan ya tenga 0 apps. No referenciar desde ninguna function app.
-module "service_plan" {
-  source              = "../../modules/service-plan"
-  name                = "asp-${local.prefix}"
-  resource_group_name = module.resource_group.name
-  location            = module.resource_group.location
-  sku_name            = "B1"
-  tags                = local.tags
-}
-
 module "monitoring" {
   source              = "../../modules/monitoring"
   name                = local.prefix


### PR DESCRIPTION
## Fase 2 de 2 (cierra la transición de #172)

Tras #174, ambas Function Apps ya corren en sus planes por dominio y el plan compartido `asp-controlasistencias-dev` quedó con **0 apps** (verificado en Azure, suscripción "Augusto"):

- `func-asist-dev-control-horas` -> `asp-asist-dev-control-horas` ✅
- `func-asist-dev-programacion` -> `asp-asist-dev-programacion` ✅
- `asp-controlasistencias-dev` -> 0 apps asociadas ✅

Esta PR elimina el `module "service_plan"` transitorio. Su destroy ya procede **sin el 409** que rompió el apply original.

**`terraform plan` esperado (gate de `infra-ci`):**
```
Plan: 0 to add, 0 to change, 1 to destroy.
```
El único `destroy` es `module.service_plan` (`asp-controlasistencias-dev`). **No debe haber cambios en las Function Apps.**

> [!WARNING]
> Si el plan mostrara algún `change`/`replace` de una `azurerm_linux_function_app`, NO mergear: indicaría que alguna app aún referencia el plan viejo.

Al mergear, `infra-cd` destruye el plan compartido vacío -> **estado objetivo de #172 alcanzado**: un Service Plan por dominio (ADR-0020).

🤖 Generated with [Claude Code](https://claude.com/claude-code)