### PR TITLE
Devolver 400 cuando el empleado es null en SolicitarProgramacionTurno

### DIFF
--- a/src/Bitakora.ControlAsistencia.Programacion/SolicitarProgramacionTurnoFunction/CommandHandler/SolicitarProgramacionTurnoValidator.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/SolicitarProgramacionTurnoFunction/CommandHandler/SolicitarProgramacionTurnoValidator.cs
@@ -10,11 +10,15 @@ public class SolicitarProgramacionTurnoValidator
         RuleFor(x => x.Id).NotEmpty();
         RuleFor(x => x.TurnoId).NotEmpty();
 
-        RuleFor(x => x.Empleado.EmpleadoId).NotEmpty();
-        RuleFor(x => x.Empleado.TipoIdentificacion).NotEmpty();
-        RuleFor(x => x.Empleado.NumeroIdentificacion).NotEmpty();
-        RuleFor(x => x.Empleado.Nombres).NotEmpty();
-        RuleFor(x => x.Empleado.Apellidos).NotEmpty();
+        RuleFor(x => x.Empleado).NotNull();
+        When(x => x.Empleado is not null, () =>
+        {
+            RuleFor(x => x.Empleado.EmpleadoId).NotEmpty();
+            RuleFor(x => x.Empleado.TipoIdentificacion).NotEmpty();
+            RuleFor(x => x.Empleado.NumeroIdentificacion).NotEmpty();
+            RuleFor(x => x.Empleado.Nombres).NotEmpty();
+            RuleFor(x => x.Empleado.Apellidos).NotEmpty();
+        });
 
         RuleFor(x => x.Fechas).NotEmpty();
     }

--- a/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoSmokeTests.cs
@@ -261,6 +261,24 @@ public class SolicitarProgramacionTurnoSmokeTests(ApiFixture api, ServiceBusFixt
 
     [Fact]
     [Trait("Category", "Smoke")]
+    public async Task SolicitarProgramacionTurno_DebeRetornar400_CuandoEmpleadoEsNull()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var payload = new
+        {
+            id = Guid.CreateVersion7(),
+            turnoId = Guid.CreateVersion7(),
+            empleado = (object?)null,
+            fechas = new[] { "2025-08-01" }
+        };
+
+        var response = await _client.PostAsJsonAsync("/api/programacion/solicitudes", payload, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    [Trait("Category", "Smoke")]
     public async Task SolicitarProgramacionTurno_DebeRetornar400_CuandoFechasEstaVacia()
     {
         var ct = TestContext.Current.CancellationToken;

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoValidatorTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoValidatorTests.cs
@@ -134,6 +134,22 @@ public class SolicitarProgramacionTurnoValidatorTests
             e.PropertyName.Contains(nameof(InformacionEmpleado.Apellidos)));
     }
 
+    // HU-225 / CA-1: Empleado null no debe lanzar excepcion (NullReferenceException por
+    // desreferencia encadenada); debe reportar IsValid == false con un error asociado a
+    // la propiedad Empleado.
+    [Fact]
+    public async Task Validar_TieneErrorEnEmpleado_CuandoEmpleadoEsNull()
+    {
+        var comando = ComandoValido() with { Empleado = null! };
+
+        var resultado = await _validator.ValidateAsync(
+            comando, TestContext.Current.CancellationToken);
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e =>
+            e.PropertyName == nameof(SolicitarProgramacionTurno.Empleado));
+    }
+
     // CA-4: Fechas debe tener al menos un elemento
     [Fact]
     public async Task DebeTenerError_CuandoFechasEstaVacia()


### PR DESCRIPTION
## Resumen

Pipeline TDD completado:
- Fase roja: tests escritos con stubs
- Fase verde: implementación completa
- Smoke tests: escritos para endpoints detectados
- Fase refactor: revisión de calidad

## Decisiones del pipeline

<details>
<summary>Test Writer (fase roja) — 3m 54s</summary>

## ES Test Writer - Decisiones

### Tipo de tarea

No es refactoring puro: el issue introduce un comportamiento nuevo (el validador debe
reportar `IsValid == false` en vez de lanzar `NullReferenceException` cuando `Empleado`
es null). No se creo archivo `pipeline-state/refactor-signal.md`.

### Tests creados
- `SolicitarProgramacionTurnoValidatorTests.cs`: +1 test (9 existentes se mantienen intactos)
  - `Validar_TieneErrorEnEmpleado_CuandoEmpleadoEsNull` - cubre CA-1: construye el comando
    con `Empleado = null!` y verifica que `ValidateAsync` retorne `IsValid == false` con un
    error asociado a la propiedad `Empleado`, sin lanzar excepcion.

Este test es el unico requerido en mi carril (Stage 1 / unit tests de borde HTTP). No es un
command handler test de event sourcing (el issue toca un `FluentValidation` validator, borde
HTTP antes del ruteo del comando), pero es el tipo de test unitario mas cercano a mi
responsabilidad dentro de este dominio y el que el issue lista explicitamente para el fix.

### Por que falla hoy (confirma fase roja)

Con el validador actual (linea 13: `RuleFor(x => x.Empleado.EmpleadoId).NotEmpty()`),
`x.Empleado` es null y FluentValidation desreferencia la cadena al evaluar la regla, lanzando
`NullReferenceException` dentro de `ValidateAsync`. El test no envuelve la llamada en
try/catch — la excepcion no manejada hace fallar el test tal como fallaria en produccion
(convertido en 500 por el host de Azure Functions, segun el issue). Cuando el implementer
agregue `RuleFor(x => x.Empleado).NotNull()` + `When(x => x.Empleado != null, ...)`, el test
pasara.

### Estructura elegida

- No se creo clase nueva: se agrego el test dentro de `SolicitarProgramacionTurnoValidatorTests.cs`
  existente, siguiendo el patron ya establecido en el archivo (constructor `_validator`, factory
  `ComandoValido()`, `with { ... }` para variar el campo bajo prueba).
- Naming: `Validar_TieneErrorEnEmpleado_CuandoEmpleadoEsNull` sigue ADR-0016
  (`<Sujeto>_<LoQuePasa>_Cuando<Condicion>`), usando el ejemplo de validator del propio ADR
  (`Validar_RechazaConErrores_CuandoNombreEstaVacio`) como referencia. Los demas tests del
  archivo usan la convencion legacy `DebeXxx_CuandoYyy` (60 tests del proyecto aun sin migrar
  segun el propio ADR-0016) — no los toque porque el issue no pide esa migracion; solo el test
  nuevo sigue la convencion vigente.

### Stubs creados

Ninguno. `SolicitarProgramacionTurnoValidator.cs` ya existe y compila (el bug es de runtime,
no de compilacion): no hace falta stub de produccion para que el proyecto de tests compile.
Tampoco se creo ningun `.resx`/`Mensajes` porque el test no verifica texto de mensaje de error
(solo `PropertyName`), igual que el resto de los tests preexistentes en el mismo archivo (ninguno
usa `.WithMessage`) — no aplica la regla de `Clase.Mensajes.Clave` porque no se referencia ningun
mensaje literal ni custom.

### Decisiones de diseno

- `Empleado = null!` (null-forgiving operator) en vez de `null` a secas: el proyecto tiene
  `<Nullable>enable</Nullable>`; el operador documenta la intencion explicita de probar el caso
  null sin generar warning CS8625 ruidoso.
- No se escribio el smoke test de CA-3 (`SolicitarProgramacionTurno_DebeRetornar400_CuandoEmpleadoEsNull`).
  Ese test es responsabilidad de `smoke-test-writer` en el Stage 2b del pipeline TDD (confirmado
  en `scripts/tdd-pipeline.sh`), no del test-writer. Mi responsabilidad (declarada en mi rol) se
  limita a tests de command handlers/validators y sus stubs minimos de compilacion.
- CA-2 (las sub-reglas de `Empleado` no-null se siguen evaluando) ya esta cubierto por los 5
  tests existentes (`DebeTenerError_CuandoEmpleadoIdEstaVacio`, etc.) — no requiere test nuevo,
  solo que sigan pasando despues del fix del implementer (verificacion, no creacion).

### Cobertura de criterios

| Criterio de aceptacion | Test(s) |
|---|---|
| CA-1: reporta invalido sin lanzar excepcion cuando Empleado es null | `Validar_TieneErrorEnEmpleado_CuandoEmpleadoEsNull` |
| CA-2: sub-reglas de Empleado siguen evaluandose cuando no es null | Tests preexistentes (`DebeTenerError_CuandoEmpleadoIdEstaVacio`, `...TipoIdentificacionEstaVacio`, `...NumeroIdentificacionEstaVacio`, `...NombresEstanVacios`, `...ApellidosEstanVacios`) — no modificados |
| CA-3: smoke 400 cuando Empleado es null/omitido | Fuera de mi carril — corresponde a `smoke-test-writer` (Stage 2b) |

### Desviaciones del plan del planner

Ninguna — la propuesta del issue (`ComandoValido() with { Empleado = null }`, nombre sugerido
`DebeTenerError_CuandoEmpleadoEsNull`) es aplicable tal cual salvo dos ajustes menores, ambos
ya anticipados como "revisables" por el propio issue:

| Sugerencia del issue | Ajuste aplicado | Razon tecnica |
|---|---|---|
| Nombre `DebeTenerError_CuandoEmpleadoEsNull` (legacy) | `Validar_TieneErrorEnEmpleado_CuandoEmpleadoEsNull` (ADR-0016) | El issue mismo marca el nombre como "sugerido, revisable segun la convencion del archivo"; ADR-0016 es la convencion vigente y aceptada del proyecto para tests nuevos |
| `Empleado = null` | `Empleado = null!` | Suprime CS8625 en un proyecto con Nullable habilitado sin cambiar el comportamiento del test |

</details>

<details>
<summary>Implementer (fase verde) — 3m 29s</summary>

## ES Implementer - Decisiones

### Enfoque de implementacion
Se aplico exactamente el "Enfoque decidido" del issue (opcion 1, guarda de nulos en el propio
validador): se agrego `RuleFor(x => x.Empleado).NotNull()` y se envolvieron las cinco sub-reglas
existentes sobre `InformacionEmpleado` (`EmpleadoId`, `TipoIdentificacion`, `NumeroIdentificacion`,
`Nombres`, `Apellidos`) en `When(x => x.Empleado is not null, () => { ... })` dentro de
`SolicitarProgramacionTurnoValidator`. No se toco ningun otro archivo de produccion: el fix es
puramente de borde HTTP (FluentValidation), no afecta el aggregate, los eventos ni el CommandHandler.

Diferencia menor respecto al snippet literal del issue: se uso `x.Empleado is not null` en vez de
`x.Empleado != null` (equivalentes en C#; se prefirio la forma de pattern-matching, mas idiomatica
y consistente con nullable reference types). No cambia el comportamiento.

### Decisiones de diseno
- `RuleFor(x => x.Empleado).NotNull()` se declara ANTES del `When`, de modo que el error sobre la
  propiedad `Empleado` (PropertyName == "Empleado") se reporta siempre que sea null, y las
  sub-reglas de `InformacionEmpleado` solo se evaluan cuando el objeto existe -- evitando la
  desreferencia encadenada que causaba el `NullReferenceException` original.
- No se creo un validador hijo `InformacionEmpleadoValidator` (opcion 2 del issue, descartada
  explicitamente por YAGNI/Rule of Three: solo un comando usa `InformacionEmpleado` hoy).
- No se toco `RequestValidator.ValidateAsync` con un try/catch generico (opcion 3 del issue,
  descartada: enmascararia NREs de cualquier otro validador y ocultaria bugs reales).

### ADRs consultados
- **ADR-0025** (`docs/adr/0025-el-modelo-de-dominio-rico-no-cruza-el-bus.md`): confirma que
  `InformacionEmpleado` es un DTO plano de Contracts; el fix endurece la validacion de ese DTO en
  el borde HTTP, antes de que el comando cruce al dominio, sin filtrar responsabilidad al dominio.
  Aplicado sin desviaciones.
- **ADR-0022** y **ADR-0006**, citados en la seccion "ADRs aplicables" del issue, **no existen como
  archivo en `docs/adr/` de este repo** (el indice de `docs/adr/` solo tiene los numeros 0001-0004,
  0007, 0009, 0017, 0019, 0020, 0025-0027; no hay 0005, 0006, 0008, 0010-0016, 0018, 0021-0024).
  Aparente drift de numeracion/documentacion entre el indice tematico de `CLAUDE.md` y los archivos
  reales de `docs/adr/`. No bloqueo el trabajo porque el propio issue ya explicita el criterio
  operativo de esos dos ADRs (convencion de naming de tests vigente en el archivo, y que el test del
  validador no usa el DSL de streams de ES) -- criterio que se siguio sin necesitar el archivo. Lo
  reporto aqui para seguimiento administrativo (posible ADR faltante o CLAUDE.md desactualizado).

### Desviaciones de ADRs
Ninguna desviacion — todos los ADRs aplicados al pie de la letra (ADR-0025 es el unico verificable
como archivo; ver nota arriba sobre ADR-0022/ADR-0006 no localizados).

### Desviaciones del plan del planner
Ninguna. El enfoque decidido en el issue se aplico literalmente (unica diferencia sintactica menor
ya documentada arriba: `is not null` en vez de `!= null`, sin cambio de comportamiento).

### Precedentes consultados
- `SolicitarProgramacionTurnoValidatorTests.cs` (test-writer, fase roja de este issue): confirma
  que el `PropertyName` esperado para el caso null es exactamente `nameof(SolicitarProgramacionTurno.Empleado)`
  -- coherente con `RuleFor(x => x.Empleado).NotNull()`.
- `CrearTurnoValidator.cs`: revisado como parte del alcance del issue; confirmado que no tiene
  desreferencias encadenadas (solo propiedades de primer nivel), por lo que no requiere el mismo
  patron `When`.

### Infraestructura modificada
Ninguna. El fix no publica eventos nuevos ni modifica el modelo de eventos existente; no aplica
`topics_config` de Terraform.

### Complejidad encontrada
- **Gap de cobertura detectado (no resuelto por este agente):** el issue declara en CA-3 y en
  "Impacto en archivos" que el test-writer debia agregar el smoke test
  `SolicitarProgramacionTurno_DebeRetornar400_CuandoEmpleadoEsNull` en
  `tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoSmokeTests.cs`.
  Sin embargo, el prompt de esta fase solo lista como creado/modificado por el test-writer el
  archivo `SolicitarProgramacionTurnoValidatorTests.cs` (unit test) — el smoke test de CA-3 no fue
  agregado. Por regla del rol (nunca agregar tests nuevos, eso es trabajo del test-writer o
  reviewer), no lo cree. La produccion ya cubre el caso (el mismo validador se ejecuta en el
  `RequestValidator` del endpoint HTTP, por lo que un `empleado` null/omitido ya responde 400 en
  runtime), pero CA-3 queda sin test automatizado que lo verifique end-to-end. Reportado para
  seguimiento administrativo del pipeline (test-writer o reviewer deberia agregar ese smoke test).
- Sin otras complejidades: el cambio fue de bajo riesgo, localizado en un unico archivo, y todos
  los tests (existentes y nuevos) pasaron en el primer intento.

### Resultado
- Tests pasando (proyecto `Bitakora.ControlAsistencia.Programacion.Tests`): 45/45
- Tests pasando (proyecto `Bitakora.ControlAsistencia.Contracts.Tests`): 87/87
- Tests pasando (proyecto `Bitakora.ControlAsistencia.ControlHoras.Tests`): 304/304
- Smoke tests: no ejecutados (requieren ServiceBus/entorno vivo; se omiten via
  `Assert.SkipWhen` cuando no hay configuracion — no forman parte de la verificacion de esta fase).

</details>
<details>
<summary>Smoke Test Writer — 0m 56s</summary>

_(El agente no generó resumen)_

</details>
<details>
<summary>Reviewer (fase refactor) — 6m 13s</summary>

## ES Reviewer - Revision

### Evaluacion general
- Calidad: **buena**
- Cambios realizados: **no** (el diff ya cumple ADRs, convenciones y criterios de aceptacion)

Baseline verde confirmado al inicio: `Programacion.Tests` 45/45. Es el unico proyecto afectado
por el diff (fix de borde HTTP en un solo validador; no toca aggregate, eventos, handlers ni
Contracts). Smoke tests compilan con 0 warnings.

### Cumplimiento de ADRs aplicables

El issue lista los ADRs con la numeracion del indice tematico de `CLAUDE.md`, que **no coincide**
con los archivos reales de `docs/adr/` del repo (drift ya reportado por el implementer). Mapeo real:

| ADR (issue) | Archivo real / autoridad | Cumplimiento | Observacion |
|---|---|---|---|
| ADR-0025: modelo rico no cruza el bus / Contracts DTOs planos | `docs/adr/0025-el-modelo-de-dominio-rico-no-cruza-el-bus.md` (existe) | **ok** | El fix valida `InformacionEmpleado` (record plano de Contracts, solo `string`) en el borde HTTP ANTES de rutear el comando al dominio. No introduce tipos ricos ni serializacion custom. Sin desviacion. |
| ADR-0022: convencion naming tests `<Sujeto>_<LoQuePasa>_Cuando<Condicion>` | No existe archivo con ese numero en `docs/adr/`; la autoridad canonica es el ADR-0016 del plugin (`0016-convencion-naming-tests.md`) | **ok** | Convencion satisfecha (ver seccion Naming abajo). |
| ADR-0006: estrategia de testing / DSL de streams | No existe archivo con ese numero en `docs/adr/` | **ok** | Criterio dado inline en el issue: el test del validador es de borde HTTP (FluentValidation), NO usa el DSL de streams de ES. Cumplido. |

**Escalamiento al planner (no bloqueante):** el issue cita ADR-0022 y ADR-0006 con numeros que no
resuelven a archivos en `docs/adr/` de este repo. El indice tematico de `CLAUDE.md` esta
desincronizado con los archivos reales. El unico ADR verificable como archivo (ADR-0025) se cumple.
Recomiendo al planner reconciliar el indice de `CLAUDE.md` con los archivos reales de `docs/adr/`
(o crear los ADRs faltantes) para que futuros issues citen numeros resolubles.

**Checklist antipatrones ADR-0012 (encapsulamiento/serializacion):** N/A. El diff no agrega
propiedades a VOs/aggregates, ni clases estaticas sobre datos crudos, ni getters solo-para-test, ni
`InternalsVisibleTo`, ni `[JsonConstructor]`, ni `record` con `IReadOnlyList`, ni eventos con marker
de bus. Es un cambio puro de validacion de entrada sobre un DTO plano existente.

### Desviaciones de ADRs

Ninguna desviacion — todos los ADRs aplicables se cumplen.

El implementer declaro una diferencia sintactica menor respecto al snippet del issue (`is not null`
en vez de `!= null`); no es una desviacion de ADR sino una eleccion idiomatica equivalente, y de
hecho es la mas alineada con pattern matching y nullable reference types. Aprobada.

### Precedentes consultados por el implementer

| Precedente | ADR aplicable | Veredicto |
|---|---|---|
| `SolicitarProgramacionTurnoValidatorTests.cs` (fase roja) | ADR-0016/0022 (naming) | alineado — `PropertyName` esperado = `nameof(SolicitarProgramacionTurno.Empleado)`, coherente con `RuleFor(x => x.Empleado).NotNull()` |
| `CrearTurnoValidator.cs` | ADR-0025 (borde) | alineado — confirmado sin desreferencias encadenadas (solo props de primer nivel); no requiere el patron `When` |

### Convenciones del pipeline (no ADRs)

| Convencion | Estado | Observacion |
|---|---|---|
| Cada test con `Then()` + `And<>()` | n/a | El DSL Given/When/Then/And aplica a tests de command handler sobre streams ES. Este es un test de FluentValidation en el borde HTTP: se verifica via `resultado.IsValid` + `resultado.Errors`, patron correcto para validators. |
| Overloads correctos para stream IDs compuestos | n/a | No hay aggregate bajo test. |
| Fakes manuales (no NSubstitute) | n/a | El validator no tiene dependencias que fakear. |
| Feature folders (produccion y tests) | ok | Validator en `SolicitarProgramacionTurnoFunction/CommandHandler/`; test unitario y smoke en carpetas espejo `SolicitarProgramacionTurnoFunction/`. |
| Smoke tests: SkipWhen, secrets, cobertura | ok | El nuevo smoke es validacion-only (400): correctamente SIN `Assert.SkipWhen` (no toca ServiceBus, igual que los otros casos 400/404 del archivo), sin secrets, sin efectos secundarios que cubrir. La cobertura de efectos del camino feliz ya la aporta `DebePublicarProgramacionTurnoDiarioSolicitada_...` (fuera de este diff). |
| Tests via ToString/comportamiento | ok | Se verifica comportamiento observable (`IsValid`, `Errors.PropertyName`), no estado interno expuesto. |
| Sin numeros magicos | ok | Status via `HttpStatusCode.BadRequest`, no literal `400`. |
| Condiciones en positivo (guardas if/else afirmativas) | ok | `When(x => x.Empleado is not null, ...)` es condicion positiva idiomatica de FluentValidation; no es guard clause en negativo. |

### Naming de tests (ADR-0016 canonico)

- Test unitario nuevo: `Validar_TieneErrorEnEmpleado_CuandoEmpleadoEsNull` — **correcto** segun
  ADR-0016 (`<Sujeto>=Validar`, `<LoQuePasa>=TieneErrorEnEmpleado`, `Cuando<Condicion>=CuandoEmpleadoEsNull`;
  cf. ejemplo canonico `Validar_RechazaConErrores_CuandoNombreEstaVacio`). Los 9 tests preexistentes
  del archivo usan el prefijo `Debe...`, que ADR-0016 marca como convencion **deprecada a migrar**;
  por eso NO renombro el test nuevo hacia `Debe...` (seria retroceder al patron deprecado). La
  migracion de los 9 legacy es un refactor dedicado fuera del alcance de esta HU.
- Smoke nuevo: `SolicitarProgramacionTurno_DebeRetornar400_CuandoEmpleadoEsNull` — sigue la
  convencion **uniforme del archivo de smoke** (`SolicitarProgramacionTurno_DebeRetornar400_Cuando...`)
  y coincide con el nombre prescrito en CA-3. Se preserva la consistencia local del archivo.

### Elegancia del codigo
- El validador quedo compacto y legible: `RuleFor(x => x.Empleado).NotNull()` declarado ANTES del
  `When`, seguido de las cinco sub-reglas dentro de `When(x => x.Empleado is not null, ...)`. El
  error sobre `Empleado` se reporta con `PropertyName == "Empleado"` y las sub-reglas solo corren
  cuando el objeto existe — elimina la desreferencia encadenada que causaba el NRE/500.
- Uso idiomatico de pattern matching (`is not null`), coherente con nullable reference types.
- Sin duplicacion, sin numeros magicos, sin cruft. Confirmado 0 warnings del compilador en el
  validador y 0 warnings en el proyecto de smoke tests.
- El codigo ya era elegante; no se requirio refactor.

### Criticas y hallazgos
- **[cosmetico / preexistente, NO corregido]** `dotnet format --verify-no-changes` sobre la solucion
  falla (exit 2) por **6 warnings IDE0005** (usings innecesarios) repartidos en el repo, de los
  cuales solo 2 caen en archivos tocados por esta HU:
  - `SolicitarProgramacionTurnoValidatorTests.cs:5` — using introducido en commit `1e03b670` (2026-04-09).
  - `SolicitarProgramacionTurnoSmokeTests.cs:6` — using introducido en commit `e636d945` (2026-04-13).
  Los otros 4 estan en `ControlHoras.Tests` y `ControlHoras.SmokeTests` (ajenos a la HU). El
  `git blame` prueba que **son preexistentes**: NO los introduce este diff (que solo agrega metodos
  de test, sin tocar bloques de `using`). Decision alineada con reglas #4/#5: **no los modifico**.
  Arreglar solo 2 de 6 no deja verde el gate y contaminaria el commit de la HU con lineas fuera del
  diff. Recomendacion: issue de limpieza dedicado (o gate de `dotnet format` en CI) para remover los
  6 usings de una sola vez en todo el repo.
- **[cosmetico / preexistente, fuera de alcance]** `CatalogoTurnos.cs:15` — warning CS0414
  (`_estaActivo` asignado pero nunca usado). Ajeno a esta HU; no se toca.
- Sin otros hallazgos. No hay defectos bloqueantes en el diff de la HU.

### Refactorings aplicados
- Ninguno. El codigo del diff ya cumple ADRs, convenciones y objetivo de elegancia. Refactorizar
  por refactorizar violaria la regla #5.

### Cobertura de criterios de aceptacion
| Criterio | Estado | Test(s) |
|---|---|---|
| CA-1: validador reporta `IsValid == false` SIN excepcion cuando `Empleado` es null, con error en la propiedad `Empleado` | cubierto | `Validar_TieneErrorEnEmpleado_CuandoEmpleadoEsNull` (unit) — verifica `IsValid == false` y `Errors` contiene `PropertyName == nameof(Empleado)`; el test fallaria con NRE si la guarda no existiera |
| CA-2: con `Empleado` no null, las 5 sub-reglas siguen evaluando; tests existentes verdes | cubierto | `DebeTenerError_CuandoEmpleadoIdEstaVacio`, `...TipoIdentificacion...`, `...NumeroIdentificacion...`, `...Nombres...`, `...Apellidos...` + `DebeSerValido_CuandoTodosLosCamposSonCorrectos` — 45/45 verdes |
| CA-3: smoke 400 (no 500) cuando `empleado` es null/omitido, sin excepcion no manejada | cubierto | `SolicitarProgramacionTurno_DebeRetornar400_CuandoEmpleadoEsNull` (smoke) — envia `empleado = (object?)null`, espera `BadRequest` |

### Tests agregados
- Ninguno. La cobertura de los tres CA ya estaba completa tras las fases roja/verde. No se
  identificaron casos borde faltantes: la matriz de validacion (Id/TurnoId vacios, sub-campos de
  empleado vacios, empleado null, fechas vacias) esta cubierta tanto en unit como en smoke.
- No aplican tests de contrato de VO (IEquatable/serializacion): el diff no agrega ni modifica value
  objects con `IEquatable<T>` ni `ConfigurarSerializacion`.

</details>

## Commits

0c5ad95 test(hu-225): smoke test 400 cuando Empleado es null en SolicitarProgramacionTurno
65fe6c1 feat(hu-225): validar Empleado null en SolicitarProgramacionTurno (fase verde)
0326c61 test(hu-225): validator rechaza Empleado null sin lanzar excepcion (fase roja)

Closes #225