### PR TITLE
Calentar la cadena Service Bus con un warm-up funcional en el fixture de smoke tests

### DIFF
--- a/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/Fixtures/AssemblyFixture.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/Fixtures/AssemblyFixture.cs
@@ -4,3 +4,8 @@ using Bitakora.ControlAsistencia.ControlHoras.SmokeTests.Fixtures;
 [assembly: AssemblyFixture(typeof(ApiFixture))]
 [assembly: AssemblyFixture(typeof(ServiceBusFixture))]
 [assembly: AssemblyFixture(typeof(PostgresFixture))]
+// Issue #166: warm-up funcional de la cadena SB. Va al final, pero su orden frente a los demas
+// es indiferente: WarmupFixture construye sus propias dependencias (xUnit v3 no inyecta un
+// AssemblyFixture en otro). Todos los AssemblyFixture corren su InitializeAsync antes de
+// cualquier test, asi que el cebado se ejecuta una vez antes de toda la suite.
+[assembly: AssemblyFixture(typeof(WarmupFixture))]

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/Fixtures/WarmupFixture.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/Fixtures/WarmupFixture.cs
@@ -1,0 +1,181 @@
+using System.Diagnostics;
+using System.Net.Http.Json;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.SmokeTests.Fixtures;
+
+// Issue #166: warm-up funcional de la cadena Service Bus.
+//
+// Problema (H1, cold start del listener SB): tras ventanas largas de inactividad el host de
+// Functions se duerme (B1 sin always_on, descartado por costo - ver ADR-0009). Un health-ping
+// HTTP solo confirma "host HTTP arriba", no "listeners SB consumiendo": la inicializacion del
+// listener (link AMQP + lease de la subscription) es asincrona y posterior al 200. El test
+// DebePublicarDiaCalculadoYPersistirMarcacionAdicionada... ya ceba implicitamente AsignarTurno
+// en su setup, pero AdicionarMarcacion arranca frio justo en el Act y los 30s no alcanzan.
+//
+// Solucion: ejecutar la cadena SB completa UNA sola vez, con identificadores descartables,
+// antes de toda la suite. La unica senal fiable de "listener vivo" es que procese un mensaje,
+// asi que el cebado publica y espera la persistencia de cada salto:
+//   1. programacion-turno-diario-solicitada -> listener AsignarTurno -> turno_diario_asignado
+//   2. POST marcacion (marcacion-registrada) -> listener AdicionarMarcacion -> marcacion_adicionada
+//
+// Nota xUnit v3: un AssemblyFixture NO puede inyectar otro AssemblyFixture
+// (https://github.com/xunit/xunit/issues/3469 - "unresolved constructor arguments"; los fixtures
+// exigen ctor sin parametros y no controlan su orden de creacion). El patron recomendado por el
+// equipo de xUnit es que la clase contenedora construya ella misma sus dependencias. Por eso este
+// fixture instancia y reutiliza las clases de fixture (cada una lee su propia config) en lugar de
+// duplicar la lectura de configuracion o las primitivas de SB/Postgres/HTTP.
+public class WarmupFixture : IAsyncLifetime
+{
+    private const string Ruta = "/api/control-horas/marcaciones";
+    private const string SchemaControlHoras = "control_horas";
+    private const string TopicProgramacionEntrada = "programacion-turno-diario-solicitada";
+    private const string TipoEventoTurnoDiarioAsignado = "turno_diario_asignado";
+    private const string TipoEventoMarcacionAdicionada = "marcacion_adicionada";
+
+    // CA-2: timeout amplio (>= 90s) para absorber el cold start del listener SB tras inactividad.
+    // Este es el unico punto donde se paga el arranque frio, controlado y una sola vez. NO se usa
+    // para inflar el Timeout = 30s de las aserciones de los tests reales.
+    private static readonly TimeSpan WarmupTimeout = TimeSpan.FromSeconds(120);
+
+    public async ValueTask InitializeAsync()
+    {
+        // Reutilizamos las clases de fixture (ver nota de cabecera): construimos instancias propias
+        // y las inicializamos nosotros mismos. No comparten estado con las que xUnit inyecta a los
+        // tests; son conexiones aparte que solo viven durante el cebado.
+        var api = new ApiFixture();
+        var serviceBus = new ServiceBusFixture();
+        var postgres = new PostgresFixture();
+
+        try
+        {
+            await api.InitializeAsync();
+            await serviceBus.InitializeAsync();
+            await postgres.InitializeAsync();
+
+            if (!serviceBus.IsConfigured || !postgres.IsConfigured)
+            {
+                Log("ServiceBus o Postgres no configurado; se omite el cebado " +
+                    "(mismo criterio de skip que los smoke tests de la cadena SB).");
+                return;
+            }
+
+            await CebarCadenaAsync(api, serviceBus, postgres);
+        }
+        catch (Exception ex)
+        {
+            // CA-3: el fallo del cebado es visible y diagnosticable, pero NO se relanza. El warm-up
+            // es best-effort a proposito: un gate que tirara reintroduciria flakiness (podria matar
+            // la suite justo cuando los listeners terminaron de calentarse tras el timeout). Los
+            // tests reales corren igual con su Timeout = 30s honesto; si el handler tiene una
+            // regresion real, ESE test falla y la regresion se ve. El cebado no la enmascara.
+            Log($"FALLO durante el cebado: {ex.GetType().Name}: {ex.Message}. " +
+                "Los tests de la cadena SB correran con su Timeout = 30s sin modificar.");
+        }
+        finally
+        {
+            await postgres.DisposeAsync();
+            await serviceBus.DisposeAsync();
+            await api.DisposeAsync();
+        }
+    }
+
+    private static async Task CebarCadenaAsync(
+        ApiFixture api, ServiceBusFixture serviceBus, PostgresFixture postgres)
+    {
+        var stopwatch = Stopwatch.StartNew();
+
+        // CA-4: identificadores descartables y unicos. El stream {empleadoId}:{fecha} queda aislado;
+        // no toca los streams ni las suscripciones que verifican los tests reales. No leemos ni
+        // purgamos la suscripcion smoke-tests de dia-calculado: el DiaCalculado que emite este
+        // cebado lleva un EmpleadoId distinto (los tests filtran por el suyo) y, ademas, el test
+        // real purga esa suscripcion antes de su Act. Confirmamos el cebado solo via Postgres,
+        // que ya prueba que ambos listeners procesaron.
+        var empleadoId = Guid.CreateVersion7().ToString();
+        var fecha = new DateOnly(2026, 1, 1);
+        var streamId = $"{empleadoId}:{fecha:yyyy-MM-dd}";
+
+        // Salto 1: publicar programacion-turno-diario-solicitada -> calienta el listener AsignarTurno,
+        // que persiste turno_diario_asignado en el stream.
+        var solicitudId = Guid.CreateVersion7();
+        var programacionPayload = new
+        {
+            SolicitudId = solicitudId,
+            Empleado = new
+            {
+                EmpleadoId = empleadoId,
+                TipoIdentificacion = "CC",
+                NumeroIdentificacion = "000000000",
+                Nombres = "[WARMUP] Cebado cadena SB",
+                Apellidos = "[WARMUP] Issue 166"
+            },
+            Fecha = fecha.ToString("yyyy-MM-dd"),
+            DetalleTurno = new
+            {
+                Nombre = "[WARMUP] Turno cebado",
+                FranjasOrdinarias = new[]
+                {
+                    new
+                    {
+                        HoraInicio = "08:00:00",
+                        HoraFin = "16:00:00",
+                        DiaOffsetFin = 0,
+                        Descansos = Array.Empty<object>(),
+                        Extras = Array.Empty<object>()
+                    }
+                }
+            }
+        };
+
+        await serviceBus.PublishAsync(TopicProgramacionEntrada, programacionPayload, solicitudId.ToString());
+
+        var turnoAsignado = await postgres.ExisteEventoAsync(
+            SchemaControlHoras, streamId, TipoEventoTurnoDiarioAsignado, WarmupTimeout,
+            campoJson: "SolicitudId", valorJson: solicitudId.ToString());
+
+        if (!turnoAsignado)
+            throw new TimeoutException(
+                $"El listener AsignarTurno no persistio {TipoEventoTurnoDiarioAsignado} " +
+                $"en el stream {streamId} dentro de {WarmupTimeout.TotalSeconds}s.");
+
+        // Salto 2: POST de la marcacion (emite marcacion-registrada) -> calienta el listener
+        // AdicionarMarcacion, que persiste marcacion_adicionada en el mismo stream. Marcacion
+        // dentro de la franja programada (entrada 08:00-16:00), fuera de ventana nocturna.
+        var timestamp = new DateTime(fecha, new TimeOnly(8, 0, 0), DateTimeKind.Utc);
+        var marcacionPayload = new
+        {
+            empleadoId,
+            timestamp = timestamp.ToString("yyyy-MM-ddTHH:mm:ss") + "Z",
+            tipoMarcacion = "ENTRADA",
+            dispositivoId = "[WARMUP] DEV-SMOKE-166"
+        };
+
+        var response = await api.Client.PostAsJsonAsync(Ruta, marcacionPayload);
+        response.EnsureSuccessStatusCode();
+
+        var marcacionAdicionada = await postgres.ExisteEventoAsync(
+            SchemaControlHoras, streamId, TipoEventoMarcacionAdicionada, WarmupTimeout,
+            campoJson: "EmpleadoId", valorJson: empleadoId);
+
+        if (!marcacionAdicionada)
+            throw new TimeoutException(
+                $"El listener AdicionarMarcacion no persistio {TipoEventoMarcacionAdicionada} " +
+                $"en el stream {streamId} dentro de {WarmupTimeout.TotalSeconds}s.");
+
+        stopwatch.Stop();
+        Log($"OK: cadena SB cebada (AsignarTurno + AdicionarMarcacion) en " +
+            $"{stopwatch.Elapsed.TotalSeconds:F1}s. Los listeners quedan calientes para la suite.");
+    }
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    // CA-3: visible y "no se traga en silencio". Console.Error aparece en el log del job de CI con
+    // verbosidad por defecto; SendDiagnosticMessage es el canal idiomatico de xUnit v3 (IMessageSink
+    // dejo de inyectarse en fixtures en v3 - https://github.com/xunit/xunit/issues/3001). El mensaje
+    // no contiene llaves para ser inocuo ante el overload de formato compuesto.
+    private static void Log(string mensaje)
+    {
+        var linea = $"[WARM-UP issue#166] {mensaje}";
+        Console.Error.WriteLine(linea);
+        TestContext.Current?.SendDiagnosticMessage(linea);
+    }
+}


### PR DESCRIPTION
## Resumen

Pipeline tooling completado:
- Writer: implementacion de la tarea
- Reviewer: revision de calidad

## Decisiones del pipeline

<details>
<summary>Writer -- 9m 45s</summary>

# Stage 1 (writer) - Issue #166: Warm-up funcional de la cadena Service Bus

## Que se hizo

Se agrego un **warm-up funcional** que ceba la cadena Service Bus una sola vez
antes de toda la suite de smoke tests de ControlHoras, forzando a los dos
listeners (`AsignarTurno` y `AdicionarMarcacion`) a conectarse con datos
descartables. Asi los tests reales corren con los listeners ya calientes.

### Archivos

- **Crea** `tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/Fixtures/WarmupFixture.cs`
  - `IAsyncLifetime`. En `InitializeAsync` ejecuta la cadena completa:
    1. `PublishAsync("programacion-turno-diario-solicitada", ...)` -> espera
       `turno_diario_asignado` en Postgres (calienta `AsignarTurno`).
    2. `POST /api/control-horas/marcaciones` -> espera `marcacion_adicionada`
       en Postgres (calienta `AdicionarMarcacion`).
  - Reutiliza las primitivas existentes: `ServiceBusFixture.PublishAsync`,
    `PostgresFixture.ExisteEventoAsync`, `ApiFixture.Client.PostAsJsonAsync`.
- **Modifica** `tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/Fixtures/AssemblyFixture.cs`
  - Registra `[assembly: AssemblyFixture(typeof(WarmupFixture))]` al final.

### Commit

- `9c39d9a feat(smoke-tests): calentar la cadena Service Bus con un warm-up funcional (#166)`

## Decision de diseno: Opcion A (WarmupFixture de assembly propio)

Se eligio la **Opcion A** del issue, pero NO en la variante que inyecta los
fixtures ya inicializados por constructor, porque xUnit v3 **no lo permite**:

- Un `AssemblyFixture` no puede recibir otro `AssemblyFixture` por inyeccion:
  da `"unresolved constructor arguments"` (xunit/xunit#3469). Los fixtures
  exigen ctor publico sin parametros, no pueden depender unos de otros ni
  controlar su orden de creacion (docs oficiales "Sharing Context between Tests").
- El patron recomendado por el equipo de xUnit para dependencias entre fixtures
  es **una clase contenedora que construya ella misma sus dependencias**. Por eso
  `WarmupFixture` instancia y reutiliza `ApiFixture`/`ServiceBusFixture`/
  `PostgresFixture` (cada una lee su propia config), sin duplicar configuracion
  ni primitivas. Son conexiones aparte que solo viven durante el cebado.
- El orden frente a los otros AssemblyFixture es indiferente: todos corren su
  `InitializeAsync` antes de cualquier test, y el warm-up es autocontenido.

### Manejo de fallos (best-effort, no gate)

Si el cebado falla o agota su timeout, se registra de forma **visible** pero
**NO se relanza**. Razon: un gate que tirara reintroduciria flakiness -podria
matar la suite justo cuando los listeners terminaron de calentarse despues del
timeout-. Al no relanzar:
- Los tests reales corren igual con su `Timeout = 30s` honesto (no se infla).
- Si el handler tiene una regresion real, ESE test falla y la regresion se ve;
  el cebado no la enmascara. Ademas se obtiene el log del warm-up Y el veredicto
  real del test (mas diagnosticable que abortar la suite).

Visibilidad del diagnostico (CA-3):
- `Console.Error.WriteLine` con marcador `[WARM-UP issue#166]` -> aparece en el
  log del job de CI con verbosidad por defecto.
- `TestContext.Current?.SendDiagnosticMessage(...)` -> canal idiomatico de
  xUnit v3 (`IMessageSink` dejo de inyectarse en fixtures: xunit/xunit#3001;
  recomendacion del maintainer en xunit/xunit discussion#3015).

## Cobertura de criterios de aceptacion

- **CA-1** (warm-up una vez, cadena completa con ids descartables que ceba ambos
  listeners): cubierto por `WarmupFixture.CebarCadenaAsync`.
- **CA-2** (timeout amplio >= 90s): `WarmupTimeout = 120s` en cada espera de
  persistencia.
- **CA-3** (fallo visible, sin enmascarar regresion ni inflar el 30s): best-effort
  con log doble; no relanza; no toca el `Timeout = 30s` de los tests.
- **CA-4** (empleadoId descartable unico, no altera streams/suscripciones de los
  tests): `Guid.CreateVersion7()` -> stream aislado `{empleadoId}:2026-01-01`. No
  lee ni purga la suscripcion `smoke-tests` de `dia-calculado` (el test real ya la
  purga antes de su Act, y filtra por su propio EmpleadoId). Confirmacion solo via
  Postgres, que ya prueba que ambos listeners procesaron.
- **CA-5** (el test pasa consistente en el job `smoke-tests / smoke-tests`,
  incluido el primer deploy tras inactividad): se valida en CI al ejecutar el
  workflow "Deploy ControlHoras". Con el warm-up activo, ambos listeners quedan
  calientes antes del Act del test real.

## Verificacion local

- `dotnet build ...ControlHoras.SmokeTests -c Release` -> **Compilacion correcta,
  0 advertencias, 0 errores**.
- Sin caracteres Unicode decorativos prohibidos: ambos `.cs` verificados como
  ASCII puro.
- No se ejecuto `dotnet test` localmente: requiere conexiones reales a Service
  Bus/Postgres de dev (secretos solo presentes en CI). Sin esos secretos el
  warm-up es un no-op por diseno (mismo criterio de skip que los smoke tests),
  por lo que la verificacion end-to-end de CA-5 ocurre en el job de CI.

## Sin cambios fuera de alcance

- No se modifico infraestructura (no se enciende `always_on`; fuera de alcance).
- No se modificaron workflows: en CI los secretos `SERVICEBUS_CONNECTION_STRING`
  y `POSTGRES_CONNECTION_STRING` ya se inyectan como `ServiceBus__/Postgres__`
  en el paso `dotnet test` (ver `smoke-tests-dominio.yml`), asi que el warm-up
  corre automaticamente dentro de la suite.
- No se toco `src/` (dominio), `commands/`, `agents/`, `docs/adr/` ni el plugin
  Mefisto.
- El `.claude/settings.json` modificado pre-existia al inicio de la sesion; no se
  incluyo en el commit del warm-up.

## Fuentes consultadas

- xUnit "Sharing Context between Tests": https://xunit.net/docs/shared-context
- xunit/xunit#3469 (inyectar AssemblyFixture en otro falla)
- xunit/xunit#3001 (IMessageSink no inyectable en fixtures v3)
- xunit/xunit discussion#3015 (diagnostic output desde AssemblyFixture en v3)

</details>

<details>
<summary>Reviewer -- 3m 14s</summary>

_(El agente no genero resumen)_

</details>

## Commits

9c39d9a feat(smoke-tests): calentar la cadena Service Bus con un warm-up funcional (#166)

Closes #166