### PR TITLE
Clasificar intervalos trabajados segun programacion de la franja

### DIFF
--- a/src/Bitakora.ControlAsistencia.ControlHoras/Entities/ClasificadorTrabajo.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Entities/ClasificadorTrabajo.cs
@@ -15,6 +15,26 @@ namespace Bitakora.ControlAsistencia.ControlHoras.Entities;
 /// </summary>
 public static class ClasificadorTrabajo
 {
+    // Fronteras de segmentacion previas a la programacion. Cada segmento producido es homogeneo en
+    // banda horaria (cortes en 6AM/7PM) y en tipo de dia (corte en medianoche, donde puede cambiar
+    // de habil a dominical/festivo). IntervaloTemporal.Segmentar expande cada hora a sus ocurrencias
+    // diarias dentro del intervalo, asi que basta con declarar las horas-del-dia una sola vez.
+    private static readonly TimeOnly[] FronterasDeSegmentacion =
+    [
+        new(0, 0), // medianoche: separa segmentos con distinto tipo de dia
+        FronterasHorariasLegales.InicioDiurna,
+        FronterasHorariasLegales.InicioNocturna,
+    ];
+
+    // Posicion del segmento respecto a la programacion. Determina si el concepto es ordinario,
+    // extra (programada o excedente) o descanso. Independiente de banda y tipo de dia.
+    private enum Posicion
+    {
+        Ordinaria,
+        Extra,
+        Descanso,
+    }
+
     /// <summary>
     /// Clasifica el intervalo trabajado contra la programacion de la franja.
     /// fechaAncla se usa solo para consultar esFestivo al clasificar el tipo de dia de cada segmento.
@@ -25,5 +45,147 @@ public static class ClasificadorTrabajo
         IntervaloTemporal trabajado,
         DateOnly fechaAncla,
         Func<DateOnly, bool> esFestivo)
-        => throw new NotImplementedException();
+    {
+        // 1. Resolver las fronteras programadas a MomentoDelDia / minutos absolutos.
+        var inicioFranja = new MomentoDelDia(programada.HoraInicio, 0);
+        var finFranja = new MomentoDelDia(programada.HoraFin, programada.DiaOffsetFin);
+        var descansos = programada.Descansos.Select(AMinutos).ToList();
+        var extras = programada.Extras.Select(AMinutos).ToList();
+
+        // 2. Entrada efectiva = max(trabajado.Inicio, inicioFranja): recorta los minutos previos al
+        // inicio programado, que no se pagan y no aparecen en el desglose.
+        var (trabajadoInicio, trabajadoFin) = Extremos(trabajado);
+        var entradaEfectiva = trabajadoInicio.CompareTo(inicioFranja) < 0 ? inicioFranja : trabajadoInicio;
+        var trabajoRecortado = IntervaloTemporal.Crear(entradaEfectiva, trabajadoFin);
+
+        // 3. Segmentar por banda horaria y por medianoche (cambio de tipo de dia).
+        // 4. Subdividir cada segmento en los cortes propios de la programacion (fin de franja,
+        // inicios/fines de descansos y extras).
+        var cortesPrograma = ConstruirCortesPrograma(finFranja, descansos, extras);
+        var segmentos = trabajoRecortado
+            .Segmentar(FronterasDeSegmentacion)
+            .SelectMany(segmento => PartirEn(segmento, cortesPrograma));
+
+        // 5-6. Clasificar cada segmento (banda + tipo de dia + posicion) y mapear a Concepto.
+        return segmentos
+            .Select(segmento => new IntervaloClasificado(
+                segmento,
+                ClasificarSegmento(segmento, finFranja, descansos, extras, fechaAncla, esFestivo)))
+            .ToList();
+    }
+
+    // Concepto de un segmento homogeneo. El descanso ignora banda y tipo de dia; el resto combina
+    // posicion (ordinaria/extra), banda (diurna/nocturna) y tipo de dia (habil/dominical-festivo).
+    private static Concepto ClasificarSegmento(
+        IntervaloTemporal segmento,
+        MomentoDelDia finFranja,
+        IReadOnlyList<(int Inicio, int Fin)> descansos,
+        IReadOnlyList<(int Inicio, int Fin)> extras,
+        DateOnly fechaAncla,
+        Func<DateOnly, bool> esFestivo)
+    {
+        var (inicio, _) = Extremos(segmento);
+        var posicion = ResolverPosicion(inicio.MinutosAbsolutos, finFranja.MinutosAbsolutos, descansos, extras);
+        if (posicion == Posicion.Descanso)
+            return Concepto.Descanso;
+
+        var banda = ClasificadorHorario.ClasificarBanda(segmento);
+        var tipoDia = ClasificadorHorario.ClasificarTipoDia(inicio, fechaAncla, esFestivo);
+        return MapearConcepto(posicion, banda, tipoDia);
+    }
+
+    // Un segmento esta dentro de una sub-franja si su inicio cae en [Inicio, Fin). Como los cortes de
+    // programacion garantizan que ningun segmento atraviesa una frontera de sub-franja, comparar el
+    // inicio basta. Excedente = inicio >= finFranja (rango (finFranja, trabajado.Fin]).
+    private static Posicion ResolverPosicion(
+        int inicioMin,
+        int finFranjaMin,
+        IReadOnlyList<(int Inicio, int Fin)> descansos,
+        IReadOnlyList<(int Inicio, int Fin)> extras)
+    {
+        if (descansos.Any(d => inicioMin >= d.Inicio && inicioMin < d.Fin))
+            return Posicion.Descanso;
+        if (inicioMin >= finFranjaMin || extras.Any(e => inicioMin >= e.Inicio && inicioMin < e.Fin))
+            return Posicion.Extra;
+        return Posicion.Ordinaria;
+    }
+
+    // Mapeo (posicion, banda, tipoDia) -> Concepto segun la tabla del issue #135.
+    // El caso Descanso se resuelve antes de llegar aqui; quedan las 8 combinaciones ordinaria/extra.
+    private static Concepto MapearConcepto(Posicion posicion, BandaHoraria banda, TipoDia tipoDia) =>
+        (posicion, banda, tipoDia) switch
+        {
+            (Posicion.Ordinaria, BandaHoraria.Diurna, TipoDia.Habil) => Concepto.OrdinariaDiurna,
+            (Posicion.Ordinaria, BandaHoraria.Nocturna, TipoDia.Habil) => Concepto.OrdinariaNocturna,
+            (Posicion.Ordinaria, BandaHoraria.Diurna, TipoDia.DominicalFestivo) => Concepto.DominicalFestivaDiurna,
+            (Posicion.Ordinaria, BandaHoraria.Nocturna, TipoDia.DominicalFestivo) => Concepto.DominicalFestivaNocturna,
+            (Posicion.Extra, BandaHoraria.Diurna, TipoDia.Habil) => Concepto.ExtraDiurna,
+            (Posicion.Extra, BandaHoraria.Nocturna, TipoDia.Habil) => Concepto.ExtraNocturna,
+            (Posicion.Extra, BandaHoraria.Diurna, TipoDia.DominicalFestivo) => Concepto.ExtraDiurnaDominicalFestiva,
+            (Posicion.Extra, BandaHoraria.Nocturna, TipoDia.DominicalFestivo) => Concepto.ExtraNocturnaDominicalFestiva,
+            _ => throw new InvalidOperationException($"Combinacion no mapeada: {posicion}/{banda}/{tipoDia}"),
+        };
+
+    // Cortes que la programacion impone sobre los segmentos de banda: el fin de la franja (separa
+    // ordinaria de excedente) y las fronteras de cada descanso y extra.
+    private static IReadOnlyList<int> ConstruirCortesPrograma(
+        MomentoDelDia finFranja,
+        IReadOnlyList<(int Inicio, int Fin)> descansos,
+        IReadOnlyList<(int Inicio, int Fin)> extras)
+    {
+        var cortes = new List<int> { finFranja.MinutosAbsolutos };
+        foreach (var (inicio, fin) in descansos.Concat(extras))
+        {
+            cortes.Add(inicio);
+            cortes.Add(fin);
+        }
+
+        return cortes;
+    }
+
+    // Parte un intervalo en cada punto (en minutos absolutos) estrictamente interior a el.
+    // Reutiliza IntervaloTemporal.Partir (#143); los puntos fuera del intervalo se ignoran.
+    private static IReadOnlyList<IntervaloTemporal> PartirEn(IntervaloTemporal intervalo, IReadOnlyList<int> puntosAbsolutos)
+    {
+        var (inicio, fin) = Extremos(intervalo);
+        var inicioMin = inicio.MinutosAbsolutos;
+        var finMin = fin.MinutosAbsolutos;
+
+        var cortes = puntosAbsolutos
+            .Where(p => p > inicioMin && p < finMin)
+            .Distinct()
+            .OrderBy(p => p)
+            .ToList();
+        if (cortes.Count == 0)
+            return [intervalo];
+
+        var resultado = new List<IntervaloTemporal>(cortes.Count + 1);
+        var actual = intervalo;
+        var baseMin = inicioMin;
+        foreach (var corte in cortes)
+        {
+            var (izquierdo, derecho) = actual.Partir(corte - baseMin);
+            resultado.Add(izquierdo);
+            actual = derecho;
+            baseMin = corte;
+        }
+
+        resultado.Add(actual);
+        return resultado;
+    }
+
+    // Convierte una sub-franja (descanso o extra) a su par de minutos absolutos [Inicio, Fin).
+    private static (int Inicio, int Fin) AMinutos(DetalleSubFranja sub) =>
+        (new MomentoDelDia(sub.HoraInicio, sub.DiaOffsetInicio).MinutosAbsolutos,
+         new MomentoDelDia(sub.HoraFin, sub.DiaOffsetFin).MinutosAbsolutos);
+
+    // Recupera los extremos de un IntervaloTemporal como MomentoDelDia. El intervalo encapsula sus
+    // extremos (PR #148, Tell-don't-Ask): no expone Inicio/Fin. Se reconstruyen via el par
+    // ResolverA/MomentoDelDia.Desde anclado a una fecha arbitraria (no se construye ningun DateTime
+    // de dominio), igual que hace ClasificadorHorario para leer la hora del inicio.
+    private static (MomentoDelDia Inicio, MomentoDelDia Fin) Extremos(IntervaloTemporal intervalo)
+    {
+        var (inicio, fin) = intervalo.ResolverA(default);
+        return (MomentoDelDia.Desde(inicio, default), MomentoDelDia.Desde(fin, default));
+    }
 }

--- a/src/Bitakora.ControlAsistencia.ControlHoras/Entities/ClasificadorTrabajo.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Entities/ClasificadorTrabajo.cs
@@ -1,0 +1,29 @@
+// Issue #135: Clasificar intervalos trabajados segun programacion de la franja.
+// Capa 3 (Parte C) del calculo de desglose de horas: integra la segmentacion (#115) y
+// la clasificacion banda+tipo (#134) con la programacion del turno (DetalleFranjaOrdinaria):
+// descansos, extras programadas y excedente (salida mas alla del fin programado).
+// Trabaja siempre en MomentoDelDia - no construye ningun DateTime en este nivel.
+using Bitakora.ControlAsistencia.Contracts.ControlHoras.ValueObjects;
+using Bitakora.ControlAsistencia.Contracts.Programacion.ValueObjects;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Entities;
+
+/// <summary>
+/// Produce la lista de IntervaloClasificado que describe cada minuto trabajado con su concepto legal,
+/// dado el contexto de una franja programada. La entrada efectiva es max(trabajado.Inicio, inicioFranja):
+/// los minutos antes del inicio programado no aparecen en el desglose.
+/// </summary>
+public static class ClasificadorTrabajo
+{
+    /// <summary>
+    /// Clasifica el intervalo trabajado contra la programacion de la franja.
+    /// fechaAncla se usa solo para consultar esFestivo al clasificar el tipo de dia de cada segmento.
+    /// Precondicion: trabajado es un intervalo valido (no vacio); la franja anomala se maneja en #136.
+    /// </summary>
+    public static IReadOnlyList<IntervaloClasificado> Clasificar(
+        DetalleFranjaOrdinaria programada,
+        IntervaloTemporal trabajado,
+        DateOnly fechaAncla,
+        Func<DateOnly, bool> esFestivo)
+        => throw new NotImplementedException();
+}

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/ClasificadorTrabajoTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/ClasificadorTrabajoTests.cs
@@ -269,4 +269,24 @@ public class ClasificadorTrabajoTests
             Clasif(M(19), M(20), Concepto.ExtraNocturna),
         });
     }
+
+    [Fact]
+    public void Clasificar_ClasificaExtrasComoDominicalFestivas_CuandoExcedenteOcurreEnDomingo()
+    {
+        // Cierra la cobertura del mapeo: combina excedente (Extra) con tipo de dia DominicalFestivo,
+        // las dos unicas ramas de MapearConcepto que ningun CA numerado ejercita
+        // (ExtraDiurnaDominicalFestiva y ExtraNocturnaDominicalFestiva). Franja 8-17 trabajada
+        // [08:00,20:00] en domingo => ordinaria festiva + excedente festivo segmentado por banda.
+        var programada = Franja(8, 17);
+        var trabajado = Intervalo(M(8), M(20));
+
+        var resultado = ClasificadorTrabajo.Clasificar(programada, trabajado, Domingo, NingunFestivo);
+
+        resultado.Should().Equal(new[]
+        {
+            Clasif(M(8), M(17), Concepto.DominicalFestivaDiurna),
+            Clasif(M(17), M(19), Concepto.ExtraDiurnaDominicalFestiva),
+            Clasif(M(19), M(20), Concepto.ExtraNocturnaDominicalFestiva),
+        });
+    }
 }

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/ClasificadorTrabajoTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/ClasificadorTrabajoTests.cs
@@ -1,0 +1,272 @@
+// Issue #135: Clasificar intervalos trabajados segun programacion de la franja.
+// Tests directos sobre ClasificadorTrabajo.Clasificar - sin harness de event sourcing
+// (es logica pura, sin interaccion de aggregate). Convencion de datos: todos los
+// trabajados se construyen via IntervaloTemporal.Crear(new MomentoDelDia(...), ...).
+// No se construye ningun DateTime en los tests.
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Contracts.ControlHoras.ValueObjects;
+using Bitakora.ControlAsistencia.Contracts.Programacion.ValueObjects;
+using Bitakora.ControlAsistencia.ControlHoras.Entities;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Tests.Entities;
+
+/// <summary>
+/// Tests de ClasificadorTrabajo.Clasificar. Cubre CA-1 a CA-13:
+/// caso base + cobertura, cruce de frontera nocturna, cruce de medianoche con cambio de
+/// tipo de dia, dia festivo, descansos programados, extras programadas, entrada temprana
+/// y excedente (salida tardia sin retardo).
+/// Fechas ancla fijas segun el issue:
+///   2026-03-16 = lunes habil
+///   2026-03-15 = domingo
+///   2026-03-14 = sabado (su dia siguiente, domingo, sirve para el cruce de medianoche)
+/// </summary>
+public class ClasificadorTrabajoTests
+{
+    private static readonly DateOnly Lunes = new(2026, 3, 16);    // habil no festivo
+    private static readonly DateOnly Domingo = new(2026, 3, 15);  // domingo
+    private static readonly DateOnly Sabado = new(2026, 3, 14);   // sabado; cruza medianoche hacia domingo
+
+    private static readonly Func<DateOnly, bool> NingunFestivo = _ => false;
+    private static readonly Func<DateOnly, bool> TodoFestivo = _ => true;
+
+    // Helpers de construccion (siempre en MomentoDelDia, nunca DateTime).
+    private static MomentoDelDia M(int hora, int minuto = 0, int diaOffset = 0) =>
+        new(new TimeOnly(hora, minuto), diaOffset);
+
+    private static IntervaloTemporal Intervalo(MomentoDelDia inicio, MomentoDelDia fin) =>
+        IntervaloTemporal.Crear(inicio, fin);
+
+    private static IntervaloClasificado Clasif(MomentoDelDia inicio, MomentoDelDia fin, Concepto concepto) =>
+        new(IntervaloTemporal.Crear(inicio, fin), concepto);
+
+    private static DetalleSubFranja Sub(int horaInicio, int horaFin, int diaOffsetInicio = 0, int diaOffsetFin = 0) =>
+        new(new TimeOnly(horaInicio, 0), new TimeOnly(horaFin, 0), diaOffsetInicio, diaOffsetFin);
+
+    private static DetalleFranjaOrdinaria Franja(
+        int horaInicio,
+        int horaFin,
+        int diaOffsetFin = 0,
+        IReadOnlyList<DetalleSubFranja>? descansos = null,
+        IReadOnlyList<DetalleSubFranja>? extras = null) =>
+        new(new TimeOnly(horaInicio, 0), new TimeOnly(horaFin, 0), diaOffsetFin,
+            descansos ?? [], extras ?? []);
+
+    [Fact]
+    public void Clasificar_DesglosaOrdinariaConDescanso_CuandoFranjaDiurnaSeTrabajaCompleta()
+    {
+        // CA-1: franja 8-17 con descanso 12-13, trabajado [08:00,17:00], lunes habil -> 3 intervalos.
+        var programada = Franja(8, 17, descansos: [Sub(12, 13)]);
+        var trabajado = Intervalo(M(8), M(17));
+
+        var resultado = ClasificadorTrabajo.Clasificar(programada, trabajado, Lunes, NingunFestivo);
+
+        resultado.Should().Equal(new[]
+        {
+            Clasif(M(8), M(12), Concepto.OrdinariaDiurna),
+            Clasif(M(12), M(13), Concepto.Descanso),
+            Clasif(M(13), M(17), Concepto.OrdinariaDiurna),
+        });
+    }
+
+    [Fact]
+    public void Clasificar_CubreTrabajoMenosMinutosPrevios_CuandoHayEntradaTemprana()
+    {
+        // CA-2: invariante de cobertura. Entrada 07:00 con franja desde 08:00 => minutosPrevios = 60.
+        // sum(intervalos.DuracionEnMinutos) == trabajado.DuracionEnMinutos - minutosPrevios.
+        var programada = Franja(8, 17, descansos: [Sub(12, 13)]);
+        var inicioTrabajado = M(7);
+        var inicioFranja = M(8);
+        var trabajado = Intervalo(inicioTrabajado, M(17));
+        var minutosPrevios = Math.Max(0, inicioFranja.MinutosAbsolutos - inicioTrabajado.MinutosAbsolutos);
+
+        var resultado = ClasificadorTrabajo.Clasificar(programada, trabajado, Lunes, NingunFestivo);
+
+        resultado.Sum(i => i.DuracionEnMinutos)
+            .Should().Be(trabajado.DuracionEnMinutos - minutosPrevios);
+    }
+
+    [Fact]
+    public void Clasificar_SegmentaPorBandaHoraria_CuandoFranjaCruzaFronteraNocturna()
+    {
+        // CA-3: franja 14-22 cruza la frontera nocturna de las 19:00, dia habil.
+        var programada = Franja(14, 22);
+        var trabajado = Intervalo(M(14), M(22));
+
+        var resultado = ClasificadorTrabajo.Clasificar(programada, trabajado, Lunes, NingunFestivo);
+
+        resultado.Should().Equal(new[]
+        {
+            Clasif(M(14), M(19), Concepto.OrdinariaDiurna),
+            Clasif(M(19), M(22), Concepto.OrdinariaNocturna),
+        });
+    }
+
+    [Fact]
+    public void Clasificar_EvaluaTipoDiaPorSegmento_CuandoCruzaMedianocheDesdeDomingo()
+    {
+        // CA-4: franja 22:00-06:00+1, ancla domingo. Pre-medianoche domingo (festivo) -> nocturna festiva;
+        // post-medianoche lunes habil -> nocturna ordinaria. El tipo de dia se evalua por segmento.
+        var programada = Franja(22, 6, diaOffsetFin: 1);
+        var trabajado = Intervalo(M(22), M(6, 0, 1));
+
+        var resultado = ClasificadorTrabajo.Clasificar(programada, trabajado, Domingo, NingunFestivo);
+
+        resultado.Should().Equal(new[]
+        {
+            Clasif(M(22), M(0, 0, 1), Concepto.DominicalFestivaNocturna),
+            Clasif(M(0, 0, 1), M(6, 0, 1), Concepto.OrdinariaNocturna),
+        });
+    }
+
+    [Fact]
+    public void Clasificar_EvaluaTipoDiaPorSegmento_CuandoCruzaMedianocheHaciaDomingo()
+    {
+        // CA-5: franja 22:00-06:00+1, ancla sabado. Inverso del CA-4: pre-medianoche sabado habil ->
+        // nocturna ordinaria; post-medianoche domingo (festivo) -> nocturna festiva.
+        var programada = Franja(22, 6, diaOffsetFin: 1);
+        var trabajado = Intervalo(M(22), M(6, 0, 1));
+
+        var resultado = ClasificadorTrabajo.Clasificar(programada, trabajado, Sabado, NingunFestivo);
+
+        resultado.Should().Equal(new[]
+        {
+            Clasif(M(22), M(0, 0, 1), Concepto.OrdinariaNocturna),
+            Clasif(M(0, 0, 1), M(6, 0, 1), Concepto.DominicalFestivaNocturna),
+        });
+    }
+
+    [Fact]
+    public void Clasificar_AplicaRecargoDominicalFestivo_CuandoDiaEsFestivoNoDomingo()
+    {
+        // CA-6: franja 8-17 con descanso 12-13 en festivo (lunes 2026-03-16, esFestivo => true).
+        // Todos los segmentos de trabajo usan conceptos DominicalFestiva*, no Ordinaria*.
+        var programada = Franja(8, 17, descansos: [Sub(12, 13)]);
+        var trabajado = Intervalo(M(8), M(17));
+
+        var resultado = ClasificadorTrabajo.Clasificar(programada, trabajado, Lunes, TodoFestivo);
+
+        resultado.Should().Equal(new[]
+        {
+            Clasif(M(8), M(12), Concepto.DominicalFestivaDiurna),
+            Clasif(M(12), M(13), Concepto.Descanso),
+            Clasif(M(13), M(17), Concepto.DominicalFestivaDiurna),
+        });
+        resultado.Should().NotContain(i => i.Concepto == Concepto.OrdinariaDiurna);
+    }
+
+    [Fact]
+    public void Clasificar_NoDuplicaRecargo_CuandoDiaEsDomingoYFestivoSimultaneamente()
+    {
+        // CA-7: un dia que es domingo y festivo a la vez produce conceptos DominicalFestiva* iguales
+        // a los de un domingo no festivo (sin duplicar recargo).
+        var programada = Franja(8, 17);
+        var trabajado = Intervalo(M(8), M(17));
+
+        var domingoNormal = ClasificadorTrabajo.Clasificar(programada, trabajado, Domingo, NingunFestivo);
+        var domingoYFestivo = ClasificadorTrabajo.Clasificar(programada, trabajado, Domingo, TodoFestivo);
+
+        domingoNormal.Should().Equal(new[] { Clasif(M(8), M(17), Concepto.DominicalFestivaDiurna) });
+        domingoYFestivo.Should().Equal(domingoNormal);
+    }
+
+    [Fact]
+    public void Clasificar_IntercalaDescansoEntreOrdinarias_CuandoDescansoEstaDentroDeLaFranja()
+    {
+        // CA-8: descanso 11-12 dentro de la franja 8-17 aparece como Descanso, con los minutos
+        // adyacentes clasificados como ordinarios.
+        var programada = Franja(8, 17, descansos: [Sub(11, 12)]);
+        var trabajado = Intervalo(M(8), M(17));
+
+        var resultado = ClasificadorTrabajo.Clasificar(programada, trabajado, Lunes, NingunFestivo);
+
+        resultado.Should().Equal(new[]
+        {
+            Clasif(M(8), M(11), Concepto.OrdinariaDiurna),
+            Clasif(M(11), M(12), Concepto.Descanso),
+            Clasif(M(12), M(17), Concepto.OrdinariaDiurna),
+        });
+    }
+
+    [Fact]
+    public void Clasificar_OmiteDescanso_CuandoEntradaEsPosteriorAlFinDelDescanso()
+    {
+        // CA-9: trabajado [14:00,17:00]; el descanso 12-13 ya paso => no aparece en el desglose.
+        var programada = Franja(8, 17, descansos: [Sub(12, 13)]);
+        var trabajado = Intervalo(M(14), M(17));
+
+        var resultado = ClasificadorTrabajo.Clasificar(programada, trabajado, Lunes, NingunFestivo);
+
+        resultado.Should().Equal(new[] { Clasif(M(14), M(17), Concepto.OrdinariaDiurna) });
+        resultado.Should().NotContain(i => i.Concepto == Concepto.Descanso);
+    }
+
+    [Fact]
+    public void Clasificar_ClasificaSubFranjaExtraComoExtra_CuandoExtraCaeDentroDelRangoTrabajado()
+    {
+        // CA-10: extra programada 17-18 como sub-franja de la franja 8-18 se clasifica como ExtraDiurna
+        // aunque caiga dentro del rango trabajado normal.
+        var programada = Franja(8, 18, extras: [Sub(17, 18)]);
+        var trabajado = Intervalo(M(8), M(18));
+
+        var resultado = ClasificadorTrabajo.Clasificar(programada, trabajado, Lunes, NingunFestivo);
+
+        resultado.Should().Equal(new[]
+        {
+            Clasif(M(8), M(17), Concepto.OrdinariaDiurna),
+            Clasif(M(17), M(18), Concepto.ExtraDiurna),
+        });
+    }
+
+    [Fact]
+    public void Clasificar_OmiteMinutosPrevios_CuandoEntradaEsAnteriorAlInicioDeFranja()
+    {
+        // CA-11: trabajado [07:00,17:00] con franja desde 08:00 => el intervalo 07:00-08:00 NO aparece;
+        // el primer intervalo del desglose empieza en 08:00.
+        var programada = Franja(8, 17, descansos: [Sub(12, 13)]);
+        var trabajado = Intervalo(M(7), M(17));
+
+        var resultado = ClasificadorTrabajo.Clasificar(programada, trabajado, Lunes, NingunFestivo);
+
+        resultado.Should().Equal(new[]
+        {
+            Clasif(M(8), M(12), Concepto.OrdinariaDiurna),
+            Clasif(M(12), M(13), Concepto.Descanso),
+            Clasif(M(13), M(17), Concepto.OrdinariaDiurna),
+        });
+    }
+
+    [Fact]
+    public void Clasificar_ClasificaExcedenteComoExtra_CuandoSalidaSuperaElFinDeFranja()
+    {
+        // CA-12: franja 8-17, trabajado [08:00,18:00], dia habil => excedente 17:00-18:00 como ExtraDiurna.
+        var programada = Franja(8, 17);
+        var trabajado = Intervalo(M(8), M(18));
+
+        var resultado = ClasificadorTrabajo.Clasificar(programada, trabajado, Lunes, NingunFestivo);
+
+        resultado.Should().Equal(new[]
+        {
+            Clasif(M(8), M(17), Concepto.OrdinariaDiurna),
+            Clasif(M(17), M(18), Concepto.ExtraDiurna),
+        });
+    }
+
+    [Fact]
+    public void Clasificar_SegmentaExcedentePorBanda_CuandoExcedenteCruzaFronteraNocturna()
+    {
+        // CA-13: franja 8-17, trabajado [08:00,20:00], dia habil => excedente segmentado por banda:
+        // 17:00-19:00 ExtraDiurna y 19:00-20:00 ExtraNocturna.
+        var programada = Franja(8, 17);
+        var trabajado = Intervalo(M(8), M(20));
+
+        var resultado = ClasificadorTrabajo.Clasificar(programada, trabajado, Lunes, NingunFestivo);
+
+        resultado.Should().Equal(new[]
+        {
+            Clasif(M(8), M(17), Concepto.OrdinariaDiurna),
+            Clasif(M(17), M(19), Concepto.ExtraDiurna),
+            Clasif(M(19), M(20), Concepto.ExtraNocturna),
+        });
+    }
+}


### PR DESCRIPTION
## Resumen

Pipeline TDD completado:
- Fase roja: tests escritos con stubs
- Fase verde: implementación completa
- Fase refactor: revisión de calidad

## Decisiones del pipeline

<details>
<summary>Test Writer (fase roja) — 7m 31s</summary>

## ES Test Writer - Decisiones (HU-135)

### Tests creados
- `tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/ClasificadorTrabajoTests.cs`: 13 tests
  - `Clasificar_DesglosaOrdinariaConDescanso_CuandoFranjaDiurnaSeTrabajaCompleta` - CA-1
  - `Clasificar_CubreTrabajoMenosMinutosPrevios_CuandoHayEntradaTemprana` - CA-2 (invariante de cobertura)
  - `Clasificar_SegmentaPorBandaHoraria_CuandoFranjaCruzaFronteraNocturna` - CA-3
  - `Clasificar_EvaluaTipoDiaPorSegmento_CuandoCruzaMedianocheDesdeDomingo` - CA-4
  - `Clasificar_EvaluaTipoDiaPorSegmento_CuandoCruzaMedianocheHaciaDomingo` - CA-5
  - `Clasificar_AplicaRecargoDominicalFestivo_CuandoDiaEsFestivoNoDomingo` - CA-6
  - `Clasificar_NoDuplicaRecargo_CuandoDiaEsDomingoYFestivoSimultaneamente` - CA-7
  - `Clasificar_IntercalaDescansoEntreOrdinarias_CuandoDescansoEstaDentroDeLaFranja` - CA-8
  - `Clasificar_OmiteDescanso_CuandoEntradaEsPosteriorAlFinDelDescanso` - CA-9
  - `Clasificar_ClasificaSubFranjaExtraComoExtra_CuandoExtraCaeDentroDelRangoTrabajado` - CA-10
  - `Clasificar_OmiteMinutosPrevios_CuandoEntradaEsAnteriorAlInicioDeFranja` - CA-11
  - `Clasificar_ClasificaExcedenteComoExtra_CuandoSalidaSuperaElFinDeFranja` - CA-12
  - `Clasificar_SegmentaExcedentePorBanda_CuandoExcedenteCruzaFronteraNocturna` - CA-13

### Estructura elegida
- **Una sola clase plana** `ClasificadorTrabajoTests` (no nested). El issue prueba un unico metodo
  estatico puro (`ClasificadorTrabajo.Clasificar`), sin aggregate ni handler. Sigue el precedente de
  `ClasificadorHorarioBandaTests` / `ClasificadorHorarioTipoDiaTests` (misma carpeta `Entities/`).
- **Sin harness Given/When/Then ni `And<>`**: la regla "Then + And<>" aplica a tests de command handler
  con event sourcing. Aqui es logica pura -> assertions directas con AwesomeAssertions
  (`Should().Equal(...)`, `Should().NotContain(...)`, `Should().Be(...)`), igual que los tests de #134.
- **Verificacion por igualdad de valor**: `IntervaloClasificado` es record y `IntervaloTemporal` tiene
  igualdad por valor, asi que comparo la lista completa esperada con `Should().Equal(...)` (sensible al
  orden). Eso fija intervalo + concepto + duracion en una sola assertion.
- **Helpers extraidos** (datos repetidos): `M(hora, minuto, diaOffset)`, `Intervalo(...)`,
  `Clasif(inicio, fin, concepto)`, `Sub(horaInicio, horaFin, ...)`, `Franja(...)`.
- **Constantes semanticas** de fecha ancla: `Lunes` (2026-03-16 habil), `Domingo` (2026-03-15),
  `Sabado` (2026-03-14). Stubs de festivos: `NingunFestivo = _ => false`, `TodoFestivo = _ => true`.

### Stubs creados
- `src/Bitakora.ControlAsistencia.ControlHoras/Entities/ClasificadorTrabajo.cs` - clase estatica con
  `Clasificar(DetalleFranjaOrdinaria, IntervaloTemporal, DateOnly, Func<DateOnly,bool>)` que lanza
  `NotImplementedException`. Firma exacta de la "Interfaz publica" del issue. Sin helpers internos
  (son responsabilidad del implementer; el issue los marca como NO publicos).

### Decisiones de diseno
- **CA-2 con entrada temprana real** (07:00 vs franja 08:00, `minutosPrevios = 60`) en lugar de
  `minutosPrevios = 0`, para ejercitar de verdad el termino de resta de la invariante de cobertura.
  El valor esperado se computa desde los datos del test (`MomentoDelDia.MinutosAbsolutos` es publico),
  no accediendo a `trabajado.Inicio` (que NO es publico por Tell-don't-Ask, ver desviaciones).
- **CA-7** compara dos invocaciones (domingo normal vs domingo+festivo) y exige ademas que el concepto
  sea `DominicalFestivaDiurna`, para que la igualdad no pase trivialmente si ambas fueran `Ordinaria`.
- **CA-6 y CA-9** anaden un `NotContain` explicito (`OrdinariaDiurna` / `Descanso` respectivamente)
  ademas de la igualdad total, para hacer visible la intencion del CA.

### Cobertura de criterios
| Criterio de aceptacion | Test |
|---|---|
| CA-1 caso base con descanso | `Clasificar_DesglosaOrdinariaConDescanso_...` |
| CA-2 invariante de cobertura | `Clasificar_CubreTrabajoMenosMinutosPrevios_...` |
| CA-3 cruce frontera nocturna | `Clasificar_SegmentaPorBandaHoraria_...` |
| CA-4 medianoche domingo->lunes | `Clasificar_EvaluaTipoDiaPorSegmento_...DesdeDomingo` |
| CA-5 medianoche sabado->domingo | `Clasificar_EvaluaTipoDiaPorSegmento_...HaciaDomingo` |
| CA-6 festivo no domingo | `Clasificar_AplicaRecargoDominicalFestivo_...` |
| CA-7 domingo y festivo a la vez | `Clasificar_NoDuplicaRecargo_...` |
| CA-8 descanso dentro de franja | `Clasificar_IntercalaDescansoEntreOrdinarias_...` |
| CA-9 entrada posterior al descanso | `Clasificar_OmiteDescanso_...` |
| CA-10 extra programada | `Clasificar_ClasificaSubFranjaExtraComoExtra_...` |
| CA-11 entrada temprana | `Clasificar_OmiteMinutosPrevios_...` |
| CA-12 excedente diurno | `Clasificar_ClasificaExcedenteComoExtra_...` |
| CA-13 excedente segmentado por banda | `Clasificar_SegmentaExcedentePorBanda_...` |

### Desviaciones del plan del planner

| Sugerencia del issue | Desviacion aplicada | Razon tecnica | Consecuencia |
|---|---|---|---|
| Algoritmo: `SegmentadorHorario.Segmentar` (#115) | No se referencia ningun `SegmentadorHorario` | En `main` la segmentacion de #115 quedo como metodo `IntervaloTemporal.Segmentar(IEnumerable<TimeOnly>)`, no como clase aparte. No afecta el test (solo prueba `Clasificar`); es decision interna del implementer. | El implementer usa `IntervaloTemporal.Segmentar`; los tests no cambian. |
| Algoritmo: `ClasificadorHorario.ClasificarTipoDia(intervalo.Inicio, ...)` y la formula de CA-2 usan `trabajado.Inicio` | Ningun test accede a `IntervaloTemporal.Inicio` | `IntervaloTemporal` no expone `Inicio`/`Fin` (Tell-don't-Ask, PR #148). `ClasificarTipoDia` recibe `MomentoDelDia`. | En CA-2 el `minutosPrevios` se calcula con los `MomentoDelDia` que el propio test construye. Obtener el inicio de cada segmento internamente es responsabilidad del implementer (helper no publico). |

### Verificacion
- `dotnet build` del proyecto de tests: **Compilacion correcta, 0 errores** (4 warnings NU1904 de Marten,
  preexistentes y ajenos a este cambio).
- No se corrieron los tests (deben fallar en rojo: el stub lanza `NotImplementedException`).

</details>

<details>
<summary>Implementer (fase verde) — 5m 56s</summary>

_(El agente no generó resumen)_

</details>
<details>
<summary>Reviewer (fase refactor) — 6m 52s</summary>

## ES Reviewer - Revision (Issue #135)

### Evaluacion general
- Calidad: **buena**
- Cambios realizados: **si** (un test de caso borde agregado; sin tocar produccion)
- Baseline: 136/137 -> 137/137 verdes. `dotnet format --verify-no-changes` limpio en ambos archivos.

### Cumplimiento de ADRs aplicables

El issue no traia seccion `## ADRs aplicables` explicita y no existe `stage-2-implementer.md`.
Apliqué los ADRs del indice tematico de CLAUDE.md pertinentes al diff:

| ADR | Cumplimiento | Observacion |
|---|---|---|
| ADR-0015: Encapsulamiento / Tell-don't-Ask en VOs | ok | No se expone estado interno de `IntervaloTemporal`. Para leer extremos se usa el round-trip `ResolverA(default)` + `MomentoDelDia.Desde(_, default)`, **mismo precedente que `ClasificadorHorario.ClasificarBanda`** (no se reintrodujo ningun getter `Inicio`/`Fin`). |
| ADR-0015: clase estatica que combina objetos distintos | ok | `ClasificadorTrabajo` combina `DetalleFranjaOrdinaria` (Programacion) + `IntervaloTemporal` (trabajado): cae en la excepcion documentada (objetos distintos que no convergen via eventos). Ademas la interfaz publica del issue la define como clase estatica. |
| ADR-0024: extraccion vs duplicacion (Rule of Three) | ok | Ver "Elegancia": `PartirEn` y `IntervaloTemporal.Segmentar` comparten forma pero distinta semantica (minutos absolutos vs ocurrencias diarias de `TimeOnly`); no procede extraer. |
| ADR-0022: naming de tests `<Sujeto>_<LoQuePasa>_Cuando<Condicion>` | ok | Los 14 tests cumplen (`Clasificar_...Cuando...`), solo `[Fact]`. |
| ADR-0002: Contracts | ok | No se modifico ningun contrato; `ClasificadorTrabajo` vive en `ControlHoras/Entities` (logica de dominio, no contrato). |

### Desviaciones de ADRs
Ninguna desviacion - todos los ADRs aplicables se cumplen.

> Nota de proceso (no bloqueante): el issue deberia incluir seccion `## ADRs aplicables` y el
> pipeline deberia haber dejado `stage-2-implementer.md`. Escalable al planner para futuras HUs.

### Precedentes consultados por el implementer
No hay `stage-2-implementer.md`. Precedente verificado por el reviewer: `ClasificadorHorario`
(round-trip `ResolverA(default)` para leer la hora sin exponer extremos) - **alineado con ADR-0015**.

### Convenciones del pipeline (no ADRs)

| Convencion | Estado | Observacion |
|---|---|---|
| Cada test con `Then()` + `And<>()` | n/a | Logica pura sin aggregate ni harness ES (el propio issue lo indica). |
| Overloads para stream IDs compuestos | n/a | Sin aggregate. |
| Fakes manuales (no NSubstitute) | n/a | `esFestivo` se prueba con stubs lambda (`_ => false`/`_ => true`), no mocks. |
| Feature folders (produccion y tests) | ok | `ControlHoras/Entities/ClasificadorTrabajo.cs` + espejo en tests. |
| Smoke tests | n/a | Esta HU no publica/consume eventos ni endpoints. |
| Tests via comportamiento (no getters de test) | ok | Verifican via `Should().Equal(...)` sobre la lista publica y `DuracionEnMinutos`. |
| Sin numeros magicos | ok | Fronteras via `FronterasHorariasLegales`; fechas y franjas con constantes/ helpers semanticos. |
| Condiciones en positivo | ok | `ResolverPosicion` y guardas leen en positivo. |
| Sin caracter U+2500 en `.cs` | ok | Verificado con grep en ambos archivos. |

### Elegancia del codigo
El codigo ya era elegante: compacto, idiomatico (LINQ + pattern matching en `switch`),
bien comentado con el "por que" (no el "que"), nombres de dominio claros en español
(`entradaEfectiva`, `trabajoRecortado`, `cortesPrograma`, `ResolverPosicion`). Observaciones
menores **no bloqueantes** (no corregidas: requerirían modificar Contracts, fuera del alcance
del issue, y siguen precedente vigente):

1. **Round-trip `Extremos` via `DateTime`**: es la tecnica disponible para leer los extremos de
   `IntervaloTemporal` sin romper Tell-don't-Ask, y replica el precedente de `ClasificadorHorario`.
   Se invoca varias veces por segmento (en `ClasificarSegmento` y en `PartirEn`); a la escala del
   problema (pocos segmentos por franja) no es un problema de rendimiento. Si el patron se repite en
   #136, conviene evaluar que `IntervaloTemporal` exponga comportamiento de particion por minutos
   absolutos (p.ej. `Partir(IEnumerable<int>)`) para que `PartirEn` y el round-trip vivan en el VO.
2. **`PartirEn` vs `IntervaloTemporal.Segmentar`**: dos bucles "cortar en puntos ordenados" con
   semantica distinta (absolutos vs `TimeOnly` por dia). Hoy son 2 ocurrencias; segun Rule of Three
   (ADR-0024) aun no procede extraer. Vigilar en #136 por si aparece la tercera.

### Criticas y hallazgos
- **Brecha de cobertura (menor, corregida)**: `MapearConcepto` tiene 8 ramas; ningun CA numerado
  ejercitaba `ExtraDiurnaDominicalFestiva` ni `ExtraNocturnaDominicalFestiva` (extra en dia
  dominical/festivo). Se agrego un test que las cubre. Sin este test, un swap de esos dos conceptos
  en el `switch` habria pasado inadvertido.
- Sin otros hallazgos. Verifiqué manualmente los 13 CA contra el algoritmo (segmentacion por banda,
  corte de medianoche con cambio de tipo de dia, entrada efectiva, descansos, extras programadas y
  excedente) y todos cuadran con los resultados esperados.

### Refactorings aplicados
Ninguno sobre produccion. El codigo de produccion no requiere cambios.

### Cobertura de criterios de aceptacion
| Criterio | Estado | Test(s) |
|---|---|---|
| CA-1: caso base con descanso | cubierto | `Clasificar_DesglosaOrdinariaConDescanso_CuandoFranjaDiurnaSeTrabajaCompleta` |
| CA-2: invariante de cobertura | cubierto | `Clasificar_CubreTrabajoMenosMinutosPrevios_CuandoHayEntradaTemprana` |
| CA-3: cruce frontera nocturna | cubierto | `Clasificar_SegmentaPorBandaHoraria_CuandoFranjaCruzaFronteraNocturna` |
| CA-4: medianoche desde domingo | cubierto | `Clasificar_EvaluaTipoDiaPorSegmento_CuandoCruzaMedianocheDesdeDomingo` |
| CA-5: medianoche hacia domingo | cubierto | `Clasificar_EvaluaTipoDiaPorSegmento_CuandoCruzaMedianocheHaciaDomingo` |
| CA-6: festivo no-domingo | cubierto | `Clasificar_AplicaRecargoDominicalFestivo_CuandoDiaEsFestivoNoDomingo` |
| CA-7: domingo y festivo simultaneo | cubierto | `Clasificar_NoDuplicaRecargo_CuandoDiaEsDomingoYFestivoSimultaneamente` |
| CA-8: descanso intra-franja | cubierto | `Clasificar_IntercalaDescansoEntreOrdinarias_CuandoDescansoEstaDentroDeLaFranja` |
| CA-9: descanso ya pasado | cubierto | `Clasificar_OmiteDescanso_CuandoEntradaEsPosteriorAlFinDelDescanso` |
| CA-10: extra programada | cubierto | `Clasificar_ClasificaSubFranjaExtraComoExtra_CuandoExtraCaeDentroDelRangoTrabajado` |
| CA-11: entrada temprana | cubierto | `Clasificar_OmiteMinutosPrevios_CuandoEntradaEsAnteriorAlInicioDeFranja` |
| CA-12: excedente diurno | cubierto | `Clasificar_ClasificaExcedenteComoExtra_CuandoSalidaSuperaElFinDeFranja` |
| CA-13: excedente segmentado por banda | cubierto | `Clasificar_SegmentaExcedentePorBanda_CuandoExcedenteCruzaFronteraNocturna` |
| (extra) extras dominicales/festivas | cubierto | `Clasificar_ClasificaExtrasComoDominicalFestivas_CuandoExcedenteOcurreEnDomingo` |

### Tests agregados
- `Clasificar_ClasificaExtrasComoDominicalFestivas_CuandoExcedenteOcurreEnDomingo`: cierra la
  cobertura de las dos ramas de `MapearConcepto` (extra + dominical/festivo) que ningun CA tocaba.
- Tests de contrato (igualdad / serializacion): n/a. `ClasificadorTrabajo` es una clase estatica
  sin estado; no implementa `IEquatable<T>` ni `ConfigurarSerializacion`.

</details>

## Cobertura

| Archivo | Cobertura | Umbral | Estado |
|---|---|---|---|
| ClasificadorTrabajo.cs | - | no evaluado | - |
## Commits

99792a0 test(hu-135): cubrir extras dominicales/festivas en el mapeo de conceptos
bb17d3b feat(hu-135): implementación fase verde
6803cb8 test(hu-135): tests para ClasificadorTrabajo.Clasificar (fase roja)

Closes #135