### PR TITLE
Actualizar los building blocks Cosmos.Event* a la version 2.1.0

### DIFF
--- a/src/Bitakora.ControlAsistencia.Contracts/Bitakora.ControlAsistencia.Contracts.csproj
+++ b/src/Bitakora.ControlAsistencia.Contracts/Bitakora.ControlAsistencia.Contracts.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cosmos.EventDriven.Abstractions" Version="0.0.8" />
+    <PackageReference Include="Cosmos.EventDriven.Abstractions" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Bitakora.ControlAsistencia.ControlHoras/Bitakora.ControlAsistencia.ControlHoras.csproj
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Bitakora.ControlAsistencia.ControlHoras.csproj
@@ -17,11 +17,11 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.OpenTelemetry" Version="1.2.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.*" />
-    <PackageReference Include="Cosmos.EventDriven.Abstractions" Version="0.0.8" />
-    <PackageReference Include="Cosmos.EventDriven.CritterStack" Version="0.0.5" />
-    <PackageReference Include="Cosmos.EventDriven.CritterStack.AzureServiceBus" Version="0.0.6" />
-    <PackageReference Include="Cosmos.EventSourcing.Abstractions" Version="0.0.12" />
-    <PackageReference Include="Cosmos.EventSourcing.CritterStack" Version="0.1.9" />
+    <PackageReference Include="Cosmos.EventDriven.Abstractions" Version="2.1.0" />
+    <PackageReference Include="Cosmos.EventDriven.CritterStack" Version="2.1.0" />
+    <PackageReference Include="Cosmos.EventDriven.CritterStack.AzureServiceBus" Version="2.1.0" />
+    <PackageReference Include="Cosmos.EventSourcing.Abstractions" Version="2.1.0" />
+    <PackageReference Include="Cosmos.EventSourcing.CritterStack" Version="2.1.0" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.*" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
   </ItemGroup>

--- a/src/Bitakora.ControlAsistencia.Programacion/Bitakora.ControlAsistencia.Programacion.csproj
+++ b/src/Bitakora.ControlAsistencia.Programacion/Bitakora.ControlAsistencia.Programacion.csproj
@@ -15,11 +15,11 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.*" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
-    <PackageReference Include="Cosmos.EventDriven.Abstractions" Version="0.0.8" />
-    <PackageReference Include="Cosmos.EventDriven.CritterStack" Version="0.0.5" />
-    <PackageReference Include="Cosmos.EventDriven.CritterStack.AzureServiceBus" Version="0.0.6" />
-    <PackageReference Include="Cosmos.EventSourcing.Abstractions" Version="0.0.12" />
-    <PackageReference Include="Cosmos.EventSourcing.CritterStack" Version="0.1.9" />
+    <PackageReference Include="Cosmos.EventDriven.Abstractions" Version="2.1.0" />
+    <PackageReference Include="Cosmos.EventDriven.CritterStack" Version="2.1.0" />
+    <PackageReference Include="Cosmos.EventDriven.CritterStack.AzureServiceBus" Version="2.1.0" />
+    <PackageReference Include="Cosmos.EventSourcing.Abstractions" Version="2.1.0" />
+    <PackageReference Include="Cosmos.EventSourcing.CritterStack" Version="2.1.0" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.4.0" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.*" />
   </ItemGroup>

--- a/tests/Bitakora.ControlAsistencia.Contracts.Tests/Bitakora.ControlAsistencia.Contracts.Tests.csproj
+++ b/tests/Bitakora.ControlAsistencia.Contracts.Tests/Bitakora.ControlAsistencia.Contracts.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cosmos.EventSourcing.Testing.Utilities" Version="0.1.*" />
+    <PackageReference Include="Cosmos.EventSourcing.Testing.Utilities" Version="2.1.0" />
     <PackageReference Include="xunit.v3.mtp-v2" Version="3.*" />
   </ItemGroup>
 

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Bitakora.ControlAsistencia.ControlHoras.Tests.csproj
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Bitakora.ControlAsistencia.ControlHoras.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cosmos.EventSourcing.Testing.Utilities" Version="0.1.*" />
+    <PackageReference Include="Cosmos.EventSourcing.Testing.Utilities" Version="2.1.0" />
     <PackageReference Include="xunit.v3.mtp-v2" Version="3.*" />
   </ItemGroup>
 

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/Bitakora.ControlAsistencia.Programacion.Tests.csproj
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/Bitakora.ControlAsistencia.Programacion.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cosmos.EventSourcing.Testing.Utilities" Version="0.1.*" />
+    <PackageReference Include="Cosmos.EventSourcing.Testing.Utilities" Version="2.1.0" />
     <PackageReference Include="xunit.v3.mtp-v2" Version="3.*" />
   </ItemGroup>
 


### PR DESCRIPTION
## Resumen

Pipeline TDD completado (refactoring puro):
- Análisis: no se requieren tests nuevos
- Justificación: El issue #207 es un bump de version de dependencias NuGet (Cosmos.EventDriven.* y Cosmos.EventSourcing.* de 0.0.x/0.1.* -> 2.1.0 exacto) en 6 archivos .csproj. Ninguno de los 6 criterios de aceptacion (CA-1 a CA-6) define comportamiento de negocio nuevo: son gates de config (version exacta en los .csproj), compilacion (dotnet build), migracion de API rota para que el codigo existente siga compilando, verdor de la suite de tests EXISTENTE (no de tests nuevos), y verificacion post-deploy contra dev (smoke tests). El propio issue lo declara explicitamente: "no es posible actualizar solo algunos sin romper la coherencia de versiones" y el trabajo consiste en "migrar" el uso de API existente hacia la nueva superficie del paquete, no en escribir comportamiento nuevo. Confirme antes de emitir esta senal que la base compila (`dotnet build ControlAsistencias.slnx --configuration Release` -> Compilacion correcta, 0 errores) y que la suite completa esta verde (`dotnet test --solution ControlAsistencias.slnx` -> total 447, correcto 439, omitido 8 [smoke tests que requieren ServiceBus/Postgres configurados, no disponibles en este entorno local], error 0). Los tests existentes (incluyendo los *SerializacionTests / *SerializacionMartenTests que ADR-0015 exige como red de seguridad para round-trip del event store, y el DSL Given/When/Then de Cosmos.EventSourcing.Testing.Utilities cubierto por ADR-0006) ya cubren la funcionalidad involucrada y son exactamente el canal que detecta breaking changes de API tras el bump: si el salto doble-mayor rompe la forma de un evento o el envelope de serializacion, esos tests existentes fallaran (rojo) y el implementer los hara pasar migrando produccion, no agregando tests nuevos. No existe un estado rojo-que-compila intermedio que un test-writer pueda preparar de antemano: la migracion de API rota es descubierta por el compilador en el momento del bump (notas tecnicas del issue: "los breaking changes concretos se descubren al compilar; no se enumeran aqui a proposito"), por lo que escribir tests nuevos ahora seria prematuro y no aporta cobertura -- el propio compilador y la suite existente son el oraculo. No se elimina ni modifica ningun test existente en este carril; si tras el bump algun test de infraestructura (DSL, fakes de Testing.Utilities) queda obsoleto por un cambio de firma en el paquete, su ajuste queda documentado aqui para que el reviewer (Stage 3) lo ejecute con este contexto. REMOVED_TESTS=0 porque en este momento (pre-bump) no se identifica ningun test que deba eliminarse; la migracion de firmas rotas por el paquete se resuelve ajustando las llamadas al DSL sin perder cobertura, no eliminando tests.
- Baseline: 425 tests pasando
- Refactoring ejecutado manteniendo todos los tests verdes

## Decisiones del pipeline

<details>
<summary>Test Writer (fase roja) — 2m 20s</summary>

_(El agente no generó resumen)_

</details>

<details>
<summary>Reviewer (fase refactor) — 9m 25s</summary>

## ES Reviewer - Revision (refactor puro, issue #207)

### Naturaleza de la tarea

Refactor puro: bump atomico de los building blocks `Cosmos.EventDriven.*` y
`Cosmos.EventSourcing.*` de `0.0.x`/`0.1.*` al pin exacto `2.1.0` en 6 `.csproj`.
No hubo fase roja ni verde previas (senal `pipeline-state/refactor-signal.md`,
`REFACTOR_ONLY=true`, `REMOVED_TESTS=0`). El reviewer ejecuto el refactor.

### Evaluacion general
- Calidad: buena
- Cambios realizados: si (solo 6 `.csproj`; 0 archivos `.cs` tocados)

### Cumplimiento de ADRs aplicables

| ADR (por tema) | Cumplimiento | Observacion |
|---|---|---|
| Serializacion / `ConfigurarSerializacion` / VOs con ctor privado (ADR-0012 en plugin) | ok | Ningun `.cs` se modifico. Los 14 tipos con `ConfigurarSerializacion` y los 13 `*SerializacionTests`/`*SerializacionMartenTests` siguen verdes tras el bump: no hay regresion de round-trip del event store. |
| Naming y versionado de eventos (ADR-0005) | ok | El bump no altero alias/tipo ni forma de ningun evento (sin cambios de codigo). Envelope sin cambios de forma detectables por la suite; riesgo residual de lectura de streams viejos cubierto por smoke contra dev (CA-6). |
| Estrategia de testing / DSL Given-When-Then (ADR-0002) | ok | `Cosmos.EventSourcing.Testing.Utilities` 2.1.0 mantiene la superficie del DSL: la suite compila y corre sin migracion de firmas. Ningun test quedo obsoleto (REMOVED_TESTS=0 confirmado). |
| Smoke tests contra dev (ADR-0013/0016) | n/a en local | CA-5/CA-6 son post-deploy. El diff no toca smoke tests ni infra; no aplica el checklist de smoke. Se ejecutan en CI/dev tras el merge. |

### Desviaciones de ADRs

Ninguna desviacion - todos los ADRs aplicables se cumplen. No hubo resumen de
implementer (refactor puro sin stage-2); no hay desviaciones declaradas que evaluar.

### Precedentes consultados por el implementer

No aplica: no hubo fase de implementer en este carril de refactor puro.

### Convenciones del pipeline (no ADRs)

| Convencion | Estado | Observacion |
|---|---|---|
| Cada test con `Then()` + `And<>()` | n/a | No se agregaron ni modificaron tests. |
| Overloads correctos para stream IDs compuestos | n/a | Sin cambios en tests. |
| Fakes manuales (no NSubstitute) | n/a | Sin cambios en tests. |
| Feature folders (produccion y tests) | ok | Estructura intacta; no se movieron archivos. |
| Smoke tests: SkipWhen, secrets, cobertura | n/a | Diff no toca smoke tests. |
| Tests via ToString/comportamiento | n/a | Sin cambios en tests. |
| Sin numeros magicos | n/a | Sin cambios de codigo. |
| Condiciones en positivo | n/a | Sin cambios de codigo. |

### Elegancia del codigo
- El diff es minimo y quirurgico: solo cambian numeros de version en XML. No hay
  cambios de codigo que evaluar por compacidad/legibilidad/idiomatismo.
- CA-1: se elimino el unico rango flotante (`Testing.Utilities` `0.1.*` -> `2.1.0`),
  ganando reproducibilidad del build. Todas las referencias Cosmos.Event* quedan en
  `2.1.0` exacto (verificado por grep: 0 referencias fuera de 2.1.0).

### Criticas y hallazgos
- **Hallazgo mayor resuelto (artefactos stale)**: tras el bump, la primera corrida de
  la suite fallo con `System.IO.FileNotFoundException: Could not load ... Cosmos.EventDriven.Abstractions, Version=0.0.8.0`
  en `ControlHoras.Tests` (host xUnit v3 abortaba, "No se ejecutaron pruebas", exit 134)
  y 4 errores en SmokeTests. Causa: DLLs/`.deps.json` de la version vieja (0.0.8) residentes
  en `bin/`/`obj/` de multiples proyectos que un build incremental no purga. Accion:
  limpieza total de `bin/`+`obj/`, `restore` + `build` + `test`. Tras la limpieza la suite
  volvio a 447/439/8/0. No es un breaking change del paquete: es contaminacion de artefactos
  del entorno local. **Nota para el gate CI**: CI parte de checkout limpio, no reproduce este
  falso rojo; pero conviene tenerlo presente si algun runner reusa workspace.
- **Warning preexistente CS0414** (`CatalogoTurnos._estaActivo` asignado y nunca usado):
  verificado contra baseline (stash) -> existe con las versiones viejas. NO lo causa el bump.
  Fuera del alcance del issue #207 (regla #4): no se toca.
- **Warnings preexistentes IDE0005** (usings innecesarios en 6 archivos): todos son
  `using Bitakora.ControlAsistencia.Contracts.Programacion.ValueObjects;` u otros namespaces
  internos del proyecto, ninguno `Cosmos.*`. No los causa el bump (un using interno no se
  vuelve innecesario por un cambio de version de paquete). Fuera de alcance: no se tocan.
- **Sin deuda de migracion** (CA-3): 0 warnings CS0618/obsolete, 0 `#pragma warning disable`
  de migracion, 0 `TODO`/`FIXME` de bump. Ningun `using Cosmos.*` quedo huerfano. El salto
  doble-mayor NO rompio la superficie de API consumida por este repo.

### Refactorings aplicados
- Ninguno sobre codigo `.cs` (no era necesario ni pertinente al issue). El unico cambio es
  el bump de versiones en los 6 `.csproj`, que ES el refactor solicitado.

### Cobertura de criterios de aceptacion
| Criterio | Estado | Evidencia |
|---|---|---|
| CA-1: 6 `.csproj` en `2.1.0` exacto (incl. Testing.Utilities sin `0.1.*`) | cubierto | grep confirma todas las referencias Cosmos.Event* en `2.1.0`; 0 rangos flotantes restantes |
| CA-2: `dotnet build --configuration Release` sin errores | cubierto | Compilacion correcta, 0 Errores (rebuild no incremental) |
| CA-3: API rota migrada en el PR, sin pragma/TODO pendientes | cubierto | Sin migracion necesaria; 0 obsolete/pragma/TODO; sin usings Cosmos huerfanos |
| CA-4: suite `dotnet test` verde, incl. *SerializacionTests/*SerializacionMartenTests | cubierto | 447 total, 439 correcto, 8 omitido (smoke sin infra local), 0 error; 13 tests de serializacion en verde |
| CA-5: smoke tests dev verdes post-deploy | pendiente post-deploy | Fuera de alcance local; se dispara el workflow `Smoke Tests` tras deploy a dev |
| CA-6: sin regresion de compatibilidad del event store | pendiente post-deploy (parcial local) | Reconstruccion de aggregates en la suite verde; lectura de streams preexistentes se valida por smoke contra dev |

### Tests agregados
- Ninguno. Coherente con el carril de refactor puro (la suite existente es el oraculo del
  bump). No se elimino ni modifico ningun test (REMOVED_TESTS=0 confirmado tras el bump:
  ningun test de infraestructura/DSL quedo obsoleto por cambio de firma).

### Nota de gate para el pipeline
- Pre-merge (CA-2, CA-4): verde local y reproducible en CI (`build-and-test`).
- Post-deploy (CA-5, CA-6): requieren deploy a dev + ejecucion manual del workflow de smoke.
  Una falla de smoke es senal de revertir el merge, no de avanzar (ADR-0016).

</details>

## Commits

affa2e0 refactor(hu-207): actualizar building blocks Cosmos.Event* a 2.1.0

Closes #207