### PR TITLE
Quitar el marker IPrivateEvent de MarcacionAdicionada y TurnoDiarioAsignado (eventos de event sourcing puros)

### DIFF
--- a/src/Bitakora.ControlAsistencia.ControlHoras/AdicionarMarcacionCuandoMarcacionRegistrada/Eventos/MarcacionAdicionada.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/AdicionarMarcacionCuandoMarcacionRegistrada/Eventos/MarcacionAdicionada.cs
@@ -1,13 +1,12 @@
 using System.Reflection;
 using System.Text.Json.Serialization.Metadata;
-using Cosmos.EventDriven.Abstractions;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.AdicionarMarcacionCuandoMarcacionRegistrada.Eventos;
 
-// HU-106: Evento privado que registra la adicion de una marcacion al ControlDiario
-// Se persiste en el stream de ControlDiarioAggregateRoot (Id = stream ID compuesto)
-// Publicado localmente via Wolverine; consumido por #107 para depuracion
-public sealed class MarcacionAdicionada : IPrivateEvent
+// HU-106: Evento de event sourcing que registra la adicion de una marcacion al ControlDiario.
+// Se persiste en el stream de ControlDiarioAggregateRoot (Id = stream ID compuesto) y no cruza el bus.
+// ADR-0024: evento del aggregate (categoria event-sourcing), sin marker de bus.
+public sealed class MarcacionAdicionada
 {
     // CA-7: Id es el stream ID del ControlDiario: "{EmpleadoId}:{Fecha:yyyy-MM-dd}"
     public string Id { get; private set; } = null!;

--- a/src/Bitakora.ControlAsistencia.ControlHoras/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/TurnoDiarioAsignado.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/TurnoDiarioAsignado.cs
@@ -2,18 +2,17 @@ using System.Reflection;
 using System.Text.Json.Serialization.Metadata;
 using Bitakora.ControlAsistencia.Contracts.Empleados.ValueObjects;
 using Bitakora.ControlAsistencia.Contracts.Programacion.ValueObjects;
-using Cosmos.EventDriven.Abstractions;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction.Eventos;
 
 /// <summary>
-/// Evento privado que registra la asignacion de un turno diario al ControlDiario.
-/// Se persiste en el stream de ControlDiarioAggregateRoot.
-/// No se publica al Service Bus.
+/// Evento de event sourcing que registra la asignacion de un turno diario al ControlDiario.
+/// Se persiste en el stream de ControlDiarioAggregateRoot y no cruza el bus.
+/// ADR-0024: evento del aggregate (categoria event-sourcing), sin marker de bus.
 /// </summary>
 // HU-12: evento de event sourcing del aggregate ControlDiario
 // CA-5: contiene InformacionEmpleado, Fecha, DetalleTurno y SolicitudId (trazabilidad)
-public sealed class TurnoDiarioAsignado : IPrivateEvent
+public sealed class TurnoDiarioAsignado
 {
     public string Id { get; private set; } = null!;
     public InformacionEmpleado InformacionEmpleado { get; private set; } = null!;


### PR DESCRIPTION
## Resumen

Pipeline TDD completado (refactoring puro):
- Análisis: no se requieren tests nuevos
- Justificación: Issue #211 pide quitar la interfaz marker `IPrivateEvent` de dos eventos de event sourcing puros (`MarcacionAdicionada` y `TurnoDiarioAsignado`) que nunca se publican -- solo se `new`-ean y se `Apply()`-an al aggregate `ControlDiarioAggregateRoot` y viven en el event store de Marten. Es el "caso mandatorio" del proceso: un cambio de firma (quitar una interfaz marker) que no introduce comportamiento nuevo. Verificacion realizada antes de emitir esta senal:
- Baseline: 425 tests pasando
- Refactoring ejecutado manteniendo todos los tests verdes

## Decisiones del pipeline

<details>
<summary>Test Writer (fase roja) — 2m 6s</summary>

_(El agente no generó resumen)_

</details>

<details>
<summary>Reviewer (fase refactor) — 5m 5s</summary>

## ES Reviewer - Revision (refactor puro, issue #211)

### Evaluacion general
- Calidad: buena
- Cambios realizados: si (el refactor mismo, tal como lo pide el issue)
- Naturaleza: refactor puro de un solo eje (quitar interfaz marker `IPrivateEvent` de dos eventos de event sourcing). No hubo fases roja/verde previas; no existe `stage-2-implementer.md`.

### Baseline y estado final
- **Baseline (antes del cambio)**: 447 total / 428 correcto / 11 error / 8 omitido. Las 11 fallas son **exclusivamente** smoke tests contra el entorno dev real (HTTP -> 500/status incorrecto por entorno no alcanzable desde la maquina): `ControlHoras.SmokeTests` (3) y `Programacion.SmokeTests` (8). Preexistentes y ajenas a #211.
- **Final (despues del cambio)**: 447 total / 428 correcto / 11 error / 8 omitido. **Delta cero**: mismas 11 fallas ambientales, ninguna regresion.
- **Proyecto afectado (`ControlHoras.Tests`)**: 296/296 verdes, incluye `MarcacionAdicionadaSerializacionTests` y `TurnoDiarioAsignadoSerializacionTests` (CA-4).
- `dotnet build` de ControlHoras: 0 advertencias, 0 errores.
- `dotnet format --verify-no-changes` sobre los dos archivos: exit 0.

### Cambios aplicados
1. `MarcacionAdicionada.cs`: quitado `: IPrivateEvent`, eliminado `using Cosmos.EventDriven.Abstractions;` (quedaba inerte), y reemplazado el comentario enganoso ("Publicado localmente via Wolverine; consumido por #107") por la descripcion correcta (evento de event sourcing del aggregate, no cruza el bus, ADR-0024).
2. `TurnoDiarioAsignado.cs`: quitado `: IPrivateEvent`, eliminado `using Cosmos.EventDriven.Abstractions;`, y precisado el `<summary>` (event sourcing, no cruza el bus, ADR-0024).
3. `ConfigurarSerializacion` y ctor privado **intactos** en ambos (serializacion Marten independiente del marker de bus).

### Verificacion de que el marker era inerte (CA-3)
- `grep IPrivateEventSender` en `src/`+`tests/`: unico uso en `RegistrarMarcacionCommandHandler` para `MarcacionRegistrada` (evento `IPrivateEvent` legitimo, **no tocado**).
- `AdicionarMarcacionCuandoMarcacionRegistradaCommandHandler`: `MarcacionAdicionada` solo se `new`-ea y se pasa a `Iniciar`/`AdicionarMarcacion`. Lo que se publica al bus es `control.CrearDiaCalculado()` (`IPublicEvent`), no el evento.
- `AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaCommandHandler`: `TurnoDiarioAsignado` solo se `new`-ea y se pasa a `Iniciar`/`AsignarTurno`. Publica `control.CrearDiaCalculado()`.
- Conclusion: ningun mecanismo rutea estos eventos por ASB; el marker no tenia efecto. Verificacion del planner reconfirmada.

### Cumplimiento de ADRs aplicables

| ADR | Cumplimiento | Observacion |
|---|---|---|
| ADR-0024 (modelo de eventos de bus: event-sourcing / privado / publico) | ok | Decision #2: los eventos del aggregate llevan marker `ninguno`, viven en el event store de Marten con modelo rico y no cruzan ASB. El refactor los reclasifica correctamente desde `IPrivateEvent` (categoria erronea) a event-sourcing. |
| ADR-0012 (modelado de objetos de dominio / frontera de serializacion event store vs bus) | ok | Rozado sin cambiarlo: `ConfigurarSerializacion` (ctor privado + backing fields via resolver) se conserva. Ademas el refactor **resuelve un antipatron #7 latente**: un evento CON marker de bus cuyo payload carga modelo rico (`TurnoDiarioAsignado` lleva `InformacionEmpleado` y `DetalleTurno`, VOs con ctor privado) seria no-portable por el bus; al quitar el marker deja de aplicar la exigencia de portabilidad y queda como evento de event store (categoria permitida a llevar modelo rico). |

Nota: la seccion `## ADRs aplicables` del issue referencia los ADRs por tema (deriva de numeracion repo/plugin). Los ADRs efectivos verificados son ADR-0024 (marco: `0024-modelo-eventos-bus-privado-publico.md`) y ADR-0012/0015 (modelado de objetos de dominio y serializacion). Sin ambiguedad de contenido.

### Desviaciones de ADRs
Ninguna desviacion — todos los ADRs aplicables se cumplen. No hubo `stage-2-implementer.md` (refactor puro), por lo que no hay desviaciones declaradas que evaluar; tampoco se detectaron desviaciones no declaradas.

### Precedentes consultados por el implementer
No aplica: refactor puro sin fase de implementacion; no se citaron precedentes.

### Antipatrones ADR-0012 (checklist activo)
- #1-#6: no aplican al cambio (no se agregan propiedades, ni clases estaticas, ni getters de test, ni `InternalsVisibleTo`, ni `[JsonConstructor]`, ni `record` con colecciones).
- #7 (evento con marker de bus que carga modelo rico): **antes** del refactor, `TurnoDiarioAsignado : IPrivateEvent` con payload de VOs ricos era un caso latente de no-portabilidad; el refactor lo elimina al quitar el marker. Post-refactor no queda ningun evento con marker de bus afectado. Correcto.

### Convenciones del pipeline (no ADRs)
| Convencion | Estado | Observacion |
|---|---|---|
| Cada test con `Then()` + `And<>()` | n/a | No se agregaron ni modificaron tests (refactor puro; los tests existentes ya cubren los CAs y siguen verdes). |
| Overloads correctos para stream IDs compuestos | n/a | Sin cambios en tests. |
| Fakes manuales (no NSubstitute) | n/a | Sin cambios en tests. |
| Feature folders (produccion y tests) | ok | Estructura intacta; solo se editaron los dos archivos de evento en su feature folder. |
| Smoke tests: SkipWhen, secrets, cobertura | n/a | Fuera de alcance de #211. Los smoke tests rojos son preexistentes y ambientales (no dependen del marker). |
| Tests via ToString/comportamiento | ok | Los tests de serializacion existentes verifican round-trip/comportamiento, no getters ad-hoc. |
| Sin numeros magicos | ok | Sin cambios que introduzcan constantes. |
| Condiciones en positivo | n/a | Sin cambios de control de flujo. |

### Elegancia del codigo
- El resultado queda mas compacto y honesto: se elimina un `using` inerte y una interfaz sin efecto, y los comentarios/`<summary>` pasan a describir la realidad (event sourcing, no cruza el bus) en lugar de sugerir una publicacion inexistente. Alineacion de intencion y codigo.

### Criticas y hallazgos
- **Cosmetico / fuera de alcance (no corregido)**: en `docs/eda/catalog.yaml` las entradas de `TurnoDiarioAsignado` (linea 73) y `MarcacionAdicionada` (linea 110) usan `visibility: private` con comentario `# evento de event sourcing del aggregate ControlDiario`. El comentario ya documenta la naturaleza correcta; el campo `visibility` usa un esquema binario `public`/`private` previo a la taxonomia de tres categorias de ADR-0024. El planner scoped `catalog.yaml` como **solo lectura** ("Lee", no "Modifica") y los CAs no lo exigen; por regla #4 no se modifica. **Recomendacion**: en un issue separado, extender el vocabulario de `visibility` para admitir `event-sourcing` y actualizar estas dos entradas, alineando el catalogo con la taxonomia de ADR-0024.
- Ningun otro hallazgo.

### Refactorings aplicados
- El refactoring mismo del issue (descrito arriba). No se aplicaron refactorings adicionales: el codigo circundante ya era idiomatico y no habia deuda relacionada dentro del alcance.

### Cobertura de criterios de aceptacion
| Criterio | Estado | Test(s) / evidencia |
|---|---|---|
| CA-1: `MarcacionAdicionada` sin `IPrivateEvent` (ctor privado y `ConfigurarSerializacion` intactos) | cubierto | Diff + `MarcacionAdicionadaSerializacionTests` verde |
| CA-2: `TurnoDiarioAsignado` sin `IPrivateEvent` (idem) | cubierto | Diff + `TurnoDiarioAsignadoSerializacionTests` verde |
| CA-3: verificacion de que nada rutea via `IPrivateEventSender`; build verde | cubierto | grep `IPrivateEventSender`/handlers + `dotnet build` 0 errores |
| CA-4: serializacion Marten sigue funcionando; ambos `ConfigurarSerializacion` registrados; tests de serializacion + suite ControlHoras verdes | cubierto | `ConfiguracionSerializacionControlHoras` intacto; 296/296 en `ControlHoras.Tests` |

### Tests agregados
Ninguno. Refactor puro sin cambio de comportamiento; los tests existentes cubren los CAs y permanecen verdes. No hay contratos nuevos de igualdad ni de serializacion que generar (no se introdujeron VOs ni eventos con marker de bus).

</details>

## Commits

5a41780 refactor(hu-211): quitar marker IPrivateEvent de MarcacionAdicionada y TurnoDiarioAsignado

Closes #211