### PR TITLE
Declarar el bounded context en harness.config.json (ADR-0023)

### DIFF
--- a/.claude/harness.config.json
+++ b/.claude/harness.config.json
@@ -6,5 +6,9 @@
   "terraformStateStorage": "stcatfstatedev",
   "githubServicePrincipalName": "github-controlasistencias-ci",
   "appInsightsApp": "controlasistencias-dev-ai",
-  "domainLabels": ["asistencia", "programacion", "contracts", "controlhoras"]
+  "domainLabels": ["asistencia", "programacion", "contracts", "controlhoras"],
+  "boundedContext": {
+    "name": "ControlAsistencias",
+    "domains": ["programacion", "controlhoras"]
+  }
 }


### PR DESCRIPTION
## Qué hace

Agrega el bloque `boundedContext` a `.claude/harness.config.json`, exigido por el **ADR-0023 del harness**. Sin él, `load_harness_config` aborta el pre-vuelo de **todos** los pipelines (`/infra`, `/tooling`, etc.) — por eso este cambio no podía hacerse por el pipeline de tooling (se auto-bloquearía) y se autora directamente.

```json
"boundedContext": {
  "name": "ControlAsistencias",
  "domains": ["programacion", "controlhoras"]
}
```

## Decisiones

- **`name = "ControlAsistencias"`**: coincide con `projectName` y el prefijo de resource group (`rg-controlasistencias`); pasa el regex `[a-zA-Z0-9-]{1,63}`.
- **`domains = ["programacion", "controlhoras"]`**: las únicas Function Apps reales en `src/`. Se **excluye** `asistencia` (label sin proyecto en `src/`; declararlo inventaría una Function App inexistente) y `contracts` (es librería/shared kernel, no tiene host de Functions). Ambos se pueden agregar cuando exista su Function App.

## Sin impacto en infra

El planner verificó que ya cumplimos la topología de ADR-0023 para un BC único: un resource group (`rg-controlasistencias-dev`) que agrupa ambos dominios + un namespace de ASB compartido (`sb-${prefix}`) que hace de "namespace interno del BC". El tráfico Programacion→ControlHoras es intra-BC (privado) y ya viaja por ese namespace. **No requiere cambios de infra.**

## Verificación

`load_harness_config` corre limpio contra la config nueva: `BC=ControlAsistencias domains=programacion controlhoras`.

## Desbloquea

Es prerequisito de la línea de Key Vault: **#200 → #195 → #196 → #197**.

Closes #200