### PR TITLE
Condicionar el smoke al SHA desplegado via endpoint /api/version

### DIFF
--- a/.github/workflows/deploy-control-horas.yml
+++ b/.github/workflows/deploy-control-horas.yml
@@ -49,7 +49,8 @@ jobs:
           dotnet build src/Bitakora.ControlAsistencia.ControlHoras/ \
             --configuration Release \
             --no-restore \
-            -r linux-x64
+            -r linux-x64 \
+            -p:SourceRevisionId=${{ github.sha }}
 
       - name: Publish
         run: |
@@ -83,6 +84,7 @@ jobs:
     with:
       base_url: https://func-asist-dev-control-horas.azurewebsites.net
       test_project: tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/
+      expected_sha: ${{ github.sha }}
     secrets:
       SERVICEBUS_CONNECTION_STRING: ${{ secrets.SERVICEBUS_CONNECTION_STRING }}
       POSTGRES_CONNECTION_STRING: ${{ secrets.POSTGRES_CONNECTION_STRING }}

--- a/.github/workflows/deploy-programacion.yml
+++ b/.github/workflows/deploy-programacion.yml
@@ -49,7 +49,8 @@ jobs:
           dotnet build src/Bitakora.ControlAsistencia.Programacion/ \
             --configuration Release \
             --no-restore \
-            -r linux-x64
+            -r linux-x64 \
+            -p:SourceRevisionId=${{ github.sha }}
 
       - name: Publish
         run: |
@@ -82,5 +83,6 @@ jobs:
     uses: ./.github/workflows/smoke-tests-dominio.yml
     with:
       test_project: tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/
+      expected_sha: ${{ github.sha }}
     secrets:
       SERVICEBUS_CONNECTION_STRING: ${{ secrets.SERVICEBUS_CONNECTION_STRING }}

--- a/.github/workflows/smoke-tests-dominio.yml
+++ b/.github/workflows/smoke-tests-dominio.yml
@@ -11,6 +11,10 @@ on:
         description: 'Ruta al proyecto de smoke tests'
         required: false
         default: 'tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/'
+      expected_sha:
+        description: 'SHA de commit esperado en /api/version (vacio = solo esperar HTTP 200)'
+        required: false
+        default: ''
   workflow_call:
     inputs:
       base_url:
@@ -21,6 +25,10 @@ on:
         type: string
         required: false
         default: 'tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/'
+      expected_sha:
+        type: string
+        required: false
+        default: ''
     secrets:
       SERVICEBUS_CONNECTION_STRING:
         required: false
@@ -39,6 +47,23 @@ jobs:
 
       - name: Warmup Function App
         run: |
+          expected_sha="${{ inputs.expected_sha }}"
+          if [ -n "$expected_sha" ]; then
+            echo "Esperando que ${{ inputs.base_url }}/api/version reporte el SHA ${expected_sha}..."
+            for i in $(seq 1 60); do
+              body=$(curl -s "${{ inputs.base_url }}/api/version" || echo "")
+              if [[ "$body" == *"$expected_sha"* ]]; then
+                echo "Version OK tras ${i} intento(s) (~$((i*2))s): ${body}"
+                exit 0
+              fi
+              echo "Intento ${i}: version desplegada '${body}' no coincide con '${expected_sha}'. Reintentando en 2s..."
+              sleep 2
+            done
+            echo "Timeout: /api/version no reporto el SHA esperado (${expected_sha}) en 120s"
+            exit 1
+          fi
+
+          echo "expected_sha vacio: degradando a chequeo simple de HTTP 200."
           echo "Esperando health endpoint en ${{ inputs.base_url }}/api/health..."
           for i in $(seq 1 60); do
             code=$(curl -s -o /dev/null -w "%{http_code}" "${{ inputs.base_url }}/api/health" || echo "000")

--- a/src/Bitakora.ControlAsistencia.ControlHoras/VersionCheck.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/VersionCheck.cs
@@ -1,0 +1,24 @@
+using System.Reflection;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+
+namespace Bitakora.ControlAsistencia.ControlHoras;
+
+public class VersionCheck
+{
+    [Function("version")]
+    public IActionResult Run(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "version")]
+        HttpRequest req)
+    {
+        var informationalVersion = Assembly.GetExecutingAssembly()
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+            .InformationalVersion;
+
+        var separatorIndex = informationalVersion?.IndexOf('+') ?? -1;
+        var sha = separatorIndex >= 0 ? informationalVersion![(separatorIndex + 1)..] : string.Empty;
+
+        return new OkObjectResult(sha);
+    }
+}

--- a/src/Bitakora.ControlAsistencia.Programacion/VersionCheck.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/VersionCheck.cs
@@ -1,0 +1,24 @@
+using System.Reflection;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+
+namespace Bitakora.ControlAsistencia.Programacion;
+
+public class VersionCheck
+{
+    [Function("version")]
+    public IActionResult Run(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "version")]
+        HttpRequest req)
+    {
+        var informationalVersion = Assembly.GetExecutingAssembly()
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+            .InformationalVersion;
+
+        var separatorIndex = informationalVersion?.IndexOf('+') ?? -1;
+        var sha = separatorIndex >= 0 ? informationalVersion![(separatorIndex + 1)..] : string.Empty;
+
+        return new OkObjectResult(sha);
+    }
+}


### PR DESCRIPTION
## Resumen

Pipeline tooling completado:
- Writer: implementacion de la tarea
- Reviewer: revision de calidad

## Decisiones del pipeline

<details>
<summary>Writer -- 2m 40s</summary>

# Stage 1 (writer) - Issue #224

## Resumen

Implementado el gate deploy->smoke por SHA descrito en el issue, siguiendo la Opcion B (endpoint dedicado `/api/version`).

## Cambios

- **Nuevo** `src/Bitakora.ControlAsistencia.Programacion/VersionCheck.cs` y `src/Bitakora.ControlAsistencia.ControlHoras/VersionCheck.cs`: funcion HTTP anonima `[Function("version")]`, ruta `version`, mismo patron que `HealthCheck.cs`. Lee `AssemblyInformationalVersionAttribute` del ensamblado en ejecucion y devuelve la porcion posterior al `+` (el SHA horneado por `SourceRevisionId`); si no hay `+`, devuelve string vacio.
- **`deploy-programacion.yml` / `deploy-control-horas.yml`**: el paso `dotnet build` (no `publish`, que corre `--no-build`) ahora agrega `-p:SourceRevisionId=${{ github.sha }}`. El job `smoke-tests` pasa `expected_sha: ${{ github.sha }}` al workflow reutilizable.
- **`smoke-tests-dominio.yml`**: nuevo input opcional `expected_sha` (default vacio) en `workflow_call` y `workflow_dispatch`. El paso "Warmup Function App" ahora:
  - Si `expected_sha` no esta vacio: hace poll a `/api/version` (mismo timeout, 60 intentos x 2s = 120s) y abre la compuerta solo cuando la respuesta contiene ese SHA; si vence el timeout, falla.
  - Si `expected_sha` esta vacio (ruta `workflow_dispatch` manual sin deploy): degrada al comportamiento original (poll a `/api/health` esperando HTTP 200).
- `/api/health` (`HealthCheck.cs`) queda intacto en ambos dominios.

## Verificacion

- `dotnet build ControlAsistencias.slnx --configuration Release`: compilacion correcta, 0 errores (los 5 warnings preexistentes no estan relacionados con este cambio).
- Build de humo simulando el paso del deploy workflow: `dotnet build src/Bitakora.ControlAsistencia.Programacion/ --configuration Release -r linux-x64 -p:SourceRevisionId=<sha-de-prueba>` compilo correctamente y el SHA de prueba quedo presente en el `.dll` resultante (confirmado con `strings`), validando que `AssemblyInformationalVersionAttribute` efectivamente lo hornea.
- Los 3 workflows modificados se validaron como YAML sintacticamente correcto (`yaml.safe_load`).
- Sin caracteres Unicode decorativos (`─` u otros) en los `.cs` nuevos.

## Criterios de aceptacion

Todos los CA-1 a CA-6 del issue quedan cubiertos por los cambios anteriores.

## Notas

- `.claude/settings.json` aparecia modificado en el working tree antes de iniciar esta tarea (fuera del alcance del issue); no se toco ni se incluyo en el commit de este stage.
- No se requirio ningun cambio al plugin Mefisto ni fuera del alcance permitido de tooling del consumidor.

## Commit

`367bce8` - feat(hu-224): condicionar el smoke al SHA desplegado via /api/version

</details>

<details>
<summary>Reviewer -- 5m 13s</summary>

# Stage 2 (reviewer) - Issue #224

## Veredicto

**Aprobado sin cambios.** La implementacion del writer cumple los seis criterios de
aceptacion, compila, los YAML son sintacticamente validos y el contrato deploy -> endpoint
-> gate quedo verificado empiricamente. No se requirieron correcciones.

## Cobertura de criterios de aceptacion

- **CA-1 (endpoint `/api/version` anonimo en ambos dominios):** OK. `VersionCheck.cs` en
  Programacion y ControlHoras, ambos con `[Function("version")]`,
  `AuthorizationLevel.Anonymous` y `Route = "version"`, replicando el patron de
  `HealthCheck.cs` (ADR-0008).
- **CA-2 (SHA horneado en `dotnet build`):** OK. Ambos `deploy-*.yml` agregan
  `-p:SourceRevisionId=${{ github.sha }}` en el paso `Build` (no en `Publish`, que corre
  `--no-build`). Verificado: al construir con un SHA de prueba, el `.dll` resultante contiene
  `1.0.0+<sha-de-prueba>` en `AssemblyInformationalVersion`.
- **CA-3 (input `expected_sha`):** OK. Declarado en `workflow_dispatch` y `workflow_call`
  (default vacio); ambos deploys lo pasan como `${{ github.sha }}`. En la misma corrida el
  build y el smoke leen el mismo `github.sha`, asi que coinciden por igualdad.
- **CA-4 (gate por SHA + fallo por timeout):** OK. Con `expected_sha` presente, el warmup
  hace poll a `/api/version` y solo abre la compuerta cuando la respuesta contiene el SHA;
  si vencen los 120s (60 x 2s) el paso hace `exit 1`.
- **CA-5 (degradacion a HTTP 200):** OK. Con `expected_sha` vacio (ruta manual sin deploy)
  cae al comportamiento original de poll a `/api/health` esperando 200. La guardia
  `if [ -n "$expected_sha" ]` evita el falso positivo del `contains` con cadena vacia.
- **CA-6 (`/api/health` intacto + calidad):** OK. `HealthCheck.cs` sigue devolviendo `"OK"`
  en ambos dominios. La solucion compila; los 3 workflows parsean como YAML; los `.cs`
  nuevos son solo ASCII (sin `-` U+2500 ni decorativos Unicode).

## Verificacion ejecutada por el reviewer

- `dotnet build` de ambos proyectos de dominio con `-p:SourceRevisionId=<sha-prueba>`:
  compilacion correcta, 0 errores (warnings preexistentes no relacionados).
- Extraccion del `AssemblyInformationalVersion` del `.dll` construido:
  `1.0.0+<sha-prueba>` -> el endpoint devuelve la porcion tras `+` = el SHA. Contrato
  end-to-end confirmado (build hornea, endpoint expone, gate matchea por `contains`).
- Los 3 workflows validados con `yaml.safe_load` -> OK.
- `grep` de caracteres no-ASCII en ambos `VersionCheck.cs` -> ninguno.

## Analisis de robustez del gate (foco: no reintroducir el falso rojo del issue)

- **Sin falso positivo:** el codigo viejo no expone `/api/version` (responde 404), cuyo body
  no contiene el SHA de 40 chars -> el gate sigue esperando hasta que el paquete nuevo vive.
  El SHA horneado es el completo (verificado, sin truncar por el SDK), por lo que el
  `contains` no matchea por prefijos accidentales.
- **`GetExecutingAssembly()` es la eleccion correcta:** `VersionCheck` vive en el ensamblado
  del dominio, que es el que se construye con `SourceRevisionId`. (Usar `GetEntryAssembly()`
  habria sido fragil.)
- **`IndexOf('+')` robusto ante pre-release tags:** en SemVer el `+` separa build-metadata; el
  primer `+` siempre precede al SHA aunque exista un sufijo `-preview`.
- **Timeout de 120s:** adecuado segun la evidencia de la field note (el paquete nuevo quedo
  vivo ~45s tras el fin del deploy). No se modifico; el issue deja el valor a criterio del
  implementer y no hay evidencia de que 120s sea insuficiente.
- **Shell:** el branch nuevo usa `[[ ... == *glob* ]]` (bash); el shell por defecto de
  `ubuntu-latest` es bash, asi que es valido.

## Nota de alcance

El issue #224 lista explicitamente los dos `VersionCheck.cs` bajo `src/` en su seccion
"Crea:"; son el entregable obligatorio de CA-1. Aunque la plantilla generica de este reviewer
marca `src/` como fuera de alcance de escritura, revertir esos archivos romperia el issue
entero. Estan verificados como correctos, de modo que se conservan sin modificacion y no fue
necesario editarlos. No se toco ninguna ruta prohibida del plugin (commands/, agents/, hooks/,
.claude-plugin/, docs/adr/).

## Cambios del reviewer

Ninguno en codigo ni workflows. Unico artefacto: este resumen.

</details>

## Commits

367bce8 feat(hu-224): condicionar el smoke al SHA desplegado via /api/version

Closes #224