### PR TITLE
Registrar un ITenantResolver mono-tenant en ControlHoras y Programacion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,6 +153,7 @@ Si tu trabajo toca uno de estos temas, consulta el ADR correspondiente antes de 
 | Extracción vs duplicación, Rule of Three, evolución del código | ADR-0024 |
 | El modelo de dominio rico vive en el dominio y no cruza el bus; Contracts solo DTOs planos | ADR-0025 |
 | Custodia de secretos: connection strings en Key Vault, referencias `@Microsoft.KeyVault(...)`, `AzureWebJobsStorage` por identidad administrada | ADR-0026 |
+| Estrategia de tenancy mono-tenant, `ITenantResolver` de valores fijos | ADR-0027 |
 
 Si una regla no aparece en ADRs pero la descubres repetida en varios lugares del proyecto, **propón un ADR** antes de replicarla en agentes.
 

--- a/docs/adr/0027-estrategia-tenancy-mono-tenant.md
+++ b/docs/adr/0027-estrategia-tenancy-mono-tenant.md
@@ -1,0 +1,78 @@
+# ADR-0027: Estrategia de tenancy mono-tenant
+
+## Estado
+
+Aceptado
+
+## Contexto
+
+El upgrade de los building blocks `Cosmos.Event*` de 0.1.9 a 2.1.0 (issue #207, commit affa2e0) es
+un breaking change no detectado: en 2.x los metodos de extension `AgregarWolverineCommandRouter()`,
+`AgregarWolverinePrivateEventRouter()` y `AgregarWolverineQueryRouter()` dejaron de auto-registrar un
+`Cosmos.MultiTenancy.ITenantResolver` por defecto -- ese registro se movio a un paquete aparte,
+`Cosmos.MultiTenancy.CritterStack` -- pero el constructor de los routers/senders
+(`WolverineCommandRouter`, `WolverineQueryRouter`, `WolverinePrivateEventRouter`,
+`WolverinePublicEventSender`, `WolverinePrivateEventSender`) lo sigue exigiendo por DI. Como ningun
+`Program.cs` de este producto registraba un `ITenantResolver`, toda activacion de funcion en
+ControlHoras y Programacion fallaba en el Function App desplegado con
+`InvalidOperationException: Unable to resolve service for type 'Cosmos.MultiTenancy.ITenantResolver'`
+(~461 excepciones en 24h en App Insights; investigacion completa en la field note de bug
+correspondiente al issue #219).
+
+Compilaba en Release y la suite de tests unitarios seguia verde porque la firma publica de los
+metodos de extension no cambio y los tests unitarios no construyen el grafo DI completo del host de
+Functions -- el fallo solo aparece en runtime al resolver el contenedor.
+
+`Cosmos.MultiTenancy` 2.1.0 expone dos resolvers listos para usar, ademas de la interfaz:
+
+```csharp
+public interface ITenantResolver { string TenantId { get; } string UserId { get; } }
+```
+
+- `AgregarTenantResolverHibrido()` / `ProxyTenantResolver`: resuelven `TenantId` y `UserId` a partir
+  de headers HTTP (`TenantId`, `user_id`) y lanzan si faltan.
+
+Ninguno encaja con este producto: **Bitakora.ControlAsistencia es mono-tenant.** Los clientes HTTP
+(Postman, smoke tests, front futuro) no envian esos headers, y exigirlos romperia todos los requests
+existentes sin aportar nada -- no hay mas de un tenant que resolver.
+
+## Decision
+
+**Se implementa un `ITenantResolver` propio, de valores fijos, en vez de adoptar los resolvers
+header-based de 2.x.**
+
+1. Clase `TenantResolverFijo : ITenantResolver` en `Infraestructura/` de cada dominio
+   (`ControlHoras` y `Programacion`). Con solo 2 usos se acepta duplicar la clase en lugar de
+   extraerla a un proyecto compartido (Rule of Three, ADR-0024 del harness); tampoco vive en
+   `Contracts`, reservado a eventos publicos y value objects compartidos (ADR-0002).
+2. `TenantId` resuelve al tenant por defecto de Marten: `JasperFx.StorageConstants.DefaultTenantId`
+   (valor `"*DEFAULT*"`). Marten mapea ese valor a `Tenancy.Default` aun con
+   `options.Policies.AllDocumentsAreMultiTenanted()` activo -- no se introduce un tenant nuevo, se
+   reutiliza el que Marten ya asume cuando no se le indica nada distinto.
+3. `UserId` es el literal fijo `"sin-identificar"`: el producto no distingue usuarios todavia: no
+   hay autenticacion de llamador que popular este campo con un valor real.
+4. Ambos valores quedan como constantes `private`, expuestas solo via los getters publicos que pide
+   la interfaz -- sin superficie publica adicional (encapsulamiento, ADR-0012 del harness).
+5. Registro en DI con lifetime **Scoped** en ambos `Program.cs`, junto a los
+   `AgregarWolverine*Router`/`AgregarWolverineEventSender` correspondientes: los routers/senders que
+   lo inyectan son Scoped, y al ser un unico registro Scoped por request/activacion, el lado que
+   publica (HTTP) y el lado que consume (Service Bus) devuelven los mismos valores fijos, lo que
+   garantiza consistencia de particion entre ambos.
+
+## Consecuencias
+
+- El contenedor DI de ambos Function Apps vuelve a resolver `ICommandRouter`, `IQueryRouter` y (en
+  ControlHoras) `IPrivateEventRouter` sin excepcion, sin exigir headers que este producto no envia.
+- Si el proyecto evoluciona a multi-tenant real (mas de un tenant logico, aislamiento de datos por
+  cliente), **este ADR es el punto de revision**: habria que reemplazar `TenantResolverFijo` por un
+  resolver que derive el tenant de una fuente real (header, claim de autenticacion, subdominio, etc.)
+  y decidir entonces si adoptar `AgregarTenantResolverHibrido()`/`ProxyTenantResolver` de
+  `Cosmos.MultiTenancy.CritterStack` en vez de la implementacion propia.
+- Este fix es puntual al registro del resolver: no se tocan los sitios de `Invoke`/publicacion de los
+  comandos y eventos existentes, que ya construyen internamente `DeliveryOptions` con
+  `TenantId`/`user_id` a partir del resolver inyectado.
+- Un upgrade futuro de `Cosmos.Event*`/`Cosmos.MultiTenancy` que vuelva a mover responsabilidades de
+  auto-registro de DI a otro paquete puede repetir este mismo sintoma (compila y pasa tests
+  unitarios, falla solo en runtime desplegado). El guardrail de proceso para detectarlo antes de
+  desplegar (test de composicion del `IHost`/`FunctionsApplication`, o smoke minimo obligatorio
+  pre-merge) queda fuera de alcance de este ADR y se rastrea en un issue aparte.

--- a/src/Bitakora.ControlAsistencia.ControlHoras/Infraestructura/TenantResolverFijo.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Infraestructura/TenantResolverFijo.cs
@@ -1,0 +1,19 @@
+using Cosmos.MultiTenancy;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Infraestructura;
+
+// Issue #219: ITenantResolver mono-tenant. Cosmos.Event* 2.x dejo de auto-registrar un
+// ITenantResolver por defecto en AgregarWolverineCommandRouter/AgregarWolverinePrivateEventRouter,
+// pero WolverineCommandRouter/WolverineQueryRouter/WolverinePrivateEventRouter/
+// WolverinePublicEventSender/WolverinePrivateEventSender lo siguen exigiendo por constructor.
+// Este proyecto es mono-tenant: se registra un ITenantResolver con valores fijos en vez de los
+// resolvers header-based de 2.x (AgregarTenantResolverHibrido/ProxyTenantResolver), que exigirian
+// headers TenantId/user_id inexistentes en este flujo HTTP.
+// Ver docs/adr/00XX-estrategia-tenancy-mono-tenant.md (numero pendiente de asignar por el
+// implementer) y docs/bitacora/field-notes/2026-07-18-1905-bug-investigation.md.
+public sealed class TenantResolverFijo : ITenantResolver
+{
+    public string TenantId => throw new NotImplementedException();
+
+    public string UserId => throw new NotImplementedException();
+}

--- a/src/Bitakora.ControlAsistencia.ControlHoras/Infraestructura/TenantResolverFijo.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Infraestructura/TenantResolverFijo.cs
@@ -1,4 +1,5 @@
 using Cosmos.MultiTenancy;
+using JasperFx;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.Infraestructura;
 
@@ -9,11 +10,14 @@ namespace Bitakora.ControlAsistencia.ControlHoras.Infraestructura;
 // Este proyecto es mono-tenant: se registra un ITenantResolver con valores fijos en vez de los
 // resolvers header-based de 2.x (AgregarTenantResolverHibrido/ProxyTenantResolver), que exigirian
 // headers TenantId/user_id inexistentes en este flujo HTTP.
-// Ver docs/adr/00XX-estrategia-tenancy-mono-tenant.md (numero pendiente de asignar por el
-// implementer) y docs/bitacora/field-notes/2026-07-18-1905-bug-investigation.md.
+// Ver docs/adr/0027-estrategia-tenancy-mono-tenant.md y
+// docs/bitacora/field-notes/2026-07-18-1905-bug-investigation.md.
 public sealed class TenantResolverFijo : ITenantResolver
 {
-    public string TenantId => throw new NotImplementedException();
+    private const string TenantIdFijo = StorageConstants.DefaultTenantId;
+    private const string UserIdFijo = "sin-identificar";
 
-    public string UserId => throw new NotImplementedException();
+    public string TenantId => TenantIdFijo;
+
+    public string UserId => UserIdFijo;
 }

--- a/src/Bitakora.ControlAsistencia.ControlHoras/Program.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Program.cs
@@ -8,6 +8,7 @@ using Cosmos.EventDriven.CritterStack;
 using Cosmos.EventDriven.CritterStack.AzureServiceBus;
 using Cosmos.EventSourcing.CritterStack;
 using Cosmos.EventSourcing.CritterStack.Commands;
+using Cosmos.MultiTenancy;
 using FluentValidation;
 using Marten;
 using Microsoft.Azure.Functions.Worker.Builder;
@@ -41,6 +42,11 @@ builder.Services.AgregarWolverineParaComandosServerless(
     });
 
 builder.Services.AgregarMartenEventStore();
+// Issue #219: Cosmos.Event* 2.x dejo de auto-registrar un ITenantResolver por defecto (se movio a
+// Cosmos.MultiTenancy.CritterStack), pero los routers/senders de Wolverine lo siguen exigiendo por
+// constructor. Este proyecto es mono-tenant: se registra un resolver de valores fijos en vez de los
+// resolvers header-based de 2.x. Ver docs/adr/0027-estrategia-tenancy-mono-tenant.md.
+builder.Services.AddScoped<ITenantResolver, TenantResolverFijo>();
 // AgregarWolverineCommandRouter se conserva: RegistrarMarcacion (HTTP) lo sigue usando.
 builder.Services.AgregarWolverineCommandRouter();
 // Issue #209/#210 (ADR-0024 decision #8): los eventos privados intra-BC (MarcacionRegistrada,

--- a/src/Bitakora.ControlAsistencia.Programacion/Infraestructura/TenantResolverFijo.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/Infraestructura/TenantResolverFijo.cs
@@ -1,4 +1,5 @@
 using Cosmos.MultiTenancy;
+using JasperFx;
 
 namespace Bitakora.ControlAsistencia.Programacion.Infraestructura;
 
@@ -9,11 +10,14 @@ namespace Bitakora.ControlAsistencia.Programacion.Infraestructura;
 // Este proyecto es mono-tenant: se registra un ITenantResolver con valores fijos en vez de los
 // resolvers header-based de 2.x (AgregarTenantResolverHibrido/ProxyTenantResolver), que exigirian
 // headers TenantId/user_id inexistentes en este flujo HTTP.
-// Ver docs/adr/00XX-estrategia-tenancy-mono-tenant.md (numero pendiente de asignar por el
-// implementer) y docs/bitacora/field-notes/2026-07-18-1905-bug-investigation.md.
+// Ver docs/adr/0027-estrategia-tenancy-mono-tenant.md y
+// docs/bitacora/field-notes/2026-07-18-1905-bug-investigation.md.
 public sealed class TenantResolverFijo : ITenantResolver
 {
-    public string TenantId => throw new NotImplementedException();
+    private const string TenantIdFijo = StorageConstants.DefaultTenantId;
+    private const string UserIdFijo = "sin-identificar";
 
-    public string UserId => throw new NotImplementedException();
+    public string TenantId => TenantIdFijo;
+
+    public string UserId => UserIdFijo;
 }

--- a/src/Bitakora.ControlAsistencia.Programacion/Infraestructura/TenantResolverFijo.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/Infraestructura/TenantResolverFijo.cs
@@ -1,0 +1,19 @@
+using Cosmos.MultiTenancy;
+
+namespace Bitakora.ControlAsistencia.Programacion.Infraestructura;
+
+// Issue #219: ITenantResolver mono-tenant. Cosmos.Event* 2.x dejo de auto-registrar un
+// ITenantResolver por defecto en AgregarWolverineCommandRouter, pero WolverineCommandRouter/
+// WolverineQueryRouter/WolverinePublicEventSender/WolverinePrivateEventSender lo siguen
+// exigiendo por constructor.
+// Este proyecto es mono-tenant: se registra un ITenantResolver con valores fijos en vez de los
+// resolvers header-based de 2.x (AgregarTenantResolverHibrido/ProxyTenantResolver), que exigirian
+// headers TenantId/user_id inexistentes en este flujo HTTP.
+// Ver docs/adr/00XX-estrategia-tenancy-mono-tenant.md (numero pendiente de asignar por el
+// implementer) y docs/bitacora/field-notes/2026-07-18-1905-bug-investigation.md.
+public sealed class TenantResolverFijo : ITenantResolver
+{
+    public string TenantId => throw new NotImplementedException();
+
+    public string UserId => throw new NotImplementedException();
+}

--- a/src/Bitakora.ControlAsistencia.Programacion/Program.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/Program.cs
@@ -9,6 +9,7 @@ using Cosmos.EventDriven.CritterStack;
 using Cosmos.EventDriven.CritterStack.AzureServiceBus;
 using Cosmos.EventSourcing.CritterStack;
 using Cosmos.EventSourcing.CritterStack.Commands;
+using Cosmos.MultiTenancy;
 using FluentValidation;
 using Marten;
 using Microsoft.Azure.Functions.Worker.Builder;
@@ -38,6 +39,11 @@ builder.Services.AgregarWolverineParaComandosServerless(
     });
 
 builder.Services.AgregarMartenEventStore();
+// Issue #219: Cosmos.Event* 2.x dejo de auto-registrar un ITenantResolver por defecto (se movio a
+// Cosmos.MultiTenancy.CritterStack), pero los routers/senders de Wolverine lo siguen exigiendo por
+// constructor. Este proyecto es mono-tenant: se registra un resolver de valores fijos en vez de los
+// resolvers header-based de 2.x. Ver docs/adr/0027-estrategia-tenancy-mono-tenant.md.
+builder.Services.AddScoped<ITenantResolver, TenantResolverFijo>();
 builder.Services.AgregarWolverineCommandRouter();
 builder.Services.AgregarWolverineEventSender();
 

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/TenantResolverFijoTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/TenantResolverFijoTests.cs
@@ -1,0 +1,34 @@
+// Issue #219: ITenantResolver mono-tenant para ControlHoras.
+// Sin este resolver registrado en el DI, WolverineCommandRouter y WolverinePrivateEventRouter no
+// pueden construirse (breaking change de Cosmos.Event* 2.x). Ver
+// docs/bitacora/field-notes/2026-07-18-1905-bug-investigation.md.
+//
+// TenantId debe resolver al tenant por defecto de Marten (JasperFx.StorageConstants.DefaultTenantId,
+// valor "*DEFAULT*"), que Marten mapea a Tenancy.Default aun con AllDocumentsAreMultiTenanted().
+// UserId es un valor fijo ("sin-identificar") porque el proyecto no distingue usuarios.
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.ControlHoras.Infraestructura;
+using Cosmos.MultiTenancy;
+using JasperFx;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Tests.Infraestructura;
+
+public class TenantResolverFijoTests
+{
+    [Fact]
+    public void TenantId_RetornaElTenantPorDefectoDeMarten()
+    {
+        ITenantResolver resolver = new TenantResolverFijo();
+
+        resolver.TenantId.Should().Be(StorageConstants.DefaultTenantId);
+    }
+
+    [Fact]
+    public void UserId_RetornaSinIdentificar()
+    {
+        ITenantResolver resolver = new TenantResolverFijo();
+
+        resolver.UserId.Should().Be("sin-identificar");
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/Infraestructura/TenantResolverFijoTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/Infraestructura/TenantResolverFijoTests.cs
@@ -1,0 +1,33 @@
+// Issue #219: ITenantResolver mono-tenant para Programacion.
+// Sin este resolver registrado en el DI, WolverineCommandRouter no puede construirse (breaking
+// change de Cosmos.Event* 2.x). Ver docs/bitacora/field-notes/2026-07-18-1905-bug-investigation.md.
+//
+// TenantId debe resolver al tenant por defecto de Marten (JasperFx.StorageConstants.DefaultTenantId,
+// valor "*DEFAULT*"), que Marten mapea a Tenancy.Default aun con AllDocumentsAreMultiTenanted().
+// UserId es un valor fijo ("sin-identificar") porque el proyecto no distingue usuarios.
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Programacion.Infraestructura;
+using Cosmos.MultiTenancy;
+using JasperFx;
+
+namespace Bitakora.ControlAsistencia.Programacion.Tests.Infraestructura;
+
+public class TenantResolverFijoTests
+{
+    [Fact]
+    public void TenantId_RetornaElTenantPorDefectoDeMarten()
+    {
+        ITenantResolver resolver = new TenantResolverFijo();
+
+        resolver.TenantId.Should().Be(StorageConstants.DefaultTenantId);
+    }
+
+    [Fact]
+    public void UserId_RetornaSinIdentificar()
+    {
+        ITenantResolver resolver = new TenantResolverFijo();
+
+        resolver.UserId.Should().Be("sin-identificar");
+    }
+}


### PR DESCRIPTION
## Resumen

Pipeline TDD completado:
- Fase roja: tests escritos con stubs
- Fase verde: implementación completa
- Fase refactor: revisión de calidad

## Decisiones del pipeline

<details>
<summary>Test Writer (fase roja) — 6m 37s</summary>

## ES Test Writer - Decisiones

### Clasificacion de la tarea

Esta HU **no es refactoring puro**: introduce comportamiento nuevo (una clase que no existe
`TenantResolverFijo` con valores fijos concretos, CA-1) aunque el vehiculo sea una correccion de
bug de wiring de DI. No hay codigo existente que se reorganice; se agrega codigo nuevo. Por la
"Regla de oro: ante la duda, escribe tests" se opto por el carril TDD normal en vez del carril de
señal de refactor puro (`pipeline-state/refactor-signal.md`).

Fuera del alcance de este agente (documentado explicitamente en la HU, CA-4): un test de
composicion del host/DI ("ese guardrail se rastrea en un issue aparte"). Por eso no se escribio
ningun test que construya el `IHost`/`FunctionsApplication` real ni que verifique el registro
`AddScoped` en `Program.cs`.

### Naturaleza del sujeto bajo prueba

`TenantResolverFijo` no es un command handler ni un aggregate: es una clase de infraestructura
(`Infraestructura/`) que implementa `Cosmos.MultiTenancy.ITenantResolver` con dos getters de
valores fijos. No aplica el harness `CommandHandlerAsyncTest<T>` (no hay EventStore, comando,
evento ni aggregate involucrados). Se siguio el precedente ya existente en el mismo proyecto para
tests de infraestructura plana: `tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/ServiceBusEndpointBaseTests.cs`
(xUnit `[Fact]` + AwesomeAssertions, sin DSL Given/When/Then/And — esa regla es especifica del
harness de command handlers y no aplica aqui).

### Tests creados

- `tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/TenantResolverFijoTests.cs` (2 tests)
  - `TenantId_RetornaElTenantPorDefectoDeMarten` - CA-1 (TenantId = `JasperFx.StorageConstants.DefaultTenantId`)
  - `UserId_RetornaSinIdentificar` - CA-1 (UserId = `"sin-identificar"`)
- `tests/Bitakora.ControlAsistencia.Programacion.Tests/Infraestructura/TenantResolverFijoTests.cs` (2 tests, mismo par)
  - `TenantId_RetornaElTenantPorDefectoDeMarten`
  - `UserId_RetornaSinIdentificar`

Ambos archivos verifican el comportamiento **via la interfaz publica** `ITenantResolver` (variable
declarada como `ITenantResolver resolver = new TenantResolverFijo();`), consistente con el patron
de "testear via interfaz publica" (seccion 6c) aunque aqui no hay una seccion "Interfaz publica
propuesta" explicita en la HU — la propia interfaz de terceros (`ITenantResolver`) ya define el
contrato completo (2 getters), sin superficie adicional que decidir.

### Oraculo independiente (regla 20)

`JasperFx.StorageConstants.DefaultTenantId` se referencia directamente (no se recalcula ni se
deriva de la implementacion bajo prueba) — es una constante de un paquete de terceros
(`JasperFx` 2.18.1), verificada por decompilacion (`ilspycmd`) como `public const string
DefaultTenantId = "*DEFAULT*"`. `"sin-identificar"` es el literal fijo tal como lo especifica la
HU (no es un mensaje de error de dominio, por lo que NO aplica la regla de `.resx`/`Mensajes` —
esa regla es para mensajes de excepcion o eventos de fallo, no para valores de configuracion fija).

### Stubs creados

- `src/Bitakora.ControlAsistencia.ControlHoras/Infraestructura/TenantResolverFijo.cs`:
  `sealed class TenantResolverFijo : ITenantResolver` con `TenantId`/`UserId` que lanzan
  `NotImplementedException`.
- `src/Bitakora.ControlAsistencia.Programacion/Infraestructura/TenantResolverFijo.cs`: mismo stub,
  duplicado por dominio (ADR-0024, Rule of Three — 2 usos no ameritan extraccion a un proyecto
  compartido; tampoco corresponde a Contracts per ADR-0002, que es solo eventos publicos y VOs
  compartidos).

Ninguno de los dos stubs es `partial class` (regla 11 aplica solo a aggregate roots y command
handlers, que soportan una clase `Mensajes` anidada; `TenantResolverFijo` no tiene mensajes de
error que resolear via `.resx`).

**No se toco `Program.cs` de ningun dominio.** El registro `AddScoped<ITenantResolver,
TenantResolverFijo>()` (CA-2) es responsabilidad del implementer; no es necesario para que los
tests aqui escritos compilen o corran.

**No se creo el ADR de estrategia de tenancy (CA-6).** Es documentacion de la decision de
arquitectura, no un test ni un stub de compilacion; queda para el stage de implementacion.

### Verificacion de la fase roja

`dotnet build -c Release` sobre la solucion completa: **compila sin errores** (0 errores, solo
warnings preexistentes no relacionados). `dotnet test` de cada proyecto de tests confirma:

- ControlHoras.Tests: 2 errores (los tests nuevos, por `NotImplementedException`) / 302 correctos
  (resto de la suite intacta).
- Programacion.Tests: 2 errores (los tests nuevos) / 42 correctos (resto de la suite intacta).

### Cobertura de criterios

| Criterio de aceptacion | Test(s) |
|---|---|
| CA-1: clase `ITenantResolver` con TenantId=default tenant Marten, UserId="sin-identificar", constantes privadas | `TenantId_RetornaElTenantPorDefectoDeMarten`, `UserId_RetornaSinIdentificar` (x2 dominios) |
| CA-2: registro Scoped en Program.cs | Fuera de alcance de este stage (implementacion pura, sin test unitario segun la HU) |
| CA-3: build Release sin errores, `JasperFx.StorageConstants.DefaultTenantId` resoluble | Verificado con `dotnet build -c Release` (ver arriba); confirmado ademas que `JasperFx` 2.18.1 y `Cosmos.MultiTenancy` 2.1.0 llegan transitivamente a ambos `.csproj` (`dotnet list package --include-transitive`) |
| CA-4: DI resuelve sin `InvalidOperationException` | Explicitamente fuera de alcance de test permanente (nota de la HU); no se escribio test de composicion del host |
| CA-5: smoke tests del proximo deploy | No aplica a este stage (verificacion post-deploy) |
| CA-6: ADR nuevo en `docs/adr/` | No aplica a este stage (documentacion, no test/stub) |

### Desviaciones del plan del planner

Ninguna - las decisiones tecnicas de la HU (nombre `TenantResolverFijo`, ubicacion en
`Infraestructura/`, valores fijos, lifetime Scoped) se aplicaron tal cual. Unica decision propia:
clasificar la tarea como TDD normal (no refactor-signal) y elegir el estilo de test plano (xUnit +
AwesomeAssertions, sin el DSL de command handlers) por no haber command handler/aggregate/evento
involucrado, siguiendo el precedente ya existente en el proyecto (`ServiceBusEndpointBaseTests.cs`).

### Verificaciones tecnicas adicionales (decompilacion)

- `Cosmos.MultiTenancy.ITenantResolver` (paquete 2.1.0, decompilado con `ilspycmd`): confirma la
  firma exacta `{ string TenantId { get; } string UserId { get; } }` tal como la describe la HU.
- `JasperFx.StorageConstants` (paquete `JasperFx` 2.18.1, decompilado con `ilspycmd`): confirma
  `public const string DefaultTenantId = "*DEFAULT*";`.
- Ambos tipos y sus paquetes contenedores llegan **transitivamente** (via
  `Cosmos.EventSourcing.CritterStack` / `Cosmos.EventDriven.CritterStack`) a los `.csproj` de
  ambos dominios y a sus proyectos de test — no requirio agregar `PackageReference` explicitos.

</details>

<details>
<summary>Implementer (fase verde) — 6m 54s</summary>

## ES Implementer - Decisiones

### Enfoque de implementacion
Se implemento `TenantResolverFijo : ITenantResolver` en la carpeta `Infraestructura/` de cada
dominio (`ControlHoras` y `Programacion`), con `TenantId` = `JasperFx.StorageConstants.DefaultTenantId`
(constante `"*DEFAULT*"`, referenciada directamente en vez de duplicar el literal) y `UserId` =
`"sin-identificar"` como constantes `private`. Se registro con `builder.Services.AddScoped<ITenantResolver, TenantResolverFijo>()`
en ambos `Program.cs`, justo antes de `AgregarWolverineCommandRouter()` (mismo bloque que los demas
`AgregarWolverine*Router`/`AgregarWolverineEventSender`), tal como pedia el issue. Los stubs
(`throw new NotImplementedException()`) dejados por el test-writer se reemplazaron por los valores
fijos; no se toco ningun archivo de test.

### Decisiones de diseno
- `TenantId`/`UserId` expuestos unicamente como propiedades de solo lectura que devuelven constantes
  `private const string` -- sin superficie publica adicional (encapsulamiento).
- Se referencia `JasperFx.StorageConstants.DefaultTenantId` directamente como inicializador de la
  `const` local (`private const string TenantIdFijo = StorageConstants.DefaultTenantId;`), en vez de
  duplicar el literal `"*DEFAULT*"` a mano: el compilador lo resuelve porque `DefaultTenantId` es a su
  vez `const` en `JasperFx` (verificado compilando; si no lo fuera, el propio build habria fallado con
  CS0133). Se agrego el `using JasperFx;` correspondiente; el paquete ya era dependencia transitiva
  (via `Cosmos.EventSourcing.CritterStack` -> Marten), no fue necesario agregar una referencia nueva
  al `.csproj`.
- Se creo el ADR-0027 (`docs/adr/0027-estrategia-tenancy-mono-tenant.md`) documentando la estrategia
  de tenancy mono-tenant, siguiendo el formato de los ADRs existentes del proyecto (Estado/Contexto/
  Decision/Consecuencias, ver ADR-0025 como referencia de forma). Se eligio el numero 0027 porque es
  el primero libre que no colisiona ni con un archivo existente en `docs/adr/` (el mas alto es 0026)
  ni con ningun numero citado en el indice tematico de `CLAUDE.md` (que tambien llega hasta 0026,
  aunque varios de esos ADRs -0015, 0016, 0021-0024- ya no viven como archivo en este repo sino en el
  plugin del harness tras la migracion de `1f812a7`).
- Se actualizaron los comentarios placeholder `docs/adr/00XX-...` (dejados por el test-writer en los
  dos `TenantResolverFijo.cs`) para apuntar al numero real asignado (`0027`).
- Se agrego una fila al indice tematico de `CLAUDE.md` para "Estrategia de tenancy mono-tenant,
  `ITenantResolver` de valores fijos -> ADR-0027", coherente con la convencion documentada en el
  propio `CLAUDE.md` de mantener ese indice como puerta de entrada a decisiones arquitectonicas.

### ADRs consultados
- ADR-0002 (Contracts: eventos publicos y value objects compartidos) -- confirma por que
  `TenantResolverFijo` NO va en Contracts.
- ADR-0024 del harness (extraccion vs duplicacion, Rule of Three) -- confirma por que se acepta
  duplicar la clase en los dos dominios en vez de extraerla a un proyecto compartido (solo 2 usos).
- ADR-0012/ADR-0015 del harness (segun version) -- encapsulamiento/Tell-Don't-Ask: los valores viven
  como constantes `private`, sin exponer mas superficie que los dos getters del contrato
  `ITenantResolver`.
- ADR-0027 (nuevo, creado como parte de este issue) -- estrategia de tenancy mono-tenant completa.

### Desviaciones de ADRs
Ninguna desviacion -- todos los ADRs aplicados al pie de la letra.

### Desviaciones del plan del planner
Ninguna desviacion relevante. El nombre sugerido `TenantResolverFijo` se conservo tal cual (ya venia
fijado por el test-writer en los stubs y en los tests, asi que no habia margen de eleccion real en
este punto). El numero de ADR (`0027`) fue una decision explicita delegada al implementer por el
propio issue ("el numero exacto es propuesta revisable"); se documenta el criterio de asignacion
arriba, en "Decisiones de diseno".

### Precedentes consultados
- `docs/adr/0025-el-modelo-de-dominio-rico-no-cruza-el-bus.md` como referencia de formato/estilo para
  el ADR nuevo (Estado/Contexto/Decision/Consecuencias). Alineado -- no se detecto ninguna violacion,
  solo se tomo como plantilla de forma.

### Infraestructura modificada
Ninguna. Este issue es puramente un registro de DI (`ITenantResolver`); no publica ni consume ningun
evento nuevo, por lo que no requiere cambios en `infra/environments/dev/main.tf`.

### Complejidad encontrada
- El `field-note` referenciado por el issue
  (`docs/bitacora/field-notes/2026-07-18-1905-bug-investigation.md`) no existe en este worktree
  local (probablemente vive en otro worktree/rama de la investigacion original). No bloqueo el
  trabajo: el cuerpo del issue ya trae el contexto completo de la investigacion (decompilacion,
  correlacion con App Insights, decision tecnica ya tomada), suficiente para implementar sin
  necesidad de leer ese archivo.
- Los proyectos `*.SmokeTests` (`ControlHoras.SmokeTests`, `Programacion.SmokeTests`) fallan al
  correr `dotnet test` sobre la solucion completa, pero por una razon ajena a este cambio: sus
  fixtures (`ApiFixture`) apuntan por diseno a los Function Apps YA DESPLEGADOS en dev
  (`https://func-asist-dev-control-horas.azurewebsites.net`, `https://func-asist-dev-programacion.azurewebsites.net`,
  ver `appsettings.json` de cada proyecto de smoke tests), que hoy en dia siguen corriendo el codigo
  ROTO (issue #207) porque este fix aun no se ha desplegado. Es precisamente el sintoma que describe
  el issue y que CA-5 marca como "verificable en el proximo deploy" -- no es un test unitario local
  que dependa de mi codigo, sino un smoke test contra un entorno remoto que solo se pondra en verde
  despues de que este PR se mergee y despliegue. No se toco ni se declaro bloqueo sobre estos tests:
  los tests unitarios reales de este issue (`TenantResolverFijoTests` en ambos dominios) y el resto
  de la suite unitaria (`ControlHoras.Tests`, `Programacion.Tests`, `Contracts.Tests`) pasan en su
  totalidad.

### Resultado
- Tests unitarios pasando: 304/304 (`ControlHoras.Tests`) + 44/44 (`Programacion.Tests`) +
  87/87 (`Contracts.Tests`) = 435/435, incluyendo los 4 tests nuevos de `TenantResolverFijoTests`
  (2 por dominio).
- `dotnet build` en Release: compilacion correcta, 0 errores, en ambos proyectos de dominio.
- Los proyectos `*.SmokeTests` fallan por depender del entorno dev desplegado (aun no actualizado
  con este fix) -- fuera del alcance de esta fase verde, consistente con CA-4/CA-5 del issue.

</details>
<details>
<summary>Reviewer (fase refactor) — 5m 47s</summary>

## ES Reviewer - Revision

### Evaluacion general
- Calidad: **buena**
- Cambios realizados: **no** (el codigo esta limpio; no se requirio refactor)

Baseline verde confirmado antes y despues de la revision:
- `ControlHoras.Tests`: 304/304 (incluye los 2 tests nuevos de `TenantResolverFijoTests`).
- `Programacion.Tests`: 44/44 (incluye los 2 tests nuevos).
- `dotnet build -c Release`: 0 errores en ambos proyectos de dominio. ControlHoras 0 warnings; Programacion 2 warnings `NU1902` (`OpenTelemetry.Api 1.14.0`, vulnerabilidad transitiva **preexistente**, ajena a este cambio).

### Cumplimiento de ADRs aplicables

El issue lista ADR-0015, ADR-0024, ADR-0002 y ADR-0027. En este repo consumidor, ADR-0015 (encapsulamiento) y ADR-0024 (Rule of Three) del **indice tematico de CLAUDE.md** corresponden a ADRs del harness, hoy versionados como `0012-estilo-modelado-objetos-dominio.md` y `0018-heuristicas-evolucion-reuso.md` respectivamente (drift de numeracion; ver observacion al final). Se verifico el diff contra el contenido vigente de esos ADRs.

| ADR | Cumplimiento | Observacion |
|---|---|---|
| ADR-0015 / harness ADR-0012 (encapsulamiento, Tell-don't-Ask) | ok | `TenantResolverFijo` expone solo los dos getters del contrato `ITenantResolver`; valores como `private const string`, sin superficie publica adicional (`sealed class`). No hay clases estaticas sobre estado crudo, ni getters solo-para-test (los getters los consume el router inyectado por DI, que es el caller real; los tests solo se apoyan en ese mismo contrato). |
| ADR-0024 / harness ADR-0018 (extraccion vs duplicacion, Rule of Three) | ok | 2 usos -> se duplica la clase en `Infraestructura/` de cada dominio en vez de extraer a un proyecto compartido. Correcto para Rule of Three. |
| ADR-0002 (Contracts: eventos publicos y VOs compartidos) | ok | La clase NO vive en Contracts (es infraestructura de DI, no evento ni VO compartido). Ubicada en `Infraestructura/` de cada dominio, como manda el issue. |
| ADR-0027 (estrategia tenancy mono-tenant) | ok | Creado como parte de este issue (CA-6). Formato Estado/Contexto/Decision/Consecuencias, coherente con ADR-0025 del repo. Numero 0027 sin colision (unico archivo `0027-*`, siguiente libre tras 0026). Fila agregada al indice de CLAUDE.md. |

Checklist de antipatrones ADR-0012 recorrido explicitamente: sin propiedad publica nueva para consumidor externo, sin clase estatica sobre VO, sin getter solo-test, sin `InternalsVisibleTo`, sin `[JsonConstructor]`, sin `record` con `IReadOnlyList`, sin evento con marker de bus. Ninguno aplica / ninguna violacion.

### Desviaciones de ADRs

Ninguna desviacion — todos los ADRs aplicables se cumplen. El implementer no declaro desviaciones y el reviewer no detecto ninguna no declarada.

### Precedentes consultados por el implementer

| Precedente | ADR aplicable | Veredicto |
|---|---|---|
| `docs/adr/0025-el-modelo-de-dominio-rico-no-cruza-el-bus.md` (solo como plantilla de forma para el ADR nuevo) | n/a (referencia de formato) | alineado — se uso solo como plantilla de estructura, sin replicar reglas |
| `tests/.../Infraestructura/ServiceBusEndpointBaseTests.cs` (citado por el test-writer como estilo de test de infra plana) | ADR-0016 (naming tests) | alineado — estilo `[Fact]` + AwesomeAssertions sin DSL de command handlers, correcto para una clase de infraestructura sin aggregate/handler |

### Convenciones del pipeline (no ADRs)

| Convencion | Estado | Observacion |
|---|---|---|
| Cada test con `Then()` + `And<>()` | n/a | El DSL Given/When/Then aplica a command handlers. `TenantResolverFijo` es infraestructura plana (sin EventStore/comando/evento/aggregate); se testea via la interfaz publica `ITenantResolver` con `[Fact]` + AwesomeAssertions. |
| Overloads correctos para stream IDs compuestos | n/a | No hay aggregate ni stream. |
| Fakes manuales (no NSubstitute) | n/a | Los tests instancian `new TenantResolverFijo()` directamente; no hay dependencias que fakear. |
| Feature folders (produccion y tests) | ok | Clase en `Infraestructura/` a nivel raiz del dominio; tests espejo en `Tests/Infraestructura/`. Un archivo por responsabilidad. |
| Smoke tests: SkipWhen, secrets, cobertura | n/a | Este issue no publica/consume eventos nuevos ni agrega smoke tests. CA-5 se verifica en el proximo deploy (fuera de alcance de test permanente, segun el issue). Sin cambios de infra requeridos. |
| Tests via ToString/comportamiento | ok | Se verifica via el contrato `ITenantResolver` (getters del contrato), no via estado interno expuesto solo-para-test. |
| Sin numeros magicos | ok | `"sin-identificar"` vive como `private const UserIdFijo`; `"*DEFAULT*"` se referencia via `StorageConstants.DefaultTenantId` (constante nombrada de terceros), evitando el literal magico. |
| Condiciones en positivo (guardas if/else afirmativas) | n/a | La clase no tiene condicionales. |

### Elegancia del codigo
- Codigo **compacto, legible e idiomatico**: `sealed class`, propiedades expression-bodied, constantes privadas con nombres que revelan intencion (`TenantIdFijo`, `UserIdFijo`).
- El par `private const` + getter no es redundancia removible: CA-1 y ADR-0027 (decision #4) **exigen** los valores como constantes privadas expuestas solo via los getters del contrato. La forma actual es la mandatada.
- Duplicacion de la clase entre dominios: intencional y justificada (Rule of Three, 2 usos).
- Sin warnings del compilador, sin debug cruft, sin caracteres Unicode decorativos (verificado: 0 ocurrencias de U+2500 en el diff). Formateo consistente.
- Conclusion: el codigo ya era elegante; no ameritaba refactor.

### Criticas y hallazgos
- **[Cosmetico] Referencia colgante a field note inexistente.** Los 4 archivos nuevos (`TenantResolverFijo.cs` x2 y `TenantResolverFijoTests.cs` x2) referencian en comentarios `docs/bitacora/field-notes/2026-07-18-1905-bug-investigation.md`, que **no existe** ni en este worktree ni en `origin/main` (verificado con `git cat-file`). El propio issue lo lista bajo "Lee:", tratandolo como artefacto existente. No se corrigio deliberadamente: (1) no afecta build, tests ni ningun CA; (2) el contexto completo de la investigacion ya vive en el cuerpo del issue y en ADR-0027 (que usa una referencia blanda, sin path hardcodeado), asi que ningun lector queda bloqueado; (3) suavizar/eliminar el puntero arriesga perder trazabilidad si el bug-investigator/historiador commitea ese field note mas adelante. **Recomendacion**: que el historiador incorpore el field note de la investigacion del #219, o que en un pase posterior se ablande la referencia al estilo de ADR-0027. Severidad: cosmetico, no bloqueante.
- Sin otros hallazgos (mayores ni menores).

### Refactorings aplicados
- Ninguno. El codigo estaba limpio y cumplia todos los ADRs; refactorizar por refactorizar habria violado la regla #5 del rol.

### Cobertura de criterios de aceptacion
| Criterio | Estado | Test(s) / Evidencia |
|---|---|---|
| CA-1: clase `ITenantResolver` en `Infraestructura/` de ambos dominios, `TenantId`=`StorageConstants.DefaultTenantId`, `UserId`=`"sin-identificar"`, valores como `private const` | cubierto | `TenantId_RetornaElTenantPorDefectoDeMarten`, `UserId_RetornaSinIdentificar` (x2 dominios) + lectura de codigo |
| CA-2: ambos `Program.cs` registran el resolver `Scoped` junto a los `AgregarWolverine*Router` | cubierto (verificacion por lectura) | `AddScoped<ITenantResolver, TenantResolverFijo>()` en L49 (ControlHoras) y L46 (Programacion), justo antes de `AgregarWolverineCommandRouter()`. Sin test permanente (fuera de alcance segun el issue). |
| CA-3: build Release 0 errores, `JasperFx.StorageConstants.DefaultTenantId` resoluble | cubierto | `dotnet build -c Release` 0 errores en ambos; simbolo resuelto en compilacion (usado como inicializador de `const`). |
| CA-4: Function Apps arrancan, DI resuelve sin `InvalidOperationException` por `ITenantResolver` | diferido a deploy | Registro en su lugar; verificacion explicitamente fuera de test permanente (nota del issue). |
| CA-5: smoke tests de ambos dominios pasan en el proximo deploy | diferido a deploy | Verificacion post-deploy; no aplica a esta fase. |
| CA-6: ADR nuevo documentando estrategia tenancy mono-tenant | cubierto | `docs/adr/0027-estrategia-tenancy-mono-tenant.md` + fila en indice de CLAUDE.md. |

### Tests agregados
- Ninguno. La cobertura de los CAs testeables (CA-1) ya estaba completa y correcta desde la fase roja (2 tests por dominio, via la interfaz publica con oraculo independiente de terceros). CA-2/CA-4/CA-5 son verificables por deploy/lectura, no por test unitario permanente (explicito en el issue). CA-3/CA-6 son build + documentacion.
- No aplica cobertura de contratos de VO: `TenantResolverFijo` no implementa `IEquatable<T>` ni `ConfigurarSerializacion`.

### Observacion para el planner (no bloqueante)
- **Drift de numeracion de ADRs**: la seccion `## ADRs aplicables` del issue cita ADR-0015 y ADR-0024 usando los numeros del indice tematico de CLAUDE.md, pero esos ADRs ya no viven como archivo en `docs/adr/` del repo consumidor (el mas alto es 0027, y 0015/0024 no existen como archivo aqui). Su contenido vigente vive en el plugin del harness como `0012-estilo-modelado-objetos-dominio.md` y `0018-heuristicas-evolucion-reuso.md`. Sugerencia: alinear el indice de CLAUDE.md y las referencias de los issues con la numeracion real del harness para evitar que un ADR aplicable "parezca ausente".

</details>

## Cobertura

| Archivo | Cobertura | Umbral | Estado |
|---|---|---|---|
| Program.cs | - | excluido | - |
| Program.cs | - | excluido | - |
| TenantResolverFijo.cs | - | no evaluado | - |
| TenantResolverFijo.cs | - | no evaluado | - |
## Commits

ecf9564 feat(hu-219): implementar ITenantResolver mono-tenant en ControlHoras y Programacion (fase verde)
4e06e58 test(hu-219): tests para ITenantResolver mono-tenant en ControlHoras y Programacion (fase roja)

Closes #219