### PR TITLE
Publicar el DesgloseHoras real en el evento DiaCalculado

### DIFF
--- a/src/Bitakora.ControlAsistencia.ControlHoras/Entities/ControlDiarioAggregateRoot.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Entities/ControlDiarioAggregateRoot.cs
@@ -152,7 +152,10 @@ public partial class ControlDiarioAggregateRoot : AggregateRoot
 
     // HU-108: construye el evento DiaCalculado desde el estado actual del aggregate.
     // Tell-don't-Ask: el aggregate es duenio del estado y entrega el evento ya empaquetado al handler.
-    // Usa DesgloseHoras.Vacio mientras la calculadora real no exista (#115/#116/#136/#139).
+    // HU-181: empaqueta el DesgloseHoras real ya consolidado por RecalcularDesgloseHoras() al final
+    //         de cada Apply. _desgloseHoras esta fresco aqui porque CrearDiaCalculado() lo invocan los
+    //         handlers despues del Apply que recalculo el desglose. Sin turno o con todas las franjas
+    //         anomalas, _desgloseHoras ya equivale a DesgloseHoras.Vacio (lo decide el consolidador).
     // El mapeo ControlFranja -> DetalleControlFranja queda encapsulado aqui (no expone _controlesDeFranja).
     public DiaCalculado CrearDiaCalculado()
     {
@@ -160,6 +163,6 @@ public partial class ControlDiarioAggregateRoot : AggregateRoot
             .Select(c => new DetalleControlFranja(c.Programada, c.Entrada, c.Salida, c.EsAnomala))
             .ToArray();
 
-        return new DiaCalculado(InformacionEmpleado, Fecha, detalles, DesgloseHoras.Vacio);
+        return new DiaCalculado(InformacionEmpleado, Fecha, detalles, _desgloseHoras);
     }
 }

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/RegistrarMarcacionFunction/RegistrarMarcacionSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/RegistrarMarcacionFunction/RegistrarMarcacionSmokeTests.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Json;
 using System.Text.Json;
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.Contracts.ControlHoras.Eventos;
+using Bitakora.ControlAsistencia.Contracts.ControlHoras.ValueObjects;
 using Bitakora.ControlAsistencia.ControlHoras.SmokeTests.Fixtures;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.SmokeTests.RegistrarMarcacionFunction;
@@ -304,7 +305,139 @@ public class RegistrarMarcacionSmokeTests(
         diaCalculado.ControlesDeFranja.Should().HaveCount(1,
             "el TurnoDiarioAsignado previo tiene una sola franja ordinaria");
         diaCalculado.DesgloseHoras.Should().NotBeNull(
-            "DiaCalculado siempre se emite con DesgloseHoras (Vacio mientras la calculadora no exista)");
+            "DiaCalculado siempre se emite con DesgloseHoras (HU-181: ya lleva el desglose real consolidado)");
+
+        // Assert: ausencia de dead letters en la suscripcion smoke-tests del topic dia-calculado.
+        var deadLetters = await serviceBus.PeekDeadLetterMessagesAsync(
+            TopicDiaCalculado, SuscripcionSmokeTests);
+
+        deadLetters.Should().BeEmpty(
+            "no deberia haber mensajes en dead letter de '{0}' del topic '{1}'",
+            SuscripcionSmokeTests, TopicDiaCalculado);
+    }
+
+    // HU-181 CA-5: camino feliz completo (turno + entrada + salida) -> el DiaCalculado publicado
+    // tras la salida lleva el DesgloseHoras REAL consolidado del dia, no DesgloseHoras.Vacio.
+    // Cada marcacion publica su propio DiaCalculado: la entrada deja la franja anomala (sin salida)
+    // y la salida la completa. Para capturar el evento posterior a la salida se purga la suscripcion
+    // smoke-tests DESPUES de confirmar que la entrada quedo persistida (su DiaCalculado ya se publico)
+    // y ANTES de registrar la salida (patron purge-before-act, ADR-0016).
+    // Asercion minima: el desglose real fluye end-to-end (OrdinariaDiurna > 0, FranjasAnomalas == 0);
+    // la matematica detallada del calculo esta cubierta en unit (#116/#136/#139).
+    // No modifica el smoke de franja incompleta (entrada-only) de arriba: ambos coexisten.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task RegistrarMarcacion_PublicaDiaCalculadoConDesgloseReal_CuandoMarcacionesCompletanLaFranja()
+    {
+        Assert.SkipWhen(!postgres.IsConfigured,
+            postgres.SkipReason ?? "Postgres no disponible.");
+        Assert.SkipWhen(!serviceBus.IsConfigured,
+            "ServiceBus no configurado. Usa appsettings.local.json o variable ServiceBus__ConnectionString.");
+
+        var ct = TestContext.Current.CancellationToken;
+
+        // Arrange: identificadores unicos por ejecucion.
+        var empleadoId = Guid.CreateVersion7().ToString();
+        var fecha = new DateOnly(2026, 4, 28);
+        var streamId = $"{empleadoId}:{fecha:yyyy-MM-dd}";
+
+        // Setup: turno 08:00-16:00 via Service Bus; esperar a que ControlHoras persista
+        // turno_diario_asignado antes de registrar las marcaciones.
+        var solicitudId = Guid.CreateVersion7();
+        var programacionPayload = new
+        {
+            SolicitudId = solicitudId,
+            Empleado = new
+            {
+                EmpleadoId = empleadoId,
+                TipoIdentificacion = "CC",
+                NumeroIdentificacion = "777666555",
+                Nombres = "[TEST] Smoke Desglose Real",
+                Apellidos = "[TEST] HU181"
+            },
+            Fecha = fecha.ToString("yyyy-MM-dd"),
+            DetalleTurno = new
+            {
+                Nombre = "[TEST] Turno HU181",
+                FranjasOrdinarias = new[]
+                {
+                    new
+                    {
+                        HoraInicio = "08:00:00",
+                        HoraFin = "16:00:00",
+                        DiaOffsetFin = 0,
+                        Descansos = Array.Empty<object>(),
+                        Extras = Array.Empty<object>()
+                    }
+                }
+            }
+        };
+
+        await serviceBus.PublishAsync(TopicProgramacionEntrada, programacionPayload, solicitudId.ToString());
+
+        var turnoAsignado = await postgres.ExisteEventoAsync(
+            SchemaControlHoras, streamId, TipoEventoTurnoDiarioAsignado, Timeout,
+            campoJson: "SolicitudId", valorJson: solicitudId.ToString());
+
+        turnoAsignado.Should().BeTrue(
+            $"el evento {TipoEventoTurnoDiarioAsignado} deberia existir antes de registrar las marcaciones");
+
+        // Act 1: ENTRADA 08:00. La franja queda con entrada pero sin salida (aun anomala).
+        var entradaTimestamp = new DateTime(fecha, new TimeOnly(8, 0, 0), DateTimeKind.Utc);
+        var entradaResponse = await _client.PostAsJsonAsync(Ruta, new
+        {
+            empleadoId,
+            timestamp = entradaTimestamp.ToString("yyyy-MM-ddTHH:mm:ss") + "Z",
+            tipoMarcacion = "ENTRADA",
+            dispositivoId = "[TEST] DEV-SMOKE-HU181"
+        }, ct);
+        entradaResponse.StatusCode.Should().Be(HttpStatusCode.Accepted);
+
+        // Esperar a que la entrada quede persistida: garantiza que su DiaCalculado ya fue publicado
+        // antes de purgar, de modo que el purge elimine el evento de la entrada (no el de la salida).
+        var entradaPersistida = await postgres.ExisteEventoAsync(
+            SchemaControlHoras, streamId, TipoEventoMarcacionAdicionada, Timeout,
+            campoJson: "EmpleadoId", valorJson: empleadoId);
+
+        entradaPersistida.Should().BeTrue(
+            $"el evento {TipoEventoMarcacionAdicionada} de la entrada deberia existir antes de purgar");
+
+        // Purge-before-act: limpiar la suscripcion para que el unico DiaCalculado restante de este
+        // empleado sea el que publique la salida (descarta los del turno y la entrada).
+        await serviceBus.PurgeAsync(TopicDiaCalculado, SuscripcionSmokeTests);
+
+        // Act 2: SALIDA 16:00. Completa la franja (entrada 08:00 + salida 16:00) -> desglose real.
+        var salidaTimestamp = new DateTime(fecha, new TimeOnly(16, 0, 0), DateTimeKind.Utc);
+        var salidaResponse = await _client.PostAsJsonAsync(Ruta, new
+        {
+            empleadoId,
+            timestamp = salidaTimestamp.ToString("yyyy-MM-ddTHH:mm:ss") + "Z",
+            tipoMarcacion = "SALIDA",
+            dispositivoId = "[TEST] DEV-SMOKE-HU181"
+        }, ct);
+        salidaResponse.StatusCode.Should().Be(HttpStatusCode.Accepted);
+
+        // Assert publicacion: el DiaCalculado posterior a la salida lleva el desglose real,
+        // filtrado por EmpleadoId (unico por ejecucion).
+        var diaCalculado = await serviceBus.WaitForMessageAsync<DiaCalculado>(
+            TopicDiaCalculado, SuscripcionSmokeTests,
+            e => e.InformacionEmpleado != null && e.InformacionEmpleado.EmpleadoId == empleadoId,
+            Timeout);
+
+        diaCalculado.Fecha.Should().Be(fecha);
+        diaCalculado.ControlesDeFranja.Should().HaveCount(1,
+            "el turno previo tiene una sola franja ordinaria, ahora completada");
+
+        // CA-5: el desglose ya NO es DesgloseHoras.Vacio. La franja quedo completa (no anomala)
+        // y una jornada 08:00-16:00 acumula horas ordinarias diurnas reales.
+        diaCalculado.DesgloseHoras.FranjasAnomalas.Should().Be(0,
+            "la franja quedo completa (entrada 08:00 + salida 16:00), no anomala");
+
+        diaCalculado.DesgloseHoras.TotalMinutosPorConcepto
+            .Should().ContainKey(Concepto.OrdinariaDiurna);
+        diaCalculado.DesgloseHoras.TotalMinutosPorConcepto[Concepto.OrdinariaDiurna]
+            .Should().BeGreaterThan(0,
+                "el desglose real consolida horas ordinarias diurnas (no DesgloseHoras.Vacio)");
 
         // Assert: ausencia de dead letters en la suscripcion smoke-tests del topic dia-calculado.
         var deadLetters = await serviceBus.PeekDeadLetterMessagesAsync(

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoMarcacionRegistrada/DepurarAlAdicionarMarcacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoMarcacionRegistrada/DepurarAlAdicionarMarcacionTests.cs
@@ -79,11 +79,13 @@ public class DepurarAlAdicionarMarcacionTests : CommandHandlerAsyncTest<Marcacio
 
         // HU-108 CA-1: el handler publica un DiaCalculado con el estado tras el recalculo.
         // EsAnomala=true porque Salida es null (franja abierta).
+        // HU-181 CA-3: la franja anomala no aporta DesgloseFranja, pero FranjasAnomalas refleja el
+        // conteo correcto (1). El desglose publicado ya NO es DesgloseHoras.Vacio (que tiene FA=0).
         ThenIsPublishedPublicly(new DiaCalculado(
             Empleado,
             Fecha,
             new[] { new DetalleControlFranja(Franja06_14, Timestamp07_00, null, true) },
-            DesgloseHoras.Vacio));
+            new DesgloseHoras([], DetalleRetardo.Vacio, 1)));
     }
 
     // CA-2 (HU-123): sin turno previo, la marcacion crea el aggregate sin DetalleTurno.
@@ -103,6 +105,8 @@ public class DepurarAlAdicionarMarcacionTests : CommandHandlerAsyncTest<Marcacio
 
         // HU-108 CA-4: se publica DiaCalculado aunque ControlesDeFranja este vacio.
         // InformacionEmpleado es null porque el ControlDiario nacio solo por marcacion.
+        // HU-181 CA-2: sin turno no hay ControlesDeFranja que consolidar -> el desglose publicado
+        // se preserva en DesgloseHoras.Vacio (caso vacio sin cambios).
         ThenIsPublishedPublicly(new DiaCalculado(
             null,
             Fecha,
@@ -138,6 +142,17 @@ public class DepurarAlAdicionarMarcacionTests : CommandHandlerAsyncTest<Marcacio
 
         // HU-108 CA-3: las dos franjas se preservan como DetalleControlFranja.
         // F1: EsAnomala=false (tiene Entrada y Salida). F2: EsAnomala=true (Salida null).
+        // HU-181 CA-3: el desglose publicado es el REAL consolidado: solo F1 (no anomala) aporta su
+        // DesgloseFranja; F2 cuenta como anomala (FranjasAnomalas=1). Ya no es DesgloseHoras.Vacio.
+        // Oraculo independiente con las primitivas del dominio (la matematica esta en #116/#136).
+        var desgloseEsperado = ConsolidadorDesgloseHoras.Consolidar(
+            new[]
+            {
+                new ControlFranja(Franja06_12, Timestamp05_50, Timestamp12_05)
+                    .CalcularDesglose(Fecha, CalendarioFestivosColombia.EsFestivo)!
+            },
+            franjasAnomalas: 1);
+
         ThenIsPublishedPublicly(new DiaCalculado(
             Empleado,
             Fecha,
@@ -146,7 +161,7 @@ public class DepurarAlAdicionarMarcacionTests : CommandHandlerAsyncTest<Marcacio
                 new DetalleControlFranja(Franja06_12, Timestamp05_50, Timestamp12_05, false),
                 new DetalleControlFranja(Franja14_18, Timestamp14_10, null, true)
             },
-            DesgloseHoras.Vacio));
+            desgloseEsperado));
     }
 
     // CA-5 (HU-108): marcacion a las 02:00 cae en ventana nocturna [00:00, 04:00).
@@ -171,6 +186,8 @@ public class DepurarAlAdicionarMarcacionTests : CommandHandlerAsyncTest<Marcacio
 
         // CA-5: dos DiaCalculado publicados, en orden: dia calendario primero, dia anterior segundo.
         // Ambos sin turno previo (InformacionEmpleado=null, ControlesDeFranja=[]).
+        // HU-181 CA-2: sin turno en ninguno de los dos streams, el desglose publicado se preserva
+        // en DesgloseHoras.Vacio para ambos (caso vacio sin cambios).
         ThenIsPublishedPublicly(
             new DiaCalculado(null, fechaDiaCal, [], DesgloseHoras.Vacio),
             new DiaCalculado(null, fechaDiaAnt, [], DesgloseHoras.Vacio));

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoMarcacionRegistrada/DepurarAlAdicionarMarcacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoMarcacionRegistrada/DepurarAlAdicionarMarcacionTests.cs
@@ -144,14 +144,25 @@ public class DepurarAlAdicionarMarcacionTests : CommandHandlerAsyncTest<Marcacio
         // F1: EsAnomala=false (tiene Entrada y Salida). F2: EsAnomala=true (Salida null).
         // HU-181 CA-3: el desglose publicado es el REAL consolidado: solo F1 (no anomala) aporta su
         // DesgloseFranja; F2 cuenta como anomala (FranjasAnomalas=1). Ya no es DesgloseHoras.Vacio.
-        // Oraculo independiente con las primitivas del dominio (la matematica esta en #116/#136).
-        var desgloseEsperado = ConsolidadorDesgloseHoras.Consolidar(
-            new[]
-            {
-                new ControlFranja(Franja06_12, Timestamp05_50, Timestamp12_05)
-                    .CalcularDesglose(Fecha, CalendarioFestivosColombia.EsFestivo)!
-            },
-            franjasAnomalas: 1);
+        // Esperado registrado A MANO con las primitivas del dominio (sin ejecutar Consolidar ni
+        // CalcularDesglose, la logica bajo prueba). F1 06:00-12:00 trabajada 05:50-12:05 (domingo):
+        // entro 05:50 -> recortado a 06:00 (sin retardo); ordinaria 06:00-12:00 DominicalFestivaDiurna
+        // y excedente 12:00-12:05 ExtraDiurnaDominicalFestiva (5min, sin retardo que lo compense).
+        var ordinaria = new IntervaloClasificado(
+            IntervaloTemporal.Crear(
+                new MomentoDelDia(new TimeOnly(6, 0)),
+                new MomentoDelDia(new TimeOnly(12, 0))),
+            Concepto.DominicalFestivaDiurna);
+        var excedente = new IntervaloClasificado(
+            IntervaloTemporal.Crear(
+                new MomentoDelDia(new TimeOnly(12, 0)),
+                new MomentoDelDia(new TimeOnly(12, 5))),
+            Concepto.ExtraDiurnaDominicalFestiva);
+
+        var desgloseEsperado = new DesgloseHoras(
+            [new DesgloseFranja(Franja06_12, [ordinaria, excedente], DetalleRetardo.Vacio)],
+            DetalleRetardo.Vacio,
+            FranjasAnomalas: 1);
 
         ThenIsPublishedPublicly(new DiaCalculado(
             Empleado,

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoMarcacionRegistrada/DesgloseHorasTrasAdicionarMarcacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoMarcacionRegistrada/DesgloseHorasTrasAdicionarMarcacionTests.cs
@@ -86,14 +86,44 @@ public class DesgloseHorasTrasAdicionarMarcacionTests : CommandHandlerAsyncTest<
             c => c.ControlesDeFranja,
             new ControlFranja[] { controlFranja1, controlFranja2 });
 
-        // Oraculo independiente: consolidar los desgloses de las dos franjas no anomalas (anomalas = 0).
-        var esperado = ConsolidadorDesgloseHoras.Consolidar(
-            new[]
-            {
-                controlFranja1.CalcularDesglose(Fecha, CalendarioFestivosColombia.EsFestivo)!,
-                controlFranja2.CalcularDesglose(Fecha, CalendarioFestivosColombia.EsFestivo)!
-            },
-            franjasAnomalas: 0);
+        // Esperado registrado A MANO con las primitivas del dominio (sin ejecutar Consolidar ni
+        // CalcularDesglose, la logica bajo prueba), para que un bug en esa logica no se filtre al
+        // esperado y el test si detecte regresiones. Escenario en domingo 2026-03-15:
+        //   F1 08:00-12:00 trabajada 08:00-12:05: ordinaria 08:00-12:00 DominicalFestivaDiurna +
+        //     excedente 12:00-12:05 ExtraDiurnaDominicalFestiva (5min, sin retardo). Retardo vacio.
+        //   F2 14:00-18:00 trabajada 14:10-18:30: retardo 10min (14:00-14:10) compensado por 10min del
+        //     excedente; ordinaria 14:10-18:00 DominicalFestivaDiurna + excedente visible 18:00-18:20
+        //     ExtraDiurnaDominicalFestiva (20min de 30min; los ultimos 10min compensan el retardo).
+        // RetardoTotal del dia = el de F2 (F1 no aporta retardo; el retardo neto del dia es 0, asi que
+        // no hay compensacion cross-franja). FranjasAnomalas = 0.
+        var f1Ordinaria = new IntervaloClasificado(
+            IntervaloTemporal.Crear(
+                new MomentoDelDia(new TimeOnly(8, 0)),
+                new MomentoDelDia(new TimeOnly(12, 0))),
+            Concepto.DominicalFestivaDiurna);
+        var f1Excedente = new IntervaloClasificado(
+            IntervaloTemporal.Crear(
+                new MomentoDelDia(new TimeOnly(12, 0)),
+                new MomentoDelDia(new TimeOnly(12, 5))),
+            Concepto.ExtraDiurnaDominicalFestiva);
+        var franja1 = new DesgloseFranja(Franja08_12, [f1Ordinaria, f1Excedente], DetalleRetardo.Vacio);
+
+        var f2Ordinaria = new IntervaloClasificado(
+            IntervaloTemporal.Crear(
+                new MomentoDelDia(new TimeOnly(14, 10)),
+                new MomentoDelDia(new TimeOnly(18, 0))),
+            Concepto.DominicalFestivaDiurna);
+        var f2Excedente = new IntervaloClasificado(
+            IntervaloTemporal.Crear(
+                new MomentoDelDia(new TimeOnly(18, 0)),
+                new MomentoDelDia(new TimeOnly(18, 20))),
+            Concepto.ExtraDiurnaDominicalFestiva);
+        var retardoF2 = DetalleRetardo.Crear(
+            [IntervaloTemporal.Crear(new MomentoDelDia(new TimeOnly(14, 0)), new MomentoDelDia(new TimeOnly(14, 10)))],
+            [IntervaloTemporal.Crear(new MomentoDelDia(new TimeOnly(18, 20)), new MomentoDelDia(new TimeOnly(18, 30)))]);
+        var franja2 = new DesgloseFranja(Franja14_18, [f2Ordinaria, f2Excedente], retardoF2);
+
+        var esperado = new DesgloseHoras([franja1, franja2], retardoF2, FranjasAnomalas: 0);
 
         And<ControlDiarioAggregateRoot, DesgloseHoras>(
             StreamId,

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/DepurarAlAsignarTurnoTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/DepurarAlAsignarTurnoTests.cs
@@ -76,11 +76,22 @@ public class DepurarAlAsignarTurnoTests
 
         // HU-131 CA-1: publica DiaCalculado con los ControlesDeFranja tras la depuracion.
         // EsAnomala=false porque Entrada=07:00 y Salida=15:00 estan presentes.
+        // HU-181 CA-3: el DesgloseHoras publicado ahora es el REAL consolidado del dia, no
+        // DesgloseHoras.Vacio. La franja 06:00-14:00 trabajada 07:00-15:00 no es anomala.
+        // Oraculo independiente con las primitivas del dominio (la matematica esta en #116/#136).
+        var desgloseEsperado = ConsolidadorDesgloseHoras.Consolidar(
+            new[]
+            {
+                new ControlFranja(Franja06_14, Timestamp07_00, Timestamp15_00)
+                    .CalcularDesglose(Fecha, CalendarioFestivosColombia.EsFestivo)!
+            },
+            franjasAnomalas: 0);
+
         ThenIsPublishedPublicly(new DiaCalculado(
             Empleado,
             Fecha,
             new[] { new DetalleControlFranja(Franja06_14, Timestamp07_00, Timestamp15_00, false) },
-            DesgloseHoras.Vacio));
+            desgloseEsperado));
     }
 
     // CA-2 (HU-131): sin marcaciones previas, el Apply(TurnoDiarioAsignado) dispara Depurar()
@@ -102,11 +113,13 @@ public class DepurarAlAsignarTurnoTests
 
         // HU-131 CA-2: DiaCalculado se publica aunque todos los controles sean anomalos.
         // EsAnomala=true porque Entrada y Salida son null.
+        // HU-181 CA-3: la franja anomala no aporta DesgloseFranja, pero FranjasAnomalas refleja el
+        // conteo correcto (1). El desglose publicado ya NO es DesgloseHoras.Vacio (que tiene FA=0).
         ThenIsPublishedPublicly(new DiaCalculado(
             Empleado,
             Fecha,
             new[] { new DetalleControlFranja(Franja06_14, null, null, true) },
-            DesgloseHoras.Vacio));
+            new DesgloseHoras([], DetalleRetardo.Vacio, 1)));
     }
 
     // CA-2 (HU-131): turno sin franjas ordinarias genera ControlesDeFranja vacio.
@@ -125,6 +138,8 @@ public class DepurarAlAsignarTurnoTests
             c => c.ControlesDeFranja.Count, 0);
 
         // HU-131 CA-2: DiaCalculado se publica aunque ControlesDeFranja este vacio.
+        // HU-181 CA-2: sin franjas que consolidar ni anomalas que contar, el desglose publicado
+        // se preserva en DesgloseHoras.Vacio (DesglosePorFranja vacio, RetardoTotal vacio, FA=0).
         ThenIsPublishedPublicly(new DiaCalculado(
             Empleado,
             Fecha,

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/DepurarAlAsignarTurnoTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/DepurarAlAsignarTurnoTests.cs
@@ -78,14 +78,24 @@ public class DepurarAlAsignarTurnoTests
         // EsAnomala=false porque Entrada=07:00 y Salida=15:00 estan presentes.
         // HU-181 CA-3: el DesgloseHoras publicado ahora es el REAL consolidado del dia, no
         // DesgloseHoras.Vacio. La franja 06:00-14:00 trabajada 07:00-15:00 no es anomala.
-        // Oraculo independiente con las primitivas del dominio (la matematica esta en #116/#136).
-        var desgloseEsperado = ConsolidadorDesgloseHoras.Consolidar(
-            new[]
-            {
-                new ControlFranja(Franja06_14, Timestamp07_00, Timestamp15_00)
-                    .CalcularDesglose(Fecha, CalendarioFestivosColombia.EsFestivo)!
-            },
-            franjasAnomalas: 0);
+        // Esperado registrado A MANO con las primitivas del dominio (sin ejecutar Consolidar ni
+        // CalcularDesglose, la logica bajo prueba): en domingo 2026-03-15 el retardo 60min (06:00-07:00)
+        // se compensa con el excedente 60min (14:00-15:00) y queda visible la ordinaria 07:00-14:00
+        // DominicalFestivaDiurna. Asi un bug en esa logica no se filtra al esperado y el test lo detecta.
+        var ordinaria = new IntervaloClasificado(
+            IntervaloTemporal.Crear(
+                new MomentoDelDia(new TimeOnly(7, 0)),
+                new MomentoDelDia(new TimeOnly(14, 0))),
+            Concepto.DominicalFestivaDiurna);
+
+        var retardo = DetalleRetardo.Crear(
+            [IntervaloTemporal.Crear(new MomentoDelDia(new TimeOnly(6, 0)), new MomentoDelDia(new TimeOnly(7, 0)))],
+            [IntervaloTemporal.Crear(new MomentoDelDia(new TimeOnly(14, 0)), new MomentoDelDia(new TimeOnly(15, 0)))]);
+
+        var desgloseEsperado = new DesgloseHoras(
+            [new DesgloseFranja(Franja06_14, [ordinaria], retardo)],
+            retardo,
+            FranjasAnomalas: 0);
 
         ThenIsPublishedPublicly(new DiaCalculado(
             Empleado,

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/CrearDiaCalculadoConDesgloseRealTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/CrearDiaCalculadoConDesgloseRealTests.cs
@@ -1,0 +1,168 @@
+// HU-181: Publicar el DesgloseHoras real en el evento DiaCalculado
+// CA-1/CA-2: CrearDiaCalculado() empaqueta el DesgloseHoras REAL recalculado del aggregate
+//            (la propiedad DesgloseHoras), no DesgloseHoras.Vacio.
+//
+// Test directo sobre CrearDiaCalculado() (metodo publico del aggregate). Como ControlHoras
+// NO expone InternalsVisibleTo, los factory internal (Iniciar/AsignarTurno/AdicionarMarcacion)
+// no son accesibles desde el proyecto de tests: el aggregate se conduce al EventStore con los
+// handlers reales (mismo patron que DesgloseHorasTras*Tests) y se verifica via el selector de
+// And<>() sobre el aggregate rehidratado. And<>() compara estructuralmente (BeEquivalentTo).
+//
+// Nested classes: CrearDiaCalculado() lo invocan ambos handlers (AsignarTurno y AdicionarMarcacion)
+// sobre el mismo aggregate, por lo que comparten datos pero requieren bases CommandHandlerAsyncTest
+// distintas (una por tipo de comando).
+//
+// El valor esperado se construye como oraculo independiente con las primitivas del dominio
+// (ConsolidadorDesgloseHoras.Consolidar + ControlFranja.CalcularDesglose); la matematica de
+// consolidacion esta testeada exhaustivamente en #116/#136/#139. Aqui se verifica el "ultimo
+// centimetro": que el evento lleve ese valor y no DesgloseHoras.Vacio.
+
+using Bitakora.ControlAsistencia.Contracts.ControlHoras.ValueObjects;
+using Bitakora.ControlAsistencia.Contracts.Empleados.ValueObjects;
+using Bitakora.ControlAsistencia.Contracts.Programacion.Eventos;
+using Bitakora.ControlAsistencia.Contracts.Programacion.ValueObjects;
+using Bitakora.ControlAsistencia.ControlHoras.AdicionarMarcacionCuandoMarcacionRegistrada.CommandHandler;
+using Bitakora.ControlAsistencia.ControlHoras.AdicionarMarcacionCuandoMarcacionRegistrada.Eventos;
+using Bitakora.ControlAsistencia.ControlHoras.AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction.CommandHandler;
+using Bitakora.ControlAsistencia.ControlHoras.AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction.Eventos;
+using Bitakora.ControlAsistencia.ControlHoras.Entities;
+using Bitakora.ControlAsistencia.ControlHoras.RegistrarMarcacionFunction.Eventos;
+using Cosmos.EventSourcing.Abstractions.Commands;
+using Cosmos.EventSourcing.Testing.Utilities;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Tests.Entities;
+
+public class CrearDiaCalculadoConDesgloseRealTests
+{
+    // Datos compartidos - el stream ID es determinista a partir de EmpleadoId+Fecha.
+    // private static: las nested classes acceden a los miembros privados de la clase contenedora.
+    private static readonly InformacionEmpleado Empleado = new(
+        "EMP-001", "CC", "1234567890", "Luis Augusto", "Barreto");
+
+    private static readonly DateOnly Fecha = new(2026, 3, 15);
+    private static readonly string StreamId = $"{Empleado.EmpleadoId}:{Fecha:yyyy-MM-dd}";
+    private static readonly Guid SolicitudId = Guid.Parse("019600d0-0000-7000-8000-000000000001");
+
+    // Franja unica 06:00-14:00 usada por los escenarios de turno.
+    private static readonly DetalleFranjaOrdinaria Franja06_14 =
+        new(new TimeOnly(6, 0), new TimeOnly(14, 0), 0, [], []);
+
+    // Marcaciones que completan la franja (entrada+salida) -> franja NO anomala (CA-1).
+    private static readonly DateTime Timestamp07_00 = new(2026, 3, 15, 7, 0, 0);
+    private static readonly DateTime Timestamp15_00 = new(2026, 3, 15, 15, 0, 0);
+
+    private static MarcacionAdicionada CrearMarcacionAdicionada(DateTime timestamp) =>
+        new(StreamId, Empleado.EmpleadoId, timestamp, "ENTRADA", "DEV-001");
+
+    private static TurnoDiarioAsignado CrearTurnoDiarioAsignado(DetalleTurno detalleTurno) =>
+        new(StreamId, Empleado, Fecha, detalleTurno, SolicitudId);
+
+    // Oraculo independiente: el DesgloseHoras real de un dia con la franja 06:00-14:00 trabajada
+    // 07:00-15:00 (no anomala). Se construye con las primitivas del dominio, igual que el hook
+    // reactivo del aggregate (RecalcularDesgloseHoras).
+    private static DesgloseHoras DesgloseRealFranjaCompleta() =>
+        ConsolidadorDesgloseHoras.Consolidar(
+            new[]
+            {
+                new ControlFranja(Franja06_14, Timestamp07_00, Timestamp15_00)
+                    .CalcularDesglose(Fecha, CalendarioFestivosColombia.EsFestivo)!
+            },
+            franjasAnomalas: 0);
+
+    public class ViaAsignarTurnoTests
+        : CommandHandlerAsyncTest<ProgramacionTurnoDiarioSolicitada>
+    {
+        protected override ICommandHandlerAsync<ProgramacionTurnoDiarioSolicitada> Handler =>
+            new AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaCommandHandler(
+                EventStore, PublicEventSender);
+
+        private static ProgramacionTurnoDiarioSolicitada CrearEvento(DetalleTurno detalleTurno) =>
+            new(SolicitudId, Empleado, Fecha, detalleTurno);
+
+        // CA-1: con turno (franja 06:00-14:00) y marcaciones previas que la completan (07:00, 15:00),
+        //       la franja queda NO anomala. CrearDiaCalculado() debe empaquetar el DesgloseHoras real
+        //       consolidado del dia (no DesgloseHoras.Vacio), exactamente el mismo valor que expone la
+        //       propiedad DesgloseHoras del aggregate.
+        [Fact]
+        public async Task CrearDiaCalculado_LlevaDesgloseRealIgualAlAggregate_CuandoFranjaNoEsAnomala()
+        {
+            Given(StreamId,
+                CrearMarcacionAdicionada(Timestamp07_00),
+                CrearMarcacionAdicionada(Timestamp15_00));
+
+            var turnoFranjaUnica = new DetalleTurno("Turno Manana", [Franja06_14]);
+            await WhenAsync(CrearEvento(turnoFranjaUnica));
+
+            Then(StreamId, CrearTurnoDiarioAsignado(turnoFranjaUnica));
+
+            var desgloseReal = DesgloseRealFranjaCompleta();
+
+            // El evento empaquetado por CrearDiaCalculado() lleva el desglose real (oraculo no vacio
+            // => no es DesgloseHoras.Vacio).
+            And<ControlDiarioAggregateRoot, DesgloseHoras>(
+                StreamId,
+                c => c.CrearDiaCalculado().DesgloseHoras,
+                desgloseReal);
+
+            // ...y coincide con la propiedad DesgloseHoras del aggregate (mismo valor consolidado):
+            // ambos equivalen al mismo oraculo, luego el evento refleja el estado del aggregate.
+            And<ControlDiarioAggregateRoot, DesgloseHoras>(
+                StreamId,
+                c => c.DesgloseHoras,
+                desgloseReal);
+        }
+
+        // CA-2 (todas las franjas anomalas): turno con franja 06:00-14:00 SIN marcaciones -> la franja
+        //       queda anomala (sin entrada ni salida). DesglosePorFranja vacio y RetardoTotal vacio,
+        //       pero FranjasAnomalas refleja el conteo correcto (1). NO es DesgloseHoras.Vacio, que
+        //       tiene FranjasAnomalas = 0.
+        [Fact]
+        public async Task CrearDiaCalculado_LlevaDesgloseConFranjasAnomalas_CuandoTurnoSinMarcaciones()
+        {
+            // Sin Given - stream nuevo, turno sin marcaciones previas.
+            var turnoFranjaUnica = new DetalleTurno("Turno Manana", [Franja06_14]);
+            await WhenAsync(CrearEvento(turnoFranjaUnica));
+
+            Then(StreamId, CrearTurnoDiarioAsignado(turnoFranjaUnica));
+
+            And<ControlDiarioAggregateRoot, DesgloseHoras>(
+                StreamId,
+                c => c.CrearDiaCalculado().DesgloseHoras,
+                new DesgloseHoras([], DetalleRetardo.Vacio, 1));
+
+            // Explicito sobre el conteo de anomalas que distingue este caso de DesgloseHoras.Vacio (FA=0).
+            And<ControlDiarioAggregateRoot, int>(
+                StreamId,
+                c => c.CrearDiaCalculado().DesgloseHoras.FranjasAnomalas,
+                1);
+        }
+    }
+
+    public class ViaAdicionarMarcacionTests
+        : CommandHandlerAsyncTest<MarcacionRegistrada>
+    {
+        protected override ICommandHandlerAsync<MarcacionRegistrada> Handler =>
+            new AdicionarMarcacionCuandoMarcacionRegistradaCommandHandler(
+                EventStore, PublicEventSender);
+
+        private static MarcacionRegistrada CrearMarcacionRegistrada(DateTime timestamp) =>
+            new(Empleado.EmpleadoId, timestamp, "ENTRADA", "DEV-001");
+
+        // CA-2 (sin turno): la marcacion crea el aggregate sin DetalleTurno -> Depurar() retorna lista
+        //       vacia -> no hay ControlesDeFranja que consolidar. CrearDiaCalculado() debe seguir
+        //       empaquetando DesgloseHoras.Vacio (se preserva el comportamiento del caso vacio).
+        [Fact]
+        public async Task CrearDiaCalculado_LlevaDesgloseVacio_CuandoNoHayTurno()
+        {
+            // Sin Given - el aggregate nace solo con la marcacion (DetalleTurno queda null).
+            await WhenAsync(CrearMarcacionRegistrada(Timestamp07_00));
+
+            Then(StreamId, CrearMarcacionAdicionada(Timestamp07_00));
+
+            And<ControlDiarioAggregateRoot, DesgloseHoras>(
+                StreamId,
+                c => c.CrearDiaCalculado().DesgloseHoras,
+                DesgloseHoras.Vacio);
+        }
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/CrearDiaCalculadoConDesgloseRealTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/CrearDiaCalculadoConDesgloseRealTests.cs
@@ -57,17 +57,28 @@ public class CrearDiaCalculadoConDesgloseRealTests
     private static TurnoDiarioAsignado CrearTurnoDiarioAsignado(DetalleTurno detalleTurno) =>
         new(StreamId, Empleado, Fecha, detalleTurno, SolicitudId);
 
-    // Oraculo independiente: el DesgloseHoras real de un dia con la franja 06:00-14:00 trabajada
-    // 07:00-15:00 (no anomala). Se construye con las primitivas del dominio, igual que el hook
-    // reactivo del aggregate (RecalcularDesgloseHoras).
-    private static DesgloseHoras DesgloseRealFranjaCompleta() =>
-        ConsolidadorDesgloseHoras.Consolidar(
-            new[]
-            {
-                new ControlFranja(Franja06_14, Timestamp07_00, Timestamp15_00)
-                    .CalcularDesglose(Fecha, CalendarioFestivosColombia.EsFestivo)!
-            },
-            franjasAnomalas: 0);
+    // Esperado registrado A MANO con las primitivas del dominio (sin ejecutar Consolidar ni
+    // CalcularDesglose, la logica bajo prueba). Dia con franja 06:00-14:00 trabajada 07:00-15:00
+    // (domingo 2026-03-15, no anomala): retardo 60min (06:00-07:00) compensado por el excedente 60min
+    // (14:00-15:00); queda visible la ordinaria 07:00-14:00 DominicalFestivaDiurna. Asi un bug en esa
+    // logica no se filtra al esperado y el test si detecta regresiones.
+    private static DesgloseHoras DesgloseRealFranjaCompleta()
+    {
+        var ordinaria = new IntervaloClasificado(
+            IntervaloTemporal.Crear(
+                new MomentoDelDia(new TimeOnly(7, 0)),
+                new MomentoDelDia(new TimeOnly(14, 0))),
+            Concepto.DominicalFestivaDiurna);
+
+        var retardo = DetalleRetardo.Crear(
+            [IntervaloTemporal.Crear(new MomentoDelDia(new TimeOnly(6, 0)), new MomentoDelDia(new TimeOnly(7, 0)))],
+            [IntervaloTemporal.Crear(new MomentoDelDia(new TimeOnly(14, 0)), new MomentoDelDia(new TimeOnly(15, 0)))]);
+
+        return new DesgloseHoras(
+            [new DesgloseFranja(Franja06_14, [ordinaria], retardo)],
+            retardo,
+            FranjasAnomalas: 0);
+    }
 
     public class ViaAsignarTurnoTests
         : CommandHandlerAsyncTest<ProgramacionTurnoDiarioSolicitada>


### PR DESCRIPTION
## Resumen

Pipeline TDD completado:
- Fase roja: tests escritos con stubs
- Fase verde: implementación completa
- Fase refactor: revisión de calidad

## Decisiones del pipeline

<details>
<summary>Test Writer (fase roja) — 14m 15s</summary>

## ES Test Writer - Decisiones (HU-181: Publicar el DesgloseHoras real en el evento DiaCalculado)

### Contexto del cambio bajo prueba

La HU solo cambia el **valor** que retorna un metodo publico existente:
`ControlDiarioAggregateRoot.CrearDiaCalculado()` debe empaquetar `_desgloseHoras` (el desglose
real recalculado reactivamente en cada `Apply`) en lugar de `DesgloseHoras.Vacio`. No hay comando,
evento ni tipo nuevo. La forma del contrato publico `DiaCalculado` no cambia.

Implicacion para la fase roja: **no se necesitan stubs de compilacion** (todos los tipos ya existen
en main). Los tests compilan contra el codigo actual y los de comportamiento nuevo fallan porque
produccion aun retorna `DesgloseHoras.Vacio`. Verificado con `dotnet build`: 0 errores.

### Tests creados

- `tests/.../Entities/CrearDiaCalculadoConDesgloseRealTests.cs` (3 tests, clase con nested classes)
  - `ViaAsignarTurnoTests.CrearDiaCalculado_LlevaDesgloseRealIgualAlAggregate_CuandoFranjaNoEsAnomala`
    - CA-1. Franja 06:00-14:00 trabajada 07:00-15:00 (no anomala). Verifica que
      `CrearDiaCalculado().DesgloseHoras` equivale al oraculo real (no vacio) **y** a la propiedad
      `DesgloseHoras` del aggregate (ambos == mismo oraculo => el evento refleja el estado).
      ROJO hoy (produccion retorna Vacio).
  - `ViaAsignarTurnoTests.CrearDiaCalculado_LlevaDesgloseConFranjasAnomalas_CuandoTurnoSinMarcaciones`
    - CA-2 (todas las franjas anomalas). Turno con franja sin marcaciones. Verifica
      `DesglosePorFranja` vacio, `RetardoTotal` vacio, `FranjasAnomalas == 1`. ROJO hoy
      (Vacio tiene FA=0).
  - `ViaAdicionarMarcacionTests.CrearDiaCalculado_LlevaDesgloseVacio_CuandoNoHayTurno`
    - CA-2 (sin turno). Marcacion sin turno previo. Verifica que el caso vacio se preserva
      (`== DesgloseHoras.Vacio`). VERDE hoy y tras el cambio (guarda de regresion).

### Tests existentes modificados (CA-3: el evento publicado por los handlers lleva el desglose real)

Los handlers publican `control.CrearDiaCalculado()` via `IPublicEventSender`. Los tests que ya
verificaban ese evento con `ThenIsPublishedPublicly` codificaban `DesgloseHoras.Vacio` para TODOS
los escenarios. Tras el cambio de produccion, los escenarios con franjas no anomalas o con anomalas
producen un desglose distinto de `Vacio`, por lo que esos tests se romperian. Se actualizaron a la
expectativa real (quedan ROJO hasta el cambio del implementer):

- `AsignarTurno.../DepurarAlAsignarTurnoTests.cs`
  - `DebeCalcularControlFranja_CuandoMarcacionesLlegaronAntesQueTurno` -> desglose real
    (`Consolidar([cf.CalcularDesglose(...)], anomalas:0)`). ROJO.
  - `ProgramacionTurnoDiarioSolicitada_PublicaDiaCalculado_CuandoNoHayMarcacionesPrevias` ->
    `new DesgloseHoras([], DetalleRetardo.Vacio, 1)`. ROJO.
  - `ProgramacionTurnoDiarioSolicitada_PublicaDiaCalculado_CuandoTurnoNoTieneFranjas` -> se
    **preserva** `DesgloseHoras.Vacio` (sin franjas ni anomalas). Solo se aclaro el comentario. VERDE.
- `AdicionarMarcacion.../DepurarAlAdicionarMarcacionTests.cs`
  - `DebeCalcularControlFranja_CuandoHayTurnoYLlegaMarcacion` (franja anomala unica) ->
    `new DesgloseHoras([], DetalleRetardo.Vacio, 1)`. ROJO.
  - `DebeRecalcularControlesDeFranjaCompletos_CuandoHayTurnoPartidoYMarcacionesAcumuladas` ->
    desglose real (`Consolidar([cf1.CalcularDesglose(...)], anomalas:1)`). ROJO.
  - `DebeDejarControlesDeFranjaVacios_CuandoNoHayTurnoPrevio` -> se **preserva** `Vacio`. VERDE.
  - `AdicionarMarcacion_PublicaDosDiaCalculado_CuandoMarcacionEstaEnVentanaNocturna` -> se
    **preserva** `Vacio` en ambos (sin turno). VERDE.

### Estructura elegida

- **Clase dedicada con nested classes** para CA-1/CA-2: `CrearDiaCalculado()` lo invocan AMBOS
  handlers sobre el mismo aggregate, pero cada `CommandHandlerAsyncTest<T>` esta atado a un tipo de
  comando. Las nested classes (`ViaAsignarTurnoTests`, `ViaAdicionarMarcacionTests`) comparten datos
  via miembros `private static` de la clase contenedora (acceso valido desde tipos anidados) y cada
  una hereda la base con su comando. Patron endorsado por el rol para multiples handlers sobre el
  mismo agregado.
- **Conduccion via handlers reales** (no construccion directa del aggregate): `ControlHoras` NO
  expone `InternalsVisibleTo`, asi que los factory `internal` (`Iniciar/AsignarTurno/AdicionarMarcacion`)
  no son accesibles desde el proyecto de tests. La verificacion directa de `CrearDiaCalculado()` se
  hace via el selector de `And<>()` sobre el aggregate rehidratado por el TestStore (idiomatico en
  este proyecto, mismo patron que `DesgloseHorasTras*Tests`).
- **Oraculo independiente** para los valores reales: `ConsolidadorDesgloseHoras.Consolidar` +
  `ControlFranja.CalcularDesglose`. La matematica de consolidacion esta testeada exhaustivamente en
  #116/#136/#139; aqui se prueba el "ultimo centimetro" (que el evento lleve ese valor, no Vacio),
  consistente con `DesgloseHorasTrasAdicionarMarcacionTests`.

### Stubs creados

Ninguno. La HU cambia el valor retornado por un metodo publico existente; todos los tipos referidos
ya existen en main (`CrearDiaCalculado`, `DiaCalculado`, `DesgloseHoras`, `ConsolidadorDesgloseHoras`,
`ControlFranja.CalcularDesglose`, `DetalleRetardo`). No se modifico ningun archivo en `src/`.

### Cobertura de criterios

| Criterio de aceptacion | Test(s) |
|---|---|
| CA-1: `CrearDiaCalculado().DesgloseHoras` = propiedad del aggregate, no Vacio | `CrearDiaCalculado_LlevaDesgloseRealIgualAlAggregate_CuandoFranjaNoEsAnomala` |
| CA-2: sin turno -> equivalente a Vacio | `CrearDiaCalculado_LlevaDesgloseVacio_CuandoNoHayTurno`; (regresion) `DepurarAl*` casos sin turno |
| CA-2: todas anomalas -> vacio con FranjasAnomalas correcto | `CrearDiaCalculado_LlevaDesgloseConFranjasAnomalas_CuandoTurnoSinMarcaciones` |
| CA-3: DiaCalculado publicado por los handlers lleva el desglose real | `DepurarAlAsignarTurnoTests` (#1, #2) + `DepurarAlAdicionarMarcacionTests` (#1, #3) |
| CA-4: comentario obsoleto eliminado/actualizado | Cambio de produccion (implementer) |
| CA-5: smoke test de franja completa | Fuera de alcance del test-writer (rol smoke-test-writer, ADR-0016) |

### Desviaciones del plan del planner

| Sugerencia del issue | Desviacion aplicada | Razon tecnica | Consecuencia |
|---|---|---|---|
| "rojo = test directo sobre `CrearDiaCalculado()`" (construyendo el aggregate) | El "test directo" se realiza via el selector de `And<>()` sobre el aggregate rehidratado, conducido por los handlers reales | `ControlHoras` no tiene `InternalsVisibleTo`; los factory `internal` no son accesibles desde tests. Es el patron idiomatico del proyecto para verificar estado del aggregate | CA-1/CA-2 cubiertos sin acceso a internals; consistente con `DesgloseHorasTras*Tests` |
| "Impacto/Modifica: tests del evento publicado por los handlers" (ubicacion revisable) | Ademas de la clase nueva (CA-1/CA-2), se modificaron 4 escenarios en `DepurarAl*Tests` | Esos tests codificaban `DesgloseHoras.Vacio` en `ThenIsPublishedPublicly`; el cambio de produccion los romperia (el implementer no puede tocar tests). Actualizarlos ES la fase roja de CA-3 | CA-3 cubierto; el green-phase del implementer (1 linea) deja todo verde sin tocar tests |

### Notas para el implementer

- Cambio esperado en `ControlDiarioAggregateRoot.CrearDiaCalculado()`: usar `DesgloseHoras`
  (la propiedad) / `_desgloseHoras` en lugar de `DesgloseHoras.Vacio`, y eliminar el comentario
  obsoleto que referencia #115/#116/#136/#139 (CA-4).
- CA-5 (smoke de franja completa entrada+salida) queda para el smoke-test-writer (ADR-0016): no es
  responsabilidad del test-writer ni se incluye en este commit.

</details>

<details>
<summary>Implementer (fase verde) — 3m 27s</summary>

## ES Implementer - Decisiones

### Enfoque de implementacion

Cambio minimo de produccion (el "ultimo centimetro"): `CrearDiaCalculado()` empaquetaba
el evento publico `DiaCalculado` con `DesgloseHoras.Vacio` aunque el aggregate ya calculaba
el desglose real reactivamente en `RecalcularDesgloseHoras()` al final de cada `Apply()`. La
implementacion cambia una sola expresion para que el evento lleve el campo interno
`_desgloseHoras` (el desglose ya consolidado) y actualiza el comentario obsoleto.

### Decisiones de diseno

- **`_desgloseHoras` (campo) sobre `DesgloseHoras` (propiedad)**: ambos son equivalentes dentro
  del aggregate (la propiedad solo expone el campo). Se eligio el campo privado para mantener la
  consistencia con como `CrearDiaCalculado()` ya construye `detalles` a partir de
  `_controlesDeFranja` (campo privado), no de la propiedad publica `ControlesDeFranja`. El metodo
  lee su propio estado interno, sin pasar por la fachada publica.
- **Frescura del valor (sin riesgo de leer desglose desactualizado)**: `CrearDiaCalculado()` lo
  invocan los handlers (`AsignarTurno...`, `AdicionarMarcacion...`) despues del `Apply()` que ya
  ejecuto `Depurar()` + `RecalcularDesgloseHoras()`. El `_desgloseHoras` esta fresco al construir
  el evento. Esto se confirma con los tests de handler (`DepurarAlAsignarTurnoTests`,
  `DepurarAlAdicionarMarcacionTests`) que verifican el `DiaCalculado` capturado en `PublicEventSender`.
- **Caso vacio preservado sin codigo especial (CA-2)**: cuando no hay turno o todas las franjas son
  anomalas, `RecalcularDesgloseHoras()` ya deja `_desgloseHoras` equivalente a `DesgloseHoras.Vacio`
  (o con `FranjasAnomalas` reflejando el conteo correcto). No hubo que ramificar: el consolidador
  decide el valor y `CrearDiaCalculado()` solo lo reenvia.
- **Comentario actualizado (CA-4)**: se elimino la linea obsoleta
  "Usa DesgloseHoras.Vacio mientras la calculadora real no exista (#115/#116/#136/#139)" y se
  documento que ahora empaqueta el desglose real ya consolidado.

### ADRs consultados

- **ADR-0002** (Contracts: eventos publicos y value objects): el cambio modifica el **contenido**
  publicado de `DiaCalculado`, no su **forma** (el campo `DesgloseHoras` ya existe en el contrato).
  No se toca Contracts.
- **ADR-0015** (Encapsulamiento / Tell-don't-Ask): `CrearDiaCalculado()` lee su propio estado
  interno (`_desgloseHoras`) y entrega el evento ya empaquetado. No expone estado crudo nuevo ni
  agrega propiedades publicas. El patron Tell-don't-Ask se respeta intacto.
- **ADR-0006** (estrategia de testing con event sourcing / DSL): los tests usan
  `CommandHandlerAsyncTest`, `And<>()` y `ThenIsPublishedPublicly`. Implementacion verde sin tocar tests.
- **ADR-0022** (convencion de nombres de metodos de test): aplica a los tests del test-writer; no
  se modificaron tests.

### Desviaciones de ADRs

Ninguna desviacion -- todos los ADRs aplicados al pie de la letra. El cambio no expone estado
interno nuevo (no agrega propiedades publicas, getters, ni `InternalsVisibleTo`).

### Precedentes consultados

- Ninguno replicado. El patron de leer el campo privado en `CrearDiaCalculado()` ya estaba presente
  para `_controlesDeFranja`; se siguio la misma forma para `_desgloseHoras` (alineado con ADR-0015).

### Infraestructura modificada

Ninguna. El topic `dia-calculado` ya existe en `infra/environments/dev/main.tf` con la suscripcion
`smoke-tests` (TTL PT5M). Este issue no agrega evento publico nuevo (cambia el contenido de uno
existente), asi que no requiere cambios de infra. Verificado contra el gap del PR #157.

### Complejidad encontrada

- **`dotnet test` con .NET 10 exige `--project`/`--solution`** (no acepta directorio posicional).
  Se uso `--project tests/.../*.csproj`.
- Ninguna complejidad de dominio: la logica de calculo (`ConsolidadorDesgloseHoras`,
  `ControlFranja.CalcularDesglose`, `RecalcularDesgloseHoras`) ya existia y estaba probada
  (#116/#136/#139). Este issue solo conecta ese calculo con el contrato publico.

### Nota sobre CA-5 (smoke test)

CA-5 pide un smoke test **nuevo** de franja completa en `RegistrarMarcacionSmokeTests`. No forma
parte de esta fase verde: el implementer **no agrega tests** (regla absoluta #2). El test-writer
entrego unicamente los tres archivos de tests unit. El smoke test (que corre contra el entorno dev
desplegado, ADR-0016) queda como trabajo del test-writer / reviewer. La infraestructura que ese
smoke test necesita (suscripcion `smoke-tests` del topic `dia-calculado`) ya esta presente.

### Resultado

- Tests pasando: 171/171 (proyecto `Bitakora.ControlAsistencia.ControlHoras.Tests`).
- Build de la solucion completa: 0 errores (solo advertencias preexistentes de NuGet: NU1904/NU1902).

</details>
<details>
<summary>Reviewer (fase refactor) — 12m 21s</summary>

## ES Reviewer - Revision (HU-181: Publicar el DesgloseHoras real en el evento DiaCalculado)

### Evaluacion general
- Calidad: buena
- Cambios realizados: si (se agrego el smoke test CA-5 faltante y se corrigio un comentario obsoleto)

### Baseline
- Unit `Bitakora.ControlAsistencia.ControlHoras.Tests`: 171/171 verde antes y despues.
- Smoke `Bitakora.ControlAsistencia.ControlHoras.SmokeTests`: compila; 5 pasan, 6 se omiten por fixtures ausentes (Postgres/ServiceBus), incluido el nuevo CA-5 (gateado con `Assert.SkipWhen`).
- Build de la solucion completa: 0 errores (solo NU1904 preexistente de Marten).

### Cumplimiento de ADRs aplicables

Nota de numeracion: el issue/CLAUDE.md y el plugin del harness usan numeros distintos para los mismos ADRs. Verifico por sustancia.

| ADR (issue) | ADR (sustancia/plugin) | Cumplimiento | Observacion |
|---|---|---|---|
| ADR-0002: Contracts (eventos/VOs publicos) | docs/adr/0002 (repo) | ok | Cambia el **contenido** publicado de `DiaCalculado`, no su **forma**. No se toco `Contracts/`. |
| ADR-0015: Encapsulamiento / Tell-don't-Ask | plugin 0012 (estilo-modelado-objetos-dominio) | ok | `CrearDiaCalculado()` lee su propio campo privado `_desgloseHoras` (igual que ya leia `_controlesDeFranja`). Sin propiedades publicas nuevas, sin getters solo-para-test, sin `InternalsVisibleTo`. |
| ADR-0006: estrategia testing ES / DSL | plugin 0002 (estrategia-testing-event-sourcing) | ok | Tests con `CommandHandlerAsyncTest<T>`, `Given/WhenAsync/Then/And<>()`, `ThenIsPublishedPublicly`. |
| ADR-0016: smoke tests contra dev | plugin 0013 (smoke-tests-contra-entorno-dev) | ok | CA-5 nuevo respeta: `Assert.SkipWhen`, purge-before-act, filtro por campo unico (`EmpleadoId`), verificacion de dead-letters. Suscripcion `smoke-tests` del topic `dia-calculado` ya existe en `infra/environments/dev/main.tf`. |
| ADR-0022: naming de tests | plugin 0016 (convencion-naming-tests) | ok (con correccion) | Patron unico `<Sujeto>_<LoQuePasa>_Cuando<Condicion>`. Ver "Convenciones" abajo. |

### Desviaciones de ADRs

**Declaradas por el implementer**: Ninguna (`stage-2-implementer.md`: "todos los ADRs aplicados al pie de la letra"). Verificado: correcto.

**Detectadas por el reviewer (no declaradas)**: Ninguna desviacion arquitectonica. (El detalle de naming del smoke test se trato como correccion de convencion, ver abajo, no como desviacion de ADR del codigo de produccion.)

Conclusion: Ninguna desviacion de ADR — todos los ADRs aplicables se cumplen.

### Precedentes consultados por el implementer

| Precedente | ADR | Veredicto |
|---|---|---|
| Lectura de campo privado (`_controlesDeFranja`) ya presente en `CrearDiaCalculado()`, replicada para `_desgloseHoras` | ADR-0015/Tell-don't-Ask | alineado — el metodo construye el evento desde su estado interno, sin exponerlo |

### Convenciones del pipeline (no ADRs)

| Convencion | Estado | Observacion |
|---|---|---|
| Cada test unit con `Then()` + al menos un `And<>()` | ok | Los 3 tests nuevos de `CrearDiaCalculadoConDesgloseRealTests` tienen `Then(...)` + `And<>()`. |
| Overloads correctos para stream IDs compuestos | ok | `Then(StreamId, ...)`, `And<T,P>(StreamId, ...)`, `Given(StreamId, ...)` — stream ID compuesto `EmpleadoId:Fecha`. |
| Fakes manuales (no NSubstitute) | n/a | Los handlers usan EventStore/PublicEventSender del harness; sin dependencias adicionales. |
| Feature folders (produccion y tests) | ok | Tests en `Entities/` y en los feature folders espejo de los handlers. Smoke en `RegistrarMarcacionFunction/`. |
| Smoke tests: SkipWhen, secrets, cobertura | ok | CA-5 nuevo cumple. Sin secrets en codigo; usa fixtures. |
| Tests via ToString/comportamiento (no getters solo-test) | ok | Se verifica via `CrearDiaCalculado()` (metodo publico real consumido por los handlers) y la propiedad `DesgloseHoras` ya existente. |
| Sin numeros magicos | ok | Horas/fechas son datos del escenario, con nombres descriptivos. |
| Naming `<Sujeto>_<LoQuePasa>_Cuando<Condicion>` | ok (corregido) | Ver hallazgos. |

### Elegancia del codigo
- Cambio de produccion minimo y correcto: una sola expresion (`DesgloseHoras.Vacio` -> `_desgloseHoras`) y comentario actualizado. Elegante: no ramifica el caso vacio porque el consolidador ya deja `_desgloseHoras` equivalente a `Vacio` cuando corresponde.
- Tests unit nuevos: oraculo independiente con primitivas del dominio (`ConsolidadorDesgloseHoras.Consolidar` + `ControlFranja.CalcularDesglose`), no duplican la matematica (ya probada en #116/#136/#139); prueban el "ultimo centimetro".
- El smoke CA-5 reusa los patrones del smoke HU-108 existente (publicar turno, esperar persistencia, purgar, actuar, esperar), manteniendo consistencia.

### Criticas y hallazgos
- **[Mayor — resuelto] CA-5 sin implementar.** Los commits de fase roja/verde (4 archivos) NO incluian el smoke test de franja completa que exige CA-5. Tanto `stage-1-test-writer.md` como `stage-2-implementer.md` lo dejaron explicitamente para el reviewer/smoke-test-writer (ADR-0016). **Accion**: se agrego `RegistrarMarcacion_PublicaDiaCalculadoConDesgloseReal_CuandoMarcacionesCompletanLaFranja` en `RegistrarMarcacionSmokeTests.cs`.
- **[Menor — resuelto] Comentario obsoleto en el smoke existente.** El test de franja incompleta (entrada-only) tenia la razon `"Vacio mientras la calculadora no exista"`, vuelta falsa por esta HU. **Accion**: se corrigio solo la cadena del mensaje (`"HU-181: ya lleva el desglose real consolidado"`); el escenario y las aserciones se preservan intactos, respetando "no tocar" del planner sobre la cobertura.
- **[Cosmetico — no aplicado] Aserciones legadas y naming legado en smoke existentes.** Los smoke tests preexistentes usan el prefijo `Debe...` (convencion legada por ADR-0016) y la asercion entrada-only solo verifica `NotBeNull` (podria afirmar `FranjasAnomalas == 1`). **No se modifican**: fuera del diff de la HU y el planner pidio no tocar ese test. Se deja como nota para una limpieza futura del backlog.

### Refactorings aplicados
- Ninguno sobre codigo de produccion (el cambio del implementer ya era minimo y correcto). Solo se agrego el test CA-5 y se corrigio una cadena de comentario.

### Cobertura de criterios de aceptacion
| Criterio | Estado | Test(s) |
|---|---|---|
| CA-1: `CrearDiaCalculado().DesgloseHoras` == desglose real del aggregate, no Vacio | cubierto | `CrearDiaCalculado_LlevaDesgloseRealIgualAlAggregate_CuandoFranjaNoEsAnomala` |
| CA-2: sin turno o todas anomalas -> equivalente a Vacio con FranjasAnomalas correcto | cubierto | `CrearDiaCalculado_LlevaDesgloseVacio_CuandoNoHayTurno`; `CrearDiaCalculado_LlevaDesgloseConFranjasAnomalas_CuandoTurnoSinMarcaciones` |
| CA-3: el `DiaCalculado` publicado por los handlers lleva el desglose real | cubierto | `DepurarAlAsignarTurnoTests` (2) + `DepurarAlAdicionarMarcacionTests` (2), via `ThenIsPublishedPublicly` |
| CA-4: comentario obsoleto en `CrearDiaCalculado()` eliminado/actualizado | cubierto | Cambio de produccion (fase verde) |
| CA-5: smoke test nuevo de franja completa (entrada+salida -> desglose real) | cubierto | `RegistrarMarcacion_PublicaDiaCalculadoConDesgloseReal_CuandoMarcacionesCompletanLaFranja` (agregado en esta fase) |

### Tests agregados
- `RegistrarMarcacion_PublicaDiaCalculadoConDesgloseReal_CuandoMarcacionesCompletanLaFranja` (smoke, CA-5): publica turno 08:00-16:00 por Service Bus, registra entrada (08:00) y salida (16:00) por HTTP con purge-before-act entre ambas, y verifica que el `DiaCalculado` posterior a la salida lleva `DesgloseHoras` real (`OrdinariaDiurna > 0`, `FranjasAnomalas == 0`) sin dead-letters.

### Nota de robustez (smoke CA-5)
La captura del evento posterior a la salida depende del purgado de la suscripcion tras confirmar la persistencia de la entrada (su `DiaCalculado` ya fue publicado en ese punto). El predicado filtra por `EmpleadoId` (unico por ejecucion), igual que el smoke HU-108 ya probado en dev. Como `WaitForMessageAsync` del fixture lanza excepcion ante un mensaje que no cumple el predicado, se filtro por `EmpleadoId` (no por contenido del desglose) para evitar falsos negativos si un evento previo se filtrara tras el purge; la asercion del contenido real se hace sobre el evento devuelto.

</details>

## Cobertura

| Archivo | Cobertura | Umbral | Estado |
|---|---|---|---|
| ControlDiarioAggregateRoot.cs | 100.0% | 95% | ok |
## Commits

1a5285d test(hu-181): agregar smoke test de franja completa (CA-5) y corregir comentario obsoleto
7a9b671 feat(hu-181): publicar el DesgloseHoras real en DiaCalculado (fase verde)
dc5488b test(hu-181): tests de DesgloseHoras real en DiaCalculado (fase roja)

Closes #181