### PR TITLE
Consolidar DesgloseFranjas del dia con compensacion cronologica inversa

### DIFF
--- a/src/Bitakora.ControlAsistencia.Contracts/ControlHoras/ValueObjects/DetalleRetardo.cs
+++ b/src/Bitakora.ControlAsistencia.Contracts/ControlHoras/ValueObjects/DetalleRetardo.cs
@@ -43,6 +43,25 @@ public sealed partial class DetalleRetardo : IEquatable<DetalleRetardo>
 
     public static readonly DetalleRetardo Vacio = new([], [], 0, 0);
 
+    // Issue #116: consolida los DetalleRetardo de las franjas de un dia en uno solo, sumando los
+    // intervalos compensados cross-franja que calcula el ConsolidadorDesgloseHoras. El tiempo
+    // retardado del dia es la concatenacion del retardado de cada franja; el compensado, la
+    // concatenacion del compensado intra-franja mas el cross-franja. Mantiene encapsulados los
+    // intervalos crudos de cada franja (ADR-0015): el consumidor entrega los DetalleRetardo
+    // completos, no lee sus intervalos. Crear recalcula los minutos y respeta el invariante.
+    public static DetalleRetardo Consolidar(
+        IEnumerable<DetalleRetardo> retardosPorFranja,
+        IReadOnlyList<IntervaloTemporal> compensacionCrossFranja)
+    {
+        var porFranja = retardosPorFranja.ToList();
+        var tiempoRetardado = porFranja.SelectMany(r => r._tiempoRetardado).ToList();
+        var tiempoCompensado = porFranja
+            .SelectMany(r => r._tiempoCompensado)
+            .Concat(compensacionCrossFranja)
+            .ToList();
+        return Crear(tiempoRetardado, tiempoCompensado);
+    }
+
     public override string ToString()
     {
         if (_tiempoRetardado.Count == 0 && _tiempoCompensado.Count == 0)

--- a/src/Bitakora.ControlAsistencia.Contracts/ControlHoras/ValueObjects/IntervaloTemporal.cs
+++ b/src/Bitakora.ControlAsistencia.Contracts/ControlHoras/ValueObjects/IntervaloTemporal.cs
@@ -10,7 +10,7 @@ namespace Bitakora.ControlAsistencia.Contracts.ControlHoras.ValueObjects;
 // PR #148 (review): aplicar Tell-don't-Ask. Los momentos de inicio y fin viven como
 // detalle interno; la API publica expone solo comportamiento (DuracionEnMinutos,
 // ResolverA, ToString, Partir, igualdad por valor).
-public sealed partial class IntervaloTemporal : IEquatable<IntervaloTemporal>
+public sealed partial class IntervaloTemporal : IEquatable<IntervaloTemporal>, IComparable<IntervaloTemporal>
 {
     private const int MinutosPorHora = 60;
 
@@ -99,6 +99,17 @@ public sealed partial class IntervaloTemporal : IEquatable<IntervaloTemporal>
         if (other is null) return false;
         if (ReferenceEquals(this, other)) return true;
         return _inicio.Equals(other._inicio) && _fin.Equals(other._fin);
+    }
+
+    // Issue #116: orden cronologico natural por inicio y, a igualdad de inicio, por fin.
+    // Permite ordenar intervalos de distintas franjas sin exponer los momentos internos
+    // (Tell-don't-Ask): el consumidor pide la comparacion, no los extremos. Delega en
+    // MomentoDelDia.CompareTo, que ordena por MinutosAbsolutos.
+    public int CompareTo(IntervaloTemporal? other)
+    {
+        if (other is null) return 1;
+        var porInicio = _inicio.CompareTo(other._inicio);
+        return porInicio != 0 ? porInicio : _fin.CompareTo(other._fin);
     }
 
     public override bool Equals(object? obj) => Equals(obj as IntervaloTemporal);

--- a/src/Bitakora.ControlAsistencia.ControlHoras/Entities/ConsolidadorDesgloseHoras.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Entities/ConsolidadorDesgloseHoras.cs
@@ -52,7 +52,9 @@ public static class ConsolidadorDesgloseHoras
     // `intervalosPorFranja`: la extra consumida por completo se remueve de su franja; la atravesada
     // parcialmente se reemplaza por su parte izquierda (la extra genuina visible). Devuelve los
     // IntervaloTemporal consumidos en orden cronologico ascendente, para el TiempoCompensado del
-    // DetalleRetardo. Precondicion: `minutos` <= suma de las duraciones de las extras del dia.
+    // DetalleRetardo. Si `minutos` excede la suma de las extras del dia, consume todas las extras
+    // disponibles y el sobrante queda como retardo neto sin compensar (caso CA-3: retardo sin
+    // excedente que lo cubra). El metodo no exige `minutos` <= extras: tolera el deficit.
     private static IReadOnlyList<IntervaloTemporal> ConsumirExtrasDesdeElFinal(
         List<List<IntervaloClasificado>> intervalosPorFranja, int minutos)
     {

--- a/src/Bitakora.ControlAsistencia.ControlHoras/Entities/ConsolidadorDesgloseHoras.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Entities/ConsolidadorDesgloseHoras.cs
@@ -6,13 +6,96 @@ namespace Bitakora.ControlAsistencia.ControlHoras.Entities;
 // aplicando compensacion cronologica inversa cross-franja sobre las extras de todas
 // las franjas. Clase estatica pura: sin interaccion de aggregate ni event sourcing.
 //
-// La integracion reactiva al aggregate (ControlDiarioAggregateRoot) se hace en #139.
+// Regla de producto: un retardo en cualquier franja se compensa con el excedente de
+// cualquier otra del mismo dia. Los ultimos minutos del excedente (cronologicamente)
+// compensan el retardo; los primeros minutos sobreviven como extras genuinas. La
+// compensacion aplica sobre TODAS las extras sin distincion de origen ni concepto;
+// nunca toca descansos ni ordinarias.
 //
-// STUB de fase roja (#116): la implementacion real la escribe el implementer.
+// La integracion reactiva al aggregate (ControlDiarioAggregateRoot) se hace en #139.
 public static class ConsolidadorDesgloseHoras
 {
     public static DesgloseHoras Consolidar(
         IReadOnlyList<DesgloseFranja> desglosesFranja,
-        int franjasAnomalas) =>
-        throw new NotImplementedException();
+        int franjasAnomalas)
+    {
+        // Copia mutable de los intervalos de cada franja: la compensacion cross-franja consume
+        // extras desde el final, removiendo o partiendo intervalos sin tocar el insumo original.
+        var intervalosPorFranja = desglosesFranja
+            .Select(franja => franja.Intervalos.ToList())
+            .ToList();
+
+        // Retardo pendiente del dia = suma de los retardos netos de cada franja (cada uno ya
+        // descontada su compensacion intra-franja, calculada por separado en #136).
+        var retardoPendiente = desglosesFranja.Sum(franja => franja.Retardo.RetardoNeto);
+
+        IReadOnlyList<IntervaloTemporal> compensacionCrossFranja = retardoPendiente > 0
+            ? ConsumirExtrasDesdeElFinal(intervalosPorFranja, retardoPendiente)
+            : [];
+
+        // El retardo del dia acumula el retardado/compensado de cada franja mas el compensado
+        // cross-franja recien consumido. DetalleRetardo lo consolida sin exponer sus intervalos.
+        var retardoTotal = DetalleRetardo.Consolidar(
+            desglosesFranja.Select(franja => franja.Retardo),
+            compensacionCrossFranja);
+
+        var desglosePorFranja = desglosesFranja
+            .Select((franja, indice) => franja with { Intervalos = intervalosPorFranja[indice] })
+            .ToList();
+
+        return new DesgloseHoras(desglosePorFranja, retardoTotal, franjasAnomalas);
+    }
+
+    // Recolecta las extras de todas las franjas, las ordena cronologicamente de forma EXPLICITA
+    // (las franjas pueden llegar en cualquier orden) y consume `minutos` desde el final segun la
+    // regla cronologica inversa: los ultimos minutos del excedente compensan el retardo. Muta
+    // `intervalosPorFranja`: la extra consumida por completo se remueve de su franja; la atravesada
+    // parcialmente se reemplaza por su parte izquierda (la extra genuina visible). Devuelve los
+    // IntervaloTemporal consumidos en orden cronologico ascendente, para el TiempoCompensado del
+    // DetalleRetardo. Precondicion: `minutos` <= suma de las duraciones de las extras del dia.
+    private static IReadOnlyList<IntervaloTemporal> ConsumirExtrasDesdeElFinal(
+        List<List<IntervaloClasificado>> intervalosPorFranja, int minutos)
+    {
+        var extrasDescendente = intervalosPorFranja
+            .SelectMany((intervalos, franja) => intervalos
+                .Where(intervalo => EsExtra(intervalo.Concepto))
+                .Select(intervalo => (franja, extra: intervalo)))
+            .OrderByDescending(item => item.extra.Intervalo)
+            .ToList();
+
+        var consumidos = new List<IntervaloTemporal>();
+        var pendientes = minutos;
+        foreach (var (franja, extra) in extrasDescendente)
+        {
+            if (pendientes == 0)
+                break;
+
+            var lista = intervalosPorFranja[franja];
+            var indice = lista.IndexOf(extra);
+            if (extra.DuracionEnMinutos <= pendientes)
+            {
+                consumidos.Add(extra.Intervalo);
+                lista.RemoveAt(indice);
+                pendientes -= extra.DuracionEnMinutos;
+            }
+            else
+            {
+                var (izquierdo, derecho) = extra.Intervalo.Partir(extra.DuracionEnMinutos - pendientes);
+                lista[indice] = new IntervaloClasificado(izquierdo, extra.Concepto);
+                consumidos.Add(derecho);
+                pendientes = 0;
+            }
+        }
+
+        consumidos.Reverse();
+        return consumidos;
+    }
+
+    // Una extra es cualquier hora extra, sin distincion de banda ni tipo de dia: compensa el retardo
+    // por igual. Las ordinarias, las dominicales/festivas ordinarias y los descansos nunca se consumen.
+    private static bool EsExtra(Concepto concepto) =>
+        concepto is Concepto.ExtraDiurna
+            or Concepto.ExtraNocturna
+            or Concepto.ExtraDiurnaDominicalFestiva
+            or Concepto.ExtraNocturnaDominicalFestiva;
 }

--- a/src/Bitakora.ControlAsistencia.ControlHoras/Entities/ConsolidadorDesgloseHoras.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Entities/ConsolidadorDesgloseHoras.cs
@@ -1,0 +1,18 @@
+using Bitakora.ControlAsistencia.Contracts.ControlHoras.ValueObjects;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Entities;
+
+// Issue #116: Consolida los DesgloseFranja de un dia operativo en un DesgloseHoras,
+// aplicando compensacion cronologica inversa cross-franja sobre las extras de todas
+// las franjas. Clase estatica pura: sin interaccion de aggregate ni event sourcing.
+//
+// La integracion reactiva al aggregate (ControlDiarioAggregateRoot) se hace en #139.
+//
+// STUB de fase roja (#116): la implementacion real la escribe el implementer.
+public static class ConsolidadorDesgloseHoras
+{
+    public static DesgloseHoras Consolidar(
+        IReadOnlyList<DesgloseFranja> desglosesFranja,
+        int franjasAnomalas) =>
+        throw new NotImplementedException();
+}

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/ConsolidadorDesgloseHorasBasicoTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/ConsolidadorDesgloseHorasBasicoTests.cs
@@ -1,0 +1,170 @@
+// HU-116: Consolidar DesgloseFranjas del dia con compensacion cronologica inversa.
+// Familia 1 - Compensacion cross-franja basica (turno partido dia habil).
+// Franja 1 (programada): 8:00-12:00. Franja 2 (programada): 14:00-18:00.
+//
+// Tests directos sobre ConsolidadorDesgloseHoras.Consolidar - logica pura, sin harness.
+// Datos sinteticos: cada DesgloseFranja se construye a mano (ver ConsolidadorDesgloseHorasTestData).
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Contracts.ControlHoras.ValueObjects;
+using Bitakora.ControlAsistencia.ControlHoras.Entities;
+using static Bitakora.ControlAsistencia.ControlHoras.Tests.Entities.ConsolidadorDesgloseHorasTestData;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Tests.Entities;
+
+public class ConsolidadorDesgloseHorasBasicoTests
+{
+    [Fact]
+    public void Consolidar_CompensaTodoElRetardoConElExcedente_CuandoElExcedenteIgualaElRetardo()
+    {
+        // CA-1: F1 retardo 30min (entrada 8:30, salida 12:00), F2 excedente 30min (salida 18:30).
+        // La compensacion cross-franja come 30min cronologico inverso = [18:00-18:30] completo.
+        // RetardoNeto = 0, extras del dia = 0, ordinarias = 450min (210 + 240).
+        var franja1 = Desglose(
+            Programada(8, 12),
+            [Clasif(M(8, 30), M(12), Concepto.OrdinariaDiurna)],
+            Retardo(retardado: [I(M(8), M(8, 30))], compensado: []));
+        var franja2 = Desglose(
+            Programada(14, 18),
+            [
+                Clasif(M(14), M(18), Concepto.OrdinariaDiurna),
+                Clasif(M(18), M(18, 30), Concepto.ExtraDiurna),
+            ],
+            DetalleRetardo.Vacio);
+
+        var resultado = ConsolidadorDesgloseHoras.Consolidar([franja1, franja2], franjasAnomalas: 0);
+
+        resultado.RetardoTotal.Should().Be(Retardo(
+            retardado: [I(M(8), M(8, 30))],
+            compensado: [I(M(18), M(18, 30))]));
+        resultado.RetardoTotal.RetardoNeto.Should().Be(0);
+        resultado.TotalMinutosPorConcepto.Should().Equal(new Dictionary<Concepto, int>
+        {
+            [Concepto.OrdinariaDiurna] = 450,
+        });
+        resultado.DesglosePorFranja[1].Intervalos.Should().Equal(new[]
+        {
+            Clasif(M(14), M(18), Concepto.OrdinariaDiurna),
+        });
+    }
+
+    [Fact]
+    public void Consolidar_DejaExtrasGenuinasYParteElIntervalo_CuandoElExcedenteSuperaElRetardo()
+    {
+        // CA-2: F1 retardo 30min, F2 excedente 45min (salida 18:45). La compensacion come 30min
+        // desde el final = [18:15-18:45]; el intervalo extra 18:00-18:45 se parte (IntervaloTemporal.Partir)
+        // en [18:00-18:15] (extra genuina visible) + [18:15-18:45] (compensado). RetardoNeto = 0.
+        // Extras del dia = 15min ExtraDiurna.
+        var franja1 = Desglose(
+            Programada(8, 12),
+            [Clasif(M(8, 30), M(12), Concepto.OrdinariaDiurna)],
+            Retardo(retardado: [I(M(8), M(8, 30))], compensado: []));
+        var franja2 = Desglose(
+            Programada(14, 18),
+            [
+                Clasif(M(14), M(18), Concepto.OrdinariaDiurna),
+                Clasif(M(18), M(18, 45), Concepto.ExtraDiurna),
+            ],
+            DetalleRetardo.Vacio);
+
+        var resultado = ConsolidadorDesgloseHoras.Consolidar([franja1, franja2], franjasAnomalas: 0);
+
+        resultado.RetardoTotal.Should().Be(Retardo(
+            retardado: [I(M(8), M(8, 30))],
+            compensado: [I(M(18, 15), M(18, 45))]));
+        resultado.RetardoTotal.RetardoNeto.Should().Be(0);
+        resultado.TotalMinutosPorConcepto.Should().Equal(new Dictionary<Concepto, int>
+        {
+            [Concepto.OrdinariaDiurna] = 450,
+            [Concepto.ExtraDiurna] = 15,
+        });
+        resultado.DesglosePorFranja[1].Intervalos.Should().Equal(new[]
+        {
+            Clasif(M(14), M(18), Concepto.OrdinariaDiurna),
+            Clasif(M(18), M(18, 15), Concepto.ExtraDiurna),
+        });
+    }
+
+    [Fact]
+    public void Consolidar_DejaRetardoNetoSinCompensar_CuandoNoHayExcedenteQueConsumir()
+    {
+        // CA-3: F1 retardo 30min, F2 puntual sin excedente. No hay extras que consumir:
+        // MinutosCompensados = 0, RetardoNeto = 30. Extras del dia = 0.
+        var franja1 = Desglose(
+            Programada(8, 12),
+            [Clasif(M(8, 30), M(12), Concepto.OrdinariaDiurna)],
+            Retardo(retardado: [I(M(8), M(8, 30))], compensado: []));
+        var franja2 = Desglose(
+            Programada(14, 18),
+            [Clasif(M(14), M(18), Concepto.OrdinariaDiurna)],
+            DetalleRetardo.Vacio);
+
+        var resultado = ConsolidadorDesgloseHoras.Consolidar([franja1, franja2], franjasAnomalas: 0);
+
+        resultado.RetardoTotal.Should().Be(Retardo(
+            retardado: [I(M(8), M(8, 30))],
+            compensado: []));
+        resultado.RetardoTotal.RetardoNeto.Should().Be(30);
+        resultado.TotalMinutosPorConcepto.Should().Equal(new Dictionary<Concepto, int>
+        {
+            [Concepto.OrdinariaDiurna] = 450,
+        });
+    }
+
+    [Fact]
+    public void Consolidar_NoRegistraRetardoNiExtras_CuandoTodasLasFranjasSonPuntuales()
+    {
+        // CA-4: F1 puntual, F2 puntual. RetardoTotal == DetalleRetardo.Vacio, extras = 0,
+        // ordinarias = 480min (240 + 240).
+        var franja1 = Desglose(
+            Programada(8, 12),
+            [Clasif(M(8), M(12), Concepto.OrdinariaDiurna)],
+            DetalleRetardo.Vacio);
+        var franja2 = Desglose(
+            Programada(14, 18),
+            [Clasif(M(14), M(18), Concepto.OrdinariaDiurna)],
+            DetalleRetardo.Vacio);
+
+        var resultado = ConsolidadorDesgloseHoras.Consolidar([franja1, franja2], franjasAnomalas: 0);
+
+        resultado.RetardoTotal.Should().Be(DetalleRetardo.Vacio);
+        resultado.RetardoTotal.RetardoNeto.Should().Be(0);
+        resultado.TotalMinutosPorConcepto.Should().Equal(new Dictionary<Concepto, int>
+        {
+            [Concepto.OrdinariaDiurna] = 480,
+        });
+    }
+
+    [Fact]
+    public void Consolidar_ConservaElExcedenteComoExtra_CuandoNoHayRetardoQueCompensar()
+    {
+        // CA-5: F1 puntual, F2 excedente 20min. No hay retardo que compensar => el excedente
+        // sobrevive como extra. Extras del dia = 20min ExtraDiurna, RetardoTotal == Vacio.
+        var franja1 = Desglose(
+            Programada(8, 12),
+            [Clasif(M(8), M(12), Concepto.OrdinariaDiurna)],
+            DetalleRetardo.Vacio);
+        var franja2 = Desglose(
+            Programada(14, 18),
+            [
+                Clasif(M(14), M(18), Concepto.OrdinariaDiurna),
+                Clasif(M(18), M(18, 20), Concepto.ExtraDiurna),
+            ],
+            DetalleRetardo.Vacio);
+
+        var resultado = ConsolidadorDesgloseHoras.Consolidar([franja1, franja2], franjasAnomalas: 0);
+
+        resultado.RetardoTotal.Should().Be(DetalleRetardo.Vacio);
+        resultado.RetardoTotal.RetardoNeto.Should().Be(0);
+        resultado.TotalMinutosPorConcepto.Should().Equal(new Dictionary<Concepto, int>
+        {
+            [Concepto.OrdinariaDiurna] = 480,
+            [Concepto.ExtraDiurna] = 20,
+        });
+        resultado.DesglosePorFranja[1].Intervalos.Should().Equal(new[]
+        {
+            Clasif(M(14), M(18), Concepto.OrdinariaDiurna),
+            Clasif(M(18), M(18, 20), Concepto.ExtraDiurna),
+        });
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/ConsolidadorDesgloseHorasConsolidacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/ConsolidadorDesgloseHorasConsolidacionTests.cs
@@ -2,7 +2,6 @@
 // Familia 3 - Consolidacion de totales y contadores (CA-8, CA-9, CA-10) y las vigilancias de
 // review (#2 suma de MinutosCompensados intra + cross-franja, #3 orden explicito de los extras).
 
-using System.Linq;
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.Contracts.ControlHoras.ValueObjects;
 using Bitakora.ControlAsistencia.ControlHoras.Entities;

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/ConsolidadorDesgloseHorasConsolidacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/ConsolidadorDesgloseHorasConsolidacionTests.cs
@@ -1,0 +1,174 @@
+// HU-116: Consolidar DesgloseFranjas del dia con compensacion cronologica inversa.
+// Familia 3 - Consolidacion de totales y contadores (CA-8, CA-9, CA-10) y las vigilancias de
+// review (#2 suma de MinutosCompensados intra + cross-franja, #3 orden explicito de los extras).
+
+using System.Linq;
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Contracts.ControlHoras.ValueObjects;
+using Bitakora.ControlAsistencia.ControlHoras.Entities;
+using static Bitakora.ControlAsistencia.ControlHoras.Tests.Entities.ConsolidadorDesgloseHorasTestData;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Tests.Entities;
+
+public class ConsolidadorDesgloseHorasConsolidacionTests
+{
+    [Fact]
+    public void Consolidar_SumaMinutosPorConceptoSobreLasFranjasAjustadas_CuandoLaCompensacionRecortaUnaExtra()
+    {
+        // CA-8: TotalMinutosPorConcepto es la suma de MinutosPorConcepto de cada franja DESPUES de
+        // aplicar el ajuste cross-franja. F1 retardo 30min; F2 extra 18:00-18:45 (45min). La
+        // compensacion recorta la extra a 18:00-18:15 (15min): el total refleja 15min, no los 45
+        // del insumo. Se verifica ademas que el total iguala la suma elemento a elemento de las
+        // franjas ya ajustadas (no de las de entrada).
+        var franja1 = Desglose(
+            Programada(8, 12),
+            [Clasif(M(8, 30), M(12), Concepto.OrdinariaDiurna)],
+            Retardo(retardado: [I(M(8), M(8, 30))], compensado: []));
+        var franja2 = Desglose(
+            Programada(14, 18),
+            [
+                Clasif(M(14), M(18), Concepto.OrdinariaDiurna),
+                Clasif(M(18), M(18, 45), Concepto.ExtraDiurna),
+            ],
+            DetalleRetardo.Vacio);
+
+        var resultado = ConsolidadorDesgloseHoras.Consolidar([franja1, franja2], franjasAnomalas: 0);
+
+        var sumaDeFranjasAjustadas = resultado.DesglosePorFranja
+            .SelectMany(f => f.MinutosPorConcepto)
+            .GroupBy(kv => kv.Key)
+            .ToDictionary(g => g.Key, g => g.Sum(kv => kv.Value));
+
+        resultado.RetardoTotal.RetardoNeto.Should().Be(0);
+        resultado.TotalMinutosPorConcepto.Should().Equal(sumaDeFranjasAjustadas);
+        resultado.TotalMinutosPorConcepto.Should().Equal(new Dictionary<Concepto, int>
+        {
+            [Concepto.OrdinariaDiurna] = 450,
+            [Concepto.ExtraDiurna] = 15,
+        });
+    }
+
+    [Fact]
+    public void Consolidar_PropagaFranjasAnomalas_CuandoSeRecibeElParametro()
+    {
+        // CA-9: FranjasAnomalas del resultado es igual al parametro recibido (el aggregate lo cuenta
+        // desde sus ControlesDeFranja en #139; aqui llega como parametro explicito).
+        var franja1 = Desglose(
+            Programada(8, 12),
+            [Clasif(M(8), M(12), Concepto.OrdinariaDiurna)],
+            DetalleRetardo.Vacio);
+        var franja2 = Desglose(
+            Programada(14, 18),
+            [Clasif(M(14), M(18), Concepto.OrdinariaDiurna)],
+            DetalleRetardo.Vacio);
+
+        var resultado = ConsolidadorDesgloseHoras.Consolidar([franja1, franja2], franjasAnomalas: 2);
+
+        resultado.FranjasAnomalas.Should().Be(2);
+        resultado.DesglosePorFranja.Should().HaveCount(2);
+        resultado.RetardoTotal.Should().Be(DetalleRetardo.Vacio);
+    }
+
+    [Fact]
+    public void Consolidar_RetornaDesgloseVacioConContador_CuandoNoHayFranjasCompletas()
+    {
+        // CA-10: Consolidar([], 3) (sin franjas completas, 3 anomalas) => DesgloseHoras vacio pero
+        // con FranjasAnomalas = 3. Todos los totales en cero y RetardoTotal == DetalleRetardo.Vacio.
+        var resultado = ConsolidadorDesgloseHoras.Consolidar([], franjasAnomalas: 3);
+
+        resultado.FranjasAnomalas.Should().Be(3);
+        resultado.DesglosePorFranja.Should().BeEmpty();
+        resultado.RetardoTotal.Should().Be(DetalleRetardo.Vacio);
+        resultado.RetardoTotal.RetardoNeto.Should().Be(0);
+        resultado.TotalMinutosPorConcepto.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Consolidar_SumaMinutosCompensadosIntraYCrossFranja_CuandoAmbasFuentesContribuyen()
+    {
+        // Vigilancia #1 + #2: una franja de entrada llega con TiempoCompensado NO vacio (estado
+        // natural post-#136: ya hubo compensacion intra-franja) y ademas hay compensacion cross-franja.
+        // F1 retardo 40min con excedente propio 10min ya compensado intra-franja (12:00-12:10);
+        // neto remanente 30min. F2 excedente 30min (18:00-18:30). El RetardoTotal debe sumar los
+        // MinutosCompensados intra (10) MAS los cross-franja (30) = 40 => RetardoNeto = 0.
+        var franja1 = Desglose(
+            Programada(8, 12),
+            [Clasif(M(8, 40), M(12), Concepto.OrdinariaDiurna)],
+            Retardo(
+                retardado: [I(M(8), M(8, 40))],
+                compensado: [I(M(12), M(12, 10))]));
+        var franja2 = Desglose(
+            Programada(14, 18),
+            [
+                Clasif(M(14), M(18), Concepto.OrdinariaDiurna),
+                Clasif(M(18), M(18, 30), Concepto.ExtraDiurna),
+            ],
+            DetalleRetardo.Vacio);
+
+        var resultado = ConsolidadorDesgloseHoras.Consolidar([franja1, franja2], franjasAnomalas: 0);
+
+        // Retardado total = 40min (F1). Compensado total = 10min intra (F1) + 30min cross ([18:00-18:30]).
+        resultado.RetardoTotal.Should().Be(Retardo(
+            retardado: [I(M(8), M(8, 40))],
+            compensado: [I(M(12), M(12, 10)), I(M(18), M(18, 30))]));
+        resultado.RetardoTotal.RetardoNeto.Should().Be(0);
+        resultado.TotalMinutosPorConcepto.Should().Equal(new Dictionary<Concepto, int>
+        {
+            // F1: 8:40-12:00 = 200min. F2 ordinaria: 14:00-18:00 = 240min. Extra consumida por completo.
+            [Concepto.OrdinariaDiurna] = 440,
+        });
+    }
+
+    [Fact]
+    public void Consolidar_ConsumeElExcedenteCronologicamenteUltimo_CuandoLasFranjasLleganEnDesorden()
+    {
+        // Vigilancia #3: la recoleccion de extras debe ordenarse cronologicamente de forma EXPLICITA,
+        // sin asumir que la lista de franjas llega ordenada cross-franja. Franjas pasadas en desorden
+        // [manana, tarde-tardia, tarde-temprana]; el retardo (30min, en la manana) debe consumir el
+        // excedente cronologicamente ultimo (20:00-20:30, en la franja tarde-tardia), NO el ultimo de
+        // la lista de entrada (16:00-16:30). Si la ordenacion fuera implicita por orden de lista, se
+        // comeria el excedente equivocado.
+        var manana = Desglose(
+            Programada(8, 12),
+            [Clasif(M(8, 30), M(12), Concepto.OrdinariaDiurna)],
+            Retardo(retardado: [I(M(8), M(8, 30))], compensado: []));
+        var tardeTardia = Desglose(
+            Programada(18, 20),
+            [
+                Clasif(M(18), M(20), Concepto.OrdinariaDiurna),
+                Clasif(M(20), M(20, 30), Concepto.ExtraDiurna),
+            ],
+            DetalleRetardo.Vacio);
+        var tardeTemprana = Desglose(
+            Programada(14, 16),
+            [
+                Clasif(M(14), M(16), Concepto.OrdinariaDiurna),
+                Clasif(M(16), M(16, 30), Concepto.ExtraDiurna),
+            ],
+            DetalleRetardo.Vacio);
+
+        var resultado = ConsolidadorDesgloseHoras.Consolidar(
+            [manana, tardeTardia, tardeTemprana], franjasAnomalas: 0);
+
+        // La compensacion comio el excedente cronologicamente ultimo (20:00-20:30).
+        resultado.RetardoTotal.Should().Be(Retardo(
+            retardado: [I(M(8), M(8, 30))],
+            compensado: [I(M(20), M(20, 30))]));
+        resultado.RetardoTotal.RetardoNeto.Should().Be(0);
+        // tardeTardia (indice 1) perdio su excedente; tardeTemprana (indice 2) lo conserva.
+        resultado.DesglosePorFranja[1].Intervalos.Should().Equal(new[]
+        {
+            Clasif(M(18), M(20), Concepto.OrdinariaDiurna),
+        });
+        resultado.DesglosePorFranja[2].Intervalos.Should().Equal(new[]
+        {
+            Clasif(M(14), M(16), Concepto.OrdinariaDiurna),
+            Clasif(M(16), M(16, 30), Concepto.ExtraDiurna),
+        });
+        resultado.TotalMinutosPorConcepto.Should().Equal(new Dictionary<Concepto, int>
+        {
+            [Concepto.OrdinariaDiurna] = 450,
+            [Concepto.ExtraDiurna] = 30,
+        });
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/ConsolidadorDesgloseHorasDescansoTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/ConsolidadorDesgloseHorasDescansoTests.cs
@@ -1,0 +1,58 @@
+// HU-116: Consolidar DesgloseFranjas del dia con compensacion cronologica inversa.
+// Familia 5 - Los intervalos de concepto Descanso NUNCA son comidos por la compensacion. Solo las
+// extras (todos los Extra* y los DominicalFestiva* cuando son extras) compensan el retardo.
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Contracts.ControlHoras.ValueObjects;
+using Bitakora.ControlAsistencia.ControlHoras.Entities;
+using static Bitakora.ControlAsistencia.ControlHoras.Tests.Entities.ConsolidadorDesgloseHorasTestData;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Tests.Entities;
+
+public class ConsolidadorDesgloseHorasDescansoTests
+{
+    [Fact]
+    public void Consolidar_NoTocaElDescanso_CuandoCompensaElRetardoConElExcedente()
+    {
+        // CA-14: F1 con descanso 12:00-13:00 (Concepto.Descanso) y retardo 30min en la entrada (8:30);
+        // F2 con excedente 30min (20:00-20:30). La compensacion consume los 30min de excedente y NO
+        // toca el descanso: el TiempoCompensado contiene solo el intervalo del excedente, y el descanso
+        // sigue apareciendo intacto en TotalMinutosPorConcepto[Descanso] = 60.
+        var franja1 = Desglose(
+            Programada(8, 17),
+            [
+                Clasif(M(8, 30), M(12), Concepto.OrdinariaDiurna),
+                Clasif(M(12), M(13), Concepto.Descanso),
+                Clasif(M(13), M(17), Concepto.OrdinariaDiurna),
+            ],
+            Retardo(retardado: [I(M(8), M(8, 30))], compensado: []));
+        var franja2 = Desglose(
+            Programada(18, 20),
+            [
+                Clasif(M(18), M(20), Concepto.OrdinariaDiurna),
+                Clasif(M(20), M(20, 30), Concepto.ExtraDiurna),
+            ],
+            DetalleRetardo.Vacio);
+
+        var resultado = ConsolidadorDesgloseHoras.Consolidar([franja1, franja2], franjasAnomalas: 0);
+
+        // El compensado es exactamente el excedente; el descanso 12:00-13:00 jamas aparece aqui.
+        resultado.RetardoTotal.Should().Be(Retardo(
+            retardado: [I(M(8), M(8, 30))],
+            compensado: [I(M(20), M(20, 30))]));
+        resultado.RetardoTotal.RetardoNeto.Should().Be(0);
+        resultado.TotalMinutosPorConcepto.Should().Equal(new Dictionary<Concepto, int>
+        {
+            // F1: 8:30-12:00 (210) + 13:00-17:00 (240) = 450; F2 ordinaria: 18:00-20:00 (120) => 570.
+            [Concepto.OrdinariaDiurna] = 570,
+            [Concepto.Descanso] = 60,
+        });
+        // El descanso sigue intacto entre los intervalos de F1 (no fue removido ni partido).
+        resultado.DesglosePorFranja[0].Intervalos.Should().Equal(new[]
+        {
+            Clasif(M(8, 30), M(12), Concepto.OrdinariaDiurna),
+            Clasif(M(12), M(13), Concepto.Descanso),
+            Clasif(M(13), M(17), Concepto.OrdinariaDiurna),
+        });
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/ConsolidadorDesgloseHorasExtrasProgramadasTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/ConsolidadorDesgloseHorasExtrasProgramadasTests.cs
@@ -1,0 +1,132 @@
+// HU-116: Consolidar DesgloseFranjas del dia con compensacion cronologica inversa.
+// Familia 4 - Compensacion sobre extras programadas (no por excedente de salida). La regla aplica
+// sobre TODAS las extras sin distincion de origen: el consolidador come la extra programada igual
+// que comeria un excedente, y es agnostico al concepto especifico (diurna/nocturna/dominical).
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Contracts.ControlHoras.ValueObjects;
+using Bitakora.ControlAsistencia.ControlHoras.Entities;
+using static Bitakora.ControlAsistencia.ControlHoras.Tests.Entities.ConsolidadorDesgloseHorasTestData;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Tests.Entities;
+
+public class ConsolidadorDesgloseHorasExtrasProgramadasTests
+{
+    [Fact]
+    public void Consolidar_ConsumeUnaExtraProgramada_CuandoNoHayExcedentePorSalida()
+    {
+        // CA-11: F1 retardo 30min, F2 con extra programada 18:00-19:00 (ExtraDiurna 60min) y salida
+        // 19:00 (sin excedente adicional). La compensacion cronologico inverso come 30min desde el
+        // final de la extra = [18:30-19:00]. Resultado: 30min ExtraDiurna (18:00-18:30). Verifica que
+        // las extras programadas son consumibles por compensacion sin distincion de origen.
+        var franja1 = Desglose(
+            Programada(8, 12),
+            [Clasif(M(8, 30), M(12), Concepto.OrdinariaDiurna)],
+            Retardo(retardado: [I(M(8), M(8, 30))], compensado: []));
+        var franja2 = Desglose(
+            Programada(14, 18),
+            [
+                Clasif(M(14), M(18), Concepto.OrdinariaDiurna),
+                Clasif(M(18), M(19), Concepto.ExtraDiurna),
+            ],
+            DetalleRetardo.Vacio);
+
+        var resultado = ConsolidadorDesgloseHoras.Consolidar([franja1, franja2], franjasAnomalas: 0);
+
+        resultado.RetardoTotal.Should().Be(Retardo(
+            retardado: [I(M(8), M(8, 30))],
+            compensado: [I(M(18, 30), M(19))]));
+        resultado.RetardoTotal.RetardoNeto.Should().Be(0);
+        resultado.TotalMinutosPorConcepto.Should().Equal(new Dictionary<Concepto, int>
+        {
+            [Concepto.OrdinariaDiurna] = 450,
+            [Concepto.ExtraDiurna] = 30,
+        });
+        resultado.DesglosePorFranja[1].Intervalos.Should().Equal(new[]
+        {
+            Clasif(M(14), M(18), Concepto.OrdinariaDiurna),
+            Clasif(M(18), M(18, 30), Concepto.ExtraDiurna),
+        });
+    }
+
+    [Fact]
+    public void Consolidar_ComeSoloLaExtraNocturnaProgramada_CuandoLaExtraCruzaLaFronteraNocturna()
+    {
+        // CA-12: F1 retardo 30min, F2 con extra programada 18:00-20:00 repartida en [ExtraDiurna
+        // 18:00-19:00 (60min) + ExtraNocturna 19:00-20:00 (60min)], salida 20:00. La compensacion
+        // cronologico inverso come 30min de ExtraNocturna desde el final = [19:30-20:00]. Resultado:
+        // ExtraDiurna 60min intacta + ExtraNocturna 30min.
+        var franja1 = Desglose(
+            Programada(8, 12),
+            [Clasif(M(8, 30), M(12), Concepto.OrdinariaDiurna)],
+            Retardo(retardado: [I(M(8), M(8, 30))], compensado: []));
+        var franja2 = Desglose(
+            Programada(14, 18),
+            [
+                Clasif(M(14), M(18), Concepto.OrdinariaDiurna),
+                Clasif(M(18), M(19), Concepto.ExtraDiurna),
+                Clasif(M(19), M(20), Concepto.ExtraNocturna),
+            ],
+            DetalleRetardo.Vacio);
+
+        var resultado = ConsolidadorDesgloseHoras.Consolidar([franja1, franja2], franjasAnomalas: 0);
+
+        resultado.RetardoTotal.Should().Be(Retardo(
+            retardado: [I(M(8), M(8, 30))],
+            compensado: [I(M(19, 30), M(20))]));
+        resultado.RetardoTotal.RetardoNeto.Should().Be(0);
+        resultado.TotalMinutosPorConcepto.Should().Equal(new Dictionary<Concepto, int>
+        {
+            [Concepto.OrdinariaDiurna] = 450,
+            [Concepto.ExtraDiurna] = 60,
+            [Concepto.ExtraNocturna] = 30,
+        });
+        resultado.DesglosePorFranja[1].Intervalos.Should().Equal(new[]
+        {
+            Clasif(M(14), M(18), Concepto.OrdinariaDiurna),
+            Clasif(M(18), M(19), Concepto.ExtraDiurna),
+            Clasif(M(19), M(19, 30), Concepto.ExtraNocturna),
+        });
+    }
+
+    [Fact]
+    public void Consolidar_ComeLaExtraDominicalFestiva_CuandoElDiaEsDomingo()
+    {
+        // CA-13: mismo escenario del CA-12 pero en domingo. Los conceptos de extras son
+        // ExtraDiurnaDominicalFestiva + ExtraNocturnaDominicalFestiva (por #135), y el tiempo ordinario
+        // es DominicalFestivaDiurna. La compensacion come 30min de ExtraNocturnaDominicalFestiva desde
+        // el final. Verifica que la compensacion es agnostica al concepto: consume cualquier extra y
+        // deja intactas las ordinarias dominicales.
+        var franja1 = Desglose(
+            Programada(8, 12),
+            [Clasif(M(8, 30), M(12), Concepto.DominicalFestivaDiurna)],
+            Retardo(retardado: [I(M(8), M(8, 30))], compensado: []));
+        var franja2 = Desglose(
+            Programada(14, 18),
+            [
+                Clasif(M(14), M(18), Concepto.DominicalFestivaDiurna),
+                Clasif(M(18), M(19), Concepto.ExtraDiurnaDominicalFestiva),
+                Clasif(M(19), M(20), Concepto.ExtraNocturnaDominicalFestiva),
+            ],
+            DetalleRetardo.Vacio);
+
+        var resultado = ConsolidadorDesgloseHoras.Consolidar([franja1, franja2], franjasAnomalas: 0);
+
+        resultado.RetardoTotal.Should().Be(Retardo(
+            retardado: [I(M(8), M(8, 30))],
+            compensado: [I(M(19, 30), M(20))]));
+        resultado.RetardoTotal.RetardoNeto.Should().Be(0);
+        resultado.TotalMinutosPorConcepto.Should().Equal(new Dictionary<Concepto, int>
+        {
+            [Concepto.DominicalFestivaDiurna] = 450,
+            [Concepto.ExtraDiurnaDominicalFestiva] = 60,
+            [Concepto.ExtraNocturnaDominicalFestiva] = 30,
+        });
+        resultado.DesglosePorFranja[1].Intervalos.Should().Equal(new[]
+        {
+            Clasif(M(14), M(18), Concepto.DominicalFestivaDiurna),
+            Clasif(M(18), M(19), Concepto.ExtraDiurnaDominicalFestiva),
+            Clasif(M(19), M(19, 30), Concepto.ExtraNocturnaDominicalFestiva),
+        });
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/ConsolidadorDesgloseHorasFronteraNocturnaTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/ConsolidadorDesgloseHorasFronteraNocturnaTests.cs
@@ -1,0 +1,95 @@
+// HU-116: Consolidar DesgloseFranjas del dia con compensacion cronologica inversa.
+// Familia 2 - Compensacion cruzando la frontera nocturna (21:00 segun #135).
+// Franja 1 (programada): 8:00-12:00. Franja 2 (programada): 14:00-18:00, salida prolongada
+// hasta 19:30 cruzando la banda nocturna (excedente repartido en ExtraDiurna + ExtraNocturna).
+//
+// Datos sinteticos: los conceptos diurno/nocturno se fijan a mano para focalizar el test en
+// la compensacion cronologica inversa (la clasificacion por banda ya esta cubierta en #135).
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Contracts.ControlHoras.ValueObjects;
+using Bitakora.ControlAsistencia.ControlHoras.Entities;
+using static Bitakora.ControlAsistencia.ControlHoras.Tests.Entities.ConsolidadorDesgloseHorasTestData;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Tests.Entities;
+
+public class ConsolidadorDesgloseHorasFronteraNocturnaTests
+{
+    [Fact]
+    public void Consolidar_ConsumeLaExtraNocturnaCompleta_CuandoElRetardoIgualaElTramoNocturno()
+    {
+        // CA-6: F1 retardo 30min, F2 excedente 90min repartido en [ExtraDiurna 18:00-19:00 (60min)
+        // + ExtraNocturna 19:00-19:30 (30min)]. La compensacion cronologico inverso come 30min =
+        // los 30min ExtraNocturna completos. Resultado: 60min ExtraDiurna + 0min ExtraNocturna.
+        // RetardoNeto = 0; la ExtraNocturna desaparece porque solo existia por el retardo.
+        var franja1 = Desglose(
+            Programada(8, 12),
+            [Clasif(M(8, 30), M(12), Concepto.OrdinariaDiurna)],
+            Retardo(retardado: [I(M(8), M(8, 30))], compensado: []));
+        var franja2 = Desglose(
+            Programada(14, 18),
+            [
+                Clasif(M(14), M(18), Concepto.OrdinariaDiurna),
+                Clasif(M(18), M(19), Concepto.ExtraDiurna),
+                Clasif(M(19), M(19, 30), Concepto.ExtraNocturna),
+            ],
+            DetalleRetardo.Vacio);
+
+        var resultado = ConsolidadorDesgloseHoras.Consolidar([franja1, franja2], franjasAnomalas: 0);
+
+        resultado.RetardoTotal.Should().Be(Retardo(
+            retardado: [I(M(8), M(8, 30))],
+            compensado: [I(M(19), M(19, 30))]));
+        resultado.RetardoTotal.RetardoNeto.Should().Be(0);
+        resultado.TotalMinutosPorConcepto.Should().Equal(new Dictionary<Concepto, int>
+        {
+            [Concepto.OrdinariaDiurna] = 450,
+            [Concepto.ExtraDiurna] = 60,
+        });
+        resultado.DesglosePorFranja[1].Intervalos.Should().Equal(new[]
+        {
+            Clasif(M(14), M(18), Concepto.OrdinariaDiurna),
+            Clasif(M(18), M(19), Concepto.ExtraDiurna),
+        });
+    }
+
+    [Fact]
+    public void Consolidar_ConsumeLaNocturnaYParteLaDiurna_CuandoElRetardoSuperaElTramoNocturno()
+    {
+        // CA-7: F1 retardo 80min (entrada 9:20), F2 excedente 90min como en CA-6. La compensacion
+        // cronologico inverso come 30min ExtraNocturna completos + 50min ExtraDiurna desde el final
+        // (18:10-19:00). Resultado: 10min ExtraDiurna (18:00-18:10). RetardoNeto = 0.
+        // Ejerce IntervaloTemporal.Partir sobre la ExtraDiurna 18:00-19:00. El TiempoCompensado
+        // cross-franja queda en orden cronologico ascendente [18:10-19:00, 19:00-19:30].
+        var franja1 = Desglose(
+            Programada(8, 12),
+            [Clasif(M(9, 20), M(12), Concepto.OrdinariaDiurna)],
+            Retardo(retardado: [I(M(8), M(9, 20))], compensado: []));
+        var franja2 = Desglose(
+            Programada(14, 18),
+            [
+                Clasif(M(14), M(18), Concepto.OrdinariaDiurna),
+                Clasif(M(18), M(19), Concepto.ExtraDiurna),
+                Clasif(M(19), M(19, 30), Concepto.ExtraNocturna),
+            ],
+            DetalleRetardo.Vacio);
+
+        var resultado = ConsolidadorDesgloseHoras.Consolidar([franja1, franja2], franjasAnomalas: 0);
+
+        resultado.RetardoTotal.Should().Be(Retardo(
+            retardado: [I(M(8), M(9, 20))],
+            compensado: [I(M(18, 10), M(19)), I(M(19), M(19, 30))]));
+        resultado.RetardoTotal.RetardoNeto.Should().Be(0);
+        resultado.TotalMinutosPorConcepto.Should().Equal(new Dictionary<Concepto, int>
+        {
+            // F1: 9:20-12:00 = 160min. F2 ordinaria: 14:00-18:00 = 240min.
+            [Concepto.OrdinariaDiurna] = 400,
+            [Concepto.ExtraDiurna] = 10,
+        });
+        resultado.DesglosePorFranja[1].Intervalos.Should().Equal(new[]
+        {
+            Clasif(M(14), M(18), Concepto.OrdinariaDiurna),
+            Clasif(M(18), M(18, 10), Concepto.ExtraDiurna),
+        });
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/ConsolidadorDesgloseHorasPuenteTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/ConsolidadorDesgloseHorasPuenteTests.cs
@@ -1,0 +1,58 @@
+// HU-116: Consolidar DesgloseFranjas del dia con compensacion cronologica inversa.
+// Familia 6 - Puente con ControlFranja.CalcularDesglose real (#136). Construye dos ControlFranja
+// con DateTime?, los pasa por CalcularDesglose y entrega la lista resultante a Consolidar.
+//
+// Este CA es REDUNDANTE en cobertura con las familias 1-5 (replica el escenario de CA-1), pero es
+// el antidoto contra divergencia silenciosa: si una refactorizacion futura de #135/#136 cambia la
+// forma de los DesgloseFranja (orden de intervalos, presencia de TiempoCompensado, conceptos), las
+// familias sinteticas seguiran verdes mientras este test fallara visiblemente.
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Contracts.ControlHoras.ValueObjects;
+using Bitakora.ControlAsistencia.Contracts.Programacion.ValueObjects;
+using Bitakora.ControlAsistencia.ControlHoras.Entities;
+using static Bitakora.ControlAsistencia.ControlHoras.Tests.Entities.ConsolidadorDesgloseHorasTestData;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Tests.Entities;
+
+public class ConsolidadorDesgloseHorasPuenteTests
+{
+    private static readonly DateOnly Lunes = new(2026, 3, 16); // habil no festivo
+    private static readonly Func<DateOnly, bool> NingunFestivo = _ => false;
+
+    // Marcacion como DateTime (frontera del dominio: las marcaciones llegan como DateTime).
+    private static DateTime Dt(int hora, int minuto = 0) => new(2026, 3, 16, hora, minuto, 0);
+
+    [Fact]
+    public void Consolidar_ProduceElMismoResultadoQueLosSinteticos_CuandoLasFranjasVienenDeCalcularDesglose()
+    {
+        // Replica el ejemplo del Contexto / CA-1 con el codigo real: F1 8:00-12:00 con entrada tardia
+        // 8:30 (retardo 30min, sin excedente); F2 14:00-18:00 con salida 18:30 (excedente 30min, sin
+        // retardo). La compensacion cross-franja come los 30min finales del excedente (18:00-18:30):
+        // RetardoNeto = 0, extras del dia = 0, ordinarias = 450min.
+        var controlFranja1 = new ControlFranja(Programada(8, 12), Dt(8, 30), Dt(12));
+        var controlFranja2 = new ControlFranja(Programada(14, 18), Dt(14), Dt(18, 30));
+
+        var desgloseFranja1 = controlFranja1.CalcularDesglose(Lunes, NingunFestivo);
+        var desgloseFranja2 = controlFranja2.CalcularDesglose(Lunes, NingunFestivo);
+
+        desgloseFranja1.Should().NotBeNull();
+        desgloseFranja2.Should().NotBeNull();
+
+        var resultado = ConsolidadorDesgloseHoras.Consolidar(
+            [desgloseFranja1!, desgloseFranja2!], franjasAnomalas: 0);
+
+        resultado.RetardoTotal.Should().Be(Retardo(
+            retardado: [I(M(8), M(8, 30))],
+            compensado: [I(M(18), M(18, 30))]));
+        resultado.RetardoTotal.RetardoNeto.Should().Be(0);
+        resultado.TotalMinutosPorConcepto.Should().Equal(new Dictionary<Concepto, int>
+        {
+            [Concepto.OrdinariaDiurna] = 450,
+        });
+        resultado.DesglosePorFranja[1].Intervalos.Should().Equal(new[]
+        {
+            Clasif(M(14), M(18), Concepto.OrdinariaDiurna),
+        });
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/ConsolidadorDesgloseHorasTestData.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/ConsolidadorDesgloseHorasTestData.cs
@@ -1,0 +1,54 @@
+// Issue #116: Helpers de construccion compartidos por las familias de tests del
+// ConsolidadorDesgloseHoras (familias 1-6). Cada familia vive en su propia clase y
+// consume estos helpers via `using static`, evitando duplicarlos en seis archivos.
+//
+// Convencion de datos: las familias 1-5 construyen DesgloseFranja a mano con
+// IntervaloClasificado concretos en lugar de pasar por ControlFranja.CalcularDesglose,
+// para focalizar los tests en el algoritmo de consolidacion (la clasificacion ya esta
+// cubierta en #135 + #136). La familia 6 (puente) usa el codigo real de #136.
+//
+// Todas las aserciones se hacen en MomentoDelDia / IntervaloTemporal / DetalleRetardo /
+// Concepto. DetalleRetardo (#114) solo expone RetardoNeto publicamente (ADR-0015,
+// Tell-don't-Ask): los minutos retardados/compensados son detalle interno, asi que el
+// retardo consolidado se verifica construyendo el DetalleRetardo esperado via
+// DetalleRetardo.Crear(...) y comparando por igualdad (que internamente compara minutos
+// e intervalos), mas RetardoNeto.
+
+using Bitakora.ControlAsistencia.Contracts.ControlHoras.ValueObjects;
+using Bitakora.ControlAsistencia.Contracts.Programacion.ValueObjects;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Tests.Entities;
+
+internal static class ConsolidadorDesgloseHorasTestData
+{
+    // Momento del dia: hora[:minuto] con offset opcional de dia.
+    public static MomentoDelDia M(int hora, int minuto = 0, int diaOffset = 0) =>
+        new(new TimeOnly(hora, minuto), diaOffset);
+
+    // Intervalo temporal entre dos momentos.
+    public static IntervaloTemporal I(MomentoDelDia inicio, MomentoDelDia fin) =>
+        IntervaloTemporal.Crear(inicio, fin);
+
+    // Intervalo clasificado con un concepto legal.
+    public static IntervaloClasificado Clasif(MomentoDelDia inicio, MomentoDelDia fin, Concepto concepto) =>
+        new(IntervaloTemporal.Crear(inicio, fin), concepto);
+
+    // Franja programada plana (sin descansos ni extras programadas declarados): solo
+    // viaja en el DesgloseFranja para que el consolidador la preserve en DesglosePorFranja.
+    // El detalle real de lo trabajado vive en los IntervaloClasificado de cada franja.
+    public static DetalleFranjaOrdinaria Programada(int horaInicio, int horaFin, int diaOffsetFin = 0) =>
+        new(new TimeOnly(horaInicio, 0), new TimeOnly(horaFin, 0), diaOffsetFin, [], []);
+
+    // DetalleRetardo de una franja, a partir de sus intervalos retardados y compensados.
+    public static DetalleRetardo Retardo(
+        IReadOnlyList<IntervaloTemporal> retardado,
+        IReadOnlyList<IntervaloTemporal> compensado) =>
+        DetalleRetardo.Crear(retardado, compensado);
+
+    // DesgloseFranja sintetico: programada + intervalos clasificados + detalle de retardo.
+    public static DesgloseFranja Desglose(
+        DetalleFranjaOrdinaria programada,
+        IReadOnlyList<IntervaloClasificado> intervalos,
+        DetalleRetardo retardo) =>
+        new(programada, intervalos, retardo);
+}


### PR DESCRIPTION
## Resumen

Pipeline TDD completado:
- Fase roja: tests escritos con stubs
- Fase verde: implementación completa
- Fase refactor: revisión de calidad

## Decisiones del pipeline

<details>
<summary>Test Writer (fase roja) — 15m 30s</summary>

## ES Test Writer - Decisiones (HU-116 Consolidar DesgloseFranjas del dia)

### Tests creados

Logica pura sobre `ConsolidadorDesgloseHoras.Consolidar` (clase estatica): sin harness de
event sourcing, igual que `CalcularDesgloseFranjaTests` (#136). xUnit + AwesomeAssertions,
`[Fact]` solamente. Aserciones siempre via interfaz publica de los VOs (DetalleRetardo solo
expone `RetardoNeto`; el resto se verifica por igualdad contra `DetalleRetardo.Crear(...)`).

- `ConsolidadorDesgloseHorasBasicoTests.cs`: 5 tests (Familia 1)
  - `Consolidar_CompensaTodoElRetardoConElExcedente_CuandoElExcedenteIgualaElRetardo` - CA-1
  - `Consolidar_DejaExtrasGenuinasYParteElIntervalo_CuandoElExcedenteSuperaElRetardo` - CA-2 (ejerce `IntervaloTemporal.Partir`)
  - `Consolidar_DejaRetardoNetoSinCompensar_CuandoNoHayExcedenteQueConsumir` - CA-3
  - `Consolidar_NoRegistraRetardoNiExtras_CuandoTodasLasFranjasSonPuntuales` - CA-4
  - `Consolidar_ConservaElExcedenteComoExtra_CuandoNoHayRetardoQueCompensar` - CA-5
- `ConsolidadorDesgloseHorasFronteraNocturnaTests.cs`: 2 tests (Familia 2)
  - `Consolidar_ConsumeLaExtraNocturnaCompleta_CuandoElRetardoIgualaElTramoNocturno` - CA-6
  - `Consolidar_ConsumeLaNocturnaYParteLaDiurna_CuandoElRetardoSuperaElTramoNocturno` - CA-7 (Partir)
- `ConsolidadorDesgloseHorasConsolidacionTests.cs`: 5 tests (Familia 3 + vigilancias)
  - `Consolidar_SumaMinutosPorConceptoSobreLasFranjasAjustadas_CuandoLaCompensacionRecortaUnaExtra` - CA-8
  - `Consolidar_PropagaFranjasAnomalas_CuandoSeRecibeElParametro` - CA-9
  - `Consolidar_RetornaDesgloseVacioConContador_CuandoNoHayFranjasCompletas` - CA-10
  - `Consolidar_SumaMinutosCompensadosIntraYCrossFranja_CuandoAmbasFuentesContribuyen` - Vigilancia #1 + #2
  - `Consolidar_ConsumeElExcedenteCronologicamenteUltimo_CuandoLasFranjasLleganEnDesorden` - Vigilancia #3
- `ConsolidadorDesgloseHorasExtrasProgramadasTests.cs`: 3 tests (Familia 4)
  - `Consolidar_ConsumeUnaExtraProgramada_CuandoNoHayExcedentePorSalida` - CA-11
  - `Consolidar_ComeSoloLaExtraNocturnaProgramada_CuandoLaExtraCruzaLaFronteraNocturna` - CA-12
  - `Consolidar_ComeLaExtraDominicalFestiva_CuandoElDiaEsDomingo` - CA-13
- `ConsolidadorDesgloseHorasDescansoTests.cs`: 1 test (Familia 5)
  - `Consolidar_NoTocaElDescanso_CuandoCompensaElRetardoConElExcedente` - CA-14
- `ConsolidadorDesgloseHorasPuenteTests.cs`: 1 test (Familia 6)
  - `Consolidar_ProduceElMismoResultadoQueLosSinteticos_CuandoLasFranjasVienenDeCalcularDesglose` - CA-15

Total: 17 tests (15 CAs + 2 tests adicionales exigidos por las "Vigilancias en review").

### Estructura elegida

- **Una clase por familia** (seis clases), como pide el issue. No se usan nested classes ni el
  harness Given/When/Then porque el SUT es una clase estatica pura, no un command handler.
- **Helpers compartidos** en `ConsolidadorDesgloseHorasTestData.cs` (clase `internal static`),
  consumidos via `using static`: `M`, `I`, `Clasif`, `Programada`, `Retardo`, `Desglose`. Evita
  duplicar los constructores de datos en seis archivos (el issue pide "comparte helpers de
  construccion"). Este archivo NO esta en la lista "Crea" del issue; se anade por DRY (ver
  desviaciones).

### Stubs creados

- `src/.../Entities/ConsolidadorDesgloseHoras.cs` - `public static class` con
  `Consolidar(IReadOnlyList<DesgloseFranja>, int) => throw new NotImplementedException()`.
  No es aggregate ni handler => no necesita `partial` ni clase `Mensajes`/`.resx` (no emite
  mensajes de error propios; la unica excepcion del flujo viene de `IntervaloTemporal.Partir`,
  que ya tiene sus mensajes en #143).

### Decisiones de diseno

- **Verificacion del retardo consolidado por igualdad.** Los CAs hablan de `MinutosRetardados` /
  `MinutosCompensados`, que NO son publicos en `DetalleRetardo` (ADR-0015, Tell-don't-Ask: solo
  `RetardoNeto`). Se construye el `DetalleRetardo` esperado con `DetalleRetardo.Crear(retardado,
  compensado)` y se compara con `.Should().Be(...)` (su `Equals` compara intervalos y minutos),
  mas `RetardoNeto`. Mismo patron que `CalcularDesgloseFranjaTests`.
- **Contrato de orden de los intervalos del retardo consolidado (pin de fase roja).** Los tests
  fijan:
  - `tiempoRetardado` = concat por franja en el orden de la lista de entrada.
  - `tiempoCompensado` = concat del `TiempoCompensado` intra-franja (orden de lista) + el
    cross-franja, con el cross-franja en **orden cronologico ascendente** (consistente con el
    `consumidos.Reverse()` de #136). Ejercido explicitamente en CA-7 (compensado de dos
    intervalos: `[18:10-19:00, 19:00-19:30]`).
- **Recoleccion de extras ordenada explicitamente (Vigilancia #3).** El test de desorden pasa las
  franjas como `[manana, tarde-tardia, tarde-temprana]` y verifica que se consume el excedente
  cronologicamente ultimo (`20:00-20:30`), no el ultimo de la lista (`16:00-16:30`). Esto preserva
  el invariante "intervalos ascendentes DENTRO de cada franja" (contrato de #136) pero fuerza el
  ordenamiento cross-franja en el consolidador.
- **Cobertura del estado natural post-#136 (Vigilancia #1).** El test de Vigilancia #2 usa una
  franja de entrada con `TiempoCompensado` NO vacio (`[12:00-12:10]`, compensacion intra-franja ya
  hecha por #136) y verifica que el `RetardoTotal` suma 10min intra + 30min cross = 40 => neto 0.
- **CA-13 (domingo) sintetico.** `Consolidar` no recibe `Fecha`; el domingo se modela usando los
  conceptos `DominicalFestivaDiurna` (ordinaria) + `ExtraDiurnaDominicalFestiva` /
  `ExtraNocturnaDominicalFestiva` (extras). Verifica que la compensacion consume las extras
  dominicales y deja intacta la ordinaria dominical (agnostica al concepto, solo mira "es extra").
- **CA-15 (puente) replica CA-1 por el camino real.** F1 8:00-12:00 entrada 8:30 (retardo 30) +
  F2 14:00-18:00 salida 18:30 (excedente 30) por `ControlFranja.CalcularDesglose` (Lunes habil
  2026-03-16). Resultado identico al sintetico CA-1: neto 0, extras 0, ordinarias 450.

### Cobertura de criterios

| Criterio | Test |
|---|---|
| CA-1 | `Consolidar_CompensaTodoElRetardoConElExcedente_...` |
| CA-2 | `Consolidar_DejaExtrasGenuinasYParteElIntervalo_...` |
| CA-3 | `Consolidar_DejaRetardoNetoSinCompensar_...` |
| CA-4 | `Consolidar_NoRegistraRetardoNiExtras_...` |
| CA-5 | `Consolidar_ConservaElExcedenteComoExtra_...` |
| CA-6 | `Consolidar_ConsumeLaExtraNocturnaCompleta_...` |
| CA-7 | `Consolidar_ConsumeLaNocturnaYParteLaDiurna_...` |
| CA-8 | `Consolidar_SumaMinutosPorConceptoSobreLasFranjasAjustadas_...` |
| CA-9 | `Consolidar_PropagaFranjasAnomalas_...` |
| CA-10 | `Consolidar_RetornaDesgloseVacioConContador_...` |
| CA-11 | `Consolidar_ConsumeUnaExtraProgramada_...` |
| CA-12 | `Consolidar_ComeSoloLaExtraNocturnaProgramada_...` |
| CA-13 | `Consolidar_ComeLaExtraDominicalFestiva_...` |
| CA-14 | `Consolidar_NoTocaElDescanso_...` |
| CA-15 | `Consolidar_ProduceElMismoResultadoQueLosSinteticos_...` |
| Vigilancia #1 + #2 | `Consolidar_SumaMinutosCompensadosIntraYCrossFranja_...` |
| Vigilancia #3 | `Consolidar_ConsumeElExcedenteCronologicamenteUltimo_...` |

### Cuestionamiento al plan del planner (escalar antes de fase verde)

**Gap de encapsulamiento: el consolidador no puede leer los intervalos del retardo por franja.**

Las "Notas tecnicas / Algoritmo" del issue (paso 4) describen construir el `RetardoTotal` asi:
`tiempoRetardado = concat(DesgloseFranja.Retardo.TiempoRetardado for each franja)` y
`tiempoCompensado = concat(DesgloseFranja.Retardo.TiempoCompensado ...) + cross`.

Pero `DetalleRetardo` (#114) **NO expone** `TiempoRetardado` ni `TiempoCompensado`: son campos
privados (`_tiempoRetardado`, `_tiempoCompensado`); la unica propiedad publica es `RetardoNeto`
(ADR-0015, Tell-don't-Ask). Y "Impacto en archivos" del issue dice **Modifica: ninguno**. El
implementer no podra ensamblar el `RetardoTotal` consolidado sin una de estas opciones:

1. Exponer publicamente esas dos listas en `DetalleRetardo` -> **rompe Tell-don't-Ask** (ADR-0015);
   convierte datos intermedios en API publica. No recomendado.
2. Anadir a `DetalleRetardo` un comportamiento de consolidacion, p.ej.
   `static DetalleRetardo Consolidar(IEnumerable<DetalleRetardo> porFranja, IReadOnlyList<IntervaloTemporal> compensadoCrossFranja)`,
   que combine las listas SIN sacarlas del VO. **Respeta Tell-don't-Ask** pero **modifica
   `DetalleRetardo`**, contradiciendo "Modifica: ninguno".

**Recomendacion del test-writer:** opcion 2 (comportamiento en el VO). Los tests de esta HU NO
dependen de la resolucion: solo usan `DetalleRetardo.Crear`, `RetardoNeto` e igualdad, todos
publicos. Por tanto NO bloquea la fase roja, pero el implementer debe decidir esto (y muy
probablemente tocar `DetalleRetardo`, ajustando el "Modifica: ninguno" del issue). Se deja para
evaluacion del usuario / implementer.

### Desviaciones del plan del planner

| Sugerencia del issue | Desviacion aplicada | Razon tecnica | Consecuencia |
|---|---|---|---|
| Lista "Crea" enumera solo los 6 archivos de test de familia | Se anade `ConsolidadorDesgloseHorasTestData.cs` (helpers `internal static`) | El issue pide "comparte helpers de construccion" entre familias; un archivo de helpers compartidos evita duplicarlos en 6 clases (mas limpio que copiar/pegar) | Un archivo de test extra (solo helpers, sin `[Fact]`); ningun CA se mueve ni se pierde |
| 14 CAs (texto) / 15 CAs (lista CA-1..CA-15) | Se cubren los 15 CAs listados + 2 tests por vigilancias | La seccion "Vigilancias en review" exige cobertura explicita de estado intra+cross y de orden cross-franja, no cubierta por los CAs base | 17 tests en total; las vigilancias quedan ancladas como tests, no como notas |

</details>

<details>
<summary>Implementer (fase verde) — 11m 17s</summary>

## ES Implementer - Decisiones

### Enfoque de implementacion

`ConsolidadorDesgloseHoras.Consolidar` consolida los `DesgloseFranja` del dia
en un `DesgloseHoras` aplicando compensacion cronologica inversa cross-franja:

1. Copia mutable de los intervalos de cada franja.
2. `retardoPendiente = sum(franja.Retardo.RetardoNeto)` (API publica de `DetalleRetardo`).
3. Si hay retardo, recolecta todas las extras de todas las franjas, las ordena
   cronologicamente de forma explicita y consume desde el final (los ultimos minutos
   del excedente compensan el retardo). La extra consumida por completo se remueve de su
   franja; la atravesada parcialmente se parte con `IntervaloTemporal.Partir(int)` (#143),
   dejando la parte izquierda como extra genuina visible.
4. Construye `RetardoTotal` via `DetalleRetardo.Consolidar(...)`.
5. Reconstruye `DesglosePorFranja` con `franja with { Intervalos = ... }` y retorna
   `new DesgloseHoras(...)`. `TotalMinutosPorConcepto` se recalcula solo (record #129).

El algoritmo de "consumir los ultimos N minutos" se mantiene **duplicado** respecto a
`ControlFranja.ConsumirDesdeElFinal` (#136), por decision explicita del issue (no extraer).

### Decisiones de diseno

- **`EsExtra(Concepto)` como helper privado del consolidador.** La pregunta "este concepto
  es extra?" solo tiene un sitio de uso (Rule of Three no se cumple), asi que vive privado
  en el consolidador en vez de tocar el enum `Concepto`. Cubre los cuatro `Extra*`
  (diurna/nocturna y sus variantes dominicales/festivas); ordinarias y descansos nunca compensan.
- **Mutacion por `IndexOf` recalculado.** Se localiza cada extra en su franja al momento de
  consumirla (no por indice cacheado), robusto ante remociones que desplazan indices.
- **Orden cronologico explicito** (`OrderByDescending` por intervalo), no por orden de la lista
  de franjas de entrada — vigilancia #3 del issue. Dos franjas en distinto momento del dia se
  interleavean correctamente.
- **Compensado cross-franja en orden ascendente**: se recolecta consumiendo desde el final y se
  invierte (`Reverse`) antes de retornar, igual que `ControlFranja` (#136).

### ADRs consultados

El indice de CLAUDE.md mapea los temas de este trabajo a **ADR-0015** (encapsulamiento,
Tell-don't-Ask, VOs con ctor privado + `ConfigurarSerializacion`) y **ADR-0024** (extraccion vs
duplicacion). **Nota de gap**: en este worktree `docs/adr/` solo contiene un subconjunto
(0001-0004, 0007, 0009, 0017, 0019, 0020); los archivos fisicos 0015 y 0024 no estan
materializados aqui (la numeracion del indice de CLAUDE.md diverge de la del harness, donde
0015 = snapshots Marten). El contenido de esos principios esta embebido en el agente implementer
(seccion "Encapsulamiento: Tell Don't Ask", leccion PR #155) y demostrado en el codigo
(`DetalleRetardo`, `IntervaloTemporal`: campos privados + superficie de solo comportamiento), que
fue la fuente aplicada. **El issue tampoco traia seccion `## ADRs aplicables`**; se procedio por
instruccion explicita del usuario de implementar y por una fase roja ya completa y commiteada,
en vez de bloquear. Recomendado para el planner: materializar/renumerar los ADRs referenciados
en el indice y anadir la seccion `## ADRs aplicables` al issue.

### Desviaciones de ADRs

Ninguna desviacion de ADR. Las dos adiciones a VOs de Contracts (abajo) son la realizacion
**conforme** a ADR-0015 del algoritmo descrito por el plan: anaden comportamiento sin exponer
estado interno. Se documentan como desviacion **del plan del planner** (no de un ADR).

### Desviaciones del plan del planner

El issue declaraba **"Modifica: ninguno"** y listaba `IntervaloTemporal`/`DetalleRetardo` solo
en **"Lee"**, pero su propia seccion "Algoritmo" (paso 3-4) asumia accesos que **no son publicos**
en el codigo actual. Se realizaron dos modificaciones, cada una eligiendo comportamiento sobre
exposicion de estado (Tell-don't-Ask, leccion PR #155):

#### Desviacion 1: `IntervaloTemporal` ahora implementa `IComparable<IntervaloTemporal>`
- **Sugerencia del issue**: usar solo `IntervaloTemporal.Partir(int)`; ordenar las extras "por
  `Intervalo.Inicio` usando `MomentoDelDia.CompareTo`".
- **Desviacion aplicada**: se anadio `IComparable<IntervaloTemporal>` (compara por `_inicio` y, a
  empate, por `_fin`, delegando en `MomentoDelDia.CompareTo`).
- **Razon tecnica**: `IntervaloTemporal` **no expone** `Inicio` ni `MinutosAbsolutos` (son
  `_inicio`/`_fin` privados, alineado con la leccion PR #155). Sin una primitiva de comparacion no
  hay forma de ordenar extras de distintas franjas. `MomentoDelDia` ya es `IComparable<MomentoDelDia>`,
  asi que esto es idiomatico en esta familia de VOs.
- **Alternativas exploradas y descartadas**: exponer `Inicio`/`MinutosAbsolutos` como propiedad
  publica -> **descartada**: filtra estado interno (exactamente lo que el reviewer humano rechazo en
  PR #155); `IComparable` es comportamiento, no estado. Resolver a `DateTime` con `ResolverA(fecha)`
  -> **descartada**: la firma `Consolidar(IReadOnlyList<DesgloseFranja>, int)` no recibe fecha.
- **Consecuencia conocida**: `IntervaloTemporal` gana un orden natural total por inicio/fin. No
  afecta serializacion (sin campos nuevos) ni rompe tests existentes.

#### Desviacion 2: nuevo `DetalleRetardo.Consolidar(retardosPorFranja, compensacionCrossFranja)`
- **Sugerencia del issue**: construir `RetardoTotal` concatenando
  `DesgloseFranja.Retardo.TiempoRetardado`/`.TiempoCompensado` de cada franja.
- **Desviacion aplicada**: se anadio un factory estatico `Consolidar` que recibe los `DetalleRetardo`
  completos por franja mas el compensado cross-franja y devuelve el consolidado via `Crear(...)`.
- **Razon tecnica**: `DetalleRetardo` **solo expone `RetardoNeto`**; `_tiempoRetardado` y
  `_tiempoCompensado` son privados (ADR-0015: "el unico observable publico es RetardoNeto"). La
  vigilancia #2 exige que el `RetardoTotal` contenga el intervalo compensado intra-franja
  (`[12:00-12:10]`), que **solo vive dentro** del `DetalleRetardo` de la franja. Sin acceso, el
  resultado es inconstruible.
- **Alternativas exploradas y descartadas**: exponer getters publicos de
  `TiempoRetardado`/`TiempoCompensado` -> **descartada**: viola ADR-0015 (expone los datos crudos que
  el VO declara internos). La operacion "consolidar varios DetalleRetardo en uno" pertenece al propio
  `DetalleRetardo` (tiene los datos): Tell-don't-Ask. El metodo mantiene los intervalos encapsulados.
- **Consecuencia conocida**: `DetalleRetardo` (Contracts) gana un metodo de consolidacion. No cambia
  la forma serializada.

### Precedentes consultados

- `ControlFranja.ConsumirDesdeElFinal` (#136, `src/.../Entities/ControlFranja.cs`): alineado con el
  patron del proyecto. Se uso como **referencia de estilo** (consumo desde el final + `Reverse`),
  pero **deliberadamente NO se extrajo ni reutilizo** (decision explicita del issue: intra y
  cross-franja se mantienen separados por posible divergencia futura del dominio laboral).
- `MomentoDelDia` (`IComparable<MomentoDelDia>`) y `IntervaloTemporal`/`DetalleRetardo` (campos
  privados + `ConfigurarSerializacion`): alineados con ADR-0015. Se siguieron como plantilla.

### Infraestructura modificada

Ninguna. Logica pura sin eventos publicos ni Service Bus.

### Complejidad encontrada

- El plan asumia accesos publicos inexistentes (`Intervalo.Inicio`, `Retardo.TiempoRetardado`).
  Resuelto anadiendo comportamiento a los VOs en vez de getters (ver desviaciones del plan).
- `dotnet format` falla en su restore implicito porque NuGetAudit eleva las vulnerabilidades de
  paquetes (Marten 8.23.0, OpenTelemetry 1.14.0) a errores. Verificado el formato con
  `dotnet format whitespace --no-restore --verify-no-changes` (exit 0, sin cambios pendientes).

### Resultado

- Tests pasando: **410/410** (403 correctos + 7 omitidos pre-existentes; 0 errores).
- Los 15 CAs de HU-116 (familias 1-6) en verde, incluyendo el test puente (CA-15) con
  `ControlFranja.CalcularDesglose` real y las tres vigilancias de review.

</details>
<details>
<summary>Reviewer (fase refactor) — 8m 9s</summary>

## ES Reviewer - Revision (HU-116 Consolidar DesgloseFranjas del dia)

### Evaluacion general
- Calidad: **buena**
- Cambios realizados: **si** (dos cosmeticos: comentario inexacto + import redundante)

### Cumplimiento de ADRs aplicables

El issue **no traia seccion `## ADRs aplicables`** (escalado al planner, ver abajo). Los ADRs
fisicos referenciados por el indice de CLAUDE.md (0015 encapsulamiento, 0024 extraccion) **no
estan materializados en este worktree** (`docs/adr/` solo contiene 0001-0004, 0007, 0009, 0017,
0019, 0020). Se verifico contra los principios embebidos en el agente (Tell-don't-Ask, leccion
PR #155) y los precedentes de VOs ya conformes.

| ADR | Cumplimiento | Observacion |
|---|---|---|
| ADR-0015 (encapsulamiento / Tell-don't-Ask) | ok | Las dos adiciones a VOs de Contracts anaden **comportamiento**, no exponen estado. Ver abajo. |
| ADR-0024 (extraccion vs duplicacion) | ok | Duplicacion de "consumir N min desde el final" vs `ControlFranja` es deliberada y, ademas, **semanticamente distinta** (ver hallazgos). |
| ADR-0012 (serializacion / igualdad VOs) | ok | Ningun campo nuevo; forma serializada de `IntervaloTemporal` y `DetalleRetardo` intacta. |

**Detalle de las dos adiciones a Contracts (conformes a Tell-don't-Ask):**
- `IntervaloTemporal : IComparable<IntervaloTemporal>` — comparacion es comportamiento; delega en
  `MomentoDelDia.CompareTo`. **No** expone `_inicio`/`_fin`. Era la alternativa correcta frente a
  publicar `Inicio`/`MinutosAbsolutos` (justo lo que el reviewer humano rechazo en PR #155).
- `DetalleRetardo.Consolidar(retardosPorFranja, compensacionCrossFranja)` — la operacion vive en el
  VO que posee los datos (`_tiempoRetardado`/`_tiempoCompensado` siguen privados). El consumidor
  entrega `DetalleRetardo` completos, no lee sus intervalos. Esto **habilita** la vigilancia #2
  (sumar compensado intra + cross-franja) sin filtrar estado interno.

**Sobre la clase estatica `ConsolidadorDesgloseHoras`** (antipatron #2 del checklist ADR-0012): no
es violacion. (a) El issue la mandata explicitamente como clase pura; (b) combina genuinamente datos
de **objetos distintos** (varias franjas) que no convergen via eventos — excepcion contemplada; (c)
no lee estado privado de los VOs: usa solo superficie publica (`RetardoNeto`, `DuracionEnMinutos`,
`Partir`, `CompareTo`, `Concepto`, `Intervalos`) y delega la consolidacion del retardo al propio VO.

### Desviaciones de ADRs

**Declaradas por el implementer:** las dos adiciones a VOs se declararon como desviaciones **del
plan del planner** (que decia "Modifica: ninguno"), no de un ADR. Evaluacion del reviewer:
**aceptables y correctas** — son la realizacion conforme a Tell-don't-Ask del algoritmo del plan;
las alternativas (exponer getters) habrian violado el principio de encapsulamiento. El plan asumia
accesos publicos (`Intervalo.Inicio`, `Retardo.TiempoRetardado`) que no existen por diseno.

**Detectadas por el reviewer (no declaradas):** ninguna.

### Precedentes consultados por el implementer

| Precedente | Principio | Veredicto |
|---|---|---|
| `ControlFranja.ConsumirDesdeElFinal` (#136) | ADR-0024 | alineado — usado como referencia de estilo, **no** reutilizado (decision del issue) |
| `MomentoDelDia` (`IComparable`), `IntervaloTemporal`/`DetalleRetardo` (campos privados) | ADR-0015 | alineados — plantilla correcta |

### Convenciones del pipeline (no ADRs)

| Convencion | Estado | Observacion |
|---|---|---|
| Given/When/Then + `And<>()` | n/a | SUT es clase estatica pura, no command handler (igual que `CalcularDesgloseFranjaTests` #136) |
| Overloads stream IDs compuestos | n/a | sin aggregate |
| Fakes manuales (no NSubstitute) | n/a | sin dependencias |
| Feature folders (produccion y tests) | ok | `Entities/` espejo en src y tests; una clase por familia |
| Smoke tests | n/a | logica pura, sin endpoint/evento |
| Tests via comportamiento (no getters de test) | ok | retardo verificado por igualdad (`DetalleRetardo.Crear`) + `RetardoNeto` publico |
| Sin numeros magicos | ok | minutos de dominio via helpers `M`/`Programada`; produccion sin constantes magicas |
| Condiciones en positivo | ok | `retardoPendiente > 0 ? ...`, `DuracionEnMinutos <= pendientes`; `if (pendientes == 0) break` es guard de salida |
| Sin caracteres U+2500/decorativos en `.cs` | ok | verificado por grep en src y tests |

### Elegancia del codigo
- LINQ idiomatico (`SelectMany` con indice, `OrderByDescending`, `with { }` en records). Nombres
  reveladores (`ConsumirExtrasDesdeElFinal`, `retardoPendiente`, `extrasDescendente`).
- Aislamiento de mutacion correcto: copia mutable por franja (`Intervalos.ToList()`); el insumo y los
  records `IntervaloClasificado` no se mutan; la particion crea records nuevos.
- `IndexOf` por valor es seguro: dentro de una franja los intervalos son disjuntos, no hay colisiones
  de igualdad estructural.

### Criticas y hallazgos
- **[menor, corregido] Comentario de precondicion inexacto** en `ConsumirExtrasDesdeElFinal`. Decia
  "Precondicion: `minutos` <= suma de las extras del dia", pero el metodo **no** la exige ni la valida:
  tolera el deficit consumiendo lo disponible y dejando el sobrante como retardo neto. CA-3 (30min de
  retardo, 0 extras) ejercita justo ese caso. A diferencia de `ControlFranja`, donde la precondicion
  si esta garantizada, aqui el comentario era un copy-adapt que podia inducir a un mantenedor a anadir
  un `assert`/`throw` y romper CA-3. Reescrito para describir el comportamiento real ante deficit.
- **[cosmetico, corregido] `using System.Linq;` redundante** en `ConsolidadorDesgloseHorasConsolidacionTests.cs`
  (ImplicitUsings habilitado; ningun otro archivo del proyecto lo importa explicito). Removido.
- **[observacion, sin accion] Diferencia semantica con #136 que valida la no-extraccion.** La version
  cross-franja **debe** filtrar `EsExtra` (un descanso podria estar al final de una franja), mientras
  `ControlFranja.ConsumirDesdeElFinal` consume ciegamente el ultimo intervalo (ahi siempre hay extra).
  No son el mismo algoritmo; la decision del issue de mantenerlos separados queda reforzada.
- **[cobertura, opcional, sin accion] Consumo que abarca dos franjas distintas.** Ningun CA consume
  extras de >1 franja en una sola compensacion (CA-7 consume dos extras pero ambas en F2). El camino de
  codigo es identico (lista unica aplanada y ordenada), por lo que el riesgo es bajo; no se agrega test
  para respetar el alcance de las familias del issue.

### Refactorings aplicados
- Reescritura del comentario de precondicion (sin cambio de comportamiento).
- Eliminacion de import redundante en el test de consolidacion.
- No se toco logica: la implementacion es correcta y bien estructurada tal como llego.

### Cobertura de criterios de aceptacion
| Criterio | Estado | Test |
|---|---|---|
| CA-1 | cubierto | `Consolidar_CompensaTodoElRetardoConElExcedente_CuandoElExcedenteIgualaElRetardo` |
| CA-2 (Partir) | cubierto | `Consolidar_DejaExtrasGenuinasYParteElIntervalo_CuandoElExcedenteSuperaElRetardo` |
| CA-3 | cubierto | `Consolidar_DejaRetardoNetoSinCompensar_CuandoNoHayExcedenteQueConsumir` |
| CA-4 | cubierto | `Consolidar_NoRegistraRetardoNiExtras_CuandoTodasLasFranjasSonPuntuales` |
| CA-5 | cubierto | `Consolidar_ConservaElExcedenteComoExtra_CuandoNoHayRetardoQueCompensar` |
| CA-6 | cubierto | `Consolidar_ConsumeLaExtraNocturnaCompleta_CuandoElRetardoIgualaElTramoNocturno` |
| CA-7 (Partir) | cubierto | `Consolidar_ConsumeLaNocturnaYParteLaDiurna_CuandoElRetardoSuperaElTramoNocturno` |
| CA-8 | cubierto | `Consolidar_SumaMinutosPorConceptoSobreLasFranjasAjustadas_CuandoLaCompensacionRecortaUnaExtra` |
| CA-9 | cubierto | `Consolidar_PropagaFranjasAnomalas_CuandoSeRecibeElParametro` |
| CA-10 | cubierto | `Consolidar_RetornaDesgloseVacioConContador_CuandoNoHayFranjasCompletas` |
| CA-11 | cubierto | `Consolidar_ConsumeUnaExtraProgramada_CuandoNoHayExcedentePorSalida` |
| CA-12 | cubierto | `Consolidar_ComeSoloLaExtraNocturnaProgramada_CuandoLaExtraCruzaLaFronteraNocturna` |
| CA-13 (domingo) | cubierto | `Consolidar_ComeLaExtraDominicalFestiva_CuandoElDiaEsDomingo` |
| CA-14 (descanso) | cubierto | `Consolidar_NoTocaElDescanso_CuandoCompensaElRetardoConElExcedente` |
| CA-15 (puente real) | cubierto | `Consolidar_ProduceElMismoResultadoQueLosSinteticos_CuandoLasFranjasVienenDeCalcularDesglose` |
| Vigilancia #1 + #2 (compensado intra+cross) | cubierto | `Consolidar_SumaMinutosCompensadosIntraYCrossFranja_CuandoAmbasFuentesContribuyen` |
| Vigilancia #3 (orden explicito) | cubierto | `Consolidar_ConsumeElExcedenteCronologicamenteUltimo_CuandoLasFranjasLleganEnDesorden` |

Naming conforme a ADR-0022: sujeto = `Consolidar` (el metodo bajo prueba).

### Tests agregados
- Ninguno. La cobertura de los 15 CAs + 3 vigilancias estaba completa y correcta.

### Resultado de la suite
- `dotnet test`: **410 total, 403 correctos, 7 omitidos (pre-existentes), 0 errores** — verde antes
  y despues del refactor.
- `dotnet format whitespace --no-restore --verify-no-changes` sobre archivos tocados: exit 0.
- Unico warning: NU1904 (Marten 8.23.0), pre-existente y ajeno a este issue.

### Escalado al planner
El issue carecia de seccion `## ADRs aplicables` y los ADRs 0015/0024 del indice de CLAUDE.md no
estan materializados en `docs/adr/` de este worktree (la numeracion del indice diverge de la del
harness). Recomendacion: materializar/renumerar esos ADRs y anadir la seccion `## ADRs aplicables`
a la plantilla de issues.

</details>

## Cobertura

| Archivo | Cobertura | Umbral | Estado |
|---|---|---|---|
| DetalleRetardo.cs | - | no evaluado | - |
| IntervaloTemporal.cs | - | no evaluado | - |
| ConsolidadorDesgloseHoras.cs | - | no evaluado | - |
## Commits

a40ab32 refactor(hu-116): corregir comentario de precondicion y remover import redundante
4a2c005 feat(hu-116): consolidacion con compensacion cronologica inversa (fase verde)
85bd446 test(hu-116): tests para ConsolidadorDesgloseHoras (fase roja)

Closes #116