### PR TITLE
Generar la trazabilidad (memoria de calculo) de HorasDiscriminadas

### DIFF
--- a/src/Bitakora.ControlAsistencia.Contracts/ControlHoras/ValueObjects/DesgloseHoras.cs
+++ b/src/Bitakora.ControlAsistencia.Contracts/ControlHoras/ValueObjects/DesgloseHoras.cs
@@ -28,17 +28,43 @@ public record DesgloseHoras(
     // Issue #183: traduce el desglose rico al payload plano que viaja en DiaCalculado hacia nomina.
     // Tell-don't-Ask: el desglose se discrimina a si mismo (no se exponen sus internos para que un
     // colaborador externo arme el diccionario). Vuelca TotalMinutosPorConcepto con clave Concepto.ToString()
-    // y agrega la clave literal "Retardo" con RetardoTotal.RetardoNeto solo cuando es > 0. Trazabilidad
-    // viaja vacia en este issue.
+    // y agrega la clave literal "Retardo" con RetardoTotal.RetardoNeto solo cuando es > 0.
+    //
+    // Issue #184: ademas puebla Trazabilidad, la memoria de calculo legible para nomina. Una linea por
+    // item con minutos > 0: por concepto, derivada de los ToString() ricos (IntervaloTemporal + etiqueta
+    // .resx); por retardo, RetardoTotal.ToString() cuando el neto es > 0. Solo viajan los strings ya
+    // traducidos: el modelo de dominio rico no cruza el bus, pero su ToString() si.
     public HorasDiscriminadas Discriminar()
     {
         var minutosPorConcepto = TotalMinutosPorConcepto
             .Where(par => par.Value > 0)
             .ToDictionary(par => par.Key.ToString(), par => par.Value);
 
-        if (RetardoTotal.RetardoNeto > 0)
-            minutosPorConcepto[ClaveRetardo] = RetardoTotal.RetardoNeto;
+        var trazabilidad = ConstruirTrazabilidadPorConcepto();
 
-        return new HorasDiscriminadas(minutosPorConcepto, []);
+        if (RetardoTotal.RetardoNeto > 0)
+        {
+            minutosPorConcepto[ClaveRetardo] = RetardoTotal.RetardoNeto;
+            trazabilidad.Add(RetardoTotal.ToString());
+        }
+
+        return new HorasDiscriminadas(minutosPorConcepto, trazabilidad);
+    }
+
+    // Una linea por concepto presente en el dia: sus intervalos (de todas las franjas, en orden
+    // cronologico) renderizados via ToString() y la etiqueta humana traducida una sola vez. Como cada
+    // intervalo dura > 0min, hay exactamente un concepto por clave de MinutosPorConcepto (sin contar
+    // "Retardo"). Para un concepto con un unico intervalo coincide con IntervaloClasificado.ToString().
+    private List<string> ConstruirTrazabilidadPorConcepto() =>
+        DesglosePorFranja
+            .SelectMany(franja => franja.Intervalos)
+            .GroupBy(intervalo => intervalo.Concepto)
+            .Select(LineaConcepto)
+            .ToList();
+
+    private static string LineaConcepto(IGrouping<Concepto, IntervaloClasificado> grupo)
+    {
+        var intervalos = string.Join(", ", grupo.OrderBy(ic => ic.Intervalo).Select(ic => ic.Intervalo));
+        return $"{intervalos}: {IntervaloClasificado.Mensajes.Etiqueta(grupo.Key)}";
     }
 }

--- a/src/Bitakora.ControlAsistencia.Contracts/ControlHoras/ValueObjects/IntervaloClasificado.Mensajes.cs
+++ b/src/Bitakora.ControlAsistencia.Contracts/ControlHoras/ValueObjects/IntervaloClasificado.Mensajes.cs
@@ -1,0 +1,26 @@
+using System.Resources;
+
+namespace Bitakora.ControlAsistencia.Contracts.ControlHoras.ValueObjects;
+
+// Issue #184: la trazabilidad (memoria de calculo) que viaja en HorasDiscriminadas es texto humano
+// traducido en el back (.resx). La etiqueta legible de cada Concepto vive aqui porque IntervaloClasificado
+// es el tipo que empareja intervalo + concepto y es el que se renderiza para nomina via ToString().
+// ADR de mensajes .resx (i18n de los ToString()): el patron es ResourceManager + accesor estatico, igual
+// que IntervaloTemporal/DetalleRetardo. Variacion menor sobre el patron: en vez de una propiedad por clave,
+// un metodo Etiqueta(Concepto) que resuelve la clave desde Concepto.ToString() (hay un recurso por concepto).
+//
+// CA-4: la clave del recurso ES Concepto.ToString() (el codigo estable: "OrdinariaDiurna", ...). El codigo
+// nunca se traduce y sigue siendo la clave de MinutosPorConcepto; solo el VALOR del recurso es texto humano.
+public sealed partial record IntervaloClasificado
+{
+    private static readonly ResourceManager ResourceManager = new(
+        "Bitakora.ControlAsistencia.Contracts.ControlHoras.ValueObjects.IntervaloClasificadoMensajes",
+        typeof(IntervaloClasificado).Assembly);
+
+    public static class Mensajes
+    {
+        // Texto humano traducido de un Concepto, para la trazabilidad. La clave es Concepto.ToString().
+        public static string Etiqueta(Concepto concepto) =>
+            ResourceManager.GetString(concepto.ToString())!;
+    }
+}

--- a/src/Bitakora.ControlAsistencia.Contracts/ControlHoras/ValueObjects/IntervaloClasificado.cs
+++ b/src/Bitakora.ControlAsistencia.Contracts/ControlHoras/ValueObjects/IntervaloClasificado.cs
@@ -2,7 +2,10 @@ namespace Bitakora.ControlAsistencia.Contracts.ControlHoras.ValueObjects;
 
 // Issue #114: Intervalo temporal con su concepto legal asignado.
 // Record con constructor primario - no tiene invariantes propios.
-public sealed record IntervaloClasificado(IntervaloTemporal Intervalo, Concepto Concepto)
+// Issue #184: partial para alojar la clase Mensajes (etiquetas .resx de Concepto) en archivo separado.
+// El ToString() humano para la trazabilidad ("{intervalo}: {etiqueta traducida}") lo provee el implementer
+// (lo cubre IntervaloClasificadoTests en fase roja); aqui no se override para no escribir implementacion.
+public sealed partial record IntervaloClasificado(IntervaloTemporal Intervalo, Concepto Concepto)
 {
     // Delega al IntervaloTemporal contenido.
     public int DuracionEnMinutos => Intervalo.DuracionEnMinutos;

--- a/src/Bitakora.ControlAsistencia.Contracts/ControlHoras/ValueObjects/IntervaloClasificado.cs
+++ b/src/Bitakora.ControlAsistencia.Contracts/ControlHoras/ValueObjects/IntervaloClasificado.cs
@@ -3,10 +3,16 @@ namespace Bitakora.ControlAsistencia.Contracts.ControlHoras.ValueObjects;
 // Issue #114: Intervalo temporal con su concepto legal asignado.
 // Record con constructor primario - no tiene invariantes propios.
 // Issue #184: partial para alojar la clase Mensajes (etiquetas .resx de Concepto) en archivo separado.
-// El ToString() humano para la trazabilidad ("{intervalo}: {etiqueta traducida}") lo provee el implementer
-// (lo cubre IntervaloClasificadoTests en fase roja); aqui no se override para no escribir implementacion.
+// El ToString() humano arma la linea de la memoria de calculo: el intervalo via su propio ToString()
+// (primitiva rica) seguido de la etiqueta traducida del concepto. La etiqueta sale del .resx (i18n del
+// back); el codigo del concepto (Concepto.ToString()) nunca aparece aqui - ese es la clave estable de
+// MinutosPorConcepto, no texto humano.
 public sealed partial record IntervaloClasificado(IntervaloTemporal Intervalo, Concepto Concepto)
 {
     // Delega al IntervaloTemporal contenido.
     public int DuracionEnMinutos => Intervalo.DuracionEnMinutos;
+
+    // "18:15-21:00 (165min): Ordinaria diurna" - intervalo rico + etiqueta humana traducida.
+    public override string ToString() =>
+        $"{Intervalo}: {Mensajes.Etiqueta(Concepto)}";
 }

--- a/src/Bitakora.ControlAsistencia.Contracts/ControlHoras/ValueObjects/IntervaloClasificadoMensajes.resx
+++ b/src/Bitakora.ControlAsistencia.Contracts/ControlHoras/ValueObjects/IntervaloClasificadoMensajes.resx
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" msdata:Ordinal="0" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter</value></resheader>
+  <data name="OrdinariaDiurna" xml:space="preserve">
+    <value>Ordinaria diurna</value>
+  </data>
+  <data name="OrdinariaNocturna" xml:space="preserve">
+    <value>Ordinaria nocturna</value>
+  </data>
+  <data name="ExtraDiurna" xml:space="preserve">
+    <value>Extra diurna</value>
+  </data>
+  <data name="ExtraNocturna" xml:space="preserve">
+    <value>Extra nocturna</value>
+  </data>
+  <data name="DominicalFestivaDiurna" xml:space="preserve">
+    <value>Dominical festiva diurna</value>
+  </data>
+  <data name="DominicalFestivaNocturna" xml:space="preserve">
+    <value>Dominical festiva nocturna</value>
+  </data>
+  <data name="ExtraDiurnaDominicalFestiva" xml:space="preserve">
+    <value>Extra diurna dominical festiva</value>
+  </data>
+  <data name="ExtraNocturnaDominicalFestiva" xml:space="preserve">
+    <value>Extra nocturna dominical festiva</value>
+  </data>
+  <data name="Descanso" xml:space="preserve">
+    <value>Descanso</value>
+  </data>
+</root>

--- a/tests/Bitakora.ControlAsistencia.Contracts.Tests/ValueObjects/ControlHoras/DesgloseHorasDiscriminarTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Contracts.Tests/ValueObjects/ControlHoras/DesgloseHorasDiscriminarTests.cs
@@ -1,9 +1,23 @@
 // Issue #183: DesgloseHoras.Discriminar() - traduce el desglose rico al payload plano que viaja en
 // DiaCalculado (Tell-don't-Ask: el desglose se discrimina a si mismo).
-// CA-2: produce MinutosPorConcepto con una entrada por cada Concepto con minutos > 0 del dia,
+// CA-2 (#183): produce MinutosPorConcepto con una entrada por cada Concepto con minutos > 0 del dia,
 //       clave = Concepto.ToString(), valor = minutos agregados (reusa TotalMinutosPorConcepto).
-// CA-3: incluye la clave literal "Retardo" con RetardoTotal.RetardoNeto cuando es > 0; no la incluye
+// CA-3 (#183): incluye la clave literal "Retardo" con RetardoTotal.RetardoNeto cuando es > 0; no la incluye
 //       cuando es 0. El enum Concepto permanece SIN un valor Retardo.
+//
+// Issue #184: Discriminar() ahora ademas puebla Trazabilidad (la memoria de calculo). Decision del planner
+// (2026-06-23): lista de lineas (IReadOnlyList<string>), una por item con valor, ya traducida en el back.
+// CA-1 (#184): una linea por concepto con minutos > 0, armada desde el/los IntervaloTemporal.ToString() del
+//       concepto y su etiqueta humana traducida (IntervaloClasificado.Mensajes.Etiqueta). Ej (issue):
+//       "18:15-21:00 (165min): Ordinaria diurna".
+// CA-2 (#184): incluye una linea para el retardo cuando RetardoNeto > 0, derivada de DetalleRetardo.ToString().
+// CA-3 (#184): las lineas estan traducidas (.resx); no hay lineas para items en cero.
+// CA-4 (#184): las claves de MinutosPorConcepto siguen como codigo ("OrdinariaDiurna", "Retardo"); solo
+//       Trazabilidad es texto humano.
+// "El modelo de dominio rico no cruza el bus": la trazabilidad se construye DESDE los ToString() de los
+// objetos ricos (IntervaloTemporal, DetalleRetardo); solo viajan los strings, no los objetos ricos.
+// Oraculo independiente (regla 20): las lineas esperadas se arman a mano con IntervaloTemporal.ToString()
+// (primitiva ya probada) y la etiqueta del recurso (no un literal), nunca ejecutando Discriminar.
 
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.Contracts.ControlHoras.ValueObjects;
@@ -29,6 +43,12 @@ public class DesgloseHorasDiscriminarTests
             .ToList<IntervaloClasificado>();
         return new DesgloseFranja(FranjaProgramada(), intervalos, DetalleRetardo.Vacio);
     }
+
+    // Oraculo independiente de la linea de trazabilidad de un concepto con UN solo intervalo:
+    // "{intervalo}: {etiqueta traducida}". Se arma desde IntervaloTemporal.ToString() (primitiva probada)
+    // y la etiqueta del recurso (no un literal), sin ejecutar Discriminar (regla 20).
+    private static string LineaConcepto(IntervaloTemporal intervalo, Concepto concepto) =>
+        $"{intervalo}: {IntervaloClasificado.Mensajes.Etiqueta(concepto)}";
 
     // ---------- CA-2: una entrada por cada Concepto con minutos > 0, clave = Concepto.ToString() ----------
 
@@ -124,16 +144,156 @@ public class DesgloseHorasDiscriminarTests
         resultado.MinutosPorConcepto.Should().ContainKey("OrdinariaDiurna");
     }
 
+    // ---------- Issue #184 - CA-1: una linea por concepto con minutos > 0 ----------
+
     [Fact]
-    public void Discriminar_DejaTrazabilidadVacia_EnEsteIssue()
+    public void Discriminar_FormateaLaLineaComoIntervaloYEtiquetaTraducida_CuandoUnSoloIntervalo()
     {
+        // Ejemplo literal del issue: "18:15-21:00 (165min): Ordinaria diurna" (18:15-21:00 es todo diurno).
         var franja = FranjaConIntervalos(
-            (new TimeOnly(8, 0), new TimeOnly(12, 0), Concepto.OrdinariaDiurna));
+            (new TimeOnly(18, 15), new TimeOnly(21, 0), Concepto.OrdinariaDiurna));
         var desglose = new DesgloseHoras([franja], DetalleRetardo.Vacio, 0);
 
         var resultado = desglose.Discriminar();
 
+        resultado.Trazabilidad.Should().ContainSingle()
+            .Which.Should().Be(LineaConcepto(
+                CrearIntervalo(new TimeOnly(18, 15), new TimeOnly(21, 0)), Concepto.OrdinariaDiurna));
+    }
+
+    [Fact]
+    public void Discriminar_PueblaUnaLineaPorConcepto_CuandoVariasFranjasYConceptos()
+    {
+        // OrdinariaDiurna aparece en dos franjas (08:00-12:00 y 13:00-17:00); OrdinariaNocturna en una.
+        var franja1 = FranjaConIntervalos(
+            (new TimeOnly(6, 0), new TimeOnly(8, 0), Concepto.OrdinariaNocturna),
+            (new TimeOnly(8, 0), new TimeOnly(12, 0), Concepto.OrdinariaDiurna));
+        var franja2 = FranjaConIntervalos(
+            (new TimeOnly(13, 0), new TimeOnly(17, 0), Concepto.OrdinariaDiurna));
+        var desglose = new DesgloseHoras([franja1, franja2], DetalleRetardo.Vacio, 0);
+
+        var resultado = desglose.Discriminar();
+
+        // CA-1: una linea por concepto (no por intervalo): 2 conceptos -> 2 lineas.
+        resultado.Trazabilidad.Should().HaveCount(2);
+
+        // La linea de OrdinariaDiurna referencia sus DOS intervalos y su etiqueta traducida (una sola vez
+        // la etiqueta -> es una linea por concepto, no por intervalo). Formato exacto del join a criterio
+        // del implementer; aqui se verifica el contenido obligatorio.
+        var diurna1 = CrearIntervalo(new TimeOnly(8, 0), new TimeOnly(12, 0));
+        var diurna2 = CrearIntervalo(new TimeOnly(13, 0), new TimeOnly(17, 0));
+        var lineaDiurna = resultado.Trazabilidad.Should()
+            .ContainSingle(l => l.Contains(IntervaloClasificado.Mensajes.Etiqueta(Concepto.OrdinariaDiurna)))
+            .Which;
+        lineaDiurna.Should().Contain(diurna1.ToString()).And.Contain(diurna2.ToString());
+
+        var nocturna = CrearIntervalo(new TimeOnly(6, 0), new TimeOnly(8, 0));
+        var lineaNocturna = resultado.Trazabilidad.Should()
+            .ContainSingle(l => l.Contains(IntervaloClasificado.Mensajes.Etiqueta(Concepto.OrdinariaNocturna)))
+            .Which;
+        lineaNocturna.Should().Contain(nocturna.ToString());
+    }
+
+    [Fact]
+    public void Discriminar_ProduceUnaLineaPorEntradaDeMinutosPorConcepto_SinRetardo()
+    {
+        // Decision del planner: "una linea por item con valor". Sin retardo, los items son los conceptos,
+        // asi que Trazabilidad.Count == MinutosPorConcepto.Count.
+        var franja1 = FranjaConIntervalos(
+            (new TimeOnly(6, 0), new TimeOnly(8, 0), Concepto.OrdinariaNocturna),
+            (new TimeOnly(8, 0), new TimeOnly(12, 0), Concepto.OrdinariaDiurna));
+        var franja2 = FranjaConIntervalos(
+            (new TimeOnly(13, 0), new TimeOnly(15, 0), Concepto.ExtraDiurna));
+        var desglose = new DesgloseHoras([franja1, franja2], DetalleRetardo.Vacio, 0);
+
+        var resultado = desglose.Discriminar();
+
+        resultado.Trazabilidad.Should().HaveCount(resultado.MinutosPorConcepto.Count);
+        resultado.Trazabilidad.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public void Discriminar_DejaTrazabilidadVacia_CuandoDesgloseEsVacio()
+    {
+        // Edge: sin conceptos ni retardo no hay memoria de calculo que mostrar.
+        var resultado = DesgloseHoras.Vacio.Discriminar();
+
         resultado.Trazabilidad.Should().BeEmpty();
+    }
+
+    // ---------- Issue #184 - CA-3 / CA-4: traducida pero claves como codigo ----------
+
+    [Fact]
+    public void Discriminar_TraduceLaTrazabilidadPeroDejaLaClaveComoCodigo_CuandoUnConcepto()
+    {
+        var franja = FranjaConIntervalos(
+            (new TimeOnly(8, 0), new TimeOnly(12, 0), Concepto.DominicalFestivaDiurna));
+        var desglose = new DesgloseHoras([franja], DetalleRetardo.Vacio, 0);
+
+        var resultado = desglose.Discriminar();
+
+        // CA-4: la clave de MinutosPorConcepto es el codigo estable Concepto.ToString().
+        resultado.MinutosPorConcepto.Should().ContainKey("DominicalFestivaDiurna");
+        // CA-3: la trazabilidad lleva el texto humano traducido del recurso, no el codigo camelCase.
+        resultado.Trazabilidad.Should().ContainSingle()
+            .Which.Should().Contain(IntervaloClasificado.Mensajes.Etiqueta(Concepto.DominicalFestivaDiurna));
+        string.Join(" | ", resultado.Trazabilidad).Should().NotContain("DominicalFestivaDiurna");
+    }
+
+    [Fact]
+    public void Discriminar_NoIncluyeLineasParaConceptosAusentes_CuandoSoloHayDiurna()
+    {
+        var franja = FranjaConIntervalos(
+            (new TimeOnly(8, 0), new TimeOnly(17, 0), Concepto.OrdinariaDiurna));
+        var desglose = new DesgloseHoras([franja], DetalleRetardo.Vacio, 0);
+
+        var resultado = desglose.Discriminar();
+
+        resultado.Trazabilidad.Should().ContainSingle();  // solo la linea de OrdinariaDiurna
+        var todas = string.Join(" | ", resultado.Trazabilidad);
+        todas.Should().NotContain(IntervaloClasificado.Mensajes.Etiqueta(Concepto.ExtraDiurna));
+        todas.Should().NotContain(IntervaloClasificado.Mensajes.Etiqueta(Concepto.OrdinariaNocturna));
+    }
+
+    // ---------- Issue #184 - CA-2: linea de retardo derivada de DetalleRetardo.ToString() ----------
+
+    [Fact]
+    public void Discriminar_IncluyeLineaDeRetardoDerivadaDeRetardoToString_CuandoRetardoNetoEsMayorACero()
+    {
+        // Retardo de 15min sin compensacion -> neto 15. DetalleRetardo.ToString() ya viene traducido por sus
+        // propios .resx; la linea de trazabilidad del retardo se deriva de el (CA-2).
+        var retardo = DetalleRetardo.Crear(
+            [CrearIntervalo(new TimeOnly(6, 0), new TimeOnly(6, 15))],
+            []);
+        var franja = FranjaConIntervalos(
+            (new TimeOnly(8, 0), new TimeOnly(12, 0), Concepto.OrdinariaDiurna));
+        var desglose = new DesgloseHoras([franja], retardo, 0);
+
+        var resultado = desglose.Discriminar();
+
+        resultado.Trazabilidad.Should().Contain(retardo.ToString());
+        // Convive con la linea del concepto.
+        resultado.Trazabilidad.Should().Contain(LineaConcepto(
+            CrearIntervalo(new TimeOnly(8, 0), new TimeOnly(12, 0)), Concepto.OrdinariaDiurna));
+    }
+
+    [Fact]
+    public void Discriminar_OmiteLineaDeRetardo_CuandoRetardoNetoEsCero()
+    {
+        // Retardo de 30min compensado con 30min -> neto 0. No hay clave "Retardo" ni linea de retardo.
+        var retardo = DetalleRetardo.Crear(
+            [CrearIntervalo(new TimeOnly(6, 0), new TimeOnly(6, 30))],
+            [CrearIntervalo(new TimeOnly(12, 0), new TimeOnly(12, 30))]);
+        var franja = FranjaConIntervalos(
+            (new TimeOnly(8, 0), new TimeOnly(12, 0), Concepto.OrdinariaDiurna));
+        var desglose = new DesgloseHoras([franja], retardo, 0);
+
+        var resultado = desglose.Discriminar();
+
+        resultado.Trazabilidad.Should().NotContain(retardo.ToString());
+        resultado.Trazabilidad.Should().ContainSingle()
+            .Which.Should().Be(LineaConcepto(
+                CrearIntervalo(new TimeOnly(8, 0), new TimeOnly(12, 0)), Concepto.OrdinariaDiurna));
     }
 
     // CA-3 (guardrail estructural): el enum Concepto NO tiene un valor Retardo; "Retardo" es una clave

--- a/tests/Bitakora.ControlAsistencia.Contracts.Tests/ValueObjects/ControlHoras/IntervaloClasificadoTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Contracts.Tests/ValueObjects/ControlHoras/IntervaloClasificadoTests.cs
@@ -6,8 +6,10 @@ namespace Bitakora.ControlAsistencia.Contracts.Tests.ValueObjects.ControlHoras;
 
 /// <summary>
 /// Tests de IntervaloClasificado - intervalo temporal con concepto legal asignado.
-/// Interfaz publica: constructor primario, Intervalo, Concepto, DuracionEnMinutos.
+/// Interfaz publica: constructor primario, Intervalo, Concepto, DuracionEnMinutos, ToString().
 /// CA-2: DuracionEnMinutos delega al IntervaloTemporal contenido.
+/// Issue #184: ToString() humano para la trazabilidad ("{intervalo}: {etiqueta traducida}") y
+/// Mensajes.Etiqueta(Concepto) que resuelve la etiqueta traducida de cada concepto (.resx).
 /// </summary>
 public class IntervaloClasificadoTests
 {
@@ -54,6 +56,43 @@ public class IntervaloClasificadoTests
         var clasificado = new IntervaloClasificado(intervalo, Concepto.Descanso);
 
         clasificado.DuracionEnMinutos.Should().Be(15);
+    }
+
+    // ---------- Issue #184: ToString() humano para la trazabilidad ----------
+
+    [Fact]
+    public void ToString_RenderizaIntervaloYEtiquetaTraducida_CuandoOrdinariaDiurna()
+    {
+        // Ejemplo del issue: "18:15-21:00 (165min): Ordinaria diurna".
+        var intervalo = IntervaloTemporal.Crear(
+            new MomentoDelDia(new TimeOnly(18, 15)), new MomentoDelDia(new TimeOnly(21, 0)));
+        var clasificado = new IntervaloClasificado(intervalo, Concepto.OrdinariaDiurna);
+
+        // Oraculo independiente: el intervalo via su ToString() (primitiva probada) y la etiqueta del
+        // recurso (no un literal). El codigo "OrdinariaDiurna" no debe aparecer (es la clave, no el texto).
+        clasificado.ToString().Should().Be(
+            $"{intervalo}: {IntervaloClasificado.Mensajes.Etiqueta(Concepto.OrdinariaDiurna)}");
+    }
+
+    [Fact]
+    public void ToString_IncluyeLaDuracionDelIntervaloYLaEtiqueta_CuandoNocturnoCruzaMedianoche()
+    {
+        var intervalo = IntervaloTemporal.Crear(Las22, Las6SiguienteDia);
+        var clasificado = new IntervaloClasificado(intervalo, Concepto.ExtraNocturna);
+
+        var texto = clasificado.ToString();
+
+        texto.Should().Contain(intervalo.ToString());  // "22:00-06:00+1 (480min)"
+        texto.Should().Contain(IntervaloClasificado.Mensajes.Etiqueta(Concepto.ExtraNocturna));
+    }
+
+    // Guardrail .resx: cada Concepto debe tener una etiqueta humana traducida (no vacia). Protege contra
+    // agregar un Concepto nuevo sin su traduccion -> Etiqueta devolveria null y la trazabilidad quedaria rota.
+    [Fact]
+    public void Etiqueta_DefineUnTextoTraducidoNoVacio_ParaCadaConcepto()
+    {
+        foreach (var concepto in Enum.GetValues<Concepto>())
+            IntervaloClasificado.Mensajes.Etiqueta(concepto).Should().NotBeNullOrWhiteSpace();
     }
 
     // Contrato IEquatable: ver IntervaloClasificadoIgualdadTests (hereda IgualdadTestBase).

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoMarcacionRegistrada/DepurarAlAdicionarMarcacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoMarcacionRegistrada/DepurarAlAdicionarMarcacionTests.cs
@@ -59,6 +59,13 @@ public class DepurarAlAdicionarMarcacionTests : CommandHandlerAsyncTest<Marcacio
     private static TurnoDiarioAsignado CrearTurnoDiarioAsignado(DetalleTurno detalleTurno) =>
         new(StreamId, Empleado, Fecha, detalleTurno, SolicitudId);
 
+    // Issue #184: oraculo independiente de una linea de trazabilidad (memoria de calculo). Se arma a
+    // mano desde IntervaloTemporal.ToString() (primitiva ya probada) y la etiqueta traducida del recurso
+    // (no un literal), sin ejecutar Discriminar (regla 20). Mismo patron que DesgloseHorasDiscriminarTests.
+    private static string LineaConcepto(TimeOnly inicio, TimeOnly fin, Concepto concepto) =>
+        $"{IntervaloTemporal.Crear(new MomentoDelDia(inicio), new MomentoDelDia(fin))}: " +
+        $"{IntervaloClasificado.Mensajes.Etiqueta(concepto)}";
+
     // CA-1 (HU-123): con TurnoDiarioAsignado (franja unica 06:00-14:00) previo y MarcacionRegistrada a las 07:00,
     //        ControlesDeFranja debe quedar con un ControlFranja(Franja06_14, Entrada=07:00, Salida=null).
     //        Verifica que el hook reactivo se dispara desde Apply(MarcacionAdicionada).
@@ -147,14 +154,23 @@ public class DepurarAlAdicionarMarcacionTests : CommandHandlerAsyncTest<Marcacio
         // 2026-03-15: entro 05:50 -> recortado a 06:00 (sin retardo); ordinaria 06:00-12:00
         // DominicalFestivaDiurna = 360min y excedente 12:00-12:05 ExtraDiurnaDominicalFestiva = 5min
         // (sin retardo que lo compense). Sin retardo neto -> no hay clave "Retardo".
+        // Issue #184: el DiaCalculado ahora viaja con la Trazabilidad (memoria de calculo) poblada. Dos
+        // conceptos -> dos lineas, en orden cronologico (ordinaria antes que excedente), cada una armada
+        // con LineaConcepto desde su intervalo y la etiqueta traducida. F2 es anomala (Salida null): no
+        // aporta intervalos ni lineas.
         ThenIsPublishedPublicly(new DiaCalculado(
             Empleado,
             Fecha,
-            new HorasDiscriminadas(new Dictionary<string, int>
-            {
-                ["DominicalFestivaDiurna"] = 360,
-                ["ExtraDiurnaDominicalFestiva"] = 5
-            }, [])));
+            new HorasDiscriminadas(
+                new Dictionary<string, int>
+                {
+                    ["DominicalFestivaDiurna"] = 360,
+                    ["ExtraDiurnaDominicalFestiva"] = 5
+                },
+                [
+                    LineaConcepto(new TimeOnly(6, 0), new TimeOnly(12, 0), Concepto.DominicalFestivaDiurna),
+                    LineaConcepto(new TimeOnly(12, 0), new TimeOnly(12, 5), Concepto.ExtraDiurnaDominicalFestiva)
+                ])));
     }
 
     // CA-5 (HU-108): marcacion a las 02:00 cae en ventana nocturna [00:00, 04:00).

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/DepurarAlAsignarTurnoTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/DepurarAlAsignarTurnoTests.cs
@@ -51,6 +51,13 @@ public class DepurarAlAsignarTurnoTests
     private static MarcacionAdicionada CrearMarcacionAdicionada(DateTime timestamp) =>
         new(StreamId, Empleado.EmpleadoId, timestamp, "ENTRADA", "DEV-001");
 
+    // Issue #184: oraculo independiente de una linea de trazabilidad (memoria de calculo). Se arma a
+    // mano desde IntervaloTemporal.ToString() (primitiva ya probada) y la etiqueta traducida del recurso
+    // (no un literal), sin ejecutar Discriminar (regla 20). Mismo patron que DesgloseHorasDiscriminarTests.
+    private static string LineaConcepto(TimeOnly inicio, TimeOnly fin, Concepto concepto) =>
+        $"{IntervaloTemporal.Crear(new MomentoDelDia(inicio), new MomentoDelDia(fin))}: " +
+        $"{IntervaloClasificado.Mensajes.Etiqueta(concepto)}";
+
     // CA-1 (HU-123): con 2 MarcacionAdicionada previas (07:00, 15:00) sin turno,
     //        al procesar ProgramacionTurnoDiarioSolicitada con franja 06:00-14:00,
     //        el Apply(TurnoDiarioAsignado) dispara Depurar() y ControlesDeFranja
@@ -82,13 +89,15 @@ public class DepurarAlAsignarTurnoTests
         // compensa con el excedente 60min (14:00-15:00) -> retardo neto 0 (no hay clave "Retardo") y
         // queda visible la ordinaria 07:00-14:00 DominicalFestivaDiurna = 420min. Asi un bug en esa
         // logica no se filtra al esperado y el test lo detecta.
+        // Issue #184: el DiaCalculado ahora viaja con la Trazabilidad (memoria de calculo) poblada. El
+        // unico concepto del dia (ordinaria 07:00-14:00, DominicalFestivaDiurna) genera una sola linea,
+        // construida con LineaConcepto desde el intervalo 07:00-14:00 y la etiqueta traducida del recurso.
         ThenIsPublishedPublicly(new DiaCalculado(
             Empleado,
             Fecha,
-            new HorasDiscriminadas(new Dictionary<string, int>
-            {
-                ["DominicalFestivaDiurna"] = 420
-            }, [])));
+            new HorasDiscriminadas(
+                new Dictionary<string, int> { ["DominicalFestivaDiurna"] = 420 },
+                [LineaConcepto(new TimeOnly(7, 0), new TimeOnly(14, 0), Concepto.DominicalFestivaDiurna)])));
     }
 
     // CA-2 (HU-131): sin marcaciones previas, el Apply(TurnoDiarioAsignado) dispara Depurar()

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/CrearDiaCalculadoConHorasDiscriminadasTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/CrearDiaCalculadoConHorasDiscriminadasTests.cs
@@ -61,9 +61,8 @@ public class CrearDiaCalculadoConHorasDiscriminadasTests
     // no anomala). El retardo 60min (06:00-07:00) se compensa con el excedente 60min (14:00-15:00) ->
     // retardo neto 0 (no hay clave "Retardo"); queda visible la ordinaria 07:00-14:00 = 420min
     // DominicalFestivaDiurna. Registrado a mano: ni Discriminar ni Consolidar se ejecutan para armarlo.
-    private static HorasDiscriminadas HorasFranjaCompleta() => new(
-        new Dictionary<string, int> { ["DominicalFestivaDiurna"] = 420 },
-        []);
+    private static IReadOnlyDictionary<string, int> MinutosFranjaCompleta() =>
+        new Dictionary<string, int> { ["DominicalFestivaDiurna"] = 420 };
 
     public class ViaAsignarTurnoTests
         : CommandHandlerAsyncTest<ProgramacionTurnoDiarioSolicitada>
@@ -78,8 +77,13 @@ public class CrearDiaCalculadoConHorasDiscriminadasTests
         // CA-4: con turno (franja 06:00-14:00) y marcaciones previas que la completan (07:00, 15:00),
         //       la franja queda NO anomala. CrearDiaCalculado() debe empaquetar el payload plano
         //       discriminado del desglose real: MinutosPorConcepto = {DominicalFestivaDiurna: 420}.
+        // Issue #184: CrearDiaCalculado() ahora ademas puebla la Trazabilidad via Discriminar(). Un solo
+        //       concepto (DominicalFestivaDiurna) y retardo neto 0 -> exactamente una linea. Se verifica
+        //       solo el conteo (robusto ante como el desglose descomponga los intervalos del concepto);
+        //       el contenido exacto de las lineas se prueba en DesgloseHorasDiscriminarTests, con geometria
+        //       controlada. Aqui basta probar que el aggregate enruta la trazabilidad hacia el payload.
         [Fact]
-        public async Task CrearDiaCalculado_LlevaMinutosPorConceptoReales_CuandoFranjaNoEsAnomala()
+        public async Task CrearDiaCalculado_LlevaMinutosYTrazabilidadReales_CuandoFranjaNoEsAnomala()
         {
             Given(StreamId,
                 CrearMarcacionAdicionada(Timestamp07_00),
@@ -90,10 +94,15 @@ public class CrearDiaCalculadoConHorasDiscriminadasTests
 
             Then(StreamId, CrearTurnoDiarioAsignado(turnoFranjaUnica));
 
-            And<ControlDiarioAggregateRoot, HorasDiscriminadas>(
+            And<ControlDiarioAggregateRoot, IReadOnlyDictionary<string, int>>(
                 StreamId,
-                c => c.CrearDiaCalculado().HorasDiscriminadas,
-                HorasFranjaCompleta());
+                c => c.CrearDiaCalculado().HorasDiscriminadas.MinutosPorConcepto,
+                MinutosFranjaCompleta());
+
+            And<ControlDiarioAggregateRoot, int>(
+                StreamId,
+                c => c.CrearDiaCalculado().HorasDiscriminadas.Trazabilidad.Count,
+                1);
         }
 
         // CA-4 (todas las franjas anomalas): turno con franja 06:00-14:00 SIN marcaciones -> la franja


### PR DESCRIPTION
## Resumen

Pipeline TDD completado:
- Fase roja: tests escritos con stubs
- Fase verde: implementación completa
- Fase refactor: revisión de calidad

## Decisiones del pipeline

<details>
<summary>Test Writer (fase roja) — 21m 11s</summary>

## ES Test Writer - Decisiones (Issue #184: trazabilidad / memoria de calculo de HorasDiscriminadas)

### Tests creados / modificados

- `DesgloseHorasDiscriminarTests.cs` (Contracts.Tests): +8 tests de trazabilidad #184; -1 test obsoleto.
  - `Discriminar_FormateaLaLineaComoIntervaloYEtiquetaTraducida_CuandoUnSoloIntervalo` - CA-1 (ancla el formato exacto al ejemplo del issue "18:15-21:00 (165min): Ordinaria diurna").
  - `Discriminar_PueblaUnaLineaPorConcepto_CuandoVariasFranjasYConceptos` - CA-1 (una linea por concepto, no por intervalo; un concepto con 2 intervalos -> 1 linea con ambos).
  - `Discriminar_ProduceUnaLineaPorEntradaDeMinutosPorConcepto_SinRetardo` - CA-1 (invariante: Trazabilidad.Count == MinutosPorConcepto.Count sin retardo; decision del planner "una por item con valor").
  - `Discriminar_DejaTrazabilidadVacia_CuandoDesgloseEsVacio` - edge (sin conceptos ni retardo -> []).
  - `Discriminar_TraduceLaTrazabilidadPeroDejaLaClaveComoCodigo_CuandoUnConcepto` - CA-3 + CA-4 (linea con etiqueta humana; clave de MinutosPorConcepto = codigo; el codigo camelCase no aparece en la trazabilidad).
  - `Discriminar_NoIncluyeLineasParaConceptosAusentes_CuandoSoloHayDiurna` - CA-3 (no hay lineas para items en cero).
  - `Discriminar_IncluyeLineaDeRetardoDerivadaDeRetardoToString_CuandoRetardoNetoEsMayorACero` - CA-2.
  - `Discriminar_OmiteLineaDeRetardo_CuandoRetardoNetoEsCero` - CA-2 / CA-3.
- `IntervaloClasificadoTests.cs` (Contracts.Tests): +3 tests.
  - `ToString_RenderizaIntervaloYEtiquetaTraducida_CuandoOrdinariaDiurna` - CA-1 (formato canonico "{intervalo}: {etiqueta}"). ROJO.
  - `ToString_IncluyeLaDuracionDelIntervaloYLaEtiqueta_CuandoNocturnoCruzaMedianoche` - CA-1. ROJO.
  - `Etiqueta_DefineUnTextoTraducidoNoVacio_ParaCadaConcepto` - guardrail .resx (VERDE: la infra ya existe).
- `CrearDiaCalculadoConHorasDiscriminadasTests.cs` (ControlHoras.Tests): test de agregado refocalizado.
  - `CrearDiaCalculado_LlevaMinutosYTrazabilidadReales_CuandoFranjaNoEsAnomala` (antes `...LlevaMinutosPorConceptoReales...`): ahora 2 `And<>()` - MinutosPorConcepto exacto + `Trazabilidad.Count == 1`.

### Stubs / infra creados

- `IntervaloClasificado.cs`: ahora `sealed partial record` (para alojar la clase Mensajes). Sin override de `ToString()` -> queda en rojo para el implementer.
- `IntervaloClasificado.Mensajes.cs` (NUEVO): `ResourceManager` + `Mensajes.Etiqueta(Concepto)`. Infra real (no stub), patron ADR mensajes .resx.
- `IntervaloClasificadoMensajes.resx` (NUEVO): etiquetas humanas traducidas de los 9 Conceptos (clave = Concepto.ToString(), valor = texto humano).

### Decisiones de diseño (autoridad de test-writer; el issue NO trae seccion "Interfaz publica")

1. **Una linea por concepto** (CA-1, literal) -> `Trazabilidad.Count` == numero de conceptos con minutos>0 (+1 si hay retardo neto). Concuerda con la decision del planner "una por item con valor": hay 1:1 con las entradas de MinutosPorConcepto.
2. **Formato de la linea de concepto = `"{intervalo(s)}: {etiqueta traducida}"`**, anclado al ejemplo literal del issue. Para conceptos de UN intervalo el formato se fija exacto; para multi-intervalo solo se verifica el contenido obligatorio (ambos intervalos + la etiqueta una vez), respetando que el join exacto es "a criterio del implementer".
3. **Las etiquetas humanas de Concepto viven en `IntervaloClasificado`** (su `.resx` + `Mensajes.Etiqueta`). Razon: la nota tecnica del issue dice "construir desde ToString() de IntervaloClasificado"; es el tipo que empareja intervalo+concepto y el que se renderiza para nomina. `IntervaloClasificado.ToString()` se vuelve humano ("{intervalo}: {etiqueta}").
4. **La linea de retardo se deriva de `DetalleRetardo.ToString()`** (ya traducido por sus propios .resx). Una sola linea (mantiene el 1:1 con la clave "Retardo" de MinutosPorConcepto).
5. **Oraculo independiente (regla 20)**: las lineas esperadas se arman a mano con `IntervaloTemporal.ToString()` (primitiva ya probada con sus propios tests) y la etiqueta del recurso (referencia `Mensajes.Etiqueta`, NUNCA literal), sin ejecutar `Discriminar`. La linea de retardo esperada usa `DetalleRetardo.ToString()` (primitiva ya probada), no Discriminar.
6. **"El modelo de dominio rico no cruza el bus"**: la trazabilidad es `IReadOnlyList<string>` construida DESDE los ToString() de los objetos ricos; solo viajan strings, los objetos ricos no se exponen en el contrato.

### Variacion del patron ADR mensajes .resx

`Mensajes.Etiqueta(Concepto)` es un METODO que resuelve la clave desde `Concepto.ToString()` (hay un recurso por concepto), en vez de una propiedad por clave. Justificacion: evita 9 propiedades repetidas y mantiene la clave del recurso alineada con el codigo estable (CA-4). Sigue siendo ResourceManager + accesor estatico.

### Estado rojo/verde esperado

- ROJO (comportamiento #184 pendiente): todos los tests de trazabilidad de `Discriminar` (Discriminar devuelve [] hoy), los 2 tests de `IntervaloClasificado.ToString()` (default record ToString), y `Trazabilidad.Count == 1` del test de agregado.
- VERDE (infra/guardrail): `Etiqueta_DefineUnTextoTraducidoNoVacio_ParaCadaConcepto` y los tests #183 preexistentes (MinutosPorConcepto, igualdad, serializacion) intactos.
- `dotnet build`: 0 errores (verificado). No se corrio `dotnet test` (regla 3).

### Cobertura de criterios

| Criterio de aceptacion (#184) | Test(s) |
|---|---|
| CA-1: una linea por concepto con minutos > 0 | `Discriminar_FormateaLaLineaComoIntervaloYEtiquetaTraducida_CuandoUnSoloIntervalo`, `Discriminar_PueblaUnaLineaPorConcepto_CuandoVariasFranjasYConceptos`, `Discriminar_ProduceUnaLineaPorEntradaDeMinutosPorConcepto_SinRetardo`, `IntervaloClasificadoTests.ToString_*` |
| CA-2: linea(s) de retardo cuando RetardoNeto > 0, desde Retardo.ToString() | `Discriminar_IncluyeLineaDeRetardoDerivadaDeRetardoToString_CuandoRetardoNetoEsMayorACero`, `Discriminar_OmiteLineaDeRetardo_CuandoRetardoNetoEsCero` |
| CA-3: traducidas (.resx), sin lineas para items en cero | `Discriminar_TraduceLaTrazabilidadPeroDejaLaClaveComoCodigo_CuandoUnConcepto`, `Discriminar_NoIncluyeLineasParaConceptosAusentes_CuandoSoloHayDiurna`, `Discriminar_DejaTrazabilidadVacia_CuandoDesgloseEsVacio`, `Etiqueta_DefineUnTextoTraducidoNoVacio_ParaCadaConcepto` |
| CA-4: claves de MinutosPorConcepto como codigo, solo Trazabilidad es humana | `Discriminar_TraduceLaTrazabilidadPeroDejaLaClaveComoCodigo_CuandoUnConcepto`, `Concepto_NoTieneValorRetardo` (preexistente) |

### Desviaciones del plan del planner

| Sugerencia del issue | Desviacion aplicada | Razon tecnica | Consecuencia |
|---|---|---|---|
| "construir desde ToString() de IntervaloClasificado/IntervaloTemporal" + ejemplo per-intervalo "18:15-21:00 (165min): Ordinaria diurna" | Linea **por concepto** (no por intervalo); para multi-intervalo la linea junta los intervalos del concepto y la etiqueta una vez | CA-1 es explicito "una linea por concepto"; el ejemplo es per-intervalo. Se honra el CA y el ejemplo coincide para conceptos de un solo intervalo | Contrato testeable y alineado con CA-1; el implementer agrupa intervalos por concepto en Discriminar |
| Trazabilidad construida en `Discriminar()` (DesgloseHoras) | Etiquetas humanas de Concepto ubicadas en `IntervaloClasificado` (.resx + Mensajes) + `IntervaloClasificado.ToString()` humano | La nota dice "desde ToString() de IntervaloClasificado"; es el tipo natural para la etiqueta y su default record ToString era inutil para nomina | Discriminar consume `IntervaloClasificado.Mensajes.Etiqueta`; el implementer implementa tambien `IntervaloClasificado.ToString()` |
| Test #183 `...LlevaMinutosPorConceptoReales...` con oraculo de objeto completo (Trazabilidad []) | Refocalizado a `MinutosPorConcepto` exacto + `Trazabilidad.Count == 1` (2 `And<>()`) | Tras #184 la trazabilidad ya no es []; el oraculo de objeto completo romperia. El conteo es robusto ante como el desglose descomponga los intervalos del concepto (no predecible a mano con certeza) | El contenido exacto de lineas se cubre en DesgloseHorasDiscriminarTests con geometria controlada; el test de agregado prueba el enrutamiento |
| Test #183 `Discriminar_DejaTrazabilidadVacia_EnEsteIssue` (afirmaba [] para desglose no vacio) | Eliminado | Contradice directamente #184 (que puebla la trazabilidad) | Reemplazado por la suite de trazabilidad #184 |

</details>

<details>
<summary>Implementer (fase verde) — 11m 18s</summary>

## ES Implementer - Decisiones (HU-184)

### Enfoque de implementacion

#184 solo puebla `HorasDiscriminadas.Trazabilidad` (la "memoria de calculo"); no cambia la forma
del contrato. Dos cambios de produccion, ambos en `Contracts`:

1. `IntervaloClasificado.ToString()`: arma la linea humana `"{intervalo}: {etiqueta traducida}"`
   reusando `IntervaloTemporal.ToString()` (primitiva rica ya probada) y
   `Mensajes.Etiqueta(Concepto)` (etiqueta `.resx` que dejo el test-writer). El codigo del concepto
   (`Concepto.ToString()`) no aparece: ese es la clave estable de `MinutosPorConcepto`, no texto humano.

2. `DesgloseHoras.Discriminar()`: ademas de `MinutosPorConcepto`, ahora arma `Trazabilidad`:
   - Una linea por concepto con minutos > 0: agrupa los `IntervaloClasificado` de todas las franjas
     por `Concepto`, ordena los intervalos cronologicamente, los renderiza via su `ToString()` y
     anexa la etiqueta humana traducida **una sola vez** por concepto (CA-1).
   - Linea de retardo derivada de `RetardoTotal.ToString()` cuando `RetardoNeto > 0` (CA-2).
   - Para un concepto con un unico intervalo, la linea coincide exactamente con
     `IntervaloClasificado.ToString()`.

El aggregate no se toco: `ControlDiarioAggregateRoot.CrearDiaCalculado()` ya enruta
`_desgloseHoras.Discriminar()`, asi que la trazabilidad fluye al payload publicado sin cambios.

### Decisiones de diseno

- **Una linea por concepto, no por intervalo** (decision del planner "una linea por item con valor").
  La etiqueta se resuelve una vez por grupo; los intervalos del concepto se concatenan con `, `.
- **Reuso de `ToString()` ricos** (Tell-don't-Ask / "aprovechar la superficie del dominio"): la
  linea se construye desde `IntervaloTemporal.ToString()` y `DetalleRetardo.ToString()`, no
  recalculando formato a mano. Solo cruzan el bus los strings ya traducidos; el modelo rico no.
- **Orden cronologico** de los intervalos dentro de cada concepto via `IntervaloTemporal : IComparable`
  (`OrderBy(ic => ic.Intervalo)`), para una memoria de calculo legible y determinista.
- **i18n**: la etiqueta sale de `IntervaloClasificadoMensajes.resx` via
  `IntervaloClasificado.Mensajes.Etiqueta`. Las claves de `MinutosPorConcepto` siguen siendo el
  codigo estable (`Concepto.ToString()`, `"Retardo"`), nunca traducido (CA-4).
- No se introdujo helper compartido entre `IntervaloClasificado.ToString()` y `LineaConcepto`:
  son dos ocurrencias del patron `"{intervalos}: {etiqueta}"` (no aplica Rule of Three); los inputs
  difieren (un clasificado vs un grupo con label unica).

### ADRs consultados

El issue lista como ADRs aplicables "ADR de mensajes .resx (i18n de los ToString())" y un
"ADR nuevo: el modelo de dominio rico no cruza el bus". En este worktree `docs/adr/` materializa
solo un subconjunto (0001-0004, 0007, 0009, 0017, 0019, 0020); los referenciados por nombre no
estan como archivo. Los principios aplicables se respetaron usando el andamiaje ya existente:
- i18n en `.resx`: patron `ResourceManager` + accesor estatico, identico a `DetalleRetardo`/
  `IntervaloTemporal`. La etiqueta y el `.resx` los creo el test-writer; solo se consumen.
- "el modelo rico no cruza el bus": la trazabilidad se construye DESDE los `ToString()` de los
  objetos ricos; solo viajan strings en el payload plano `HorasDiscriminadas`.

### Desviaciones de ADRs

Ninguna desviacion - todos los principios aplicables se aplicaron al pie de la letra. No se
expuso estado interno nuevo (ningun getter, propiedad publica ni `InternalsVisibleTo` agregado);
la implementacion solo agrega comportamiento (`ToString()` y poblado de `Trazabilidad`).

### Precedentes consultados

- `DetalleRetardo.Mensajes.cs` / `IntervaloTemporal.Mensajes.cs`: patron de `Mensajes` + `.resx`
  (alineado con el ADR de mensajes). Solo como referencia de estilo; la clase `Mensajes` de
  `IntervaloClasificado` ya la creo el test-writer.
- `IntervaloTemporal.ToString()` / `DetalleRetardo.ToString()`: fuente de los strings ricos
  reutilizados (alineado con "el modelo rico no cruza el bus").

### Infraestructura modificada

Ninguna. #184 no agrega eventos publicos ni topics; `DiaCalculado` y su topic ya existen.

### Complejidad encontrada (BLOQUEO PARCIAL)

Dos tests pre-existentes (`DepurarAlAsignarTurnoTests.DebeCalcularControlFranja_CuandoMarcacionesLlegaronAntesQueTurno`
y `DepurarAlAdicionarMarcacionTests.DebeRecalcularControlesDeFranjaCompletos_CuandoHayTurnoPartidoYMarcacionesAcumuladas`)
verifican el `DiaCalculado` publicado completo con `Trazabilidad: []` cableado, para la misma
geometria que los tests nuevos de #184. El test-writer no actualizo esos oraculos en fase roja
(commit `57cdb60` no toca esos archivos). Es una contradiccion irreconciliable: mismo input, un
test exige `[]` y #184 exige la lista poblada.

Por la regla #1 del implementer (NUNCA modificar tests; y la prohibicion de escribir el esperado
a partir de la salida propia, regla 20 de oraculo independiente) **no se modificaron esos tests**.
Se reporto en `.claude/pipeline/blockage-report.md` para resolucion del reviewer (seccion 2b) o
del test-writer (regla #19), con el valor esperado correcto construido de forma independiente.

### Resultado

- Tests de #184: verdes (Contracts 214/214; nuevos `CrearDiaCalculadoConHorasDiscriminadasTests` verdes).
- Suite total: 381/383. Los 2 fallos son los oraculos obsoletos reportados como bloqueo estructural.
- Implementacion commiteada: `9aab6fe`.

</details>
<details>
<summary>Reviewer (fase refactor) — 12m 42s</summary>

## ES Reviewer - Revision (Issue #184: trazabilidad / memoria de calculo de HorasDiscriminadas)

### Evaluacion general
- Calidad: **buena**
- Cambios realizados: **si** (solo en tests: resolucion del bloqueo heredado; ningun cambio de produccion)

### Resolucion del bloqueo heredado (seccion 2b)

El implementer dejo 2 tests rojos por una **contradiccion estructural** (no por implementacion
defectuosa): dos oraculos pre-existentes (`DepurarAlAsignarTurnoTests`, `DepurarAlAdicionarMarcacionTests`)
verificaban el `DiaCalculado` publicado completo con `Trazabilidad: []` cableado, para geometrias
que el proposito mismo de #184 (poblar `Trazabilidad`) volvio imposibles de satisfacer con `[]`.
El test-writer no los toco en fase roja (commit `57cdb60`).

Resuelto en el **primer intento** (excepcion b de la seccion 2b): actualice los dos oraculos
construyendo el esperado de forma **independiente** (regla 20) -- helper local `LineaConcepto`
que arma `$"{IntervaloTemporal.ToString()}: {IntervaloClasificado.Mensajes.Etiqueta(concepto)}"`
con intervalos y conceptos derivados a mano (los mismos que el autor original ya habia razonado
para `MinutosPorConcepto`), sin ejecutar `Discriminar`. Al correr `dotnet test` el oraculo
independiente coincidio con produccion -> confirma razonamiento + implementacion. Detalle completo
en `.claude/pipeline/blockage-report.md` ("Resolucion de bloqueo heredado"). **No se modifico
codigo de produccion ni se elimino ningun test**; los CAs quedan cubiertos (ver tabla de cobertura).

### Cumplimiento de ADRs aplicables

> Nota de contexto: el issue lista los ADRs por nombre ("ADR de mensajes .resx", "ADR nuevo: el
> modelo de dominio rico no cruza el bus"). El `docs/adr/` del repo consumidor solo materializa un
> subconjunto del proyecto; los ADRs del **marco** viven en el plugin `mefisto`
> (`~/.claude/plugins/cache/.../mefisto/0.6.0/docs/adr/`), con numeracion propia. Verifique contra
> los del plugin: ADR-0009 (mensajes .resx) y ADR-0012 (modelado / frontera de serializacion).

| ADR | Cumplimiento | Observacion |
|---|---|---|
| ADR-0009: Patron de mensajes .resx per-clase + clase `Mensajes` anidada | ok (con variacion menor declarada) | `IntervaloClasificado.Mensajes` usa `ResourceManager` + accesor estatico. Variacion: `Etiqueta(Concepto)` es un **metodo** (clave = `Concepto.ToString()`) en vez de una propiedad por clave. Declarada por el test-writer; evita 9 propiedades y alinea la clave con el codigo estable (CA-4). Reforzada por el guardrail `Etiqueta_DefineUnTextoTraducidoNoVacio_ParaCadaConcepto` (mas fuerte que la seguridad implicita del patron de propiedades). **Aceptable.** |
| ADR-0012: Modelado de objetos / "el modelo rico no cruza el bus" + Tell-don't-Ask | ok | `HorasDiscriminadas` viaja 100% plano (`IReadOnlyDictionary<string,int>` + `IReadOnlyList<string>`); la trazabilidad son `string` derivados de los `ToString()` ricos. El modelo rico (`IntervaloClasificado`/`IntervaloTemporal`/`DetalleRetardo`) se queda en el dominio. `IntervaloClasificado.ToString()` es **comportamiento** (Tell-don't-Ask: el objeto se renderiza a si mismo), no un getter de estado. Guardrail de portabilidad existente (`HorasDiscriminadasTests.RoundTrip_...ConSerializadorPorDefecto`) sigue verde. |
| ADR-0018: Heuristicas de evolucion y reuso (Rule of Three) | ok | El implementer documento NO extraer un helper compartido entre `IntervaloClasificado.ToString()` y `DesgloseHoras.LineaConcepto` (2 sitios, inputs distintos). Correcto: "el reviewer no pide extraccion si el implementer no la ofrece" salvo evolucion conjunta documentada. No la pido. |

### Desviaciones de ADRs

**Declaradas por el implementer**: el implementer reporto "Ninguna desviacion". Coincido respecto
a los principios de modelado/serializacion.

**Detectadas por el reviewer (NO declaradas)**: ninguna desviacion arquitectonica. La unica
variacion (metodo `Etiqueta(Concepto)` vs propiedad por clave en ADR-0009) fue **declarada por el
test-writer** en su resumen (seccion "Variacion del patron ADR mensajes .resx") y es legitima bajo
el disclaimer de heuristicas de ADR-0009/0018. Sin desviaciones inaceptables.

### Precedentes consultados por el implementer

| Precedente | ADR aplicable | Veredicto |
|---|---|---|
| `DetalleRetardo.Mensajes.cs` / `IntervaloTemporal.Mensajes.cs` (patron `Mensajes` + `.resx`) | ADR-0009 | alineado |
| `IntervaloTemporal.ToString()` / `DetalleRetardo.ToString()` (strings ricos reutilizados) | ADR-0012 | alineado ("aprovechar la superficie del dominio") |

### Convenciones del pipeline (no ADRs)

| Convencion | Estado | Observacion |
|---|---|---|
| Cada test con `Then()` + `And<>()` | ok | Los 2 tests resueltos conservan `Then(streamId, ...)` + `And<>()` + `ThenIsPublishedPublicly`. No agregue tests nuevos (la cobertura ya existia). |
| Overloads correctos para stream IDs compuestos | ok | StreamId compuesto `EmpleadoId:Fecha`; los tests usan `Then(StreamId, ...)`, `And<,>(StreamId, ...)`, `Given(StreamId, ...)`. |
| Fakes manuales (no NSubstitute) | n/a | Sin dependencias nuevas; handlers usan `EventStore`/`PublicEventSender` del harness. |
| Feature folders (produccion y tests) | ok | Sin cambios estructurales; archivos en sus folders existentes. |
| Smoke tests: SkipWhen, secrets, cobertura | n/a | #184 no agrega eventos/endpoints; los smoke tests existentes se omiten por infra (esperado). |
| Tests via ToString/comportamiento | ok | El oraculo se verifica via `ToString()` de las primitivas y `Mensajes.Etiqueta`, no via getters de estado interno. |
| Sin numeros magicos | ok | Los `TimeOnly`/conceptos de los oraculos son datos de dominio del escenario, ya documentados en los comentarios del test. |
| Condiciones en positivo (guardas if/else) | n/a | No hay nuevas bifurcaciones en el codigo tocado. |

### Elegancia del codigo

Codigo de produccion de #184 (`IntervaloClasificado.ToString()`, `IntervaloClasificado.Mensajes`,
`DesgloseHoras.ConstruirTrazabilidadPorConcepto`/`LineaConcepto`): **elegante**.
- Compacto e idiomatico: LINQ (`SelectMany`/`GroupBy`/`Select`), interpolacion, expresiones de
  cuerpo unico. Sin codigo muerto ni verbosidad.
- Aprovecha la superficie del dominio (ADR-0012, cara positiva): reusa `IntervaloTemporal.ToString()`,
  `OrderBy(ic => ic.Intervalo)` via `IComparable`, `DetalleRetardo.ToString()`; no reimplementa formato.
- La etiqueta se resuelve **una sola vez por grupo** (no por intervalo) -> "una linea por concepto"
  (CA-1) con O(n) sobre los intervalos.
- Mi cambio (helper `LineaConcepto` local por archivo de test) sigue el estilo prevalente del
  proyecto (factories estaticas privadas por archivo de test, para minimizar acoplamiento/merge entre
  agentes paralelos). Mismo patron que `DesgloseHorasDiscriminarTests.LineaConcepto`.

### Criticas y hallazgos

- **Causa raiz del bloqueo (proceso, severidad menor)**: el test-writer debio actualizar estos dos
  oraculos en fase roja (su regla #19); la omision propago un rojo estructural al implementer y luego
  al reviewer. No es un defecto de codigo, sino del flujo; queda documentado para retroalimentar al
  test-writer. El codigo de produccion de #184 era correcto y completo desde la fase verde.
- Sin otros hallazgos. No hay warnings nuevos del compilador atribuibles a #184 (persiste NU1904 de
  `Marten 8.23.0`, preexistente y ajeno a este issue).

### Refactorings aplicados

- Ninguno sobre el codigo de produccion (estaba limpio; rule 5: no refactorizar por refactorizar).
- En tests: solo la resolucion del bloqueo (2 oraculos + 1 helper `LineaConcepto` por archivo).

### Cobertura de criterios de aceptacion

| Criterio | Estado | Test(s) |
|---|---|---|
| CA-1: `Discriminar()` puebla `Trazabilidad` con una linea por concepto con minutos > 0 | cubierto | `Discriminar_FormateaLaLineaComoIntervaloYEtiquetaTraducida_CuandoUnSoloIntervalo`, `Discriminar_PueblaUnaLineaPorConcepto_CuandoVariasFranjasYConceptos`, `Discriminar_ProduceUnaLineaPorEntradaDeMinutosPorConcepto_SinRetardo`, `IntervaloClasificadoTests.ToString_*`; enrutamiento aggregate: `CrearDiaCalculado_LlevaMinutosYTrazabilidadReales_CuandoFranjaNoEsAnomala`, `DebeCalcularControlFranja_CuandoMarcacionesLlegaronAntesQueTurno` |
| CA-2: linea de retardo cuando `RetardoNeto > 0`, desde `Retardo.ToString()` | cubierto | `Discriminar_IncluyeLineaDeRetardoDerivadaDeRetardoToString_CuandoRetardoNetoEsMayorACero`, `Discriminar_OmiteLineaDeRetardo_CuandoRetardoNetoEsCero` |
| CA-3: lineas traducidas (.resx); sin lineas para items en cero | cubierto | `Discriminar_TraduceLaTrazabilidadPeroDejaLaClaveComoCodigo_CuandoUnConcepto`, `Discriminar_NoIncluyeLineasParaConceptosAusentes_CuandoSoloHayDiurna`, `Discriminar_DejaTrazabilidadVacia_CuandoDesgloseEsVacio`, `Etiqueta_DefineUnTextoTraducidoNoVacio_ParaCadaConcepto` |
| CA-4: claves de `MinutosPorConcepto` como codigo estable; solo `Trazabilidad` es texto humano | cubierto | `Discriminar_TraduceLaTrazabilidadPeroDejaLaClaveComoCodigo_CuandoUnConcepto`, `Concepto_NoTieneValorRetardo`; reforzado en los oraculos resueltos (clave `"DominicalFestivaDiurna"` codigo + linea traducida) |

### Tests agregados

- Ninguno nuevo (la cobertura de CAs ya estaba completa en fase roja). Solo se resolvieron 2 oraculos
  obsoletos y se agrego el helper `LineaConcepto` (oraculo independiente) en cada uno de sus archivos.
- Tests de contrato (igualdad/serializacion de `HorasDiscriminadas`): ya existian de #183
  (`HorasDiscriminadasIgualdadTests`, `HorasDiscriminadasTests` round-trip por defecto) y siguen verdes.

### Estado final
- `dotnet test`: **447 total / 439 verde / 8 omitidos (smoke sin infra) / 0 errores**.
- `dotnet format --verify-no-changes` sobre los archivos modificados: sin cambios.

</details>

## Cobertura

| Archivo | Cobertura | Umbral | Estado |
|---|---|---|---|
| IntervaloClasificado.Mensajes.cs | - | excluido | - |
| DesgloseHoras.cs | - | no evaluado | - |
| IntervaloClasificado.cs | - | no evaluado | - |
## Commits

be5aa33 test(hu-184): actualizar oraculos de DiaCalculado con Trazabilidad poblada (fase refactor)
9aab6fe feat(hu-184): poblar Trazabilidad (memoria de calculo) de HorasDiscriminadas (fase verde)
57cdb60 test(hu-184): tests para trazabilidad (memoria de calculo) de HorasDiscriminadas (fase roja)

Closes #184