### PR TITLE
Migrar las cadenas de conexion (ASB, Postgres, App Insights) a referencias de Key Vault

### DIFF
--- a/infra/environments/dev/main.tf
+++ b/infra/environments/dev/main.tf
@@ -100,6 +100,15 @@ module "key_vault" {
   tags                = local.tags
 }
 
+# Referencias versionless a Key Vault (ADR-0025 decision #2): el app setting
+# lleva la referencia, no el valor. El valor lo siembra un admin (decision #6).
+# Versionless (sin sufijo de version): toma la ultima al rotar el secreto.
+locals {
+  service_bus_connection_kv_ref  = "@Microsoft.KeyVault(SecretUri=${module.key_vault.uri}secrets/service-bus-connection)"
+  marten_connection_kv_ref       = "@Microsoft.KeyVault(SecretUri=${module.key_vault.uri}secrets/marten-connection)"
+  app_insights_connection_kv_ref = "@Microsoft.KeyVault(SecretUri=${module.key_vault.uri}secrets/app-insights-connection)"
+}
+
 resource "random_string" "storage_suffix_programacion" {
   length  = 6
   special = false
@@ -123,11 +132,11 @@ module "function_app_programacion" {
   storage_account_name              = module.storage_programacion.name
   storage_account_connection_string = module.storage_programacion.primary_connection_string
   storage_account_access_key        = module.storage_programacion.primary_access_key
-  app_insights_connection_string    = module.monitoring.connection_string
+  app_insights_connection_string    = local.app_insights_connection_kv_ref
   app_settings = {
-    SERVICE_BUS_CONNECTION = module.service_bus.default_primary_connection_string
+    SERVICE_BUS_CONNECTION = local.service_bus_connection_kv_ref
     DOMINIO                = "programacion"
-    MartenConnectionString = "Host=${module.postgresql.server_fqdn};Database=${module.postgresql.database_name};Username=pgadmin;Password=${var.postgresql_admin_password};SSL Mode=Require"
+    MartenConnectionString = local.marten_connection_kv_ref
   }
   tags = local.tags
 }
@@ -155,12 +164,27 @@ module "function_app_control_horas" {
   storage_account_name              = module.storage_control_horas.name
   storage_account_connection_string = module.storage_control_horas.primary_connection_string
   storage_account_access_key        = module.storage_control_horas.primary_access_key
-  app_insights_connection_string    = module.monitoring.connection_string
+  app_insights_connection_string    = local.app_insights_connection_kv_ref
   app_settings = {
-    SERVICE_BUS_CONNECTION = module.service_bus.default_primary_connection_string
+    SERVICE_BUS_CONNECTION = local.service_bus_connection_kv_ref
     DOMINIO                = "control-horas"
-    MartenConnectionString = "Host=${module.postgresql.server_fqdn};Database=${module.postgresql.database_name};Username=pgadmin;Password=${var.postgresql_admin_password};SSL Mode=Require"
+    MartenConnectionString = local.marten_connection_kv_ref
   }
   tags = local.tags
+}
+
+# RBAC data-plane (ADR-0024 decision #6): la managed identity de cada Function
+# App necesita "Key Vault Secrets User" para resolver las referencias
+# @Microsoft.KeyVault(...) de sus app settings.
+resource "azurerm_role_assignment" "kv_secrets_user_programacion" {
+  scope                = module.key_vault.id
+  role_definition_name = "Key Vault Secrets User"
+  principal_id         = module.function_app_programacion.principal_id
+}
+
+resource "azurerm_role_assignment" "kv_secrets_user_control_horas" {
+  scope                = module.key_vault.id
+  role_definition_name = "Key Vault Secrets User"
+  principal_id         = module.function_app_control_horas.principal_id
 }
 


### PR DESCRIPTION
## Qué hace

Conmuta los tres app settings sensibles de ambas Function Apps de **valor literal** a **referencia** `@Microsoft.KeyVault(SecretUri=...)` versionless (ADR-0025 decisión #2), y otorga a cada managed identity el rol para leerlas.

- **Locals** con las 3 referencias versionless usando `module.key_vault.uri`:
  - `service-bus-connection` → `SERVICE_BUS_CONNECTION`
  - `marten-connection` → `MartenConnectionString`
  - `app-insights-connection` → `APPLICATIONINSIGHTS_CONNECTION_STRING`
- **Role assignment** `Key Vault Secrets User` por Function App (ADR-0024 #6), scope = el Key Vault, principal = la managed identity de cada app.
- **No cambia las claves** de app setting → no toca C#.

## Verificación local

- `terraform validate`: OK (CA-1).
- `terraform plan`: **`2 to add, 2 to change, 0 to destroy`** — 2 role assignments nuevos + 2 Function Apps in-place; sin destrucciones (CA-2).
- Los app settings **dejan de estar marcados como sensitive**: el state ahora guarda referencias, no los valores secretos (CA-7).

## Prerequisitos (cumplidos)

- Key Vault `kv-asist-67ltbw` provisionado (#195, mergeado).
- Los 3 secretos **ya sembrados** administrativamente (`az keyvault secret set`).
- Principal de CI con `roleAssignments/write` sobre el RG (#201, RBAC Administrator) → el apply del role assignment no fallará con `AuthorizationFailed`.

## Despliegue y verificación post-merge

Al mergear, `infra-cd.yml` aplica en CI. Después:
- **Reiniciar** ambas Function Apps para que resuelvan las referencias (CA-6).
- Verificar con `az functionapp config appsettings list` que muestran `@Microsoft.KeyVault(...)` y que el estado de resolución no queda en error.

## Nota

El plan muestra `site_config.application_insights_connection_string -> null`: es un campo redundante que el módulo no gestiona (la telemetría la maneja el app setting `APPLICATIONINSIGHTS_CONNECTION_STRING`). Es un cambio in-place preexistente, no una destrucción.

Closes #196