### PR TITLE
Calcular retardo, compensacion intra-franja y ensamblar DesgloseFranja

### DIFF
--- a/src/Bitakora.ControlAsistencia.ControlHoras/Entities/ControlFranja.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Entities/ControlFranja.cs
@@ -1,3 +1,4 @@
+using Bitakora.ControlAsistencia.Contracts.ControlHoras.ValueObjects;
 using Bitakora.ControlAsistencia.Contracts.Programacion.ValueObjects;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.Entities;
@@ -9,4 +10,10 @@ public record ControlFranja(DetalleFranjaOrdinaria Programada, DateTime? Entrada
 {
     // CA-9: propiedad calculada; anomala cuando falta Entrada o Salida
     public bool EsAnomala => Entrada is null || Salida is null;
+
+    // HU-136: capa 4 (final) del desglose de franja. Frontera unica DateTime -> MomentoDelDia.
+    // Integra la lista base de ClasificadorTrabajo (#135) con retardo, excedente bruto y
+    // compensacion intra-franja. Retorna null si la franja es anomala (entrada o salida nula).
+    public DesgloseFranja? CalcularDesglose(DateOnly fecha, Func<DateOnly, bool> esFestivo) =>
+        throw new NotImplementedException();
 }

--- a/src/Bitakora.ControlAsistencia.ControlHoras/Entities/ControlFranja.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Entities/ControlFranja.cs
@@ -14,6 +14,74 @@ public record ControlFranja(DetalleFranjaOrdinaria Programada, DateTime? Entrada
     // HU-136: capa 4 (final) del desglose de franja. Frontera unica DateTime -> MomentoDelDia.
     // Integra la lista base de ClasificadorTrabajo (#135) con retardo, excedente bruto y
     // compensacion intra-franja. Retorna null si la franja es anomala (entrada o salida nula).
-    public DesgloseFranja? CalcularDesglose(DateOnly fecha, Func<DateOnly, bool> esFestivo) =>
-        throw new NotImplementedException();
+    public DesgloseFranja? CalcularDesglose(DateOnly fecha, Func<DateOnly, bool> esFestivo)
+    {
+        if (EsAnomala)
+            return null;
+
+        // Frontera unica DateTime -> MomentoDelDia: a partir de aqui todo es MomentoDelDia /
+        // IntervaloTemporal. El DateTime no reaparece en el resto del metodo (#143).
+        var entradaMomento = MomentoDelDia.Desde(Entrada!.Value, fecha);
+        var salidaMomento = MomentoDelDia.Desde(Salida!.Value, fecha);
+        var trabajado = IntervaloTemporal.Crear(entradaMomento, salidaMomento);
+
+        // Lista base: cada minuto trabajado con su concepto legal, ya recortado a la entrada
+        // efectiva y segmentado por banda/tipo de dia/programacion (#135). Mutable para aplicar
+        // la compensacion consumiendo desde el final sin romper el orden cronologico ascendente.
+        var intervalos = ClasificadorTrabajo.Clasificar(Programada, trabajado, fecha, esFestivo).ToList();
+
+        // Retardo y excedente bruto se calculan mirando la franja completa contra lo programado.
+        var inicioFranja = new MomentoDelDia(Programada.HoraInicio, 0);
+        var finFranja = new MomentoDelDia(Programada.HoraFin, Programada.DiaOffsetFin);
+        var retardo = Math.Max(0, entradaMomento.MinutosAbsolutos - inicioFranja.MinutosAbsolutos);
+        var excedenteBruto = Math.Max(0, salidaMomento.MinutosAbsolutos - finFranja.MinutosAbsolutos);
+
+        // Compensacion intra-franja: los ultimos N minutos del excedente (N = min(retardo, excedente))
+        // compensan el retardo en vez de pagarse como extra. Consistente con la regla cronologica
+        // inversa de #116. Cuando no hay ambos, N = 0 y la lista base queda intacta.
+        var compensacion = Math.Min(retardo, excedenteBruto);
+        IReadOnlyList<IntervaloTemporal> tiempoCompensado = compensacion > 0
+            ? ConsumirDesdeElFinal(intervalos, compensacion)
+            : [];
+
+        IReadOnlyList<IntervaloTemporal> tiempoRetardado = retardo > 0
+            ? [IntervaloTemporal.Crear(inicioFranja, entradaMomento)]
+            : [];
+
+        return new DesgloseFranja(Programada, intervalos, DetalleRetardo.Crear(tiempoRetardado, tiempoCompensado));
+    }
+
+    // Consume los ultimos `minutos` de la lista clasificada recorriendola en orden cronologico
+    // inverso, y devuelve los IntervaloTemporal concretos consumidos en orden cronologico ascendente
+    // (para el TiempoCompensado del DetalleRetardo). Muta `intervalos`: el intervalo consumido por
+    // completo se remueve; el que se atraviesa parcialmente se reemplaza por su parte izquierda
+    // (visible) mientras la derecha pasa a la compensacion. Precondicion: minutos <= suma de
+    // duraciones de la lista (garantizada por compensacion <= excedenteBruto <= tiempo trabajado).
+    private static IReadOnlyList<IntervaloTemporal> ConsumirDesdeElFinal(
+        List<IntervaloClasificado> intervalos, int minutos)
+    {
+        var consumidos = new List<IntervaloTemporal>();
+        var pendientes = minutos;
+        while (pendientes > 0)
+        {
+            var indice = intervalos.Count - 1;
+            var ultimo = intervalos[indice];
+            if (ultimo.DuracionEnMinutos <= pendientes)
+            {
+                consumidos.Add(ultimo.Intervalo);
+                intervalos.RemoveAt(indice);
+                pendientes -= ultimo.DuracionEnMinutos;
+            }
+            else
+            {
+                var (izquierdo, derecho) = ultimo.Intervalo.Partir(ultimo.DuracionEnMinutos - pendientes);
+                intervalos[indice] = new IntervaloClasificado(izquierdo, ultimo.Concepto);
+                consumidos.Add(derecho);
+                pendientes = 0;
+            }
+        }
+
+        consumidos.Reverse();
+        return consumidos;
+    }
 }

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/CalcularDesgloseFranjaTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/CalcularDesgloseFranjaTests.cs
@@ -1,0 +1,252 @@
+// Issue #136: Calcular retardo, compensacion intra-franja y ensamblar DesgloseFranja.
+// Capa 4 (Parte D, final) del desglose de horas. Tests directos sobre
+// ControlFranja.CalcularDesglose - logica pura sin harness de event sourcing.
+//
+// Convencion de datos (issue #136): los ControlFranja se construyen con DateTime? (frontera
+// del dominio: las marcaciones llegan como DateTime), pero TODAS las aserciones sobre
+// resultados se hacen en MomentoDelDia / IntervaloTemporal / DetalleRetardo. El DateTime solo
+// aparece al construir la entrada del metodo.
+//
+// DetalleRetardo (#114) solo expone RetardoNeto publicamente (ADR-0015, Tell-don't-Ask): los
+// minutos retardados/compensados son detalle interno. Por eso el retardo se verifica
+// construyendo el DetalleRetardo esperado via DetalleRetardo.Crear(...) y comparando por
+// igualdad (que internamente compara esos minutos y los intervalos), mas RetardoNeto.
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Contracts.ControlHoras.ValueObjects;
+using Bitakora.ControlAsistencia.Contracts.Programacion.ValueObjects;
+using Bitakora.ControlAsistencia.ControlHoras.Entities;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Tests.Entities;
+
+/// <summary>
+/// Tests de ControlFranja.CalcularDesglose. Cubre CA-1 a CA-8: compuerta de anomala, retardo
+/// simple sin excedente, puntualidad, excedente sin retardo, compensacion intra-franja (incluido
+/// el cruce de frontera nocturna) y el invariante de cobertura. Los escenarios base del desglose
+/// (segmentacion, festivos, descansos) ya estan cubiertos en ClasificadorTrabajoTests (#135).
+///
+/// Fecha ancla fija: 2026-03-16 = lunes habil. Todas las marcaciones de los CA caen ese dia.
+/// </summary>
+public class CalcularDesgloseFranjaTests
+{
+    private static readonly DateOnly Lunes = new(2026, 3, 16); // habil no festivo
+
+    private static readonly Func<DateOnly, bool> NingunFestivo = _ => false;
+
+    // Construccion de la entrada del metodo: ControlFranja recibe DateTime? (frontera del dominio).
+    private static DateTime Dt(int hora, int minuto = 0) => new(2026, 3, 16, hora, minuto, 0);
+
+    private static ControlFranja Control(DetalleFranjaOrdinaria programada, DateTime? entrada, DateTime? salida) =>
+        new(programada, entrada, salida);
+
+    // Helpers de asercion: siempre en MomentoDelDia / IntervaloTemporal, nunca DateTime.
+    private static MomentoDelDia M(int hora, int minuto = 0, int diaOffset = 0) =>
+        new(new TimeOnly(hora, minuto), diaOffset);
+
+    private static IntervaloTemporal Intervalo(MomentoDelDia inicio, MomentoDelDia fin) =>
+        IntervaloTemporal.Crear(inicio, fin);
+
+    private static IntervaloClasificado Clasif(MomentoDelDia inicio, MomentoDelDia fin, Concepto concepto) =>
+        new(IntervaloTemporal.Crear(inicio, fin), concepto);
+
+    private static DetalleSubFranja Sub(int horaInicio, int horaFin, int diaOffsetInicio = 0, int diaOffsetFin = 0) =>
+        new(new TimeOnly(horaInicio, 0), new TimeOnly(horaFin, 0), diaOffsetInicio, diaOffsetFin);
+
+    private static DetalleFranjaOrdinaria Franja(
+        int horaInicio,
+        int horaFin,
+        int diaOffsetFin = 0,
+        IReadOnlyList<DetalleSubFranja>? descansos = null,
+        IReadOnlyList<DetalleSubFranja>? extras = null) =>
+        new(new TimeOnly(horaInicio, 0), new TimeOnly(horaFin, 0), diaOffsetFin,
+            descansos ?? [], extras ?? []);
+
+    // ----- CA-1: compuerta de anomala -----
+
+    [Fact]
+    public void CalcularDesglose_RetornaNull_CuandoEntradaEsNula()
+    {
+        // CA-1: sin entrada => EsAnomala => CalcularDesglose retorna null (no se intenta desglosar).
+        var control = Control(Franja(8, 17), entrada: null, salida: Dt(17));
+
+        var desglose = control.CalcularDesglose(Lunes, NingunFestivo);
+
+        control.EsAnomala.Should().BeTrue();
+        desglose.Should().BeNull();
+    }
+
+    [Fact]
+    public void CalcularDesglose_RetornaNull_CuandoSalidaEsNula()
+    {
+        // CA-1: sin salida => EsAnomala => CalcularDesglose retorna null.
+        var control = Control(Franja(8, 17), entrada: Dt(8), salida: null);
+
+        var desglose = control.CalcularDesglose(Lunes, NingunFestivo);
+
+        control.EsAnomala.Should().BeTrue();
+        desglose.Should().BeNull();
+    }
+
+    // ----- CA-2, CA-3: retardo simple (sin excedente) -----
+
+    [Fact]
+    public void CalcularDesglose_RegistraRetardoSinCompensacion_CuandoEntradaLlegaTarde()
+    {
+        // CA-2: franja 8-17, entrada 08:30 (30min tarde), salida 17:00 puntual, dia habil.
+        // Retardo = 30, sin excedente => sin compensacion. Los Intervalos arrancan en la entrada
+        // efectiva 08:30 (no incluyen el tiempo previo). TiempoRetardado = [08:00-08:30].
+        var control = Control(Franja(8, 17), Dt(8, 30), Dt(17));
+
+        var desglose = control.CalcularDesglose(Lunes, NingunFestivo);
+
+        desglose.Should().NotBeNull();
+        desglose!.Programada.Should().Be(Franja(8, 17));
+        desglose.Intervalos.Should().Equal(new[]
+        {
+            Clasif(M(8, 30), M(17), Concepto.OrdinariaDiurna),
+        });
+        desglose.Retardo.Should().Be(DetalleRetardo.Crear(
+            tiempoRetardado: [Intervalo(M(8), M(8, 30))],
+            tiempoCompensado: []));
+        desglose.Retardo.RetardoNeto.Should().Be(30);
+    }
+
+    [Fact]
+    public void CalcularDesglose_NoRegistraRetardo_CuandoEntradaEsPuntual()
+    {
+        // CA-3: franja 8-17, entrada 08:00 puntual, salida 17:00 => retardo 0 y sin excedente.
+        // DetalleRetardo == DetalleRetardo.Vacio.
+        var control = Control(Franja(8, 17), Dt(8), Dt(17));
+
+        var desglose = control.CalcularDesglose(Lunes, NingunFestivo);
+
+        desglose.Should().NotBeNull();
+        desglose!.Intervalos.Should().Equal(new[]
+        {
+            Clasif(M(8), M(17), Concepto.OrdinariaDiurna),
+        });
+        desglose.Retardo.Should().Be(DetalleRetardo.Vacio);
+        desglose.Retardo.RetardoNeto.Should().Be(0);
+    }
+
+    // ----- CA-4: excedente sin retardo -----
+
+    [Fact]
+    public void CalcularDesglose_ClasificaExcedenteComoExtra_CuandoSalidaSeProlongaSinRetardo()
+    {
+        // CA-4: franja 8-17, entrada 08:00, salida 18:00, dia habil => excedente 17:00-18:00
+        // clasificado como ExtraDiurna (herencia de #135). Sin retardo => sin compensacion, la
+        // extra sobrevive completa. DetalleRetardo == Vacio.
+        var control = Control(Franja(8, 17), Dt(8), Dt(18));
+
+        var desglose = control.CalcularDesglose(Lunes, NingunFestivo);
+
+        desglose.Should().NotBeNull();
+        desglose!.Intervalos.Should().Equal(new[]
+        {
+            Clasif(M(8), M(17), Concepto.OrdinariaDiurna),
+            Clasif(M(17), M(18), Concepto.ExtraDiurna),
+        });
+        desglose.Retardo.Should().Be(DetalleRetardo.Vacio);
+        desglose.Retardo.RetardoNeto.Should().Be(0);
+    }
+
+    // ----- CA-5, CA-6: compensacion intra-franja -----
+
+    [Fact]
+    public void CalcularDesglose_CompensaExcedenteConRetardo_CuandoHayAmbosEnLaFranja()
+    {
+        // CA-5: franja 8-17, entrada 08:30, salida 18:00, dia habil. Retardo = 30, excedente bruto
+        // = 60. Compensacion = min(30, 60) = 30 desde el final: parte la extra 17:00-18:00 en
+        // 17:00-17:30 (visible) + 17:30-18:00 (compensado). Este CA ejerce IntervaloTemporal.Partir.
+        // RetardoNeto = 0 (todo el retardo queda compensado).
+        var control = Control(Franja(8, 17), Dt(8, 30), Dt(18));
+
+        var desglose = control.CalcularDesglose(Lunes, NingunFestivo);
+
+        desglose.Should().NotBeNull();
+        desglose!.Intervalos.Should().Equal(new[]
+        {
+            Clasif(M(8, 30), M(17), Concepto.OrdinariaDiurna),
+            Clasif(M(17), M(17, 30), Concepto.ExtraDiurna),
+        });
+        desglose.Retardo.Should().Be(DetalleRetardo.Crear(
+            tiempoRetardado: [Intervalo(M(8), M(8, 30))],
+            tiempoCompensado: [Intervalo(M(17, 30), M(18))]));
+        desglose.Retardo.RetardoNeto.Should().Be(0);
+    }
+
+    [Fact]
+    public void CalcularDesglose_TopaCompensacionAlExcedente_CuandoRetardoSuperaExcedente()
+    {
+        // CA-6: franja 8-17, entrada 09:00, salida 17:30. Retardo = 60, excedente bruto = 30.
+        // Compensacion = min(60, 30) = 30 => la unica extra 17:00-17:30 se consume completa y
+        // desaparece de los Intervalos. RetardoNeto = 60 - 30 = 30.
+        var control = Control(Franja(8, 17), Dt(9), Dt(17, 30));
+
+        var desglose = control.CalcularDesglose(Lunes, NingunFestivo);
+
+        desglose.Should().NotBeNull();
+        desglose!.Intervalos.Should().Equal(new[]
+        {
+            Clasif(M(9), M(17), Concepto.OrdinariaDiurna),
+        });
+        desglose.Intervalos.Should().NotContain(i => i.Concepto == Concepto.ExtraDiurna);
+        desglose.Retardo.Should().Be(DetalleRetardo.Crear(
+            tiempoRetardado: [Intervalo(M(8), M(9))],
+            tiempoCompensado: [Intervalo(M(17), M(17, 30))]));
+        desglose.Retardo.RetardoNeto.Should().Be(30);
+    }
+
+    // ----- CA-7: compensacion cruzando frontera nocturna -----
+
+    [Fact]
+    public void CalcularDesglose_ConsumeExtraNocturnaDesdeElFinal_CuandoCompensacionCruzaFronteraNocturna()
+    {
+        // CA-7: franja 8-17, entrada 08:30, salida 19:30, dia habil. Retardo = 30, excedente bruto
+        // = 150 (17:00-19:00 ExtraDiurna 120min + 19:00-19:30 ExtraNocturna 30min). La compensacion
+        // de 30min consume desde el final exactamente la franja nocturna 19:00-19:30 completa: la
+        // extra nocturna desaparece (solo existia por el retardo) y la diurna 17:00-19:00 sobrevive.
+        var control = Control(Franja(8, 17), Dt(8, 30), Dt(19, 30));
+
+        var desglose = control.CalcularDesglose(Lunes, NingunFestivo);
+
+        desglose.Should().NotBeNull();
+        desglose!.Intervalos.Should().Equal(new[]
+        {
+            Clasif(M(8, 30), M(17), Concepto.OrdinariaDiurna),
+            Clasif(M(17), M(19), Concepto.ExtraDiurna),
+        });
+        desglose.Intervalos.Should().NotContain(i => i.Concepto == Concepto.ExtraNocturna);
+        desglose.Retardo.Should().Be(DetalleRetardo.Crear(
+            tiempoRetardado: [Intervalo(M(8), M(8, 30))],
+            tiempoCompensado: [Intervalo(M(19), M(19, 30))]));
+        desglose.Retardo.RetardoNeto.Should().Be(0);
+    }
+
+    // ----- CA-8: invariante de cobertura -----
+
+    [Fact]
+    public void CalcularDesglose_PreservaInvarianteDeCobertura_CuandoHayCompensacion()
+    {
+        // CA-8: sum(Intervalos.DuracionEnMinutos) + minutosCompensados == trabajadoEfectivo.
+        // Reusa el escenario de CA-5 (entrada 08:30, salida 18:00). La entrada efectiva tras el
+        // recorte es 08:30 (ya posterior al inicio de franja), asi que trabajadoEfectivo = 08:30-18:00.
+        // Los minutos compensados se derivan del DetalleRetardo esperado (TiempoCompensado), cuya
+        // igualdad ancla el test: 17:30-18:00 = 30min.
+        var control = Control(Franja(8, 17), Dt(8, 30), Dt(18));
+        var trabajadoEfectivo = Intervalo(M(8, 30), M(18));
+        var tiempoCompensado = new[] { Intervalo(M(17, 30), M(18)) };
+        var minutosCompensados = tiempoCompensado.Sum(i => i.DuracionEnMinutos);
+
+        var desglose = control.CalcularDesglose(Lunes, NingunFestivo);
+
+        desglose.Should().NotBeNull();
+        // Ancla: el TiempoCompensado del resultado es exactamente el que sumamos en el invariante.
+        desglose!.Retardo.Should().Be(DetalleRetardo.Crear(
+            tiempoRetardado: [Intervalo(M(8), M(8, 30))],
+            tiempoCompensado: tiempoCompensado));
+        (desglose.Intervalos.Sum(i => i.DuracionEnMinutos) + minutosCompensados)
+            .Should().Be(trabajadoEfectivo.DuracionEnMinutos);
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/CalcularDesgloseFranjaTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/CalcularDesgloseFranjaTests.cs
@@ -224,6 +224,34 @@ public class CalcularDesgloseFranjaTests
         desglose.Retardo.RetardoNeto.Should().Be(0);
     }
 
+    [Fact]
+    public void CalcularDesglose_DevuelveCompensacionEnDosIntervalosAscendentes_CuandoElConsumoParteLaFranjaDiurna()
+    {
+        // Refuerzo de CA-7: el caso multi-intervalo descrito en "Estructura de DetalleRetardo
+        // producido". Franja 8-17, entrada 09:30 (retardo 90), salida 19:30. Excedente bruto = 150
+        // (17:00-19:00 ExtraDiurna 120min + 19:00-19:30 ExtraNocturna 30min). Compensacion = min(90,150)
+        // = 90: consume entera la nocturna 19:00-19:30 (30) y PARTE la diurna 17:00-19:00 en 18:00 - la
+        // izquierda 17:00-18:00 sobrevive como extra visible y la derecha 18:00-19:00 se compensa. Asi
+        // el TiempoCompensado queda con DOS intervalos en orden cronologico ascendente
+        // [18:00-19:00, 19:00-19:30]. Este test ancla el contrato de orden (el Reverse interno del
+        // helper) que los demas CA no ejercen porque su compensacion cabe en un solo intervalo.
+        var control = Control(Franja(8, 17), Dt(9, 30), Dt(19, 30));
+
+        var desglose = control.CalcularDesglose(Lunes, NingunFestivo);
+
+        desglose.Should().NotBeNull();
+        desglose!.Intervalos.Should().Equal(new[]
+        {
+            Clasif(M(9, 30), M(17), Concepto.OrdinariaDiurna),
+            Clasif(M(17), M(18), Concepto.ExtraDiurna),
+        });
+        desglose.Intervalos.Should().NotContain(i => i.Concepto == Concepto.ExtraNocturna);
+        desglose.Retardo.Should().Be(DetalleRetardo.Crear(
+            tiempoRetardado: [Intervalo(M(8), M(9, 30))],
+            tiempoCompensado: [Intervalo(M(18), M(19)), Intervalo(M(19), M(19, 30))]));
+        desglose.Retardo.RetardoNeto.Should().Be(0);
+    }
+
     // ----- CA-8: invariante de cobertura -----
 
     [Fact]


### PR DESCRIPTION
## Resumen

Pipeline TDD completado:
- Fase roja: tests escritos con stubs
- Fase verde: implementación completa
- Fase refactor: revisión de calidad

## Decisiones del pipeline

<details>
<summary>Test Writer (fase roja) — 6m 33s</summary>

## ES Test Writer - Decisiones (Issue #136)

### Tests creados
- `tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/CalcularDesgloseFranjaTests.cs`: 9 tests
  - `CalcularDesglose_RetornaNull_CuandoEntradaEsNula` - CA-1 (compuerta anomala, entrada nula)
  - `CalcularDesglose_RetornaNull_CuandoSalidaEsNula` - CA-1 (compuerta anomala, salida nula)
  - `CalcularDesglose_RegistraRetardoSinCompensacion_CuandoEntradaLlegaTarde` - CA-2
  - `CalcularDesglose_NoRegistraRetardo_CuandoEntradaEsPuntual` - CA-3
  - `CalcularDesglose_ClasificaExcedenteComoExtra_CuandoSalidaSeProlongaSinRetardo` - CA-4
  - `CalcularDesglose_CompensaExcedenteConRetardo_CuandoHayAmbosEnLaFranja` - CA-5 (ejerce IntervaloTemporal.Partir)
  - `CalcularDesglose_TopaCompensacionAlExcedente_CuandoRetardoSuperaExcedente` - CA-6
  - `CalcularDesglose_ConsumeExtraNocturnaDesdeElFinal_CuandoCompensacionCruzaFronteraNocturna` - CA-7
  - `CalcularDesglose_PreservaInvarianteDeCobertura_CuandoHayCompensacion` - CA-8

### Estructura elegida
- **Una sola clase de test sin nested classes**: el sujeto bajo prueba es un unico metodo
  (`ControlFranja.CalcularDesglose`), no varios handlers sobre un mismo agregado. No aplica
  el patron nested.
- **Sin harness de event sourcing**: ControlFranja es un value object (record), no un aggregate
  ni command handler. Tests directos sobre el metodo publico, replicando el idioma de
  `ClasificadorTrabajoTests` (#135): helpers `M`, `Intervalo`, `Clasif`, `Franja`, `Sub`.
- **Helpers nuevos de frontera**: `Dt(hora, minuto)` (construye el DateTime de entrada/salida,
  anclado a 2026-03-16) y `Control(...)` (construye el ControlFranja). Reflejan que la entrada
  del metodo es DateTime y la salida se asierta en MomentoDelDia/IntervaloTemporal.

### Stubs creados
- `ControlFranja.CalcularDesglose(DateOnly, Func<DateOnly,bool>): DesgloseFranja?` -
  stub `throw new NotImplementedException()`. Se agrega el `using` de
  `Contracts.ControlHoras.ValueObjects` para `DesgloseFranja`.
- No se crearon fakes manuales: el metodo no recibe dependencias inyectadas (solo `fecha` y el
  predicado `esFestivo`, que se pasan como lambdas inline `_ => false`).

### Decisiones de diseno
- **Verificacion del retardo via igualdad, no via getters de minutos**: `DetalleRetardo` (#114)
  expone publicamente solo `RetardoNeto` (ADR-0015, Tell-don't-Ask: minutos retardados/compensados
  e intervalos son detalle interno). Aunque los CA describen `MinutosRetardados`/`MinutosCompensados`,
  esos miembros NO son publicos. Verifico construyendo el `DetalleRetardo.Crear(tiempoRetardado,
  tiempoCompensado)` esperado y comparando con `.Be(...)`; el `Equals` de DetalleRetardo compara
  internamente esos minutos y los intervalos concretos, asi que la igualdad cubre toda la estructura
  (incluido `TiempoCompensado` con los intervalos exactos que pide cada CA). Complemento con
  `RetardoNeto`.
- **No comparar el DesgloseFranja completo por igualdad**: `DesgloseFranja` es un record con
  `IReadOnlyList<IntervaloClasificado>`, cuya igualdad de record compara la lista por referencia.
  Por eso aserto `Intervalos` con `.Equal(...)` (igualdad de secuencia, orden cronologico ascendente
  = contrato publico del metodo) y `Retardo` con `.Be(...)` por separado, como indica el issue.
- **CA-8 (invariante) sin acceso a estado interno**: como `MinutosCompensados` no es publico, el
  test deriva los minutos compensados de los intervalos de `TiempoCompensado` que el propio test
  declara como esperados, y ancla esa expectativa asertando `Retardo.Should().Be(...)` con esos
  mismos intervalos. Asi el invariante `sum(Intervalos) + minutosCompensados == trabajadoEfectivo`
  se valida sobre la superficie publica sin romper el encapsulamiento de DetalleRetardo.
- **Reuso del escenario CA-5 en CA-8**: el invariante se ejercita con retardo + excedente +
  compensacion no triviales (entrada 08:30, salida 18:00). La entrada efectiva tras el recorte es
  08:30 (ya posterior al inicio de franja), por lo que `trabajadoEfectivo = 08:30-18:00`.

### Cobertura de criterios
| Criterio de aceptacion | Test(s) |
|---|---|
| CA-1: anomala (entrada/salida nula) -> null | `CalcularDesglose_RetornaNull_CuandoEntradaEsNula`, `CalcularDesglose_RetornaNull_CuandoSalidaEsNula` |
| CA-2: retardo 30 sin excedente | `CalcularDesglose_RegistraRetardoSinCompensacion_CuandoEntradaLlegaTarde` |
| CA-3: puntual, retardo 0 = Vacio | `CalcularDesglose_NoRegistraRetardo_CuandoEntradaEsPuntual` |
| CA-4: excedente 60min ExtraDiurna, sin retardo | `CalcularDesglose_ClasificaExcedenteComoExtra_CuandoSalidaSeProlongaSinRetardo` |
| CA-5: compensacion 30min, Partir(int), RetardoNeto 0 | `CalcularDesglose_CompensaExcedenteConRetardo_CuandoHayAmbosEnLaFranja` |
| CA-6: compensacion topada al excedente, RetardoNeto 30 | `CalcularDesglose_TopaCompensacionAlExcedente_CuandoRetardoSuperaExcedente` |
| CA-7: compensacion cruza frontera nocturna, extra nocturna desaparece | `CalcularDesglose_ConsumeExtraNocturnaDesdeElFinal_CuandoCompensacionCruzaFronteraNocturna` |
| CA-8: invariante de cobertura | `CalcularDesglose_PreservaInvarianteDeCobertura_CuandoHayCompensacion` |

### Desviaciones del plan del planner

| Sugerencia del issue | Desviacion aplicada | Razon tecnica | Consecuencia |
|---|---|---|---|
| CA describen `DetalleRetardo.MinutosRetardados` / `MinutosCompensados` como aserciones | Verificacion via igualdad de `DetalleRetardo.Crear(...)` + `RetardoNeto`, sin getters de minutos | Esos miembros NO son publicos en DetalleRetardo (#114, ADR-0015): solo `RetardoNeto` lo es. Exponerlos para el test romperia el encapsulamiento deliberado del VO. `DetalleRetardo` no esta en "Impacto/Modifica" de #136. | Los CA-2/5/6/7 quedan cubiertos por la igualdad estructural (que compara internamente esos minutos y los intervalos de TiempoCompensado). No se modifica DetalleRetardo. |
| "DesgloseFranja(Programada, Intervalos, Retardo)" como resultado a comparar | Se asertan `Intervalos` (`.Equal`) y `Retardo` (`.Be`) por separado, no el record completo | DesgloseFranja es un record con IReadOnlyList; la igualdad de record compara la lista por referencia y un `.Be(desgloseEsperado)` daria falso negativo. | Aserciones robustas sobre orden cronologico (contrato publico) y sobre el retardo. |

### Notas para el implementer
- El stub `CalcularDesglose` lanza `NotImplementedException` y debe implementar el algoritmo de
  las "Notas tecnicas" del issue (frontera DateTime->MomentoDelDia una sola vez, clasificacion via
  ClasificadorTrabajo, calculo de retardo/excedente, compensacion desde el final con
  IntervaloTemporal.Partir). Helpers de compensacion = privados dentro de ControlFranja (opcion (a)
  del issue). NO promover a clase estatica compartida con #116 (decision explicita del issue).
- ControlFranja sigue siendo `record` (value object), no se convierte a partial/aggregate: no hay
  mensajes de error (.resx) porque la rama anomala retorna null, no lanza.

</details>

<details>
<summary>Implementer (fase verde) — 5m 43s</summary>

## ES Implementer - Decisiones

### Enfoque de implementacion

Implementacion del metodo publico `ControlFranja.CalcularDesglose(DateOnly, Func<DateOnly,bool>)`
siguiendo el algoritmo de 5 pasos del issue #136 (capa 4, final, del desglose por franja):

1. Compuerta de anomala: `if (EsAnomala) return null;` como guard clause.
2. Frontera unica DateTime -> MomentoDelDia: `MomentoDelDia.Desde(Entrada!.Value, fecha)` y
   `MomentoDelDia.Desde(Salida!.Value, fecha)`, luego `IntervaloTemporal.Crear`. El DateTime no
   reaparece despues.
3. Lista base via `ClasificadorTrabajo.Clasificar(...)` (#135), materializada a `List<>` mutable.
4. Retardo y excedente bruto en minutos absolutos contra `inicioFranja`/`finFranja` programados.
5. Compensacion = `min(retardo, excedente)`; si > 0 se consume desde el final con el helper
   privado `ConsumirDesdeElFinal`. Ensamblado final con `DetalleRetardo.Crear` y `new DesgloseFranja`.

### Decisiones de diseno

- **Helper privado `ConsumirDesdeElFinal` dentro de `ControlFranja`**: opcion (a) que el issue
  decidio explicitamente. No se extrajo a clase estatica externa (el issue prohibe promover el
  algoritmo como atajo de DRY frente a #116; compensacion intra y cross pueden divergir).
- **No se duplico el algoritmo de #116 ni se intento reutilizarlo**: implementacion local por
  separado, como manda el issue.
- **Recorrido con `while` (no LINQ)**: la regla "LINQ sobre for/foreach" no aplica aqui — la
  operacion es un consumo con estado desde el final que muta la lista visible y parte el intervalo
  de frontera; LINQ no la expresa con claridad. El resto del metodo es declarativo.
- **Orden cronologico ascendente preservado**: los intervalos consumidos se acumulan en orden
  cronologico inverso y se invierten con `Reverse()` antes de devolverlos, para que tanto
  `DesgloseFranja.Intervalos` como `TiempoCompensado` queden en orden ascendente (contrato publico
  del que depende #116). En los CA actuales el `TiempoCompensado` tiene un solo intervalo, pero el
  `Reverse` honra el contrato para el caso multi-intervalo (cruce de frontera nocturna con consumo
  parcial descrito en el issue).
- **Solo se consumio API publica existente**: `IntervaloTemporal.Partir`, `DuracionEnMinutos`,
  `MomentoDelDia.MinutosAbsolutos`, `IntervaloClasificado.Intervalo/Concepto`. No se expuso ningun
  estado interno nuevo (Tell-don't-Ask respetado).
- **Colecciones tipadas explicitamente** (`IReadOnlyList<IntervaloTemporal> tiempoRetardado/...`)
  para que las expresiones de coleccion `[]` y `[x]` resuelvan al tipo esperado por
  `DetalleRetardo.Crear`.

### ADRs consultados

El issue #136 no incluye seccion `## ADRs aplicables` explicita en el prompt recibido, pero
referencia principios de ADR-0015 (encapsulamiento / Tell-don't-Ask) y ADR-0024 (extraccion vs
duplicacion, Rule of Three). Nota: los ficheros `docs/adr/0015-*.md` y `docs/adr/0024-*.md` no
estan materializados en esta rama (solo existen 0001-0004, 0007, 0009, 0017, 0019, 0020). Los
principios estaban no obstante claramente recogidos en el agente implementer y en el propio issue,
y se aplicaron: helpers privados, no extraer el algoritmo, no exponer estado interno.

### Desviaciones de ADRs

Ninguna desviacion — todos los principios aplicables (encapsulamiento, no-extraccion del algoritmo
de compensacion, Tell-don't-Ask) se aplicaron al pie de la letra.

### Precedentes consultados

- `ClasificadorTrabajo` (#135): referencia para naming (`inicioFranja`/`finFranja`), uso de
  `MomentoDelDia.MinutosAbsolutos` y reutilizacion de `IntervaloTemporal.Partir`. Alineado con los
  principios del proyecto.
- `DetalleRetardo` (#114) e `IntervaloTemporal` (#143): se consumieron sus factories publicos
  (`Crear`, `Partir`) sin replicar logica.

### Infraestructura modificada

Ninguna. Logica de dominio pura; sin handlers, eventos publicos ni topics.

### Complejidad encontrada

- El runner de tests es Microsoft.Testing.Platform (xunit.v3.mtp-v2). En .NET 10 `dotnet test
  <ruta>` ya no funciona; se ejecuto con `dotnet run --project <test.csproj>`. Sin impacto en codigo.
- Warning preexistente NU1904 (Marten 8.23.0 vulnerable) — ajeno a este issue, no se toca.

### Resultado

- Tests pasando: 146/146 (incluye los 9 nuevos de `CalcularDesgloseFranjaTests`, CA-1 a CA-8).

</details>
<details>
<summary>Reviewer (fase refactor) — 6m 15s</summary>

## ES Reviewer - Revision

### Evaluacion general
- Calidad: **buena**
- Cambios realizados: **si** (un test de caso borde agregado; sin cambios en codigo de produccion)

### Cumplimiento de ADRs aplicables

El issue #136 **no incluye seccion `## ADRs aplicables`** en el prompt recibido. Ademas, los ADRs
arquitectonicos clave que CLAUDE.md referencia para este tipo de trabajo (ADR-0012, 0015, 0022,
0024) **no estan materializados en esta rama**: `docs/adr/` solo contiene 0001-0004, 0007, 0009,
0017, 0019, 0020. El implementer ya lo flageo en `stage-2-implementer.md`.

Verificacion contra los principios igualmente (recogidos en CLAUDE.md y en los agentes):

| Principio | Cumplimiento | Observacion |
|---|---|---|
| Encapsulamiento / Tell-don't-Ask (ADR-0015) | ok | `CalcularDesglose` es metodo del propio `ControlFranja`; no expone estado nuevo |
| VO con factory + igualdad estructural | ok | Solo consume `DetalleRetardo.Crear`, `IntervaloTemporal.Crear/Partir`; nada nuevo |
| No-extraccion del algoritmo de compensacion (ADR-0024 / instruccion explicita del issue) | ok | Helper privado `ConsumirDesdeElFinal` local; no se promovio a clase estatica reutilizable |
| Naming de tests (ADR-0022) | ok | `<Sujeto>_<LoQuePasa>_Cuando<Condicion>`, solo `[Fact]` |

**Escalamiento al planner**: el issue deberia declarar `## ADRs aplicables` y la rama deberia
sincronizar los ADRs 0012/0015/0022/0024 que CLAUDE.md da por existentes. No bloquea este PR
(los principios se cumplieron), pero es deuda de proceso.

### Desviaciones de ADRs

Ninguna desviacion. Todos los principios aplicables (encapsulamiento, Tell-don't-Ask,
no-extraccion del algoritmo intra-franja frente a #116) se cumplen.

### Precedentes consultados por el implementer

| Precedente | Principio aplicable | Veredicto |
|---|---|---|
| `ClasificadorTrabajo` (#135) | naming `inicioFranja`/`finFranja`, uso de `MinutosAbsolutos`, reuso de `Partir` | alineado |
| `DetalleRetardo` (#114), `IntervaloTemporal` (#143) | consumo de factories publicos, sin replicar logica | alineado |

### Convenciones del pipeline (no ADRs)

| Convencion | Estado | Observacion |
|---|---|---|
| Cada test con `Then()` + `And<>()` | n/a | No es test de event sourcing (logica pura sobre VO); el DSL Given/When/Then no aplica |
| Overloads correctos para stream IDs compuestos | n/a | No hay aggregate ni stream |
| Fakes manuales (no NSubstitute) | n/a | Dependencia inyectada es `Func<DateOnly,bool>` (lambda), no mock |
| Feature folders (produccion y tests) | ok | `Entities/ControlFranja.cs` y espejo en tests `Entities/CalcularDesgloseFranjaTests.cs` |
| Smoke tests: SkipWhen, secrets, cobertura | n/a | El diff no incluye smoke tests; logica de dominio pura sin endpoint/evento |
| Tests via ToString/comportamiento | ok | Se verifica por igualdad de VO (`DetalleRetardo.Crear`) y `RetardoNeto`, no por getters de estado interno |
| Sin numeros magicos | ok | `0` en `Math.Max`/`DiaOffset` es semantico |
| Condiciones en positivo (guardas if/else afirmativas) | ok | `if (EsAnomala) return null;` es guard clause de salida temprana, correcta |
| Sin caracteres prohibidos (U+2500, etc.) | ok | grep confirmo solo `-` ASCII en ambos archivos |

### Elegancia del codigo

El codigo de produccion ya era elegante; no se modifico:

- **Compacto y legible**: la frontera DateTime -> MomentoDelDia ocurre una sola vez (lineas 24-26);
  el resto es `MomentoDelDia`/`IntervaloTemporal`. Naming revela intencion (`excedenteBruto`,
  `compensacion`, `pendientes`, `consumidos`, `izquierdo`/`derecho`).
- **Idiomatico**: expresiones de coleccion `[]`/`[x]`, ternarios para `tiempoCompensado`/`tiempoRetardado`.
- **Eficiente**: `ConsumirDesdeElFinal` recorre la cola en O(k) (k = intervalos tocados), muta in-place;
  la justificacion del `while` sobre LINQ (consumo con estado + particion) es correcta.
- **Robusto**: la precondicion de `ConsumirDesdeElFinal` (`minutos <= suma de duraciones`) esta
  documentada y garantizada por `compensacion <= excedenteBruto <= duracion de la lista`. El punto de
  `Partir` siempre cae estrictamente interior (rama `else` solo cuando `duracion > pendientes > 0`),
  asi que nunca lanza.

### Criticas y hallazgos

1. **[Menor — corregido] Hueco de cobertura: compensacion multi-intervalo no ejercida.** Todos los
   CA-1..CA-8 producen un `TiempoCompensado` de **un solo intervalo**, de modo que el
   `consumidos.Reverse()` y el contrato de **orden cronologico ascendente** para 2+ intervalos
   (descrito explicitamente en la seccion "Estructura de DetalleRetardo producido" del issue) nunca
   se verificaban. Agregue un test que fuerza consumo parcial cruzando la frontera nocturna
   (entrada 09:30, salida 19:30: compensacion 90 consume la nocturna 19:00-19:30 entera y parte la
   diurna 17:00-19:00 en 18:00), produciendo `TiempoCompensado = [18:00-19:00, 19:00-19:30]`. Sin el
   `Reverse` interno el test fallaria (saldria `[19:00-19:30, 18:00-19:00]`), de modo que ahora el
   contrato de orden queda anclado. La implementacion ya lo manejaba correctamente: el test pasa sin
   tocar produccion.

2. **[Observacion — no bloqueante] Interaccion compensacion + descanso programado no testeada.**
   CA-2 y CA-5 mencionan "el descanso aparece si aun aplica", pero ningun test usa una franja con
   descanso. No lo agregue porque el descanso vive antes de `finFranja` y `ConsumirDesdeElFinal`
   solo toca la cola (excedente), con `compensacion <= excedenteBruto` garantizando que nunca
   alcanza la region ordinaria/descanso; un test asi re-verificaria sobre todo la clasificacion de
   #135 (ya cubierta en `ClasificadorTrabajoTests`). Aporte marginal frente al scope explicito del
   issue. Se deja como nota.

3. **[Observacion de proceso] Sin `## ADRs aplicables` en el issue y ADRs clave ausentes de la rama**
   (ver seccion de cumplimiento). Escalar al planner.

### Refactorings aplicados

Ninguno. El codigo de produccion esta limpio y no se requieren cambios; refactorizar por
refactorizar violaria la regla 5 del agente.

### Cobertura de criterios de aceptacion

| Criterio | Estado | Test(s) |
|---|---|---|
| CA-1: anomala (entrada o salida nula) -> null | cubierto | `CalcularDesglose_RetornaNull_CuandoEntradaEsNula`, `..._CuandoSalidaEsNula` |
| CA-2: retardo simple sin excedente (30min) | cubierto | `CalcularDesglose_RegistraRetardoSinCompensacion_CuandoEntradaLlegaTarde` |
| CA-3: entrada puntual -> retardo 0, DetalleRetardo.Vacio | cubierto | `CalcularDesglose_NoRegistraRetardo_CuandoEntradaEsPuntual` |
| CA-4: excedente sin retardo -> ExtraDiurna sobrevive | cubierto | `CalcularDesglose_ClasificaExcedenteComoExtra_CuandoSalidaSeProlongaSinRetardo` |
| CA-5: compensacion intra-franja (ejerce Partir) | cubierto | `CalcularDesglose_CompensaExcedenteConRetardo_CuandoHayAmbosEnLaFranja` |
| CA-6: retardo > excedente -> tope al excedente, RetardoNeto 30 | cubierto | `CalcularDesglose_TopaCompensacionAlExcedente_CuandoRetardoSuperaExcedente` |
| CA-7: compensacion cruza frontera nocturna (consumo exacto) | cubierto | `CalcularDesglose_ConsumeExtraNocturnaDesdeElFinal_CuandoCompensacionCruzaFronteraNocturna` |
| CA-7 (extension): compensacion multi-intervalo, orden ascendente | cubierto (agregado) | `CalcularDesglose_DevuelveCompensacionEnDosIntervalosAscendentes_CuandoElConsumoParteLaFranjaDiurna` |
| CA-8: invariante sum(intervalos)+compensados == trabajadoEfectivo | cubierto | `CalcularDesglose_PreservaInvarianteDeCobertura_CuandoHayCompensacion` |

### Tests agregados

- `CalcularDesglose_DevuelveCompensacionEnDosIntervalosAscendentes_CuandoElConsumoParteLaFranjaDiurna`:
  caso borde de compensacion que abarca dos intervalos del excedente (consumo parcial cruzando la
  frontera nocturna). Ancla el contrato de orden cronologico ascendente del `TiempoCompensado`
  (el `consumidos.Reverse()` del helper), antes no verificado por ningun CA.

### Resultado de la suite
- 147/147 tests verdes (146 previos + 1 agregado). Sin warnings nuevos (persiste NU1904 preexistente
  de Marten 8.23.0, ajeno a este issue).

</details>

## Cobertura

| Archivo | Cobertura | Umbral | Estado |
|---|---|---|---|
| ControlFranja.cs | - | no evaluado | - |
## Commits

a01659f test(hu-136): cubrir compensacion multi-intervalo y orden ascendente del TiempoCompensado
0169ac4 feat(hu-136): implementación fase verde
2877f14 test(hu-136): tests para ControlFranja.CalcularDesglose (fase roja)

Closes #136