### PR TITLE
Migrar AzureWebJobsStorage a identidad administrada

### DIFF
--- a/infra/environments/dev/main.tf
+++ b/infra/environments/dev/main.tf
@@ -124,15 +124,13 @@ module "storage_programacion" {
 }
 
 module "function_app_programacion" {
-  source                            = "../../modules/function-app"
-  name                              = "func-${local.prefix_short}-programacion"
-  resource_group_name               = module.resource_group.name
-  location                          = module.resource_group.location
-  service_plan_id                   = module.service_plan_programacion.id
-  storage_account_name              = module.storage_programacion.name
-  storage_account_connection_string = module.storage_programacion.primary_connection_string
-  storage_account_access_key        = module.storage_programacion.primary_access_key
-  app_insights_connection_string    = local.app_insights_connection_kv_ref
+  source                         = "../../modules/function-app"
+  name                           = "func-${local.prefix_short}-programacion"
+  resource_group_name            = module.resource_group.name
+  location                       = module.resource_group.location
+  service_plan_id                = module.service_plan_programacion.id
+  storage_account_name           = module.storage_programacion.name
+  app_insights_connection_string = local.app_insights_connection_kv_ref
   app_settings = {
     SERVICE_BUS_CONNECTION = local.service_bus_connection_kv_ref
     DOMINIO                = "programacion"
@@ -156,15 +154,13 @@ module "storage_control_horas" {
 }
 
 module "function_app_control_horas" {
-  source                            = "../../modules/function-app"
-  name                              = "func-${local.prefix_short}-control-horas"
-  resource_group_name               = module.resource_group.name
-  location                          = module.resource_group.location
-  service_plan_id                   = module.service_plan_control_horas.id
-  storage_account_name              = module.storage_control_horas.name
-  storage_account_connection_string = module.storage_control_horas.primary_connection_string
-  storage_account_access_key        = module.storage_control_horas.primary_access_key
-  app_insights_connection_string    = local.app_insights_connection_kv_ref
+  source                         = "../../modules/function-app"
+  name                           = "func-${local.prefix_short}-control-horas"
+  resource_group_name            = module.resource_group.name
+  location                       = module.resource_group.location
+  service_plan_id                = module.service_plan_control_horas.id
+  storage_account_name           = module.storage_control_horas.name
+  app_insights_connection_string = local.app_insights_connection_kv_ref
   app_settings = {
     SERVICE_BUS_CONNECTION = local.service_bus_connection_kv_ref
     DOMINIO                = "control-horas"
@@ -185,6 +181,32 @@ resource "azurerm_role_assignment" "kv_secrets_user_programacion" {
 resource "azurerm_role_assignment" "kv_secrets_user_control_horas" {
   scope                = module.key_vault.id
   role_definition_name = "Key Vault Secrets User"
+  principal_id         = module.function_app_control_horas.principal_id
+}
+
+# Storage por identidad administrada (ADR-0025 decision #3): AzureWebJobsStorage
+# no puede ir por referencia de Key Vault (el runtime necesita el storage al
+# arrancar, antes de resolver referencias). La managed identity de cada Function
+# App necesita los tres roles de datos de Storage sobre su propia cuenta.
+locals {
+  storage_data_roles = toset([
+    "Storage Blob Data Owner",
+    "Storage Queue Data Contributor",
+    "Storage Table Data Contributor",
+  ])
+}
+
+resource "azurerm_role_assignment" "storage_data_programacion" {
+  for_each             = local.storage_data_roles
+  scope                = module.storage_programacion.id
+  role_definition_name = each.value
+  principal_id         = module.function_app_programacion.principal_id
+}
+
+resource "azurerm_role_assignment" "storage_data_control_horas" {
+  for_each             = local.storage_data_roles
+  scope                = module.storage_control_horas.id
+  role_definition_name = each.value
   principal_id         = module.function_app_control_horas.principal_id
 }
 

--- a/infra/modules/function-app/main.tf
+++ b/infra/modules/function-app/main.tf
@@ -23,18 +23,6 @@ variable "storage_account_name" {
   type        = string
 }
 
-variable "storage_account_connection_string" {
-  description = "Connection string de la storage account (para App Settings)"
-  type        = string
-  sensitive   = true
-}
-
-variable "storage_account_access_key" {
-  description = "Access key de la storage account (requerida por azurerm_linux_function_app)"
-  type        = string
-  sensitive   = true
-}
-
 variable "app_insights_connection_string" {
   description = "Connection string de Application Insights"
   type        = string
@@ -58,9 +46,9 @@ resource "azurerm_linux_function_app" "this" {
   resource_group_name = var.resource_group_name
   location            = var.location
 
-  service_plan_id            = var.service_plan_id
-  storage_account_name       = var.storage_account_name
-  storage_account_access_key = var.storage_account_access_key
+  service_plan_id               = var.service_plan_id
+  storage_account_name          = var.storage_account_name
+  storage_uses_managed_identity = true
 
   site_config {
     application_stack {


### PR DESCRIPTION
## Qué hace

Migra el storage del host de ambas Function Apps de **access key en claro** a **identidad administrada** (ADR-0025 decisión #3). El access key sale del state y de la configuración de la app.

- **Módulo `function-app`**: `storage_account_access_key = ...` → `storage_uses_managed_identity = true`. Se eliminan las variables `storage_account_access_key` (ya no se usa) y `storage_account_connection_string` (estaba muerta — declarada sin uso).
- **`environments/dev`**: se quitan esos dos argumentos de ambas llamadas al módulo; se agregan **3 role assignments de datos por Function App** sobre su propia Storage Account, vía `for_each`:
  - `Storage Blob Data Owner`
  - `Storage Queue Data Contributor`
  - `Storage Table Data Contributor`

## Verificación local

- `terraform validate`: OK (CA-1). `terraform fmt`: aplicado.
- `terraform plan`: **`6 to add, 2 to change, 0 to destroy`** — 6 role assignments nuevos + 2 Function Apps in-place (`storage_account_access_key → null`, `storage_uses_managed_identity: false → true`); sin destrucciones (CA-2, CA-7).

## Prerequisito (cumplido)

Principal de CI con `roleAssignments/write` sobre el RG (#201) → el apply de los role assignments no falla con `AuthorizationFailed`.

## ⚠️ Riesgo conocido (mismo race que #196, potencialmente peor)

`AzureWebJobsStorage` por identidad necesita que los roles de datos **propaguen antes de que el host arranque**. A diferencia de las referencias de Key Vault (que se cachean y se pueden refrescar), **el runtime necesita el storage al arrancar**. Si tras el apply de CI las apps no levantan por permisos, la remediación es la misma que aplicamos en #196: esperar la propagación del RBAC y **reiniciar** ambas Function Apps. Hay que verificar el arranque post-apply (CA-6).

## Post-merge

- Verificar que ambas apps arrancan healthy (reiniciar si es necesario tras propagar el RBAC).
- Confirmar `az functionapp config appsettings list` sin access key literal (CA-5).

Closes #197