### PR TITLE
Reclasificar ProgramacionTurnoDiarioSolicitada como evento privado y migrar AsignarTurno a EventHandler

### DIFF
--- a/src/Bitakora.ControlAsistencia.Contracts/Programacion/Eventos/ProgramacionTurnoDiarioSolicitada.cs
+++ b/src/Bitakora.ControlAsistencia.Contracts/Programacion/Eventos/ProgramacionTurnoDiarioSolicitada.cs
@@ -5,11 +5,13 @@ using Cosmos.EventDriven.Abstractions;
 namespace Bitakora.ControlAsistencia.Contracts.Programacion.Eventos;
 
 /// <summary>
-/// Evento publico que se publica al Service Bus via IPublicEventSender.
+/// Evento privado intra-BC que se publica al namespace interno del Bounded Context
+/// via IPrivateEventSender (ADR-0024 decision #3: todo evento privado cruza fisicamente el ASB).
 /// Se emite uno por cada fecha del arreglo del comando.
-/// Consumidor: ControlHoras.
+/// Consumidor: ControlHoras (mismo Bounded Context "Control de Asistencia") -> es intra-BC,
+/// por eso es IPrivateEvent y no IPublicEvent (ADR-0024 decision #2).
 /// </summary>
-public sealed class ProgramacionTurnoDiarioSolicitada : IPublicEvent
+public sealed class ProgramacionTurnoDiarioSolicitada : IPrivateEvent
 {
     public Guid SolicitudId { get; private set; }
     public InformacionEmpleado Empleado { get; private set; } = null!;

--- a/src/Bitakora.ControlAsistencia.ControlHoras/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/EventHandler/ProgramacionTurnoDiarioSolicitadaEventHandler.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/EventHandler/ProgramacionTurnoDiarioSolicitadaEventHandler.cs
@@ -4,23 +4,26 @@ using Bitakora.ControlAsistencia.ControlHoras.Entities;
 using Cosmos.EventDriven.Abstractions;
 using Cosmos.EventSourcing.Abstractions.Commands;
 
-namespace Bitakora.ControlAsistencia.ControlHoras.AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction.CommandHandler;
+namespace Bitakora.ControlAsistencia.ControlHoras.AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction.EventHandler;
 
-// HU-12: Handler que asigna el turno diario al ControlDiario cuando llega
-//        ProgramacionTurnoDiarioSolicitada desde Service Bus.
+// HU-12 / issue #210: EventHandler que asigna el turno diario al ControlDiario cuando llega
+//   ProgramacionTurnoDiarioSolicitada desde el ASB interno del BC.
+// ADR-0024 (decision #8): ProgramacionTurnoDiarioSolicitada es un IPrivateEvent intra-BC y el comando
+//   equivalente seria un espejo del evento (mismos campos, sin semantica propia), asi que se consume
+//   directo con IPrivateEventHandlerAsync<ProgramacionTurnoDiarioSolicitada> - sin comando espejo.
 // Patron crear-o-actualizar:
 //   - CA-3: si NO existe el stream para EmpleadoId+Fecha -> StartStream
 //   - CA-4: si YA existe -> GetAggregateRootAsync + AsignarTurno (SaveChanges automatico)
-// HU-131: publica DiaCalculado via IPublicEventSender tras el Apply(TurnoDiarioAsignado)
-//         que dispara el recalculo reactivo de ControlesDeFranja.
+// HU-131 / CA-4: publica DiaCalculado via IPublicEventSender tras el Apply(TurnoDiarioAsignado)
+//   que dispara el recalculo reactivo de ControlesDeFranja.
 // ADR-0015: partial class para soportar clase Mensajes en archivo separado si se requiere
-public partial class AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaCommandHandler
-    : ICommandHandlerAsync<ProgramacionTurnoDiarioSolicitada>
+public partial class ProgramacionTurnoDiarioSolicitadaEventHandler
+    : IPrivateEventHandlerAsync<ProgramacionTurnoDiarioSolicitada>
 {
     private readonly IEventStore _eventStore;
     private readonly IPublicEventSender _publicEventSender;
 
-    public AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaCommandHandler(
+    public ProgramacionTurnoDiarioSolicitadaEventHandler(
         IEventStore eventStore,
         IPublicEventSender publicEventSender)
     {
@@ -28,13 +31,13 @@ public partial class AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaCommandH
         _publicEventSender = publicEventSender;
     }
 
-    public async Task HandleAsync(ProgramacionTurnoDiarioSolicitada command, CancellationToken ct = default)
+    public async Task HandleAsync(ProgramacionTurnoDiarioSolicitada @event, CancellationToken ct = default)
     {
         var streamId = ControlDiarioAggregateRoot.ComputarStreamId(
-            command.Empleado.EmpleadoId, command.Fecha);
+            @event.Empleado.EmpleadoId, @event.Fecha);
 
         var evento = new TurnoDiarioAsignado(
-            streamId, command.Empleado, command.Fecha, command.DetalleTurno, command.SolicitudId);
+            streamId, @event.Empleado, @event.Fecha, @event.DetalleTurno, @event.SolicitudId);
 
         var existe = await _eventStore.ExistsAsync<ControlDiarioAggregateRoot>(streamId, ct);
 

--- a/src/Bitakora.ControlAsistencia.ControlHoras/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/FunctionEndpoint.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/FunctionEndpoint.cs
@@ -1,18 +1,20 @@
 using Azure.Messaging.ServiceBus;
 using Bitakora.ControlAsistencia.Contracts.Programacion.Eventos;
 using Bitakora.ControlAsistencia.ControlHoras.Infraestructura;
-using Cosmos.EventSourcing.Abstractions.Commands;
+using Cosmos.EventDriven.Abstractions;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction;
 
-// HU-12: Primer ServiceBusTrigger del proyecto.
-// CA-1: Funcion Azure que consume ProgramacionTurnoDiarioSolicitada desde Service Bus.
-// CA-2: Deserializa el evento del mensaje y lo despacha al CommandHandler.
+// HU-12: ServiceBusTrigger que consume ProgramacionTurnoDiarioSolicitada desde el ASB interno del BC.
+// issue #210 / ADR-0024 (decision #8): el evento es IPrivateEvent intra-BC y el comando equivalente
+//   seria un espejo, asi que se despacha directo al IPrivateEventHandlerAsync via IPrivateEventRouter
+//   (PrivateEventEndpointBase) - sin comando espejo.
+// CA-3: el [Function] y el [ServiceBusTrigger] sobre topic/subscription se conservan.
 // ADR-0008: [Function("{Accion}Cuando{Evento}")]
-public class FunctionEndpoint(ICommandRouter commandRouter, ILogger<FunctionEndpoint> logger)
-    : ServiceBusEndpointBase<ProgramacionTurnoDiarioSolicitada>(commandRouter, logger)
+public class FunctionEndpoint(IPrivateEventRouter privateEventRouter, ILogger<FunctionEndpoint> logger)
+    : PrivateEventEndpointBase<ProgramacionTurnoDiarioSolicitada>(privateEventRouter, logger)
 {
     [Function("AsignarTurnoCuandoProgramacionTurnoDiarioSolicitada")]
     public async Task Run(

--- a/src/Bitakora.ControlAsistencia.ControlHoras/Infraestructura/PrivateEventEndpointBase.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Infraestructura/PrivateEventEndpointBase.cs
@@ -1,0 +1,43 @@
+using Azure.Messaging.ServiceBus;
+using Cosmos.EventDriven.Abstractions;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Infraestructura;
+
+/// <summary>
+/// Clase base para FunctionEndpoints de ServiceBus que consumen un evento privado del BC.
+/// Contraparte de <see cref="ServiceBusEndpointBase{TEvento}"/> (ADR-0024 decision #8): en vez de
+/// traducir el evento a un comando espejo y rutearlo via ICommandRouter, lo despacha directamente
+/// al IPrivateEventHandlerAsync via IPrivateEventRouter.
+/// Encapsula la orquestacion: deserializar -> despachar al private event router -> complete/lock-lost/dead-letter.
+/// Cada endpoint concreto hereda, define [Function] + [ServiceBusTrigger] y delega a <see cref="ProcesarMensaje"/>.
+/// </summary>
+public abstract class PrivateEventEndpointBase<TPrivateEvent>(
+    IPrivateEventRouter privateEventRouter, ILogger logger)
+    where TPrivateEvent : class, IPrivateEvent
+{
+    protected async Task ProcesarMensaje(
+        ServiceBusReceivedMessage message,
+        ServiceBusMessageActions messageActions,
+        CancellationToken ct)
+    {
+        try
+        {
+            var evento = ServiceBusDeserializador.Deserializar<TPrivateEvent>(message.Body);
+            await privateEventRouter.InvokeAsync(evento, ct);
+            await messageActions.CompleteMessageAsync(message, ct);
+        }
+        catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.MessageLockLost)
+        {
+            logger.LogWarning(ex,
+                "Lock perdido para mensaje {MessageId} - Service Bus lo re-entregara automaticamente",
+                message.MessageId);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error procesando mensaje {MessageId}", message.MessageId);
+            await messageActions.DeadLetterMessageAsync(message, cancellationToken: ct);
+        }
+    }
+}

--- a/src/Bitakora.ControlAsistencia.ControlHoras/Program.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Program.cs
@@ -35,11 +35,11 @@ builder.Services.AgregarWolverineParaComandosServerless(
     });
 
 builder.Services.AgregarMartenEventStore();
-// AgregarWolverineCommandRouter se conserva: RegistrarMarcacion (HTTP) y
-// AsignarTurnoCuandoProgramacionTurnoDiarioSolicitada (evento publico -> comando) lo siguen usando.
+// AgregarWolverineCommandRouter se conserva: RegistrarMarcacion (HTTP) lo sigue usando.
 builder.Services.AgregarWolverineCommandRouter();
-// Issue #209 (ADR-0024 decision #8): MarcacionRegistrada (IPrivateEvent intra-BC) se consume
-// directo con IPrivateEventHandlerAsync via IPrivateEventRouter, sin comando espejo.
+// Issue #209/#210 (ADR-0024 decision #8): los eventos privados intra-BC (MarcacionRegistrada,
+// ProgramacionTurnoDiarioSolicitada) se consumen directo con IPrivateEventHandlerAsync via
+// IPrivateEventRouter, sin comando espejo.
 builder.Services.AgregarWolverinePrivateEventRouter();
 builder.Services.AgregarWolverineEventSender();
 

--- a/src/Bitakora.ControlAsistencia.Programacion/Program.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/Program.cs
@@ -29,6 +29,10 @@ builder.Services.AgregarWolverineParaComandosServerless(
     options =>
     {
         options.HabilitarAzureServiceBusParaServerLess(serviceBusConnectionString);
+        // ADR-0024 decision #3: aunque ProgramacionTurnoDiarioSolicitada es IPrivateEvent (issue #210),
+        // sigue cruzando fisicamente el ASB interno del BC. El topic mapping se conserva: el constraint
+        // de PublicarEventoServerless es IEvent y Wolverine rutea por el tipo concreto del mensaje, asi
+        // que el mismo mapeo aplica ya sea que se publique via IPublicEventSender o IPrivateEventSender.
         options.PublicarEventoServerless<ProgramacionTurnoDiarioSolicitada>(
             "programacion-turno-diario-solicitada");
     });

--- a/src/Bitakora.ControlAsistencia.Programacion/SolicitarProgramacionTurnoFunction/CommandHandler/SolicitarProgramacionTurnoCommandHandler.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/SolicitarProgramacionTurnoFunction/CommandHandler/SolicitarProgramacionTurnoCommandHandler.cs
@@ -10,14 +10,14 @@ public partial class SolicitarProgramacionTurnoCommandHandler
     : ICommandHandlerAsync<SolicitarProgramacionTurno>
 {
     private readonly IEventStore _eventStore;
-    private readonly IPublicEventSender _publicEventSender;
+    private readonly IPrivateEventSender _privateEventSender;
 
     public SolicitarProgramacionTurnoCommandHandler(
         IEventStore eventStore,
-        IPublicEventSender publicEventSender)
+        IPrivateEventSender privateEventSender)
     {
         _eventStore = eventStore;
-        _publicEventSender = publicEventSender;
+        _privateEventSender = privateEventSender;
     }
 
     public async Task HandleAsync(SolicitarProgramacionTurno command, CancellationToken ct = default)
@@ -39,11 +39,13 @@ public partial class SolicitarProgramacionTurnoCommandHandler
 
         _eventStore.StartStream(solicitud);
 
-        var eventosPublicos = command.Fechas
-            .Select(fecha => (IPublicEvent)new ProgramacionTurnoDiarioSolicitada(
+        // ADR-0024 decision #2/#3: ProgramacionTurnoDiarioSolicitada es intra-BC (lo consume
+        // ControlHoras, mismo BC) -> IPrivateEvent publicado al ASB interno via IPrivateEventSender.
+        var eventosPrivados = command.Fechas
+            .Select(fecha => new ProgramacionTurnoDiarioSolicitada(
                 command.Id, command.Empleado, fecha, detalleTurno))
             .ToArray();
 
-        await _publicEventSender.PublishAsync(eventosPublicos);
+        await _privateEventSender.PublishAsync(eventosPrivados);
     }
 }

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/DepurarAlAsignarTurnoTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/DepurarAlAsignarTurnoTests.cs
@@ -10,16 +10,16 @@ using Bitakora.ControlAsistencia.Contracts.Empleados.ValueObjects;
 using Bitakora.ControlAsistencia.Contracts.Programacion.Eventos;
 using Bitakora.ControlAsistencia.Contracts.Programacion.ValueObjects;
 using Bitakora.ControlAsistencia.ControlHoras.AdicionarMarcacionCuandoMarcacionRegistrada.Eventos;
-using Bitakora.ControlAsistencia.ControlHoras.AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction.CommandHandler;
+using Bitakora.ControlAsistencia.ControlHoras.AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction.EventHandler;
 using Bitakora.ControlAsistencia.ControlHoras.AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction.Eventos;
 using Bitakora.ControlAsistencia.ControlHoras.Entities;
-using Cosmos.EventSourcing.Abstractions.Commands;
+using Cosmos.EventDriven.Abstractions;
 using Cosmos.EventSourcing.Testing.Utilities;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.Tests.AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction;
 
 public class DepurarAlAsignarTurnoTests
-    : CommandHandlerAsyncTest<ProgramacionTurnoDiarioSolicitada>
+    : PrivateEventHandlerAsyncTest<ProgramacionTurnoDiarioSolicitada>
 {
     // Datos de prueba fijos - el stream ID es determinista a partir de EmpleadoId+Fecha
     private static readonly Guid SolicitudId =
@@ -40,8 +40,8 @@ public class DepurarAlAsignarTurnoTests
     private static readonly DateTime Timestamp15_00 = new(2026, 3, 15, 15, 0, 0);
 
     // HU-131: handler ahora requiere IPublicEventSender para publicar DiaCalculado
-    protected override ICommandHandlerAsync<ProgramacionTurnoDiarioSolicitada> Handler =>
-        new AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaCommandHandler(EventStore, PublicEventSender);
+    protected override IPrivateEventHandlerAsync<ProgramacionTurnoDiarioSolicitada> Handler =>
+        new ProgramacionTurnoDiarioSolicitadaEventHandler(EventStore, PublicEventSender);
 
     private static ProgramacionTurnoDiarioSolicitada CrearEvento(DetalleTurno detalleTurno) =>
         new(SolicitudId, Empleado, Fecha, detalleTurno);
@@ -67,7 +67,7 @@ public class DepurarAlAsignarTurnoTests
     // CA-1 (HU-131): el handler publica DiaCalculado con InformacionEmpleado, Fecha
     //        y ControlesDeFranja actualizados (Entrada y Salida presentes, EsAnomala=false).
     [Fact]
-    public async Task DebeCalcularControlFranja_CuandoMarcacionesLlegaronAntesQueTurno()
+    public async Task ProgramacionTurnoDiarioSolicitada_CalculaControlFranja_CuandoMarcacionesLlegaronAntesQueTurno()
     {
         var turnoConFranjaUnica = new DetalleTurno("Turno Manana", [Franja06_14]);
         Given(StreamId,

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/DesgloseHorasTrasAsignarTurnoTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/DesgloseHorasTrasAsignarTurnoTests.cs
@@ -13,16 +13,16 @@ using Bitakora.ControlAsistencia.Contracts.Empleados.ValueObjects;
 using Bitakora.ControlAsistencia.Contracts.Programacion.Eventos;
 using Bitakora.ControlAsistencia.Contracts.Programacion.ValueObjects;
 using Bitakora.ControlAsistencia.ControlHoras.AdicionarMarcacionCuandoMarcacionRegistrada.Eventos;
-using Bitakora.ControlAsistencia.ControlHoras.AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction.CommandHandler;
+using Bitakora.ControlAsistencia.ControlHoras.AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction.EventHandler;
 using Bitakora.ControlAsistencia.ControlHoras.AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction.Eventos;
 using Bitakora.ControlAsistencia.ControlHoras.Entities;
-using Cosmos.EventSourcing.Abstractions.Commands;
+using Cosmos.EventDriven.Abstractions;
 using Cosmos.EventSourcing.Testing.Utilities;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.Tests.AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction;
 
 public class DesgloseHorasTrasAsignarTurnoTests
-    : CommandHandlerAsyncTest<ProgramacionTurnoDiarioSolicitada>
+    : PrivateEventHandlerAsyncTest<ProgramacionTurnoDiarioSolicitada>
 {
     // Datos de prueba fijos - el stream ID es determinista a partir de EmpleadoId+Fecha
     private static readonly Guid SolicitudId =
@@ -48,8 +48,8 @@ public class DesgloseHorasTrasAsignarTurnoTests
     private static readonly DateTime Timestamp07_00 = new(2026, 3, 15, 7, 0, 0);
     private static readonly DateTime Timestamp15_00 = new(2026, 3, 15, 15, 0, 0);
 
-    protected override ICommandHandlerAsync<ProgramacionTurnoDiarioSolicitada> Handler =>
-        new AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaCommandHandler(EventStore, PublicEventSender);
+    protected override IPrivateEventHandlerAsync<ProgramacionTurnoDiarioSolicitada> Handler =>
+        new ProgramacionTurnoDiarioSolicitadaEventHandler(EventStore, PublicEventSender);
 
     private static ProgramacionTurnoDiarioSolicitada CrearEvento(DetalleTurno detalleTurno) =>
         new(SolicitudId, Empleado, Fecha, detalleTurno);

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/FunctionEndpointTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/FunctionEndpointTests.cs
@@ -3,7 +3,7 @@
 using AwesomeAssertions;
 using Azure.Messaging.ServiceBus;
 using Bitakora.ControlAsistencia.ControlHoras.AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction;
-using Cosmos.EventSourcing.Abstractions.Commands;
+using Cosmos.EventDriven.Abstractions;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 
@@ -11,7 +11,8 @@ namespace Bitakora.ControlAsistencia.ControlHoras.Tests.AsignarTurnoCuandoProgra
 
 /// <summary>
 /// Tests del endpoint ServiceBus AsignarTurnoCuandoProgramacionTurnoDiarioSolicitada.
-/// Verifica orquestacion: deserializacion + despacho al command router + manejo de errores de Service Bus.
+/// issue #210 / ADR-0024 #8: el evento privado se despacha directo al IPrivateEventRouter (sin comando espejo).
+/// Verifica orquestacion: deserializacion + despacho al private event router + manejo de errores de Service Bus.
 /// Regresion del issue #48: no intentar dead-letter cuando se pierde el lock.
 /// </summary>
 public class FunctionEndpointTests
@@ -47,11 +48,11 @@ public class FunctionEndpointTests
     private static ServiceBusReceivedMessage CrearMensaje()
         => ServiceBusModelFactory.ServiceBusReceivedMessage(body: BinaryData.FromString(JsonFormatoWolverine));
 
-    // CA-1: camino feliz - deserializa el JSON, despacha al command router, completa el mensaje
+    // CA-1: camino feliz - deserializa el JSON, despacha al private event router, completa el mensaje
     [Fact]
     public async Task DebeCompletarMensaje_CuandoProcesamientoEsExitoso()
     {
-        var router = new FakeCommandRouter();
+        var router = new FakePrivateEventRouter();
         var messageActions = new FakeServiceBusMessageActions();
         var logger = new FakeLogger();
         var endpoint = new FunctionEndpoint(router, logger);
@@ -71,7 +72,7 @@ public class FunctionEndpointTests
         var lockLostException = new ServiceBusException(
             "Lock del mensaje expirado",
             ServiceBusFailureReason.MessageLockLost);
-        var router = new FakeCommandRouter();
+        var router = new FakePrivateEventRouter();
         var messageActions = new FakeServiceBusMessageActions(excepcionAlCompletar: lockLostException);
         var logger = new FakeLogger();
         var endpoint = new FunctionEndpoint(router, logger);
@@ -86,7 +87,7 @@ public class FunctionEndpointTests
     [Fact]
     public async Task DebeEnviarADeadLetter_CuandoOcurreErrorGenerico()
     {
-        var router = new FakeCommandRouter(
+        var router = new FakePrivateEventRouter(
             excepcion: new InvalidOperationException("Error inesperado en el handler"));
         var messageActions = new FakeServiceBusMessageActions();
         var logger = new FakeLogger();
@@ -102,29 +103,25 @@ public class FunctionEndpointTests
 // ---- Fakes manuales - NO NSubstitute ----
 
 /// <summary>
-/// Fake configurable de ICommandRouter. Puede completar exitosamente o lanzar
+/// Fake configurable de IPrivateEventRouter. Puede despachar exitosamente o lanzar
 /// una excepcion especifica para simular distintos escenarios de fallo.
 /// </summary>
-internal class FakeCommandRouter : ICommandRouter
+internal class FakePrivateEventRouter : IPrivateEventRouter
 {
     private readonly Exception? _excepcion;
 
-    public FakeCommandRouter(Exception? excepcion = null)
+    public FakePrivateEventRouter(Exception? excepcion = null)
     {
         _excepcion = excepcion;
     }
 
-    public Task InvokeAsync<TCommand>(TCommand command, CancellationToken ct = default)
-        where TCommand : class
+    public Task InvokeAsync<TEvent>(TEvent @event, CancellationToken cancellationToken)
+        where TEvent : class, IPrivateEvent
     {
         if (_excepcion is not null)
             throw _excepcion;
         return Task.CompletedTask;
     }
-
-    public Task<TResult> InvokeAsync<TCommand, TResult>(TCommand command, CancellationToken ct = default)
-        where TCommand : class
-        => throw new NotImplementedException();
 }
 
 /// <summary>

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/ProgramacionTurnoDiarioSolicitadaEventHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/ProgramacionTurnoDiarioSolicitadaEventHandlerTests.cs
@@ -1,18 +1,19 @@
-// HU-12: Asignar turno diario al control cuando se solicita programacion
+// HU-12 / issue #210: Asignar turno diario al control cuando llega ProgramacionTurnoDiarioSolicitada.
+// ADR-0024 #8: el evento privado intra-BC se consume directo con IPrivateEventHandlerAsync, sin comando espejo.
 
 using Bitakora.ControlAsistencia.Contracts.Empleados.ValueObjects;
 using Bitakora.ControlAsistencia.Contracts.Programacion.Eventos;
 using Bitakora.ControlAsistencia.Contracts.Programacion.ValueObjects;
-using Bitakora.ControlAsistencia.ControlHoras.AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction.CommandHandler;
+using Bitakora.ControlAsistencia.ControlHoras.AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction.EventHandler;
 using Bitakora.ControlAsistencia.ControlHoras.AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction.Eventos;
 using Bitakora.ControlAsistencia.ControlHoras.Entities;
-using Cosmos.EventSourcing.Abstractions.Commands;
+using Cosmos.EventDriven.Abstractions;
 using Cosmos.EventSourcing.Testing.Utilities;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.Tests.AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction;
 
-public class AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaCommandHandlerTests
-    : CommandHandlerAsyncTest<ProgramacionTurnoDiarioSolicitada>
+public class ProgramacionTurnoDiarioSolicitadaEventHandlerTests
+    : PrivateEventHandlerAsyncTest<ProgramacionTurnoDiarioSolicitada>
 {
     // Datos de prueba fijos - el stream ID es determinista a partir de EmpleadoId+Fecha
     private static readonly Guid SolicitudId =
@@ -30,8 +31,8 @@ public class AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaCommandHandlerTe
         "Turno Manana",
         [new DetalleFranjaOrdinaria(new TimeOnly(8, 0), new TimeOnly(16, 0), 0, [], [])]);
 
-    protected override ICommandHandlerAsync<ProgramacionTurnoDiarioSolicitada> Handler =>
-        new AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaCommandHandler(EventStore, PublicEventSender);
+    protected override IPrivateEventHandlerAsync<ProgramacionTurnoDiarioSolicitada> Handler =>
+        new ProgramacionTurnoDiarioSolicitadaEventHandler(EventStore, PublicEventSender);
 
     private static ProgramacionTurnoDiarioSolicitada CrearEvento() =>
         new(SolicitudId, Empleado, Fecha, DetalleTurnoTest);
@@ -44,7 +45,7 @@ public class AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaCommandHandlerTe
     // CA-6: el aggregate actualiza InformacionEmpleado, Fecha y DetalleTurno
     // CA-7: el stream ID resultante es "{EmpleadoId}:{Fecha:yyyy-MM-dd}"
     [Fact]
-    public async Task DebeEmitirTurnoDiarioAsignado_CuandoNoExisteControlDiario()
+    public async Task ProgramacionTurnoDiarioSolicitada_EmiteTurnoDiarioAsignado_CuandoNoExisteControlDiario()
     {
         // Sin Given - el stream no existe para este EmpleadoId+Fecha
         await WhenAsync(CrearEvento());
@@ -60,7 +61,7 @@ public class AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaCommandHandlerTe
     // CA-5: el nuevo evento contiene todos los campos actualizados
     // CA-8: el segundo mensaje opera sobre el mismo stream (mismo EmpleadoId+Fecha = mismo StreamId)
     [Fact]
-    public async Task DebeEmitirTurnoDiarioAsignado_CuandoYaExisteControlDiario()
+    public async Task ProgramacionTurnoDiarioSolicitada_EmiteTurnoDiarioAsignado_CuandoYaExisteControlDiario()
     {
         var solicitudAnteriorId = Guid.Parse("019600b0-0000-7000-8000-000000000002");
         var turnoAnterior = new TurnoDiarioAsignado(StreamId, Empleado, Fecha, DetalleTurnoTest, solicitudAnteriorId);

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/CrearDiaCalculadoConHorasDiscriminadasTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/CrearDiaCalculadoConHorasDiscriminadasTests.cs
@@ -9,10 +9,10 @@
 // patron que DesgloseHorasTras*Tests) y se verifica via el selector de And<>() sobre el aggregate
 // rehidratado. And<>() compara estructuralmente (BeEquivalentTo).
 //
-// Nested classes: CrearDiaCalculado() lo conducen ambos handlers sobre el mismo aggregate, por lo que
-// comparten datos pero requieren bases de test distintas: AsignarTurno es un comando genuino
-// (CommandHandlerAsyncTest<ProgramacionTurnoDiarioSolicitada>); AdicionarMarcacion, tras issue #209,
-// consume el evento privado directo (PrivateEventHandlerAsyncTest<MarcacionRegistrada>, ADR-0024 #8).
+// Nested classes: CrearDiaCalculado() lo conducen ambos EventHandlers sobre el mismo aggregate, por lo
+// que comparten datos pero reaccionan a eventos privados distintos. Tras issue #209 y #210 ambos
+// consumen su evento privado directo con PrivateEventHandlerAsyncTest<TEvent> (ADR-0024 #8):
+// AsignarTurno reacciona a ProgramacionTurnoDiarioSolicitada; AdicionarMarcacion a MarcacionRegistrada.
 //
 // El valor esperado se registra A MANO como oraculo independiente: el diccionario de minutos por
 // concepto se calcula de la geometria del dia, sin ejecutar Discriminar ni Consolidar (la logica bajo
@@ -24,12 +24,11 @@ using Bitakora.ControlAsistencia.Contracts.Programacion.Eventos;
 using Bitakora.ControlAsistencia.Contracts.Programacion.ValueObjects;
 using Bitakora.ControlAsistencia.ControlHoras.AdicionarMarcacionCuandoMarcacionRegistrada.EventHandler;
 using Bitakora.ControlAsistencia.ControlHoras.AdicionarMarcacionCuandoMarcacionRegistrada.Eventos;
-using Bitakora.ControlAsistencia.ControlHoras.AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction.CommandHandler;
+using Bitakora.ControlAsistencia.ControlHoras.AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction.EventHandler;
 using Bitakora.ControlAsistencia.ControlHoras.AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction.Eventos;
 using Bitakora.ControlAsistencia.ControlHoras.Entities;
 using Bitakora.ControlAsistencia.ControlHoras.RegistrarMarcacionFunction.Eventos;
 using Cosmos.EventDriven.Abstractions;
-using Cosmos.EventSourcing.Abstractions.Commands;
 using Cosmos.EventSourcing.Testing.Utilities;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.Tests.Entities;
@@ -67,10 +66,10 @@ public class CrearDiaCalculadoConHorasDiscriminadasTests
         new Dictionary<string, int> { ["DominicalFestivaDiurna"] = 420 };
 
     public class ViaAsignarTurnoTests
-        : CommandHandlerAsyncTest<ProgramacionTurnoDiarioSolicitada>
+        : PrivateEventHandlerAsyncTest<ProgramacionTurnoDiarioSolicitada>
     {
-        protected override ICommandHandlerAsync<ProgramacionTurnoDiarioSolicitada> Handler =>
-            new AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaCommandHandler(
+        protected override IPrivateEventHandlerAsync<ProgramacionTurnoDiarioSolicitada> Handler =>
+            new ProgramacionTurnoDiarioSolicitadaEventHandler(
                 EventStore, PublicEventSender);
 
         private static ProgramacionTurnoDiarioSolicitada CrearEvento(DetalleTurno detalleTurno) =>

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoCommandHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoCommandHandlerTests.cs
@@ -38,7 +38,7 @@ public class SolicitarProgramacionTurnoCommandHandlerTests
     // --- Configuracion del handler ---
 
     protected override ICommandHandlerAsync<SolicitarProgramacionTurno> Handler =>
-        new SolicitarProgramacionTurnoCommandHandler(EventStore, PublicEventSender);
+        new SolicitarProgramacionTurnoCommandHandler(EventStore, PrivateEventSender);
 
     // --- Factory methods ---
 
@@ -60,7 +60,7 @@ public class SolicitarProgramacionTurnoCommandHandlerTests
 
         Then(new ProgramacionTurnoSolicitada(
             GuidAggregateId, Empleado, [Fecha1], DetalleEsperado));
-        ThenIsPublishedPublicly(new ProgramacionTurnoDiarioSolicitada(
+        ThenIsPublishedPrivately(new ProgramacionTurnoDiarioSolicitada(
             GuidAggregateId, Empleado, Fecha1, DetalleEsperado));
         And<SolicitudProgramacionAggregateRoot, int>(s => s.Fechas.Count, 1);
     }
@@ -75,7 +75,7 @@ public class SolicitarProgramacionTurnoCommandHandlerTests
 
         Then(new ProgramacionTurnoSolicitada(
             GuidAggregateId, Empleado, [Fecha1, Fecha2], DetalleEsperado));
-        ThenIsPublishedPublicly(
+        ThenIsPublishedPrivately(
             new ProgramacionTurnoDiarioSolicitada(
                 GuidAggregateId, Empleado, Fecha1, DetalleEsperado),
             new ProgramacionTurnoDiarioSolicitada(


### PR DESCRIPTION
## Resumen

Pipeline TDD completado (refactoring puro):
- Análisis: no se requieren tests nuevos
- Justificación: Issue #210 reclasifica ProgramacionTurnoDiarioSolicitada de IPublicEvent a IPrivateEvent (quita/cambia el marker) y migra AsignarTurno de comando espejo (ICommandHandlerAsync+ServiceBusEndpointBase+ICommandRouter) a EventHandler directo (IPrivateEventHandlerAsync+PrivateEventEndpointBase+IPrivateEventRouter, ADR-0024 del marco decision #8); es el caso mandatorio de refactor a nivel de firma de test-writer.md seccion 2: el cast (IPublicEvent) en SolicitarProgramacionTurnoCommandHandler y el ICommandHandlerAsync<ProgramacionTurnoDiarioSolicitada> dejan de compilar en cuanto cambia el marker, asi que produccion y tests deben cambiar juntos solo para compilar, sin estado rojo intermedio posible; el comportamiento observable es identico (se sigue asignando el turno y publicando DiaCalculado tras Apply(TurnoDiarioAsignado)), solo cambia el mecanismo de transporte/consumo, por eso no hay comportamiento nuevo que testear en rojo. Tests que el reviewer debe REESCRIBIR con el patron nuevo (mismo comportamiento, no eliminar sin reemplazo): tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaCommandHandlerTests.cs (2 tests: migrar de CommandHandlerAsyncTest<ProgramacionTurnoDiarioSolicitada> a PrivateEventHandlerAsyncTest<ProgramacionTurnoDiarioSolicitada> contra el nuevo EventHandler, mismos Given/Then/And con streamId compuesto EmpleadoId:Fecha); FunctionEndpointTests.cs (3 tests: reemplazar FakeCommandRouter por un fake de IPrivateEventRouter y ServiceBusEndpointBase por PrivateEventEndpointBase<ProgramacionTurnoDiarioSolicitada>, conservando los 3 escenarios CA-1/CA-2/CA-3 de completar/lock-lost/dead-letter); DepurarAlAsignarTurnoTests.cs (3 tests) y DesgloseHorasTrasAsignarTurnoTests.cs (2 tests), ambos migrar de CommandHandlerAsyncTest a PrivateEventHandlerAsyncTest conservando Given/Then/And y ThenIsPublishedPublicly(DiaCalculado) intactos; en tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoCommandHandlerTests.cs (2 de 4 tests: los que hacen ThenIsPublishedPublicly(new ProgramacionTurnoDiarioSolicitada(...)) deben cambiar a ThenIsPublishedPrivately, y el Handler override de la clase debe inyectar PrivateEventSender en vez de PublicEventSender, lo que tambien obliga a re-verificar los otros 2 tests de esa clase que no cambian su asercion pero comparten el override). Trabajo de produccion que el reviewer/implementer debe hacer junto con lo anterior: cambiar el marker de ProgramacionTurnoDiarioSolicitada (Contracts) a IPrivateEvent; actualizar SolicitarProgramacionTurnoCommandHandler para inyectar IPrivateEventSender y publicar sin cast; crear PrivateEventEndpointBase<TEvento> en ControlHoras/Infraestructura (analogo a ServiceBusEndpointBase pero enruta a IPrivateEventRouter.InvokeAsync en vez de ICommandRouter.InvokeAsync); crear el EventHandler ProgramacionTurnoDiarioSolicitadaEventHandler : IPrivateEventHandlerAsync<ProgramacionTurnoDiarioSolicitada> conservando la logica crear-o-actualizar y la publicacion de DiaCalculado; registrar AgregarWolverinePrivateEventRouter() en Program.cs de ControlHoras conservando AgregarWolverineCommandRouter() (RegistrarMarcacion via HTTP lo sigue usando); ajustar el topic mapping de Program.cs de Programacion para que el evento privado siga cruzando el ASB propio del BC. Smoke tests (AsignarTurnoViaSbSmokeTests.cs, SolicitarProgramacionTurnoSmokeTests.cs) no se tocan: mismo topic/subscription fisico, siguen validos sin cambios.
- Baseline: 425 tests pasando
- Refactoring ejecutado manteniendo todos los tests verdes

## Decisiones del pipeline

<details>
<summary>Test Writer (fase roja) — 8m 36s</summary>

_(El agente no generó resumen)_

</details>

<details>
<summary>Reviewer (fase refactor) — 18m 34s</summary>

## ES Reviewer - Revision

### Evaluacion general
- Calidad: buena
- Cambios realizados: si (este era un refactor puro; el reviewer ejecuto el refactor completo — produccion + migracion de tests — a partir de la senal del test-writer)

Nota de contexto: `pipeline-state/refactor-signal.md` marca `REFACTOR_ONLY=true`. El test-writer
dejo la senal (carril de senal) sin tocar produccion ni tests. El reviewer ejecuto el refactor
completo en pasos seguros, con `dotnet test` tras la fase de cambios.

### Baseline
- Unit tests (ControlHoras.Tests, Programacion.Tests, Contracts.Tests): **verdes** antes y despues.
- 11 fallos en los proyectos **SmokeTests** (Programacion.SmokeTests: 8, ControlHoras.SmokeTests: 3)
  son **preexistentes y ambientales**: requieren ServiceBus/Postgres del entorno dev (no configurado
  localmente). Identicos en el baseline (working tree limpio) y tras el refactor -> delta de fallos = 0.
  Estado final identico al baseline: `total: 447, error: 11, correcto: 428, omitido: 8`.

### Cumplimiento de ADRs aplicables

| ADR | Cumplimiento | Observacion |
|---|---|---|
| ADR-0024 (marco): modelo de eventos privado/publico + EventHandler directo (decision #2/#3/#8) | ok | Evento reclasificado a `IPrivateEvent` (intra-BC); consumidor migrado a `IPrivateEventHandlerAsync` + `PrivateEventEndpointBase` + `IPrivateEventRouter`, sin comando espejo. Las 3 condiciones de decision #8 se cumplen: (1) `IPrivateEvent`, (2) subscription de un unico topic (no fan-in), (3) el comando era espejo del evento. |
| ADR-0023 (marco): topologia ASB del BC | ok | El evento privado sigue cruzando fisicamente el ASB interno (decision #3). Payload plano y portable (decision #3). |
| ADR-0002 (repo): estrategia testing / DSL | ok | Migracion de `CommandHandlerAsyncTest<>` a `PrivateEventHandlerAsyncTest<>`, DSL Given/WhenAsync/Then/And conservado, overloads de streamId compuesto correctos. |
| ADR-0006 (repo): naming de funciones Azure | ok | `[Function("AsignarTurnoCuandoProgramacionTurnoDiarioSolicitada")]` y `[ServiceBusTrigger]` sobre topic/subscription conservados; solo cambia la clase base del endpoint. |
| ADR-0001/0004 (repo): un topic por evento | ok | Topic `programacion-turno-diario-solicitada` y sus subscriptions intactos; sin cambio de infra (confirmado contra `infra/environments/dev/main.tf`). |
| ADR-0002/0025 (repo): Contracts solo DTOs planos | ok | El evento vive en Contracts; su payload (`SolicitudId`, `InformacionEmpleado`, `DetalleTurno`, `Fecha`) son `record` DTOs planos. Solo cambio el marker. |
| ADR-0012/0015 (repo): serializacion / frontera event store vs bus | ok | Ver antipatron #7 abajo. Payload plano; `ServiceBusDeserializador` usa STJ por defecto; guardrail de round-trip existente. |
| ADR-0016 (repo): naming de tests | ok | Tests migrados con sujeto = nombre del evento (`ProgramacionTurnoDiarioSolicitada_...`). Se normalizo 1 nombre que empezaba con `Debe` (ver refactorings). |

**Antipatron #7 de ADR-0012 (evento con marker de bus que carga modelo rico) — verificado
activamente:** el payload de `ProgramacionTurnoDiarioSolicitada` es plano y portable:
`InformacionEmpleado` y `DetalleTurno` son `record` positionales de primitivas/colecciones planas
(Contracts). `ServiceBusDeserializador` deserializa con `JsonSerializerOptions` **por defecto**
(solo `PropertyNameCaseInsensitive`, sin resolver custom), y existe el guardrail de round-trip con
serializador por defecto: `ProgramacionTurnoDiarioSolicitadaDeserializacionTests`
(`Deserializar_ReconstruyeEvento_CuandoJsonEsFormatoWolverine`). Ademas el evento ya cruzaba el ASB
como `IPublicEvent`, asi que la portabilidad estaba establecida; la reclasificacion no cambia la
serializacion. **Sin hallazgo.**

### Desviaciones de ADRs

Ninguna desviacion — todos los ADRs aplicables se cumplen.

(No hubo resumen de implementer que evaluar: fase de refactor puro. La senal del test-writer no
declaro desviaciones.)

### Precedentes consultados

| Precedente | ADR aplicable | Veredicto |
|---|---|---|
| PR #216 / issue #209: `MarcacionRegistradaEventHandler` (`AdicionarMarcacionCuandoMarcacionRegistrada/EventHandler/`) | ADR-0024 #8 | alineado. Precedente del mismo patron en el propio repo. Diferencia relevante: #209 consume un evento **local** (mismo Function App) ruteado in-process, sin `[ServiceBusTrigger]` ni endpoint; #210 consume un evento de **otro** Function App (Programacion) via `[ServiceBusTrigger]`, por eso #210 SI necesita el endpoint con `PrivateEventEndpointBase`. |
| `Cosmos.ControlPlane` PR #94 (migracion de 4 consumidores) | ADR-0024 #8 | alineado (citado por el ADR; no verificable en este repo, es cross-repo). |
| API paquete `Cosmos.EventDriven.CritterStack(.AzureServiceBus)` 2.1.0 | ADR-0024 #8 | verificado por decompilacion: `PublicarEventoServerless<T>` tiene constraint `IEvent` (no `IPublicEvent`) y Wolverine rutea por tipo concreto del mensaje -> el topic mapping sigue valido publicando via `IPrivateEventSender`. `IPrivateEventRouter.InvokeAsync<T> where T: class, IPrivateEvent`. `PrivateEventHandlerAsyncTest<T> where T: IPrivateEvent`. |

### Convenciones del pipeline (no ADRs)

| Convencion | Estado | Observacion |
|---|---|---|
| Cada test con `Then()` + `And<>()` | ok | Los tests de handler (EventHandler, Depurar, Desglose, CrearDiaCalculado) tienen `Then(...)` + `And<>()`. Los tests de endpoint usan aserciones directas (orquestacion, no estado de aggregate) — DSL Then/And no aplica; los del productor usan `Then` + `ThenIsPublishedPrivately` + `And`. |
| Overloads correctos para stream IDs compuestos | ok | `ControlDiarioAggregateRoot` usa `ComputarStreamId(EmpleadoId, Fecha)` -> todos los tests usan `Given(streamId, ...)`, `Then(streamId, ...)`, `And<T,P>(streamId, ...)`. |
| Fakes manuales (no NSubstitute) | ok | `FakePrivateEventRouter`, `FakeServiceBusMessageActions`, `FakeLogger` — clases fake concretas. |
| Feature folders (produccion y tests) | ok | Handler en subcarpeta `EventHandler/` (espejo de `CommandHandler/`); `PrivateEventEndpointBase` en `Infraestructura/`. Tests reflejan la estructura. |
| Smoke tests: SkipWhen, secrets, cobertura | n/a | No se tocan (mismo topic/subscription fisico). Suscripcion `smoke-tests` del topic ya existe en infra. Los smoke tests existentes siguen cubriendo el flujo publicar/consumir. |
| Tests via ToString/comportamiento | ok | Los selectores `And<>()` leen propiedades publicas del aggregate ya existentes en la suite (no getters agregados para test). |
| Sin numeros magicos | ok | El EventHandler no introduce constantes magicas. |
| Condiciones en positivo (guardas if/else afirmativas) | ok | El EventHandler usa `if (existe) {...} else {...}` (positivo); `PrivateEventEndpointBase` usa try/catch con filtro, sin guardas negadas. |

### Elegancia del codigo
- `PrivateEventEndpointBase<TPrivateEvent>` reusa la misma forma que `ServiceBusEndpointBase<TEvento>`
  (deserializar -> despachar -> complete/lock-lost/dead-letter), cambiando solo el router. Compacto,
  idiomatico (primary constructor, pattern matching en el `catch when`), consistente con el precedente.
- El productor elimino el cast `(IPublicEvent)`; ahora publica un `ProgramacionTurnoDiarioSolicitada[]`
  (covarianza de arrays a `IPrivateEvent[]`) sin ceremonia extra — mas limpio que antes.
- Comentarios de intencion actualizados en cada archivo tocado (referencian ADR-0024 decisiones #2/#3/#8).
- Sin warnings del compilador nuevos (solo NU1902 preexistente de paquete y CS0414 preexistente en
  Programacion `CatalogoTurnos._estaActivo`). Sin caracteres U+2500. Formato verificado con
  `dotnet format --verify-no-changes` (exit 0).

### Criticas y hallazgos
- **[menor, resuelto] Archivo no listado en la senal**: `Entities/CrearDiaCalculadoConHorasDiscriminadasTests.cs`
  (nested `ViaAsignarTurnoTests`) referenciaba el `CommandHandler` eliminado y NO estaba en los 12
  tests declarados por la senal. Sin migrarlo, el proyecto de tests no compilaba (contradiccion
  estructural: la base `CommandHandlerAsyncTest<ProgramacionTurnoDiarioSolicitada>` ya no tiene handler
  que satisfacer). Se migro a `PrivateEventHandlerAsyncTest<ProgramacionTurnoDiarioSolicitada>` con el
  nuevo `ProgramacionTurnoDiarioSolicitadaEventHandler`, conservando Given/When/Then/And y los oraculos
  independientes (regla 2b: ajuste mecanico, el intent no cambia; los CAs siguen cubiertos).
- **[cosmetico, resuelto] Naming ADR-0016**: `DebeCalcularControlFranja_...` en `DepurarAlAsignarTurnoTests`
  usaba prefijo `Debe`. Renombrado a `ProgramacionTurnoDiarioSolicitada_CalculaControlFranja_Cuando...`
  para alinear con el sujeto = nombre del evento (los otros tests del archivo ya lo hacian).
- **[informativo] Coordinacion con #209 (mismo `Program.cs` de ControlHoras)**: `AgregarWolverinePrivateEventRouter()`
  ya estaba registrado por #209 (ya mergeado). NO se duplico; solo se actualizo el comentario que
  mencionaba a AsignarTurno como consumidor de `ICommandRouter` (ya no lo es). `AgregarWolverineCommandRouter()`
  se conserva para `RegistrarMarcacion` (HTTP).
- Sin otros hallazgos.

### Refactorings aplicados
- Renombrado del archivo/clase de test `AsignarTurno...CommandHandlerTests` ->
  `ProgramacionTurnoDiarioSolicitadaEventHandlerTests` (via `git mv`), espejo del naming del precedente
  #209 y de ADR-0024 #8. Justificacion: el test ya no prueba un command handler.
- Normalizacion de 1 nombre de test a ADR-0016 (ver hallazgos).
- Eliminacion del `CommandHandler` viejo (`git rm`) tras crear el `EventHandler` (git detecta rename).

### Cobertura de criterios de aceptacion
| Criterio | Estado | Test(s) |
|---|---|---|
| CA-1: evento implementa `IPrivateEvent` | cubierto | Verificado por compilacion (`PrivateEventHandlerAsyncTest<T> where T: IPrivateEvent`) + `ThenIsPublishedPrivately` en el productor. |
| CA-2: productor publica via `IPrivateEventSender`; topic mapping conservado | cubierto | `SolicitarProgramacionTurnoCommandHandlerTests.DebeEmitirProgramacionSolicitadaYPublicarEvento_CuandoDatosValidos`, `DebePublicarUnEventoPorCadaFecha_CuandoHayMultiplesFechas` (`ThenIsPublishedPrivately`). |
| CA-3: consumidor via `IPrivateEventHandlerAsync` + `PrivateEventEndpointBase`; trigger conservado | cubierto | `ProgramacionTurnoDiarioSolicitadaEventHandlerTests` (2), `FunctionEndpointTests` (3: complete/lock-lost/dead-letter). |
| CA-4: se conserva publicacion de `DiaCalculado` | cubierto | `DepurarAlAsignarTurnoTests` (3, `ThenIsPublishedPublicly(DiaCalculado)`), `DesgloseHorasTrasAsignarTurnoTests` (2). |
| CA-5: `Program.cs` de ControlHoras registra `AgregarWolverinePrivateEventRouter` conservando `AgregarWolverineCommandRouter` | cubierto | Verificacion estatica de `Program.cs` (registro presente una sola vez; command router conservado para HTTP). |
| CA-6: tests del consumidor migrados a `PrivateEventHandlerAsyncTest`; suites verdes | cubierto | ControlHoras.Tests 296 verde, Programacion.Tests 42 verde, Contracts.Tests 87 verde. |

### Tests agregados
- No se agregaron tests nuevos (refactor puro: comportamiento observable identico, sin CA nuevo).
- Se migraron 12 tests declarados por la senal + 2 tests adicionales (nested `ViaAsignarTurnoTests`
  no declarados) al patron `PrivateEventHandlerAsyncTest` / `IPrivateEventRouter`, conservando su
  comportamiento y aserciones.
- Guardrails de portabilidad y serializacion (`ProgramacionTurnoDiarioSolicitadaDeserializacionTests`,
  `TurnoDiarioAsignadoSerializacionTests`) ya existentes y siguen verdes; no requirieron cambios.

</details>

## Commits

ca8c7e5 refactor(hu-210): reclasificar ProgramacionTurnoDiarioSolicitada como IPrivateEvent y migrar AsignarTurno a EventHandler

Closes #210