### PR TITLE
Consumir MarcacionRegistrada via ServiceBusTrigger fisico en vez de ruteo in-process

### DIFF
--- a/src/Bitakora.ControlAsistencia.ControlHoras/AdicionarMarcacionCuandoMarcacionRegistrada/EventHandler/MarcacionRegistradaEventHandler.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/AdicionarMarcacionCuandoMarcacionRegistrada/EventHandler/MarcacionRegistradaEventHandler.cs
@@ -10,8 +10,9 @@ namespace Bitakora.ControlAsistencia.ControlHoras.AdicionarMarcacionCuandoMarcac
 // ADR-0024 (decision #8): MarcacionRegistrada es un IPrivateEvent intra-BC y el comando equivalente
 // seria un espejo del evento (mismos campos, sin semantica propia), asi que se consume directo con
 // IPrivateEventHandlerAsync<MarcacionRegistrada> - sin comando espejo.
-// Trigger: evento local MarcacionRegistrada publicado via WolverinePrivateEventSender (#105),
-// ruteado in-process por IPrivateEventRouter (sin ServiceBusTrigger ni endpoint en este feature folder).
+// Trigger: MarcacionRegistrada publicado via WolverinePrivateEventSender (#105) cruza
+// fisicamente el ASB interno del BC (topic marcacion-registrada, issue #212/#213) y es
+// despachado a este handler por FunctionEndpoint (PrivateEventEndpointBase) via IPrivateEventRouter.
 // Patron crear-o-actualizar: ExistsAsync -> si no existe StartStream, si existe GetAggregateRootAsync
 // CA-9: ventana de traslape nocturno con corte a las 04:00 como constante del handler
 // ADR-0015: partial class para soportar clase Mensajes en archivo separado si se requiere

--- a/src/Bitakora.ControlAsistencia.ControlHoras/AdicionarMarcacionCuandoMarcacionRegistrada/FunctionEndpoint.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/AdicionarMarcacionCuandoMarcacionRegistrada/FunctionEndpoint.cs
@@ -1,0 +1,31 @@
+using Azure.Messaging.ServiceBus;
+using Bitakora.ControlAsistencia.ControlHoras.Infraestructura;
+using Bitakora.ControlAsistencia.ControlHoras.RegistrarMarcacionFunction.Eventos;
+using Cosmos.EventDriven.Abstractions;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.AdicionarMarcacionCuandoMarcacionRegistrada;
+
+// issue #213: ServiceBusTrigger que consume MarcacionRegistrada desde el ASB interno del BC.
+// ADR-0024 (marco) decision #3: todo evento privado cruza fisicamente el ASB, aun intra-BC;
+// decision #8: se despacha directo al IPrivateEventHandlerAsync via IPrivateEventRouter
+// (PrivateEventEndpointBase) - sin comando espejo. Reemplaza la entrega in-process previa
+// (#209/#105) que no tenia [ServiceBusTrigger] ni FunctionEndpoint en este feature folder.
+// ADR-0008: [Function("{Accion}Cuando{Evento}")]
+// Topic "marcacion-registrada" + subscription "control-horas-escucha-marcacion" provisionados
+// en #212 (infra/environments/dev/main.tf).
+public class FunctionEndpoint(IPrivateEventRouter privateEventRouter, ILogger<FunctionEndpoint> logger)
+    : PrivateEventEndpointBase<MarcacionRegistrada>(privateEventRouter, logger)
+{
+    [Function("AdicionarMarcacionCuandoMarcacionRegistrada")]
+    public Task Run(
+        [ServiceBusTrigger(
+            topicName: "marcacion-registrada",
+            subscriptionName: "control-horas-escucha-marcacion",
+            Connection = "SERVICE_BUS_CONNECTION")]
+        ServiceBusReceivedMessage message,
+        ServiceBusMessageActions messageActions,
+        CancellationToken ct)
+        => throw new NotImplementedException();
+}

--- a/src/Bitakora.ControlAsistencia.ControlHoras/AdicionarMarcacionCuandoMarcacionRegistrada/FunctionEndpoint.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/AdicionarMarcacionCuandoMarcacionRegistrada/FunctionEndpoint.cs
@@ -19,7 +19,7 @@ public class FunctionEndpoint(IPrivateEventRouter privateEventRouter, ILogger<Fu
     : PrivateEventEndpointBase<MarcacionRegistrada>(privateEventRouter, logger)
 {
     [Function("AdicionarMarcacionCuandoMarcacionRegistrada")]
-    public Task Run(
+    public async Task Run(
         [ServiceBusTrigger(
             topicName: "marcacion-registrada",
             subscriptionName: "control-horas-escucha-marcacion",
@@ -27,5 +27,5 @@ public class FunctionEndpoint(IPrivateEventRouter privateEventRouter, ILogger<Fu
         ServiceBusReceivedMessage message,
         ServiceBusMessageActions messageActions,
         CancellationToken ct)
-        => throw new NotImplementedException();
+        => await ProcesarMensaje(message, messageActions, ct);
 }

--- a/src/Bitakora.ControlAsistencia.ControlHoras/Program.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Program.cs
@@ -3,6 +3,7 @@ using Azure.Monitor.OpenTelemetry.Exporter;
 using Bitakora.ControlAsistencia.Contracts.ControlHoras.Eventos;
 using Bitakora.ControlAsistencia.ControlHoras;
 using Bitakora.ControlAsistencia.ControlHoras.Infraestructura;
+using Bitakora.ControlAsistencia.ControlHoras.RegistrarMarcacionFunction.Eventos;
 using Cosmos.EventDriven.CritterStack;
 using Cosmos.EventDriven.CritterStack.AzureServiceBus;
 using Cosmos.EventSourcing.CritterStack;
@@ -32,6 +33,11 @@ builder.Services.AgregarWolverineParaComandosServerless(
         // HU-108: registra el topic destino para DiaCalculado.
         // ADR-0004 + ADR-0005: un topic por evento, naming kebab-case en participio.
         options.PublicarEventoServerless<DiaCalculado>("dia-calculado");
+        // issue #213 (ADR-0024 marco decision #3): MarcacionRegistrada es IPrivateEvent y debe
+        // cruzar fisicamente el ASB interno del BC, aun siendo consumido dentro del mismo
+        // Function App (AdicionarMarcacionCuandoMarcacionRegistrada). Topic + subscription
+        // provisionados en #212 (infra/environments/dev/main.tf).
+        options.PublicarEventoServerless<MarcacionRegistrada>("marcacion-registrada");
     });
 
 builder.Services.AgregarMartenEventStore();

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoMarcacionRegistrada/FunctionEndpointTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoMarcacionRegistrada/FunctionEndpointTests.cs
@@ -1,0 +1,191 @@
+// issue #213: Tests del FunctionEndpoint del ServiceBus trigger AdicionarMarcacionCuandoMarcacionRegistrada
+
+using AwesomeAssertions;
+using Azure.Messaging.ServiceBus;
+using Bitakora.ControlAsistencia.ControlHoras.AdicionarMarcacionCuandoMarcacionRegistrada;
+using Cosmos.EventDriven.Abstractions;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Tests.AdicionarMarcacionCuandoMarcacionRegistrada;
+
+/// <summary>
+/// Tests del endpoint ServiceBus AdicionarMarcacionCuandoMarcacionRegistrada.
+/// issue #213 / ADR-0024 (marco) decision #3 + #8: MarcacionRegistrada deja de entregarse
+/// in-process (#209) y cruza fisicamente el ASB interno del BC; el evento se despacha directo
+/// al IPrivateEventRouter (sin comando espejo).
+/// Verifica orquestacion: deserializacion + despacho al private event router + manejo de
+/// errores de Service Bus (patron identico a AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction).
+/// </summary>
+public class FunctionEndpointTests
+{
+    // JSON en formato camelCase - Wolverine serializa con camelCase por defecto al publicar al Service Bus.
+    // Mismos campos que MarcacionRegistradaSerializacionTests (EmpleadoId, TimestampNormalizado,
+    // TipoMarcacion, DispositivoId); MarcacionRegistrada solo tiene un constructor publico, por lo
+    // que ServiceBusDeserializador (case-insensitive) lo resuelve via constructor parametrizado.
+    private const string JsonFormatoWolverine = """
+        {
+          "empleadoId": "EMP-001",
+          "timestampNormalizado": "2026-03-15T08:09:00",
+          "tipoMarcacion": "ENTRADA",
+          "dispositivoId": "DEV-001"
+        }
+        """;
+
+    private static ServiceBusReceivedMessage CrearMensaje()
+        => ServiceBusModelFactory.ServiceBusReceivedMessage(body: BinaryData.FromString(JsonFormatoWolverine));
+
+    // CA-2: camino feliz - deserializa el JSON, despacha al private event router, completa el mensaje
+    [Fact]
+    public async Task AdicionarMarcacionCuandoMarcacionRegistrada_CompletaMensaje_CuandoProcesamientoEsExitoso()
+    {
+        var router = new FakePrivateEventRouter();
+        var messageActions = new FakeServiceBusMessageActions();
+        var logger = new FakeLogger();
+        var endpoint = new FunctionEndpoint(router, logger);
+
+        await endpoint.Run(CrearMensaje(), messageActions, CancellationToken.None);
+
+        messageActions.MensajeCompletado.Should().BeTrue();
+        messageActions.MensajeEnDeadLetter.Should().BeFalse();
+    }
+
+    // CA-2: lock perdido al intentar completar -> log warning, NO dead-letter
+    // Regresion del issue #48 (ya cubierta en AsignarTurno): el lock ya no es valido, intentar
+    // DeadLetterMessageAsync tambien fallaria. El Service Bus re-entregara el mensaje automaticamente.
+    [Fact]
+    public async Task AdicionarMarcacionCuandoMarcacionRegistrada_LogueaWarning_CuandoSePierdeLockAlCompletar()
+    {
+        var lockLostException = new ServiceBusException(
+            "Lock del mensaje expirado",
+            ServiceBusFailureReason.MessageLockLost);
+        var router = new FakePrivateEventRouter();
+        var messageActions = new FakeServiceBusMessageActions(excepcionAlCompletar: lockLostException);
+        var logger = new FakeLogger();
+        var endpoint = new FunctionEndpoint(router, logger);
+
+        await endpoint.Run(CrearMensaje(), messageActions, CancellationToken.None);
+
+        messageActions.MensajeEnDeadLetter.Should().BeFalse("el lock ya no es valido, no se puede dead-letter");
+        logger.WarningLogueado.Should().BeTrue();
+    }
+
+    // CA-2: error generico durante el procesamiento -> dead-letter el mensaje para inspeccion
+    [Fact]
+    public async Task AdicionarMarcacionCuandoMarcacionRegistrada_EnviaADeadLetter_CuandoOcurreErrorGenerico()
+    {
+        var router = new FakePrivateEventRouter(
+            excepcion: new InvalidOperationException("Error inesperado en el handler"));
+        var messageActions = new FakeServiceBusMessageActions();
+        var logger = new FakeLogger();
+        var endpoint = new FunctionEndpoint(router, logger);
+
+        await endpoint.Run(CrearMensaje(), messageActions, CancellationToken.None);
+
+        messageActions.MensajeEnDeadLetter.Should().BeTrue();
+        messageActions.MensajeCompletado.Should().BeFalse();
+    }
+}
+
+// ---- Fakes manuales - NO NSubstitute ----
+
+/// <summary>
+/// Fake configurable de IPrivateEventRouter. Puede despachar exitosamente o lanzar
+/// una excepcion especifica para simular distintos escenarios de fallo.
+/// </summary>
+internal class FakePrivateEventRouter : IPrivateEventRouter
+{
+    private readonly Exception? _excepcion;
+
+    public FakePrivateEventRouter(Exception? excepcion = null)
+    {
+        _excepcion = excepcion;
+    }
+
+    public Task InvokeAsync<TEvent>(TEvent @event, CancellationToken cancellationToken)
+        where TEvent : class, IPrivateEvent
+    {
+        if (_excepcion is not null)
+            throw _excepcion;
+        return Task.CompletedTask;
+    }
+}
+
+/// <summary>
+/// Fake de ServiceBusMessageActions. Registra si el mensaje fue completado o enviado a dead-letter.
+/// Puede configurarse para lanzar una excepcion al completar (simulando lock perdido).
+/// </summary>
+internal class FakeServiceBusMessageActions : ServiceBusMessageActions
+{
+    private readonly Exception? _excepcionAlCompletar;
+
+    public bool MensajeCompletado { get; private set; }
+    public bool MensajeEnDeadLetter { get; private set; }
+
+    public FakeServiceBusMessageActions(Exception? excepcionAlCompletar = null)
+    {
+        _excepcionAlCompletar = excepcionAlCompletar;
+    }
+
+    public override Task CompleteMessageAsync(
+        ServiceBusReceivedMessage message,
+        CancellationToken cancellationToken = default)
+    {
+        if (_excepcionAlCompletar is not null)
+            throw _excepcionAlCompletar;
+        MensajeCompletado = true;
+        return Task.CompletedTask;
+    }
+
+    public override Task DeadLetterMessageAsync(
+        ServiceBusReceivedMessage message,
+        Dictionary<string, object>? propertiesToModify = null,
+        string? deadLetterReason = null,
+        string? deadLetterErrorDescription = null,
+        CancellationToken cancellationToken = default)
+    {
+        MensajeEnDeadLetter = true;
+        return Task.CompletedTask;
+    }
+
+    public override Task AbandonMessageAsync(
+        ServiceBusReceivedMessage message,
+        IDictionary<string, object>? propertiesToModify = null,
+        CancellationToken cancellationToken = default)
+        => throw new NotImplementedException();
+
+    public override Task DeferMessageAsync(
+        ServiceBusReceivedMessage message,
+        IDictionary<string, object>? propertiesToModify = null,
+        CancellationToken cancellationToken = default)
+        => throw new NotImplementedException();
+
+    public override Task RenewMessageLockAsync(
+        ServiceBusReceivedMessage message,
+        CancellationToken cancellationToken = default)
+        => throw new NotImplementedException();
+}
+
+/// <summary>
+/// Fake de ILogger[FunctionEndpoint]. Registra si se loguo algun Warning
+/// para verificar el camino de lock perdido.
+/// </summary>
+internal class FakeLogger : ILogger<FunctionEndpoint>
+{
+    public bool WarningLogueado { get; private set; }
+
+    public void Log<TState>(
+        LogLevel logLevel,
+        EventId eventId,
+        TState state,
+        Exception? exception,
+        Func<TState, Exception?, string> formatter)
+    {
+        if (logLevel == LogLevel.Warning)
+            WarningLogueado = true;
+    }
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+}

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoMarcacionRegistrada/MarcacionRegistradaDeserializacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoMarcacionRegistrada/MarcacionRegistradaDeserializacionTests.cs
@@ -1,0 +1,76 @@
+// issue #213: guardrail de portabilidad por el bus para MarcacionRegistrada.
+
+using System.Text.Json;
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.ControlHoras.Infraestructura;
+using Bitakora.ControlAsistencia.ControlHoras.RegistrarMarcacionFunction.Eventos;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Tests.AdicionarMarcacionCuandoMarcacionRegistrada;
+
+/// <summary>
+/// Verifica que MarcacionRegistrada (IPrivateEvent) sobrevive el cruce fisico del ASB interno del BC
+/// (issue #213 / ADR-0024 decision #3): el productor la serializa con Wolverine (camelCase) y el
+/// consumidor la deserializa con ServiceBusDeserializador, que usa el serializador por defecto
+/// (PropertyNameCaseInsensitive, SIN el resolver custom de Marten). Este es el guardrail de
+/// portabilidad por el bus: distinto de MarcacionRegistradaSerializacionTests, que ejercita el
+/// round-trip del event store (con CrearOpcionesMarten y el resolver del dominio) y pasaria incluso
+/// si el payload no fuera portable. El payload plano de MarcacionRegistrada (string, DateTime,
+/// string?) debe reconstruirse sin perdida via su constructor publico.
+/// </summary>
+public class MarcacionRegistradaDeserializacionTests
+{
+    // JSON en formato camelCase - exactamente como Wolverine lo serializa al publicar al Service Bus.
+    private const string JsonFormatoWolverine = """
+        {
+          "empleadoId": "EMP-001",
+          "timestampNormalizado": "2026-03-15T08:09:00",
+          "tipoMarcacion": "ENTRADA",
+          "dispositivoId": "DEV-001"
+        }
+        """;
+
+    // CA-2: el evento cruza el ASB y se reconstruye sin perdida via el serializador por defecto del bus.
+    [Fact]
+    public void Deserializar_ReconstruyeEvento_CuandoJsonEsFormatoWolverine()
+    {
+        var body = BinaryData.FromString(JsonFormatoWolverine);
+
+        var evento = ServiceBusDeserializador.Deserializar<MarcacionRegistrada>(body);
+
+        evento.Should().NotBeNull();
+        evento.EmpleadoId.Should().Be("EMP-001");
+        evento.TimestampNormalizado.Should().Be(new DateTime(2026, 3, 15, 8, 9, 0));
+        evento.TipoMarcacion.Should().Be("ENTRADA");
+        evento.DispositivoId.Should().Be("DEV-001");
+    }
+
+    // CA-2: los campos opcionales (nullable) que hacen al payload portable se preservan cuando estan ausentes.
+    [Fact]
+    public void Deserializar_PreservaCamposOpcionalesNulos_CuandoTipoYDispositivoAusentes()
+    {
+        var body = BinaryData.FromString("""
+            {
+              "empleadoId": "EMP-002",
+              "timestampNormalizado": "2026-03-15T08:09:00"
+            }
+            """);
+
+        var evento = ServiceBusDeserializador.Deserializar<MarcacionRegistrada>(body);
+
+        evento.Should().NotBeNull();
+        evento.EmpleadoId.Should().Be("EMP-002");
+        evento.TimestampNormalizado.Should().Be(new DateTime(2026, 3, 15, 8, 9, 0));
+        evento.TipoMarcacion.Should().BeNull();
+        evento.DispositivoId.Should().BeNull();
+    }
+
+    [Fact]
+    public void Deserializar_LanzaExcepcion_CuandoJsonEsInvalido()
+    {
+        var body = BinaryData.FromString("esto no es json");
+
+        var act = () => ServiceBusDeserializador.Deserializar<MarcacionRegistrada>(body);
+
+        act.Should().ThrowExactly<JsonException>();
+    }
+}


### PR DESCRIPTION
## Resumen

Pipeline TDD completado:
- Fase roja: tests escritos con stubs
- Fase verde: implementación completa
- Fase refactor: revisión de calidad

## Decisiones del pipeline

<details>
<summary>Test Writer (fase roja) — 7m 59s</summary>

## ES Test Writer - Decisiones

### Tests creados
- `tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoMarcacionRegistrada/FunctionEndpointTests.cs`: 3 tests
  - `AdicionarMarcacionCuandoMarcacionRegistrada_CompletaMensaje_CuandoProcesamientoEsExitoso` - CA-2: camino feliz, deserializa el JSON, despacha al `IPrivateEventRouter`, completa el mensaje.
  - `AdicionarMarcacionCuandoMarcacionRegistrada_LogueaWarning_CuandoSePierdeLockAlCompletar` - CA-2: lock perdido al completar -> log warning, sin dead-letter (regresion issue #48, ya cubierta para el patron hermano `AsignarTurno...`).
  - `AdicionarMarcacionCuandoMarcacionRegistrada_EnviaADeadLetter_CuandoOcurreErrorGenerico` - CA-2: error generico del router -> dead-letter del mensaje.

### Estructura elegida
- **Una sola clase de test**, sin DSL `CommandHandlerAsyncTest`/`Given`/`Then`: este componente es un `FunctionEndpoint` (orquestacion HTTP/ServiceBus), no un command handler de event sourcing. Sigue el mismo estilo (xUnit plano + AwesomeAssertions + fakes manuales) que el precedente exacto del repo: `AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/FunctionEndpointTests.cs`. Por eso esta clase de test no lleva `Then(...)`/`And<>()` (esa regla aplica al DSL de command handlers, no a endpoints).
- Fakes manuales reusando los mismos nombres que el precedente (`FakePrivateEventRouter`, `FakeServiceBusMessageActions`, `FakeLogger`), scoping por namespace propio (`...Tests.AdicionarMarcacionCuandoMarcacionRegistrada`) para evitar cualquier ambiguidad con los fakes homonimos del feature folder de `AsignarTurno`.
- JSON de entrada en camelCase (formato real que emite Wolverine al publicar), con los 4 campos de `MarcacionRegistrada` (`empleadoId`, `timestampNormalizado`, `tipoMarcacion`, `dispositivoId`); `MarcacionRegistrada` solo expone un constructor publico, por lo que `ServiceBusDeserializador` (case-insensitive, sin resolver custom) lo resuelve via constructor parametrizado - verificado leyendo `ServiceBusDeserializador.cs` y `MarcacionRegistrada.cs` antes de escribir el test.

### Stubs creados
- `src/Bitakora.ControlAsistencia.ControlHoras/AdicionarMarcacionCuandoMarcacionRegistrada/FunctionEndpoint.cs`:
  - `public class FunctionEndpoint(IPrivateEventRouter, ILogger<FunctionEndpoint>) : PrivateEventEndpointBase<MarcacionRegistrada>` con `[Function("AdicionarMarcacionCuandoMarcacionRegistrada")]` + `[ServiceBusTrigger(topicName: "marcacion-registrada", subscriptionName: "control-horas-escucha-marcacion", Connection: "SERVICE_BUS_CONNECTION")]`.
  - Constructor, herencia y atributos de wiring se dejan con los valores reales (topic/subscription ya provisionados en #212, verificados en `infra/environments/dev/main.tf:83-95`) porque son metadata de configuracion requerida para compilar, no logica de negocio.
  - El cuerpo de `Run(...)` es `=> throw new NotImplementedException();` - es la unica pieza que el implementer debe completar (un one-liner `=> ProcesarMensaje(message, messageActions, ct);`, ya que toda la orquestacion real vive en `PrivateEventEndpointBase`, clase ya existente e implementada desde #209/#210). Verificado con los 3 tests: los 3 fallan en rojo por `NotImplementedException`.

### Decisiones de diseno
- **No se toco `Program.cs`**: el repo no tiene convencion de tests unitarios sobre `Program.cs` (verificado: ningun `find`/`grep` encontro un test que lo ejercite en ninguna HU anterior, incluyendo los topic-mappings analogos de HU-108, HU-131, #209, #210). El registro de `PublicarEventoServerless<MarcacionRegistrada>("marcacion-registrada")` (CA-1) y la verificacion de no-duplicar `AgregarWolverinePrivateEventRouter()` (CA-3, ya registrado desde #209) quedan para el implementer; no requieren stub de compilacion porque no son referenciados por ningun test.
- **No se escribio el smoke test de CA-5**: es responsabilidad del agente `smoke-test-writer` (catalogo de agentes en `CLAUDE.md`), que corre en un pipeline distinto al de TDD (`/implement` no lo invoca). El precedente `AsignarTurnoViaSbSmokeTests.cs` (patron de referencia citado por el issue) usa fixtures reales de ServiceBus/Postgres contra un entorno desplegado - fuera del alcance de este agente.
- **No se toco `MarcacionRegistradaEventHandler` ni sus tests existentes** (`MarcacionRegistradaEventHandlerTests.cs`, `DepurarAlAdicionarMarcacionTests.cs`, `DesgloseHorasTrasAdicionarMarcacionTests.cs`): el issue no cambia el comportamiento del handler (CA-4 es "conservar", no modificar), solo agrega la capa de transporte fisico alrededor de el. Esos tests siguen ejercitando el handler de forma aislada (llaman `HandleAsync` directo) y permanecen validos y verdes.
- Se evaluo si este issue calificaba para el carril de "refactoring puro" (seccion 2): se descarto porque hay comportamiento observable **nuevo** (un `ServiceBusTrigger` real con sus propios modos de fallo -- dead-letter, lock-lost -- que hoy no existen para este evento, entregado in-process). No hay cambio de firma que fuerce produccion+tests a moverse juntos solo para compilar (a diferencia de #209/#210, que si calificaron como refactor puro porque cambiaban la interfaz que implementaba el handler).

### Cobertura de criterios
| Criterio de aceptacion | Test(s) / cobertura |
|---|---|
| CA-1: topic mapping en Program.cs | Fuera de alcance de test-writer (sin convencion de test sobre Program.cs); pendiente para implementer/reviewer |
| CA-2: FunctionEndpoint : PrivateEventEndpointBase<MarcacionRegistrada> con [ServiceBusTrigger] | Los 3 tests de `FunctionEndpointTests.cs` |
| CA-3: sin duplicar AgregarWolverinePrivateEventRouter() | Ya registrado desde #209 (verificado en `Program.cs` actual); sin test nuevo, solo verificacion de no-regresion para el implementer |
| CA-4: comportamiento de AdicionarMarcacion se conserva | Cubierto por tests existentes de `MarcacionRegistradaEventHandler` (sin cambios en este issue) |
| CA-5: smoke test del cruce fisico del ASB | Fuera de alcance de test-writer; corresponde al agente `smoke-test-writer` |
| CA-6: suite completa verde | Se valida al final del pipeline (stage de implementer + reviewer); en esta fase la suite queda con 3 tests nuevos en rojo (esperado) |

### Desviaciones del plan del planner

Ninguna respecto a la forma de los archivos sugeridos. Una precision de alcance:

| Sugerencia del issue | Desviacion aplicada | Razon tecnica | Consecuencia |
|---|---|---|---|
| "Crea: ... smoke test en tests/.../SmokeTests/AdicionarMarcacionCuandoMarcacionRegistrada/" | No se crea en esta etapa | El agente test-writer no escribe smoke tests (responsabilidad de `smoke-test-writer`, otro agente/pipeline segun `CLAUDE.md`) | CA-5 queda pendiente para la etapa/agente correspondiente; no bloquea el ciclo rojo-verde de este pipeline TDD |
| "Modifica: Program.cs (topic mapping + verificar router privado)" | No se modifica Program.cs en esta etapa | Sin convencion de test unitario sobre Program.cs en el repo; es wiring de configuracion, no un command handler | CA-1/CA-3 quedan como trabajo de implementacion directa (sin test que los ejercite en rojo), consistente con el resto del proyecto |

</details>

<details>
<summary>Implementer (fase verde) — 5m 8s</summary>

## ES Implementer - Decisiones

### Enfoque de implementacion
El test-writer ya habia creado el `FunctionEndpoint.cs` heredando de
`PrivateEventEndpointBase<MarcacionRegistrada>` con el `[ServiceBusTrigger]` apuntando al
topic `marcacion-registrada` / subscription `control-horas-escucha-marcacion`, con el cuerpo
del metodo `Run` en `throw new NotImplementedException()`. La implementacion consistio en:

1. Reemplazar el stub por `await ProcesarMensaje(message, messageActions, ct)` -- exactamente
   el mismo patron que `AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/FunctionEndpoint.cs`
   (precedente citado por el planner en el issue), que ya delega complete/lock-lost/dead-letter
   y el despacho al `IPrivateEventRouter` en la clase base.
2. Registrar en `Program.cs` de ControlHoras el topic mapping de `MarcacionRegistrada`
   (`options.PublicarEventoServerless<MarcacionRegistrada>("marcacion-registrada")`), simetrico
   al ya existente para `DiaCalculado`. Sin este registro, `IPrivateEventSender.PublishAsync`
   no tenia a donde enrutar el evento hacia el ASB fisico (CA-1 del issue). Verificado por
   decompilacion (`ilspycmd`) que `PublicarEventoServerless<TEvent>` acepta cualquier `TEvent :
   IEvent` (superinterfaz comun de `IPrivateEvent`/`IPublicEvent`), igual que el uso existente.
3. Actualizar un comentario desactualizado en `MarcacionRegistradaEventHandler.cs` (issue #209)
   que aun describia el ruteo in-process ("sin ServiceBusTrigger ni endpoint en este feature
   folder"), ahora incorrecto tras este issue.

`AgregarWolverinePrivateEventRouter()` ya estaba registrado en `Program.cs` desde #209/#210 --
no se duplico (CA-3).

### Decisiones de diseno
- Ninguna decision de diseño nueva: el issue es cableado puro siguiendo un precedente exacto
  ya presente en el mismo dominio (`AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction`).

### ADRs consultados
- ADR-0024 (marco, `docs/adr/0024-modelo-eventos-bus-privado-publico.md` en el plugin): decision
  #3 (todo evento privado cruza fisicamente el ASB) y decision #8 (EventHandler directo via
  `PrivateEventEndpointBase`/`IPrivateEventRouter`).
- ADR-0004 (repo, topics y subscriptions de Service Bus): un topic por evento -- verificado que
  el topic/subscription ya estaban provisionados en `infra/environments/dev/main.tf` (issue #212,
  ya cerrado).
- Indice CLAUDE.md -- naming de funciones Azure (`{Accion}Cuando{Evento}`): respetado, ya
  presente en el `[Function]` creado por el test-writer.

### Desviaciones de ADRs
Ninguna desviacion -- todos los ADRs aplicados al pie de la letra.

### Precedentes consultados
- `AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/FunctionEndpoint.cs` (issue #210):
  alineado con ADR-0024 decision #8, replicado tal cual (mismo shape de constructor, mismo
  `ProcesarMensaje`).
- `RegistrarMarcacionCommandHandler.cs`: confirma que la publicacion ya usaba
  `IPrivateEventSender.PublishAsync`, sin cambios necesarios ahi.

### Infraestructura modificada
- Ninguna. El topic `marcacion-registrada` y las subscriptions `control-horas-escucha-marcacion`
  + `smoke-tests` ya estaban provisionados en `infra/environments/dev/main.tf` por el issue
  hermano #212 (`tipo:infra`, ya mergeado). Solo se verifico su existencia y que el nombre de
  subscription coincidiera con el usado en el `[ServiceBusTrigger]`.

### Complejidad encontrada
- Ninguna. Unico punto de verificacion no trivial: confirmar via decompilacion (`ilspycmd`) que
  `PublicarEventoServerless<TEvent>` de `Cosmos.EventDriven.CritterStack.AzureServiceBus` 2.1.0
  acepta el marker `IEvent` generico (no solo `IPublicEvent`), ya que el issue no especificaba
  la firma exacta del "equivalente privado" a usar (CA-1 del issue lo dejaba abierto a
  verificacion del implementer).

### Nota fuera de alcance (CA-5, smoke test)
El issue incluye CA-5 (smoke test que verifica el cruce fisico del ASB, analogo a
`AsignarTurnoViaSbSmokeTests.cs`). Los tests entregados por el test-writer para esta fase
(`FunctionEndpoint.cs` + `FunctionEndpointTests.cs`) son exclusivamente unitarios; no se
crearon smoke tests en esta iteracion, y por rol el implementer no escribe tests (unitarios ni
smoke). Ese trabajo corresponde a la etapa de `smoke-test-writer` del pipeline, fuera del
alcance de esta fase verde.

### Resultado
- Tests pasando: 299/299 (ControlHoras.Tests), 428/428 (suite completa: Contracts.Tests +
  Programacion.Tests + ControlHoras.Tests).
- Tests bloqueados: 0.

</details>
<details>
<summary>Reviewer (fase refactor) — 8m 32s</summary>

## ES Reviewer - Revision

### Evaluacion general
- Calidad: **buena**
- Cambios realizados: **si** (un test de contrato agregado; sin cambios en produccion)

El issue es cableado puro de transporte: registra el topic mapping de `MarcacionRegistrada`
en `Program.cs` (CA-1) y migra el consumo de `AdicionarMarcacion` a un
`FunctionEndpoint : PrivateEventEndpointBase<MarcacionRegistrada>` con `[ServiceBusTrigger]`
(CA-2), eliminando la entrega in-process. El endpoint es un espejo exacto del precedente
`AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/FunctionEndpoint.cs`. La
implementacion y los tests estan limpios y bien alineados a los ADRs.

### Cumplimiento de ADRs aplicables

| ADR | Cumplimiento | Observacion |
|---|---|---|
| ADR-0024 (marco): modelo de eventos de bus del BC | ok | Decision #3 (todo evento privado cruza fisicamente el ASB, aun intra-Function-App): se elimina la entrega in-process y se registra `PublicarEventoServerless<MarcacionRegistrada>("marcacion-registrada")` + `[ServiceBusTrigger]`. Decision #8 (EventHandler directo via `PrivateEventEndpointBase`/`IPrivateEventRouter`, sin comando espejo): el endpoint delega en `ProcesarMensaje` de la base; el `MarcacionRegistradaEventHandler` es `IPrivateEventHandlerAsync<MarcacionRegistrada>`. Sin comando espejo. |
| ADR-0004/0001 (repo): un topic por evento, subscriptions | ok | Topic `marcacion-registrada` + subscription `control-horas-escucha-marcacion` provisionados en `infra/environments/dev/main.tf:83-95` (issue #212). El `subscriptionName` del trigger coincide con el provisionado. Tambien existe la subscription `smoke-tests` (prerequisito de CA-5). |
| ADR-0006/0008: naming de funciones Azure (`{Accion}Cuando{Evento}`) | ok | `[Function("AdicionarMarcacionCuandoMarcacionRegistrada")]`, ServiceBus trigger sin sufijo `Function` en la clase (clase `FunctionEndpoint`), feature folder correcto. |
| ADR-0002/0006: estrategia de testing / DSL | ok (con matiz) | El componente bajo prueba es un `FunctionEndpoint` (orquestacion ServiceBus), no un command handler de event sourcing: no aplica el DSL Given/When/Then ni la regla `Then()`+`And<>()`. Estilo xUnit plano + fakes manuales, identico al precedente. |
| ADR-0016: naming de tests | ok (mejora sobre el precedente) | Los 3 tests usan `<Sujeto>_<LoQuePasa>_Cuando<Condicion>` (`AdicionarMarcacionCuandoMarcacionRegistrada_CompletaMensaje_CuandoProcesamientoEsExitoso`, etc.). El precedente `AsignarTurno` aun usa el viejo `Debe...` (deuda pre-existente, fuera de alcance). |
| ADR-0012/0015 (marco/repo): frontera de serializacion event store vs bus | ok (guardrail agregado) | `MarcacionRegistrada` es `IPrivateEvent` con payload plano y portable (`string`, `DateTime`, `string?`). Con #213 cruza el ASB por primera vez (antes era in-process sin serializacion). Ver seccion "Tests agregados". |

El issue **si** traia seccion `## ADRs aplicables` (referenciada por tema). No hay que escalar al planner.

### Desviaciones de ADRs

**Ninguna desviacion — todos los ADRs aplicables se cumplen.**

El implementer no declaro desviaciones y la revision no detecto ninguna no declarada. La unica
verificacion no trivial (que `PublicarEventoServerless<TEvent>` acepta el marker `IEvent`
generico, no solo `IPublicEvent`) fue confirmada por el implementer via decompilacion y es
consistente con el uso existente de `DiaCalculado`; el codigo compila y los tests pasan.

### Precedentes consultados por el implementer

| Precedente | ADR aplicable | Veredicto |
|---|---|---|
| `AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/FunctionEndpoint.cs` (#210) | ADR-0024 #8 | alineado — replicado tal cual (mismo shape de ctor, mismo `ProcesarMensaje`) |
| `RegistrarMarcacionCommandHandler.cs` | ADR-0024 #3 | alineado — ya publicaba via `IPrivateEventSender.PublishAsync`; sin cambios |
| `dia-calculado` topic mapping en `Program.cs` (HU-108) | ADR-0004 | alineado — el mapping de `marcacion-registrada` es simetrico |

### Convenciones del pipeline (no ADRs)

| Convencion | Estado | Observacion |
|---|---|---|
| Cada test con `Then()` + `And<>()` | n/a | No aplica: son tests de endpoint ServiceBus / deserializacion, no de command handler con DSL |
| Overloads correctos para stream IDs compuestos | n/a | No hay command handler ni aggregate bajo test en este diff |
| Fakes manuales (no NSubstitute) | ok | `FakePrivateEventRouter`, `FakeServiceBusMessageActions`, `FakeLogger` — clases fake concretas, scoping por namespace propio para evitar colision con las del feature hermano |
| Feature folders (produccion y tests) | ok | `AdicionarMarcacionCuandoMarcacionRegistrada/FunctionEndpoint.cs` (produccion) espejado en tests; subcarpeta `EventHandler/` para el handler |
| Smoke tests: SkipWhen, secrets, cobertura | parcial (CA-5 pendiente en otro pipeline) | Ver "Cobertura de criterios" y "Criticas". Infra (`smoke-tests` subscription) lista; `appsettings.json` con connection strings vacios (sin secrets) — correcto |
| Tests via ToString/comportamiento | ok | No se exponen getters solo-para-test |
| Sin numeros magicos | ok | Topic/subscription son metadata de configuracion, no magic numbers de dominio |
| Condiciones en positivo | n/a | No hay bifurcaciones nuevas en el diff |

### Elegancia del codigo
- El `FunctionEndpoint` es un one-liner que delega en la base (`=> await ProcesarMensaje(...)`):
  compacto, idiomatico y sin duplicar la orquestacion (complete/lock-lost/dead-letter vive en
  `PrivateEventEndpointBase`). No hay nada que refactorizar.
- Comentarios precisos y actualizados: el comentario obsoleto del `MarcacionRegistradaEventHandler`
  (que describia el ruteo in-process) fue corregido por el implementer.
- `Program.cs`: el nuevo mapping queda junto al de `DiaCalculado`, con comentario que cita el ADR
  y el issue de infra. Consistente.
- Sin warnings de compilacion, sin caracteres prohibidos (U+2500), formato conforme.

### Criticas y hallazgos
- **[menor, no bloqueante] Guardrail de portabilidad por el bus ausente para `MarcacionRegistrada`.**
  El unico test de serializacion existente (`MarcacionRegistradaSerializacionTests`) usa
  `CrearOpcionesMarten()` (resolver del dominio) — cubre el event store, no el bus. Como #213 es
  el issue que hace cruzar el evento fisicamente por el ASB por primera vez, faltaba el análogo
  del precedente (`ProgramacionTurnoDiarioSolicitadaDeserializacionTests`). **Corregido** en fase
  refactor (ver "Tests agregados").
- **[informativo] CA-5 (smoke test) no esta en el diff.** Es responsabilidad del agente
  `smoke-test-writer` (pipeline distinto al TDD), como documentaron test-writer e implementer y
  como ocurrio con el feature hermano `AsignarTurnoViaSbSmokeTests.cs`. El prerequisito de infra
  (subscription `smoke-tests` del topic `marcacion-registrada`) ya esta provisionado. No bloquea
  este pipeline. Se deja como pendiente trazable para el pipeline de smoke tests.
- **[informativo, fuera de alcance] 11 fallos de smoke tests en el baseline.** Los proyectos
  `*.SmokeTests` (3 en ControlHoras, 8 en Programacion) fallan porque ejecutan HTTP real contra el
  entorno dev desplegado, que hoy responde 500. Son **preexistentes y dependientes del entorno**
  (el diff de #213 no toca ningun archivo de smoke tests), no una regresion de este issue. Los
  tests dependientes de `ServiceBusFixture`/`PostgresFixture` se omiten correctamente via
  `Assert.SkipWhen` (6 omitidos). No accion.

### Refactorings aplicados
- Ninguno sobre codigo de produccion: el diff ya era minimo, idiomatico y alineado al precedente.

### Cobertura de criterios de aceptacion
| Criterio | Estado | Test(s) / evidencia |
|---|---|---|
| CA-1: topic mapping de `MarcacionRegistrada` en `Program.cs` | cubierto | Verificado por inspeccion (`PublicarEventoServerless<MarcacionRegistrada>("marcacion-registrada")`). Sin test unitario por convencion del repo (Program.cs no se testea; igual que `DiaCalculado`) |
| CA-2: `FunctionEndpoint : PrivateEventEndpointBase<MarcacionRegistrada>` con `[ServiceBusTrigger]` | cubierto | `FunctionEndpointTests` (3 tests) + `MarcacionRegistradaDeserializacionTests` (3 tests) |
| CA-3: `AgregarWolverinePrivateEventRouter()` sin duplicar | cubierto | Verificado por inspeccion: una sola llamada en `Program.cs` (registrada desde #209/#210) |
| CA-4: comportamiento de `AdicionarMarcacion` conservado (ventana 04:00, idempotencia, `DiaCalculado` por fecha-destino) | cubierto | `MarcacionRegistradaEventHandler` sin cambios (solo comentario); tests existentes verdes (`MarcacionRegistradaEventHandlerTests`, `DepurarAlAdicionarMarcacionTests`, `DesgloseHorasTrasAdicionarMarcacionTests`) |
| CA-5: smoke test del cruce fisico del ASB | pendiente (otro pipeline) | Responsabilidad de `smoke-test-writer`; infra prerequisito lista; portabilidad garantizada a nivel unitario por `MarcacionRegistradaDeserializacionTests` |
| CA-6: suite completa verde | cubierto (unit) | ControlHoras.Tests 302/302 verde. Fallos de smoke tests son preexistentes/dependientes del entorno (ver Criticas) |

### Tests agregados
- `tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoMarcacionRegistrada/MarcacionRegistradaDeserializacionTests.cs`
  (3 `[Fact]`): guardrail de portabilidad por el bus, analogo a
  `ProgramacionTurnoDiarioSolicitadaDeserializacionTests` del feature hermano.
  - `Deserializar_ReconstruyeEvento_CuandoJsonEsFormatoWolverine` — fidelidad campo a campo desde
    JSON camelCase de Wolverine, via `ServiceBusDeserializador` (serializador por defecto, SIN el
    resolver de Marten).
  - `Deserializar_PreservaCamposOpcionalesNulos_CuandoTipoYDispositivoAusentes` — los campos
    nullable que hacen al payload portable se preservan cuando estan ausentes.
  - `Deserializar_LanzaExcepcion_CuandoJsonEsInvalido` — JSON invalido lanza `JsonException`.
- No se agregaron tests de igualdad (`IEquatable`): `MarcacionRegistrada` no implementa
  `IEquatable<T>` y no fue tocado por este issue.

</details>

## Commits

ef77e82 test(hu-213): guardrail de portabilidad por el bus para MarcacionRegistrada
06006cb feat(hu-213): implementar FunctionEndpoint de AdicionarMarcacionCuandoMarcacionRegistrada (fase verde)
7b0ef9d test(hu-213): tests para FunctionEndpoint del ServiceBus trigger AdicionarMarcacion (fase roja)

Closes #213