### PR TITLE
docs(bitacora): entradas del 2026-06-17 y 2026-06-18

### DIFF
--- a/docs/bitacora/2026-06-17.md
+++ b/docs/bitacora/2026-06-17.md
@@ -1,0 +1,59 @@
+# 2026-06-17 - El Motor Avanza y el Smoke Test Miente
+
+> Dos piezas del motor de desglose llegaron a main en 64 minutos de pipeline TDD; la noche reveló que los smoke tests fallaban por saturación de throughput, no por el bug que señalaban.
+
+## Lo que se logró
+
+**PR #164 mergeado — #134 cerrado: ClasificadorHorario implementado (16:55)**
+La clasificación de segmentos horarios por banda (diurna, nocturna, festiva-diurna, festiva-nocturna) y tipo de día llegó a main. El pipeline TDD corrió casi en paralelo con #131: fase roja a las 16:23, verde a las 16:32, refactor de casos borde a las 16:42. El `ClasificadorHorario` es el componente que permite al motor de desglose determinar a qué tarifa aplica cada segmento trabajado según la legislación laboral colombiana.
+
+**PR #165 mergeado — #131 cerrado: DiaCalculado emitido tras asignar turno (17:26)**
+El `AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaCommandHandler` ahora publica el evento `DiaCalculado` después de aplicar el turno al control. Pipeline TDD completado en paralelo con #134: roja a las 16:24, verde a las 16:39, smoke tests a las 16:45, fix de comentarios de revisión a las 17:19. El evento viaja via outbox de Marten con commit atómico — el `StartStream` y el mensaje saliente se commitean juntos al final del handler.
+
+**Investigación de smoke tests (field note 19:43)**
+Cinco fallos en rerun del smoke test (~23:08-23:18 UTC): Cluster A (3 tests) con `turno_diario_asignado` nunca escrito en stream, y Cluster B (2 tests) con `TaskCanceledException` por `HttpClient.Timeout` de 100s en `RegistrarMarcacion`. El mensaje de aserción del Cluster A citaba `PropertyNameCaseInsensitive=true`, apuntando al deserializador como sospechoso inmediato. La investigación descartó esa hipótesis y llegó al diagnóstico real.
+
+## Problemas encontrados
+
+**Los smoke tests fallaban por saturación de throughput, no por el deserializador**
+
+El mensaje de aserción del Cluster A referenciaba `ServiceBusDeserializador` — una nota histórica del fix del issue #29, no una indicación del estado actual. El código en `ServiceBusDeserializador.cs` (línea 14) ya tenía `PropertyNameCaseInsensitive = true` desde el commit `5d098fc`, muy anterior a #165. No hubo regresión.
+
+App Insights contribuyó a la confusión: 0 excepciones, 0 requests fallidas, 0 dead letters en todas las subscriptions. El SDK no emitió telemetría en 12 horas (hipótesis: sampling bajo saturación + worker isolated bloqueado). Parecía todo sano — pero las métricas de plataforma de Azure Monitor contaron la historia real:
+
+- `HttpResponseTime` máximo: **101.3s, 204.9s, 103.6s** en ventanas de 30 minutos. Supera el timeout de 100s del HttpClient → `TaskCanceledException` exacto del Cluster B.
+- `Http2xx` muy por debajo del total de `Requests`: la app recibía pero no respondía a tiempo.
+- Service Bus `IncomingMessages` > `OutgoingMessages`: backlog acumulándose por consumo lento.
+
+Causa raíz: la combinación **B1 (1 core) + `maxConcurrentCalls: 1`** procesa requests HTTP y mensajes de Service Bus en serie. Bajo la ráfaga del smoke test (HTTP + SB simultáneos), cada operación encola detrás de otra y la latencia se dispara. El Cluster A no falla por deserialización — el mensaje llega al bus pero el consumidor, saturado, no lo procesa dentro del timeout de 30s del test. Sin DLQ porque el mensaje no falla: simplemente espera.
+
+`#165` pudo agravar marginalmente la latencia (ahora publica `DiaCalculado` adicional via outbox), pero no es el origen. La configuración preexistente del scaffold (host.json + plan B1) es la causa base.
+
+Issue #166 quedó abierto como bug `estado:borrador` — pendiente de definir si la solución es subir `maxConcurrentCalls`, escalar el plan, o ajustar los timeouts del runner de smoke tests.
+
+## Lo que descartamos
+
+- **Regresión del deserializador en #165** — el mensaje de aserción era ruido histórico. El código no cambió desde `5d098fc`.
+- **Postgres saturado** — refutado antes de la sesión de investigación (dos hipótesis previas ya descartadas en corridas anteriores).
+- **Cold start** — el rerun se ejecutó con la app caliente.
+- **DLQ acumulada** — cero dead letters en todas las subscriptions, incluyendo la de los smoke tests.
+
+## Aprendizajes
+
+1. **Las métricas de plataforma (Azure Monitor) y las métricas del SDK (App Insights) son fuentes independientes.** Cuando el SDK no emite bajo saturación, las métricas de plataforma siguen contando. `HttpResponseTime` y la brecha `Requests - Http2xx` revelaron el problema sin una sola excepción en los logs.
+
+2. **Los mensajes de aserción que citan bugs históricos son trampa de diagnóstico.** El string `"PropertyNameCaseInsensitive=true"` apuntó al deserializador como primer sospechoso; la investigación tuvo que refutar esa pista antes de llegar a la causa real. Un mensaje de aserción que dice "qué debe ser verdad" es diferente a un mensaje que describe la falla actual.
+
+3. **`maxConcurrentCalls: 1` es correcto para volumen bajo y secuencial (ADR-0017), pero no para ráfagas mixtas HTTP+SB simultáneas.** El supuesto del ADR no se sostiene bajo la carga del runner de smoke tests. La solución requiere elegir entre ajustar la configuración del host, escalar el plan, o reducir la concurrencia del runner.
+
+## Números del día
+
+| Métrica | Valor |
+|---|---|
+| Commits | 10 |
+| PRs mergeados | 2 (#164, #165) |
+| Issues cerrados | 2 (#134, #131) |
+| Issues abiertos al final | 1 (#166, bug estado:borrador) |
+| Archivos cambiados | 18 |
+| Líneas agregadas | ~478 |
+| Líneas eliminadas | 19 |

--- a/docs/bitacora/2026-06-18.md
+++ b/docs/bitacora/2026-06-18.md
@@ -1,0 +1,64 @@
+# 2026-06-18 - El Plan Compartido que No Quería Morir
+
+> La mañana fue de instrumentación y limpieza de tooling; la noche fue de un fallo de Terraform que tardó 34 minutos en resolverse porque el grafo de dependencias no sabía que una cosa debía morir después de otra.
+
+## Lo que se logró
+
+**Cuatro PRs de infraestructura y tooling mergeados antes de las 09:00**
+
+- **PR #168 — OTel instrumentado en ControlHoras** (07:17): worker instrumentado con OpenTelemetry hacia App Insights (traces, métricas, logs). Sampler configurable via `APPLICATIONINSIGHTS_SAMPLING_PERCENTAGE` para control de costos según ADR-0009 Capa 2. Esta instrumentación era el faltante que hizo opaca la investigación del día anterior — con OTel activo, las próximas sesiones de diagnóstico tendrán trazas reales del SDK en lugar de depender solo de las métricas de plataforma.
+- **PR #170 — fix de dependencia** (08:29): `Microsoft.Azure.Functions.Worker` alineado a 2.52.0 requerido por OTel. Arrastre inmediato de la instrumentación del PR #168.
+- **PR #169 — issue #167 cerrado: GitHub Actions actualizados** (07:53): workflows actualizados a sus últimas versiones major. Deuda de mantenimiento de CI saldada.
+- **PR #171 — CI restringido a PRs** (08:46): los workflows ya no corren en push directo a ramas, solo en pull requests. Reduce ruido y costo de minutos de CI.
+
+**PR #173 + #174 + #175 mergeados — issue #172 cerrado: App Service Plan por dominio en producción (noche)**
+
+El issue #172 (un App Service Plan dedicado por dominio: `asp-asist-dev-control-horas` y `asp-asist-dev-programacion`, reemplazando el plan compartido `asp-controlasistencias-dev`) llegó a main en tres PRs durante 34 minutos de cirugía de Terraform. Detalles en la sección de problemas.
+
+## Problemas encontrados
+
+**Terraform destruyó el plan compartido antes de reasociar las apps — 409 Conflict**
+
+El PR #173 mergeó el código correcto: crear dos planes nuevos y eliminar el plan compartido de la configuración. El plan de Terraform fue limpio: `0 to add, 2 to change, 1 to destroy`. Pero Terraform ejecutó primero el `destroy` del plan compartido, antes de aplicar los dos `update in-place` de `service_plan_id` de las Function Apps.
+
+Azure respondió con `409 Conflict` — ExtendedCode 11003:
+
+> *"Server farm 'asp-controlasistencias-dev' cannot be deleted because it has web app(s) func-asist-dev-control-horas, func-asist-dev-programacion assigned to it."*
+
+La investigación (field note 20:41) confirmó que el módulo eliminado no tenía `lifecycle { create_before_destroy }` ni dependencia explícita que garantizara el orden reassign-antes-de-destroy. El grafo de Terraform es agnóstico al orden cuando el recurso a destruir no tiene aristas que lo anclen después de los updates. Estado del entorno tras el fallo: los dos planes nuevos ya existían (creados por el apply local del worktree) pero con 0 apps. Las Function Apps seguían Running en el plan viejo. Sin outage.
+
+**Solución: dos PRs quirúrgicos en 12 minutos**
+
+- **PR #174 — Fase 1** (merge 20:57): reintroducir `module "service_plan"` en la config. El plan compartido vuelve a estar declarado explícitamente, lo que fuerza el orden: el apply reasocia las apps a sus planes nuevos *mientras el plan viejo sigue declarado y no puede ser destruido*.
+- **PR #175 — Fase 2** (merge 21:05): eliminar `module "service_plan"` de la config. Ahora las apps ya están en sus planes nuevos → el destroy del plan compartido (con 0 apps) procede limpiamente. Issue #172 cerrado.
+
+Entre el merge del PR #173 (20:31) y el merge final del PR #175 (21:05): 34 minutos de diagnóstico y cirugía. Entre Fase 1 y Fase 2: 8 minutos.
+
+## Lo que descartamos
+
+**Solución con `lifecycle { create_before_destroy = true }` en el módulo del plan** — no resuelve el caso de un recurso *eliminado de la config* (no es una recreación, es un destroy puro). La opción correcta era separar el cambio en dos applies consecutivos.
+
+**Reintento del apply tal cual** — la field note lo documentó explícitamente: el 409 de Azure es determinístico mientras el plan tenga apps asignadas. Reintentar sin cambiar el código hubiera fallado idénticamente.
+
+**`-target` para forzar el orden** — era la Opción A de la field note (sin tocar código). Descartada a favor del enfoque de dos PRs porque deja el historial de applies más auditable: cada PR tiene un plan y apply limpios sin targets manuales que distorsionen el state.
+
+## Aprendizajes
+
+1. **Terraform no garantiza el orden destroy-antes-de-reassign cuando el recurso eliminado no tiene dependencias explícitas hacia los recursos que cambian.** Migrar un recurso compartido a recursos dedicados requiere dos applies separados: primero declarar los nuevos y reasociar, luego eliminar el viejo de la config.
+
+2. **Un apply local previo en el worktree puede dejar recursos creados en Azure antes de que CI lo haga.** Los dos planes nuevos ya existían porque el pipeline del harness corrió `terraform apply` localmente. No causó el fallo del 409, pero es una asimetría de estado entre el worktree y CI que vale documentar.
+
+3. **La instrumentación OTel que faltaba ayer se instaló hoy — en respuesta directa a lo que reveló la investigación de smoke tests.** El ciclo diagnóstico-acción funcionó: la field note del 17 identificó que el SDK no emitía nada; el 18 se instrumentó el worker con OTel. El próximo fallo tendrá trazas reales del SDK en lugar de solo métricas de plataforma.
+
+## Números del día
+
+| Métrica | Valor |
+|---|---|
+| Commits | 18 |
+| PRs mergeados | 7 (#168, #169, #170, #171, #173, #174, #175) |
+| Issues cerrados | 2 (#167, #172) |
+| Archivos cambiados | 18 |
+| Líneas agregadas | ~114 |
+| Líneas eliminadas | 45 |
+| Fases de Terraform para completar #172 | 3 (original + 2 fixes) |
+| Minutos entre merge de #173 y cierre definitivo | 34 |

--- a/docs/bitacora/field-notes/procesadas/2026-06-17-1943-bug-investigation.md
+++ b/docs/bitacora/field-notes/procesadas/2026-06-17-1943-bug-investigation.md
@@ -1,0 +1,92 @@
+---
+fecha: 2026-06-17
+hora: 19:43
+sesion: bug-investigator
+tema: Smoke tests ControlHoras fallan en rerun (Cluster A turno_diario_asignado no escrito; Cluster B HTTP timeout 100s)
+---
+
+## Sintoma reportado
+Rerun de smoke tests (ventana ~23:08-23:18 UTC del 2026-06-17), 5 fallos en 2 clusters:
+- Cluster A: `turno_diario_asignado` nunca se escribe en el stream (3 tests). Uno de los mensajes
+  de asercion sugiere que `ServiceBusDeserializador` no usa `PropertyNameCaseInsensitive=true`.
+- Cluster B: endpoint HTTP `RegistrarMarcacion` no responde, `TaskCanceledException` por
+  `HttpClient.Timeout` de 100s (2 tests).
+Dos hipotesis previas ya refutadas: NO es Postgres saturado, NO es cold start (rerun con app caliente).
+
+## Investigacion
+
+### Correlacion con codigo (pista del deserializador) - REFUTADA
+- `ServiceBusDeserializador.cs` SI usa `PropertyNameCaseInsensitive = true` (linea 14). El mensaje
+  de asercion del test es solo un recordatorio historico del bug #29, no refleja el codigo actual.
+- git log del deserializador: ultimo cambio `5d098fc` (HU-29), MUY anterior a #165. No es regresion.
+- `ServiceBusEndpointBase.ProcesarMensaje`: ante cualquier excepcion hace `DeadLetterMessageAsync`.
+  Si el deserializador o el handler fallaran, habria DLQ. NO la hay (ver abajo).
+
+### Cambio de #165 (issue #131)
+- Solo toco `AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaCommandHandler.cs`: agrega
+  `await _publicEventSender.PublishAsync(control.CrearDiaCalculado())` tras Apply.
+- `CrearDiaCalculado()` no lanza (usa `DesgloseHoras.Vacio`). Replica el patron de #108.
+- Transaccion: Wolverine `AutoApplyTransactions()` + `IntegrateWithWolverine()` (outbox Marten).
+  El `StartStream` y el mensaje saliente se commitean atomicamente al final del handler.
+
+### App Insights (queries ejecutadas)
+- `exceptions --hours 6`: CERO excepciones.
+- `function-errors --hours 6`: CERO requests fallidas.
+- `servicebus-dlq`: CERO dead letters en TODAS las subscriptions (incl. consumidor y smoke-tests).
+- 3 queries custom (union de traces/requests/exceptions/dependencies/customEvents, hasta 12h):
+  CERO telemetria del SDK. La app esta Running pero el SDK no emite (sampling/flush no alcanza
+  bajo saturacion; host.json tiene samplingSettings con maxTelemetryItemsPerSecond=5).
+
+### Metricas de plataforma (Azure Monitor, independientes del SDK) - EVIDENCIA DURA
+- `Requests` (HTTP recibidas): 37, 34, 28, 9 por bin de 30m (21:30-23:00). La app SI recibe trafico.
+- `FunctionExecutionCount`: 24, 4, 4, 9 (22:30-23:15). SI ejecuta funciones.
+- `Http5xx`: VACIO. `Http2xx`: 22, 4, 1 -> muchas menos respuestas 2xx que requests recibidas.
+- `HttpResponseTime` maximo: **101.3s, 204.9s, 103.6s** (22:30-23:15). Supera el timeout de 100s
+  del HttpClient -> el cliente cancela -> `TaskCanceledException` (Cluster B exacto).
+- Service Bus `IncomingMessages`: 2, 3, 6 / `OutgoingMessages`: 2, 1, 3 (22:45-23:15). Los mensajes
+  del smoke test SI llegan, pero salen menos de los que entran -> backlog por consumo lento.
+- `MemoryWorkingSet`: pico ~442 MB. No es saturacion de memoria.
+
+### Infraestructura
+- Function App `Running`, `enabled`, `availabilityState: Normal`. App settings obligatorios OK
+  (dotnet-isolated, ~4, placeholder=1, run-from-package=1). App Insights conectado al recurso correcto.
+- Plan: **B1 (Basic, 1 core, 1 instancia)**. Cumple ADR-0020 (>= B1).
+- host.json: `maxConcurrentCalls: 1`, `prefetchCount: 0` (viene del scaffold + fix #50). ADR-0017.
+
+## Diagnostico
+**Causa raiz unica para ambos clusters: saturacion de throughput de la Function App, NO el
+deserializador ni #165.**
+
+La combinacion B1 (1 core) + `maxConcurrentCalls: 1` procesa requests HTTP y mensajes de Service
+Bus de a UNO, en serie. Bajo la rafaga del smoke test (HTTP + SB simultaneos) cada operacion
+encola detras de otra y la latencia se dispara a >100s:
+- Cluster B: las requests HTTP de `RegistrarMarcacion` no responden en 100s -> `TaskCanceledException`.
+  Confirmado por `HttpResponseTime` maximo > 100s y ausencia de Http5xx.
+- Cluster A: el mensaje `ProgramacionTurnoDiarioSolicitada` llega al SB pero el consumidor (mismo
+  worker saturado, `maxConcurrentCalls: 1`) no lo procesa dentro del timeout de 30s del smoke test.
+  `turno_diario_asignado` aun no esta escrito cuando el test verifica. Sin DLQ ni excepciones porque
+  el mensaje no falla: solo espera en cola.
+
+**No es regresion de #165.** El deserializador no fue tocado; el cambio de #165 no lanza y se commitea
+atomicamente. La causa es de capacidad/configuracion, preexistente (host.json del scaffold + plan B1).
+#165 pudo *agravar* marginalmente la latencia (cada mensaje ahora publica DiaCalculado adicional via
+outbox), pero no es el origen.
+
+## Acciones
+Issues propuestos (NO creados, pendiente de validacion del usuario):
+1. tipo:infra/tooling - Subir `maxConcurrentCalls` (ej. 4-8) y `prefetchCount` proporcional
+   (guia MS: maxConcurrentCalls x 20) en host.json de ControlHoras; revisar ADR-0017 (asume volumen
+   bajo y secuencial; los smoke tests concurrentes rompen ese supuesto). Evaluar lock_duration.
+2. tipo:infra - Evaluar escalar el plan o numberOfWorkers de B1 para dev, o reducir la concurrencia
+   del runner de smoke tests / subir timeouts (HttpClient 100s, polling SB 30s) para tolerar B1.
+3. tipo:tooling - Bug menor en `appinsights-query.sh function-status`: concatena los nombres de las
+   Function Apps en un solo recurso ("func-...-control-horas func-...-programacion") -> ResourceNotFound.
+
+## Preguntas abiertas
+- Por que el SDK de App Insights no emitio NADA en 12h pese a estar conectado y la app Running.
+  Hipotesis: sampling + flush bajo saturacion + worker isolated bloqueado. Requiere monitoreo:
+  revisar si con la app ociosa la telemetria vuelve a fluir (descartar telemetria rota de fondo).
+- Cuanta concurrencia real soporta B1 sin degradar (1 core). Definir el target de `maxConcurrentCalls`
+  con una prueba de carga controlada antes de fijar el valor.
+- Confirmar si el runner de smoke tests lanza los tests en paralelo (xUnit parallelization), lo que
+  amplificaria la rafaga contra un worker de concurrencia 1.

--- a/docs/bitacora/field-notes/procesadas/2026-06-18-2041-bug-investigation.md
+++ b/docs/bitacora/field-notes/procesadas/2026-06-18-2041-bug-investigation.md
@@ -1,0 +1,118 @@
+---
+fecha: 2026-06-18
+hora: 20:41
+sesion: bug-investigator
+tema: terraform apply de #172 (App Service Plan por dominio) falla con 409 al destruir el plan compartido que aun tiene apps asignadas
+---
+
+## Sintoma reportado
+El `terraform apply` del issue #172 ("Provisionar un App Service Plan por dominio") fallo en
+GitHub Actions. Run 27799876170, job 82267680160, workflow "Infra CD - Terraform Apply"
+(`.github/workflows/infra-cd.yml`), disparado por push a `main` (commit 9dc3d0d, merge del PR #173).
+
+## Investigacion
+
+### Triage de deploy
+No aplica el checklist de Function App (no es build/publish .NET): es un fallo de Terraform contra
+Azure. Fui directo a leer el log real del job y a verificar el estado en Azure (solo lectura).
+
+### Log del job (evidencia dura, `gh run view 27799876170 --log-failed`)
+- El plan ejecutado fue exactamente: `Plan: 0 to add, 2 to change, 1 to destroy`.
+  - 2 change in-place: ambas Function Apps cambian `service_plan_id` del plan viejo al nuevo.
+  - 1 destroy: `module.service_plan.azurerm_service_plan.this` (asp-controlasistencias-dev),
+    "because azurerm_service_plan.this is not in configuration".
+- Terraform empezo por el destroy: `module.service_plan...: Destroying...` y fallo de inmediato:
+
+  > Error: deleting App Service Plan (... Server Farm Name: "asp-controlasistencias-dev"):
+  > unexpected status 409 (409 Conflict) ... "Server farm 'asp-controlasistencias-dev' cannot be
+  > deleted because it has web app(s) func-asist-dev-control-horas,func-asist-dev-programacion
+  > assigned to it." ExtendedCode 11003.
+
+- El apply adquirio el lock sin problema ("Acquiring state lock... Releasing state lock") y libero
+  al terminar. NO hubo colision de lock ni timeout de lock.
+
+### Codigo correlacionado (commit 9dc3d0d, `main.tf` de #172)
+- Define `module "service_plan_programacion"` (linea 11) y `module "service_plan_control_horas"`
+  (linea 20), ambos B1 Linux, source `../../modules/service-plan`.
+- Reapunta `service_plan_id` de cada Function App a su plan nuevo (lineas 101 y 133).
+- ELIMINA `module "service_plan"` (el compartido). Por eso Terraform lo marca destroy.
+- `modules/service-plan/main.tf` y `modules/function-app/main.tf` NO tienen
+  `lifecycle { create_before_destroy }` ni ningun mecanismo que ordene el reassign antes del destroy.
+
+### Estado real en Azure (suscripcion "Augusto" 50fc1901-..., solo lectura)
+Nota operativa: el deploy corre contra la suscripcion "Augusto"; mi CLI local tiene "Azure Cosmos"
+como default (por eso el primer `az` dio ResourceGroupNotFound). Consultas hechas con
+`--subscription 50fc1901-...`.
+- `asp-controlasistencias-dev` (B1): EXISTE, con 2 apps asignadas. NO se destruyo.
+- `asp-asist-dev-control-horas` (B1): EXISTE, 0 apps.
+- `asp-asist-dev-programacion` (B1): EXISTE, 0 apps.
+- `func-asist-dev-control-horas`: Running, sigue apuntando a `asp-controlasistencias-dev` (plan VIEJO).
+- `func-asist-dev-programacion`: Running, sigue apuntando a `asp-controlasistencias-dev` (plan VIEJO).
+
+### Sospechosos del brief, evaluados
+- Sospechoso #1 (orden destroy-antes-de-reassign): CONFIRMADO. Es la causa raiz.
+- Sospechoso #2 (lock/apply concurrente): DESCARTADO. El log muestra lock adquirido y liberado
+  limpiamente; el error es 409 de Azure, no lock de estado. El apply local previo (worktree #172)
+  pudo haber CREADO los dos planes nuevos (estan creados con 0 apps), pero no causo el fallo de hoy.
+- Auth / backend / quota / naming: DESCARTADOS. El plan corrio, refresco todo el estado, adquirio
+  lock; el unico Error es el 409 de borrado.
+
+## Diagnostico
+
+### Causa raiz (confianza: ALTA)
+El grafo de dependencias de Terraform no garantiza que las dos Function Apps se reasocien a los
+planes nuevos ANTES de destruir el plac compartido. Como el plan viejo se marca destroy (ya no esta
+en la config) sin `create_before_destroy`, Terraform intento borrarlo y Azure respondio 409: un
+App Service Plan no se puede eliminar mientras tenga web apps asignadas (ExtendedCode 11003).
+En este apply Terraform ejecuto PRIMERO el destroy del plan, antes de aplicar los `~ update in-place`
+de `service_plan_id` de las apps, por lo que el plan aun tenia ambas apps cuando intento borrarlo.
+
+### Estado del entorno: PARCIAL pero FUNCIONAL
+- 0 recursos modificados en este apply: el destroy fallo primero y aborto los dos updates in-place.
+  Ambas Function Apps siguen en el plan viejo y Running. No hay outage.
+- Los dos planes nuevos ya existen (con 0 apps), creados por el apply local previo. Reintentar NO
+  los duplicara (Terraform los vera en estado y los dejara igual).
+- El unico paso pendiente es: reasociar las 2 apps a sus planes nuevos y luego destruir el viejo.
+  Mientras el plan viejo tenga apps, su destroy seguira dando 409 en cada reintento. Reintentar el
+  apply tal cual fallara identicamente de forma deterministica.
+
+## Hipotesis (ordenadas por probabilidad)
+
+### H1: orden del grafo destruye el plan compartido antes de reasociar las apps (confianza: ALTA)
+- Evidencia: el log muestra el destroy ejecutado primero y el 409 11003 "has web app(s) ... assigned".
+  El codigo elimina `module.service_plan` sin `create_before_destroy`. Azure confirma que el plan
+  viejo sigue con 2 apps.
+- Contra-evidencia: ninguna.
+- Verificacion: ya verificada con log + estado en Azure.
+
+### H2: colision con el apply local concurrente (confianza: BAJA)
+- Evidencia: existio un apply local en paralelo (worktree #172); los 2 planes nuevos ya estan creados.
+- Contra-evidencia: el log de CI adquiere y libera el lock sin error; el fallo es 409 de Azure, no
+  lock de estado ni drift. El apply local solo dejo los planes nuevos creados; no es la causa del 409.
+- Verificacion: revisar el log del apply local del harness si se quiere cerrar el cabo de "quien creo
+  los planes nuevos", pero no cambia la causa raiz ni la remediacion.
+
+## Acciones
+Pendiente de validacion del usuario. Opciones de remediacion propuestas (NINGUNA ejecutada):
+
+1. Reintento en dos fases con el codigo actual (sin tocar codigo):
+   - Fase A: `terraform apply -target=module.function_app_control_horas
+     -target=module.function_app_programacion` para reasociar ambas apps a los planes nuevos.
+   - Fase B: `terraform apply` completo; el plan viejo ya quedara sin apps y su destroy procedera.
+   - Requiere ejecutar `apply` (escritura): fuera del alcance de esta sesion de solo lectura.
+
+2. Fix en codigo (issue): agregar `lifecycle { create_before_destroy = true }` no resuelve por si solo
+   el caso "destruir un recurso eliminado de la config"; la opcion robusta es separar el cambio en dos
+   PRs/applies (primero crear planes + reasociar apps; luego, en un segundo apply, eliminar el plac
+   viejo de la config) o usar `-target` como en (1). Evaluar con infra-writer.
+
+3. Issue propuesto: `bug, tipo:infra, dom:infra, estado:listo` -
+   "Reasociar Function Apps a sus planes por dominio antes de destruir el plan compartido (#172)".
+
+## Preguntas abiertas
+- Quien lanzo el apply local en paralelo y si dejo el state remoto consistente con lo que ve Azure
+  (los 2 planes nuevos en state). Conviene un `terraform plan` limpio para confirmar que el unico
+  pendiente sean los 2 reassign + 1 destroy, sin drift adicional.
+- Por que el grafo eligio destroy-first en este apply. AzureRM normalmente prioriza updates, pero al
+  ser el plan viejo un recurso "removido de config" sin dependencia explicita hacia las apps tras el
+  reapunte, el orden no esta garantizado. Documentar en el issue de fix.


### PR DESCRIPTION
Entradas de bitácora del 17 y 18 de junio. Consolida las field notes de ambas sesiones `bug-investigator`.

- **2026-06-17 — El Motor Avanza y el Smoke Test Miente**: ClasificadorHorario (#134) y DiaCalculado tras asignación de turno (#131) cerrados en TDD paralelo; investigación de smoke tests que reveló saturación de throughput B1 + `maxConcurrentCalls: 1` como causa raíz, no el deserializador.
- **2026-06-18 — El Plan Compartido que No Quería Morir**: OTel instrumentado + 4 PRs de tooling/CI en la mañana; migración del App Service Plan por dominio (#172) resuelta en 3 PRs tras un 409 de Terraform que intentó destruir el plan compartido antes de reasociar las apps.

Field notes procesadas:
- `field-notes/2026-06-17-1943-bug-investigation.md` → `procesadas/`
- `field-notes/2026-06-18-2041-bug-investigation.md` → `procesadas/`