### PR TITLE
Consumir MarcacionRegistrada con IPrivateEventHandlerAsync en vez de ICommandHandlerAsync

### DIFF
--- a/src/Bitakora.ControlAsistencia.ControlHoras/AdicionarMarcacionCuandoMarcacionRegistrada/EventHandler/MarcacionRegistradaEventHandler.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/AdicionarMarcacionCuandoMarcacionRegistrada/EventHandler/MarcacionRegistradaEventHandler.cs
@@ -4,15 +4,19 @@ using Bitakora.ControlAsistencia.ControlHoras.RegistrarMarcacionFunction.Eventos
 using Cosmos.EventDriven.Abstractions;
 using Cosmos.EventSourcing.Abstractions.Commands;
 
-namespace Bitakora.ControlAsistencia.ControlHoras.AdicionarMarcacionCuandoMarcacionRegistrada.CommandHandler;
+namespace Bitakora.ControlAsistencia.ControlHoras.AdicionarMarcacionCuandoMarcacionRegistrada.EventHandler;
 
-// HU-106: Handler de Wolverine que adiciona una marcacion al ControlDiario correspondiente
-// Trigger: evento local MarcacionRegistrada publicado via WolverinePrivateEventSender (#105)
+// HU-106 / issue #209: EventHandler que adiciona una marcacion al ControlDiario correspondiente.
+// ADR-0024 (decision #8): MarcacionRegistrada es un IPrivateEvent intra-BC y el comando equivalente
+// seria un espejo del evento (mismos campos, sin semantica propia), asi que se consume directo con
+// IPrivateEventHandlerAsync<MarcacionRegistrada> - sin comando espejo.
+// Trigger: evento local MarcacionRegistrada publicado via WolverinePrivateEventSender (#105),
+// ruteado in-process por IPrivateEventRouter (sin ServiceBusTrigger ni endpoint en este feature folder).
 // Patron crear-o-actualizar: ExistsAsync -> si no existe StartStream, si existe GetAggregateRootAsync
 // CA-9: ventana de traslape nocturno con corte a las 04:00 como constante del handler
 // ADR-0015: partial class para soportar clase Mensajes en archivo separado si se requiere
-public partial class AdicionarMarcacionCuandoMarcacionRegistradaCommandHandler
-    : ICommandHandlerAsync<MarcacionRegistrada>
+public partial class MarcacionRegistradaEventHandler
+    : IPrivateEventHandlerAsync<MarcacionRegistrada>
 {
     private readonly IEventStore _eventStore;
     private readonly IPublicEventSender _publicEventSender;
@@ -21,7 +25,7 @@ public partial class AdicionarMarcacionCuandoMarcacionRegistradaCommandHandler
     // vendra de un servicio externo, no de aqui.
     internal static readonly TimeOnly HoraCorteTraslapeNocturno = new TimeOnly(4, 0);
 
-    public AdicionarMarcacionCuandoMarcacionRegistradaCommandHandler(
+    public MarcacionRegistradaEventHandler(
         IEventStore eventStore,
         IPublicEventSender publicEventSender)
     {
@@ -29,10 +33,10 @@ public partial class AdicionarMarcacionCuandoMarcacionRegistradaCommandHandler
         _publicEventSender = publicEventSender;
     }
 
-    public async Task HandleAsync(MarcacionRegistrada command, CancellationToken ct = default)
+    public async Task HandleAsync(MarcacionRegistrada @event, CancellationToken ct = default)
     {
-        var fechaCalendario = DateOnly.FromDateTime(command.TimestampNormalizado);
-        var horaDelDia = TimeOnly.FromDateTime(command.TimestampNormalizado);
+        var fechaCalendario = DateOnly.FromDateTime(@event.TimestampNormalizado);
+        var horaDelDia = TimeOnly.FromDateTime(@event.TimestampNormalizado);
 
         // CA-1: fuera de la ventana nocturna la marcacion va solo al dia calendario
         // CA-2 / CA-9: dentro de la ventana [00:00, 04:00) se agrega tambien al dia anterior
@@ -43,7 +47,7 @@ public partial class AdicionarMarcacionCuandoMarcacionRegistradaCommandHandler
 
         foreach (var fecha in fechasDestino)
         {
-            await AdicionarAControlDiarioAsync(command, fecha, ct);
+            await AdicionarAControlDiarioAsync(@event, fecha, ct);
         }
     }
 
@@ -55,15 +59,15 @@ public partial class AdicionarMarcacionCuandoMarcacionRegistradaCommandHandler
     //         Idempotencia (#106): si AdicionarMarcacion ignora el duplicado, no se
     //         agrega evento al stream y por tanto no se publica DiaCalculado redundante.
     private async Task AdicionarAControlDiarioAsync(
-        MarcacionRegistrada command, DateOnly fecha, CancellationToken ct)
+        MarcacionRegistrada @event, DateOnly fecha, CancellationToken ct)
     {
-        var streamId = ControlDiarioAggregateRoot.ComputarStreamId(command.EmpleadoId, fecha);
+        var streamId = ControlDiarioAggregateRoot.ComputarStreamId(@event.EmpleadoId, fecha);
         var evento = new MarcacionAdicionada(
             streamId,
-            command.EmpleadoId,
-            command.TimestampNormalizado,
-            command.TipoMarcacion,
-            command.DispositivoId);
+            @event.EmpleadoId,
+            @event.TimestampNormalizado,
+            @event.TipoMarcacion,
+            @event.DispositivoId);
 
         var existe = await _eventStore.ExistsAsync<ControlDiarioAggregateRoot>(streamId, ct);
 

--- a/src/Bitakora.ControlAsistencia.ControlHoras/Program.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Program.cs
@@ -35,7 +35,12 @@ builder.Services.AgregarWolverineParaComandosServerless(
     });
 
 builder.Services.AgregarMartenEventStore();
+// AgregarWolverineCommandRouter se conserva: RegistrarMarcacion (HTTP) y
+// AsignarTurnoCuandoProgramacionTurnoDiarioSolicitada (evento publico -> comando) lo siguen usando.
 builder.Services.AgregarWolverineCommandRouter();
+// Issue #209 (ADR-0024 decision #8): MarcacionRegistrada (IPrivateEvent intra-BC) se consume
+// directo con IPrivateEventHandlerAsync via IPrivateEventRouter, sin comando espejo.
+builder.Services.AgregarWolverinePrivateEventRouter();
 builder.Services.AgregarWolverineEventSender();
 
 // Registrar serializacion custom para tipos con constructores privados

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoMarcacionRegistrada/DepurarAlAdicionarMarcacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoMarcacionRegistrada/DepurarAlAdicionarMarcacionTests.cs
@@ -8,17 +8,17 @@ using Bitakora.ControlAsistencia.Contracts.ControlHoras.ValueObjects;
 using Bitakora.ControlAsistencia.ControlHoras.ValueObjects;
 using Bitakora.ControlAsistencia.Contracts.Empleados.ValueObjects;
 using Bitakora.ControlAsistencia.Contracts.Programacion.ValueObjects;
-using Bitakora.ControlAsistencia.ControlHoras.AdicionarMarcacionCuandoMarcacionRegistrada.CommandHandler;
+using Bitakora.ControlAsistencia.ControlHoras.AdicionarMarcacionCuandoMarcacionRegistrada.EventHandler;
 using Bitakora.ControlAsistencia.ControlHoras.AdicionarMarcacionCuandoMarcacionRegistrada.Eventos;
 using Bitakora.ControlAsistencia.ControlHoras.AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction.Eventos;
 using Bitakora.ControlAsistencia.ControlHoras.Entities;
 using Bitakora.ControlAsistencia.ControlHoras.RegistrarMarcacionFunction.Eventos;
-using Cosmos.EventSourcing.Abstractions.Commands;
+using Cosmos.EventDriven.Abstractions;
 using Cosmos.EventSourcing.Testing.Utilities;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.Tests.AdicionarMarcacionCuandoMarcacionRegistrada;
 
-public class DepurarAlAdicionarMarcacionTests : CommandHandlerAsyncTest<MarcacionRegistrada>
+public class DepurarAlAdicionarMarcacionTests : PrivateEventHandlerAsyncTest<MarcacionRegistrada>
 {
     // Datos de prueba fijos - misma ancla de fecha que los tests del handler
     private const string EmpleadoId = "EMP-001";
@@ -48,8 +48,8 @@ public class DepurarAlAdicionarMarcacionTests : CommandHandlerAsyncTest<Marcacio
     private static readonly DateTime Timestamp14_10 = new(2026, 3, 15, 14, 10, 0);
 
     // HU-108: handler ahora requiere IPublicEventSender para publicar DiaCalculado
-    protected override ICommandHandlerAsync<MarcacionRegistrada> Handler =>
-        new AdicionarMarcacionCuandoMarcacionRegistradaCommandHandler(EventStore, PublicEventSender);
+    protected override IPrivateEventHandlerAsync<MarcacionRegistrada> Handler =>
+        new MarcacionRegistradaEventHandler(EventStore, PublicEventSender);
 
     private static MarcacionRegistrada CrearMarcacionRegistrada(DateTime timestamp) =>
         new(EmpleadoId, timestamp, "ENTRADA", "DEV-001");

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoMarcacionRegistrada/DesgloseHorasTrasAdicionarMarcacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoMarcacionRegistrada/DesgloseHorasTrasAdicionarMarcacionTests.cs
@@ -13,17 +13,17 @@
 using Bitakora.ControlAsistencia.ControlHoras.ValueObjects;
 using Bitakora.ControlAsistencia.Contracts.Empleados.ValueObjects;
 using Bitakora.ControlAsistencia.Contracts.Programacion.ValueObjects;
-using Bitakora.ControlAsistencia.ControlHoras.AdicionarMarcacionCuandoMarcacionRegistrada.CommandHandler;
+using Bitakora.ControlAsistencia.ControlHoras.AdicionarMarcacionCuandoMarcacionRegistrada.EventHandler;
 using Bitakora.ControlAsistencia.ControlHoras.AdicionarMarcacionCuandoMarcacionRegistrada.Eventos;
 using Bitakora.ControlAsistencia.ControlHoras.AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction.Eventos;
 using Bitakora.ControlAsistencia.ControlHoras.Entities;
 using Bitakora.ControlAsistencia.ControlHoras.RegistrarMarcacionFunction.Eventos;
-using Cosmos.EventSourcing.Abstractions.Commands;
+using Cosmos.EventDriven.Abstractions;
 using Cosmos.EventSourcing.Testing.Utilities;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.Tests.AdicionarMarcacionCuandoMarcacionRegistrada;
 
-public class DesgloseHorasTrasAdicionarMarcacionTests : CommandHandlerAsyncTest<MarcacionRegistrada>
+public class DesgloseHorasTrasAdicionarMarcacionTests : PrivateEventHandlerAsyncTest<MarcacionRegistrada>
 {
     // Datos de prueba fijos - mismo ancla de fecha y stream ID compuesto que los tests del handler
     private const string EmpleadoId = "EMP-001";
@@ -47,8 +47,8 @@ public class DesgloseHorasTrasAdicionarMarcacionTests : CommandHandlerAsyncTest<
     private static readonly DateTime Timestamp14_10 = new(2026, 3, 15, 14, 10, 0);
     private static readonly DateTime Timestamp18_30 = new(2026, 3, 15, 18, 30, 0);
 
-    protected override ICommandHandlerAsync<MarcacionRegistrada> Handler =>
-        new AdicionarMarcacionCuandoMarcacionRegistradaCommandHandler(EventStore, PublicEventSender);
+    protected override IPrivateEventHandlerAsync<MarcacionRegistrada> Handler =>
+        new MarcacionRegistradaEventHandler(EventStore, PublicEventSender);
 
     private static MarcacionRegistrada CrearMarcacionRegistrada(DateTime timestamp) =>
         new(EmpleadoId, timestamp, "ENTRADA", "DEV-001");

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoMarcacionRegistrada/MarcacionRegistradaEventHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoMarcacionRegistrada/MarcacionRegistradaEventHandlerTests.cs
@@ -2,17 +2,17 @@
 
 using Bitakora.ControlAsistencia.Contracts.Empleados.ValueObjects;
 using Bitakora.ControlAsistencia.Contracts.Programacion.ValueObjects;
-using Bitakora.ControlAsistencia.ControlHoras.AdicionarMarcacionCuandoMarcacionRegistrada.CommandHandler;
+using Bitakora.ControlAsistencia.ControlHoras.AdicionarMarcacionCuandoMarcacionRegistrada.EventHandler;
 using Bitakora.ControlAsistencia.ControlHoras.AdicionarMarcacionCuandoMarcacionRegistrada.Eventos;
 using Bitakora.ControlAsistencia.ControlHoras.Entities;
 using Bitakora.ControlAsistencia.ControlHoras.RegistrarMarcacionFunction.Eventos;
-using Cosmos.EventSourcing.Abstractions.Commands;
+using Cosmos.EventDriven.Abstractions;
 using Cosmos.EventSourcing.Testing.Utilities;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.Tests.AdicionarMarcacionCuandoMarcacionRegistrada;
 
-public class AdicionarMarcacionCuandoMarcacionRegistradaCommandHandlerTests
-    : CommandHandlerAsyncTest<MarcacionRegistrada>
+public class MarcacionRegistradaEventHandlerTests
+    : PrivateEventHandlerAsyncTest<MarcacionRegistrada>
 {
     // Datos de prueba fijos
     private const string EmpleadoId = "EMP-001";
@@ -27,8 +27,8 @@ public class AdicionarMarcacionCuandoMarcacionRegistradaCommandHandlerTests
     private static readonly string StreamIdDia15 = $"{EmpleadoId}:2026-03-15";
     private static readonly string StreamIdDia14 = $"{EmpleadoId}:2026-03-14";
 
-    protected override ICommandHandlerAsync<MarcacionRegistrada> Handler =>
-        new AdicionarMarcacionCuandoMarcacionRegistradaCommandHandler(EventStore, PublicEventSender);
+    protected override IPrivateEventHandlerAsync<MarcacionRegistrada> Handler =>
+        new MarcacionRegistradaEventHandler(EventStore, PublicEventSender);
 
     // Factory para MarcacionRegistrada; el timestamp decide si cae en la ventana nocturna.
     private static MarcacionRegistrada CrearMarcacionRegistrada(

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/CrearDiaCalculadoConHorasDiscriminadasTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/CrearDiaCalculadoConHorasDiscriminadasTests.cs
@@ -9,9 +9,10 @@
 // patron que DesgloseHorasTras*Tests) y se verifica via el selector de And<>() sobre el aggregate
 // rehidratado. And<>() compara estructuralmente (BeEquivalentTo).
 //
-// Nested classes: CrearDiaCalculado() lo invocan ambos handlers (AsignarTurno y AdicionarMarcacion)
-// sobre el mismo aggregate, por lo que comparten datos pero requieren bases CommandHandlerAsyncTest
-// distintas (una por tipo de comando).
+// Nested classes: CrearDiaCalculado() lo conducen ambos handlers sobre el mismo aggregate, por lo que
+// comparten datos pero requieren bases de test distintas: AsignarTurno es un comando genuino
+// (CommandHandlerAsyncTest<ProgramacionTurnoDiarioSolicitada>); AdicionarMarcacion, tras issue #209,
+// consume el evento privado directo (PrivateEventHandlerAsyncTest<MarcacionRegistrada>, ADR-0024 #8).
 //
 // El valor esperado se registra A MANO como oraculo independiente: el diccionario de minutos por
 // concepto se calcula de la geometria del dia, sin ejecutar Discriminar ni Consolidar (la logica bajo
@@ -21,12 +22,13 @@ using Bitakora.ControlAsistencia.Contracts.ControlHoras.ValueObjects;
 using Bitakora.ControlAsistencia.Contracts.Empleados.ValueObjects;
 using Bitakora.ControlAsistencia.Contracts.Programacion.Eventos;
 using Bitakora.ControlAsistencia.Contracts.Programacion.ValueObjects;
-using Bitakora.ControlAsistencia.ControlHoras.AdicionarMarcacionCuandoMarcacionRegistrada.CommandHandler;
+using Bitakora.ControlAsistencia.ControlHoras.AdicionarMarcacionCuandoMarcacionRegistrada.EventHandler;
 using Bitakora.ControlAsistencia.ControlHoras.AdicionarMarcacionCuandoMarcacionRegistrada.Eventos;
 using Bitakora.ControlAsistencia.ControlHoras.AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction.CommandHandler;
 using Bitakora.ControlAsistencia.ControlHoras.AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction.Eventos;
 using Bitakora.ControlAsistencia.ControlHoras.Entities;
 using Bitakora.ControlAsistencia.ControlHoras.RegistrarMarcacionFunction.Eventos;
+using Cosmos.EventDriven.Abstractions;
 using Cosmos.EventSourcing.Abstractions.Commands;
 using Cosmos.EventSourcing.Testing.Utilities;
 
@@ -126,10 +128,10 @@ public class CrearDiaCalculadoConHorasDiscriminadasTests
     }
 
     public class ViaAdicionarMarcacionTests
-        : CommandHandlerAsyncTest<MarcacionRegistrada>
+        : PrivateEventHandlerAsyncTest<MarcacionRegistrada>
     {
-        protected override ICommandHandlerAsync<MarcacionRegistrada> Handler =>
-            new AdicionarMarcacionCuandoMarcacionRegistradaCommandHandler(
+        protected override IPrivateEventHandlerAsync<MarcacionRegistrada> Handler =>
+            new MarcacionRegistradaEventHandler(
                 EventStore, PublicEventSender);
 
         private static MarcacionRegistrada CrearMarcacionRegistrada(DateTime timestamp) =>


### PR DESCRIPTION
## Resumen

Pipeline TDD completado (refactoring puro):
- Análisis: no se requieren tests nuevos
- Justificación: Issue #209 es el "caso mandatorio" de refactoring puro (seccion 2 del rol
- Baseline: 425 tests pasando
- Refactoring ejecutado manteniendo todos los tests verdes

## Decisiones del pipeline

<details>
<summary>Test Writer (fase roja) — 2m 17s</summary>

_(El agente no generó resumen)_

</details>

<details>
<summary>Reviewer (fase refactor) — 11m 36s</summary>

## ES Reviewer - Revision (issue #209 - refactoring puro)

### Evaluacion general
- Calidad: buena
- Cambios realizados: si (este agente ejecuto el refactor completo; era refactoring puro, sin fases roja/verde previas)

### Naturaleza de la tarea
Refactoring puro senalizado en `pipeline-state/refactor-signal.md` (REFACTOR_ONLY=true, REMOVED_TESTS=0).
Cambio de mecanismo de consumo de `MarcacionRegistrada`: de `ICommandHandlerAsync<MarcacionRegistrada>`
a `IPrivateEventHandlerAsync<MarcacionRegistrada>` (ADR-0024 marco, decision #8 - consumo directo de
evento privado sin comando espejo). Baseline verde confirmado antes de empezar (296 ControlHoras.Tests).

### Cumplimiento de ADRs aplicables

| ADR | Cumplimiento | Observacion |
|---|---|---|
| ADR-0024 marco (modelo eventos bus, decision #8) | ok | Las 3 condiciones del patron se cumplen: (1) `MarcacionRegistrada : IPrivateEvent` intra-BC; (2) subscription de un unico topic, no fan-in; (3) el comando era un espejo degenerado (el evento ES el comando, nunca existio tipo comando espejo). Handler renombrado a `MarcacionRegistradaEventHandler` en subcarpeta `EventHandler/`, firma `HandleAsync(MarcacionRegistrada @event, CancellationToken)`. Test base migrada a `PrivateEventHandlerAsyncTest<MarcacionRegistrada>`. `AgregarWolverinePrivateEventRouter()` registrado en `Program.cs`. |
| ADR-0002 marco (estrategia testing / DSL) | ok | Los 4 test containers afectados migran a `PrivateEventHandlerAsyncTest<MarcacionRegistrada>`. DSL `Given`/`WhenAsync(evento)`/`Then`/`And<>`/`ThenIsPublishedPublicly` intacto (misma `CommandHandlerTestBase`, `EventStore` y `PublicEventSender` disponibles). Cada test conserva `Then(...)` + `And<>()`. |
| ADR-0003 marco (wiring Marten + Wolverine) | ok | `AgregarWolverinePrivateEventRouter()` agregado junto a `AgregarWolverineEventSender()`; `AgregarWolverineCommandRouter()` conservado (RegistrarMarcacion HTTP y AsignarTurno evento->comando lo siguen usando). Ambos routers conviven sin conflicto. |

Los ADRs declarados **NO disparados** (serializacion/modelado ADR-0012 marco, naming funciones Azure
ADR-0006 marco) se confirmaron: `MarcacionRegistrada` y su `ConfigurarSerializacion` no se tocan; no
se agrega ni renombra ninguna `[Function]` (routing in-process, sin endpoint).

### Desviaciones de ADRs
Ninguna desviacion introducida por este diff - todos los ADRs aplicables se cumplen.

### Precedentes consultados
| Precedente | ADR aplicable | Veredicto |
|---|---|---|
| `Cosmos.ControlPlane` PR #94 (`TenantOnboardingStartedEventHandler : IPrivateEventHandlerAsync<TenantOnboardingStarted>`) | ADR-0024 #8 | alineado (mismo patron `{Evento}EventHandler` aplicado aqui) |

### Convenciones del pipeline (no ADRs)
| Convencion | Estado | Observacion |
|---|---|---|
| Cada test con `Then()` + `And<>()` | ok | Verificado en los 4 test containers migrados; no se altero ninguna asercion. |
| Overloads correctos para stream IDs compuestos | ok | Tests usan `Given(streamId, ...)`, `Then(streamId, ...)`, `And<T,P>(streamId, ...)` (stream ID `{EmpleadoId}:{Fecha}` via `ComputarStreamId`). Sin cambios. |
| Fakes manuales (no NSubstitute) | n/a | El handler solo depende de `IEventStore` y `IPublicEventSender`, provistos por la base de test. |
| Feature folders (produccion y tests) | ok | Handler movido a `AdicionarMarcacionCuandoMarcacionRegistrada/EventHandler/` (espejo de `CommandHandler/`, per ADR-0024). Carpeta `CommandHandler/` vacia eliminada. Tests: espejo mantenido. |
| Smoke tests: SkipWhen, secrets, cobertura | n/a | `ControlHoras.SmokeTests` compila; solo referencia el feature por nombre en comentarios (feature folder conserva su nombre). Sin cambios de efectos secundarios. |
| Tests via ToString/comportamiento | ok | Sin getters nuevos expuestos solo para test. |
| Sin numeros magicos | ok | `HoraCorteTraslapeNocturno` sigue como constante nombrada. |
| Condiciones en positivo | n/a | No se introdujeron bifurcaciones nuevas; el `if (!existe)` del patron crear-o-actualizar es guard/early-branch legitimo, sin cambio. |

### Elegancia del codigo
- El handler nuevo es compacto y legible; el cuerpo de `HandleAsync`/`AdicionarAControlDiarioAsync` se
  conserva byte a byte (solo cambia el nombre del parametro `command` -> `@event`, idiomatico para el
  patron EventHandler). Comentarios de cabecera actualizados para citar ADR-0024 #8 y el routing in-process.
- `Program.cs`: los dos registros de router quedan documentados con el porque (cuales handlers necesitan
  cada uno), evitando que un futuro lector retire `AgregarWolverineCommandRouter()` por error.
- Sin warnings del compilador en los proyectos tocados; sin caracter U+2500; formato consistente
  (`dotnet format --verify-no-changes` limpio en ambos proyectos).

### Criticas y hallazgos
- **Cobertura de referencias mas amplia que la lista del issue (menor, resuelto).** El issue listaba 3
  archivos de test; se encontro un 4to (`Entities/CrearDiaCalculadoConHorasDiscriminadasTests.cs`,
  nested class `ViaAdicionarMarcacionTests`) que instanciaba el handler como `ICommandHandlerAsync`.
  Tras el cambio de interfaz ese test no compilaba, asi que se migro tambien (solo la nested de
  AdicionarMarcacion; `ViaAsignarTurnoTests` sigue como `CommandHandlerAsyncTest` porque AsignarTurno es
  comando genuino). Consecuencia necesaria del refactor, no scope creep.
- **Portabilidad de `MarcacionRegistrada` por el bus (observacion, pre-existente, fuera de alcance).**
  `MarcacionRegistrada` es `IPrivateEvent` con payload de campos primitivos (plano) pero se reconstruye
  con resolver custom (`ConfigurarSerializacion`, ctor privado + private setters). Para un evento privado
  intra-BC esto NO es un gap: productor y consumidor viven en el mismo assembly `ControlHoras`, que
  registra `ConfiguracionSerializacionControlHoras.ConfigurarResolver` en `Program.cs` (lineas 42-53), y
  existe el guardrail `MarcacionRegistradaSerializacionTests`. El evento no se modifica en este issue
  (ADR-0012 explicitamente no disparado). Si algun dia lo consumiera OTRO BC, habria que aplanarlo; hoy
  no aplica.
- **Routing in-process sin `PrivateEventEndpointBase` (observacion, confirmado por el issue).** No hay
  `ServiceBusTrigger`/`FunctionEndpoint` para `MarcacionRegistrada` (igual que antes con `ICommandRouter`).
  El refactor solo cambia el mecanismo de consumo; el routing in-process se conserva. La verificacion del
  round-trip fisico por el ASB (principio "todo evento cruza el ASB" de ADR-0024) es una consideracion
  arquitectonica pre-existente, explicitamente diferida por el issue a smoke test/deploy. No bloqueante.

### Refactorings aplicados
- Renombre `AdicionarMarcacionCuandoMarcacionRegistradaCommandHandler` -> `MarcacionRegistradaEventHandler`
  y movimiento de `CommandHandler/` a `EventHandler/` (decision #1 del issue: seguir la convencion del
  marco `{Evento}EventHandler`; el sufijo `CommandHandler` era factualmente incorrecto tras la migracion).
- Renombre del archivo/clase de test `AdicionarMarcacionCuandoMarcacionRegistradaCommandHandlerTests` ->
  `MarcacionRegistradaEventHandlerTests` para alinear con produccion (decision #1: "si se renombra,
  actualizar los nombres de las clases de test y sus referencias").
- Comentario de cabecera de `CrearDiaCalculadoConHorasDiscriminadasTests` actualizado (ya no son "dos
  bases CommandHandlerAsyncTest"; ahora una de comando + una de evento privado).

### Cobertura de criterios de aceptacion
| Criterio | Estado | Test(s) |
|---|---|---|
| CA-1: handler implementa `IPrivateEventHandlerAsync<MarcacionRegistrada>`, logica intacta | cubierto | `MarcacionRegistradaEventHandler` (produccion); cuerpo sin cambios |
| CA-2: `Program.cs` registra `AgregarWolverinePrivateEventRouter()`, conserva `AgregarWolverineCommandRouter()` | cubierto | `Program.cs` lineas 40-44 |
| CA-3: los 3 tests del feature migran a `PrivateEventHandlerAsyncTest` con `Handler` tipado | cubierto | `MarcacionRegistradaEventHandlerTests`, `DepurarAlAdicionarMarcacionTests`, `DesgloseHorasTrasAdicionarMarcacionTests` (+ 4to: `ViaAdicionarMarcacionTests`) |
| CA-4: sin cambio de comportamiento observable | cubierto | Mismas aserciones de estado del aggregate y de publicacion de `DiaCalculado`; 296/296 verde |
| CA-5: `dotnet build` y `dotnet test` verdes; ningun otro consumidor modificado | cubierto | Solucion compila 0 errores; Contracts 87 + ControlHoras 296 + Programacion 42 = 425 verde. RegistrarMarcacion/CrearTurno/AsignarTurno intactos |

### Tests agregados
- Ninguno. Es refactoring puro: la cobertura pre-existente ya ejercita todos los CAs y se conserva 1:1.
  No aplica generacion de tests de contrato (el VO/evento afectado no se modifica).

</details>

## Commits

68f87f8 refactor(hu-209): consumir MarcacionRegistrada con IPrivateEventHandlerAsync

Closes #209