### PR TITLE
Acotar los asserts de dead-letter de los smoke tests de Service Bus a la corrida

### DIFF
--- a/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/AsignarTurnoViaSbSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/AsignarTurnoViaSbSmokeTests.cs
@@ -113,21 +113,23 @@ public class AsignarTurnoViaSbSmokeTests(ServiceBusFixture serviceBus, PostgresF
         diaCalculado.HorasDiscriminadas.MinutosPorConcepto.Should().BeEmpty(
             "el turno sin marcaciones deja la franja anomala, sin minutos por concepto");
 
-        // Assert: verificar ausencia de dead letters en la suscripcion del consumidor de entrada
-        var deadLetters = await serviceBus.PeekDeadLetterMessagesAsync(
-            TopicEntrada, SuscripcionConsumidor);
+        // Assert: verificar ausencia de dead letter de ESTA corrida en la suscripcion del consumidor
+        // de entrada (issue #223: acotado por SolicitudId, no "DLQ globalmente vacio").
+        var existeDeadLetterProgramacion = await serviceBus.ExisteDeadLetterDeEstaCorridaAsync<ProgramacionTurnoDiarioSolicitadaMinimo>(
+            TopicEntrada, SuscripcionConsumidor, e => e.SolicitudId == solicitudId);
 
-        deadLetters.Should().BeEmpty(
-            "no deberia haber mensajes en dead letter de '{0}' - si los hay, el consumidor fallo al procesar el evento",
-            SuscripcionConsumidor);
+        existeDeadLetterProgramacion.Should().BeFalse(
+            "no deberia haber un dead letter de esta corrida (SolicitudId {0}) en '{1}' - si lo hay, el consumidor fallo al procesar el evento",
+            solicitudId, SuscripcionConsumidor);
 
-        // Assert: verificar ausencia de dead letters en la suscripcion smoke-tests del topic dia-calculado
-        var deadLettersDiaCalculado = await serviceBus.PeekDeadLetterMessagesAsync(
-            TopicDiaCalculado, SuscripcionSmokeTests);
+        // Assert: verificar ausencia de dead letter de ESTA corrida en la suscripcion smoke-tests
+        // del topic dia-calculado (issue #223: acotado por EmpleadoId).
+        var existeDeadLetterDiaCalculado = await serviceBus.ExisteDeadLetterDeEstaCorridaAsync<DiaCalculadoMinimo>(
+            TopicDiaCalculado, SuscripcionSmokeTests, e => e.InformacionEmpleado?.EmpleadoId == empleadoId);
 
-        deadLettersDiaCalculado.Should().BeEmpty(
-            "no deberia haber mensajes en dead letter de '{0}' del topic '{1}'",
-            SuscripcionSmokeTests, TopicDiaCalculado);
+        existeDeadLetterDiaCalculado.Should().BeFalse(
+            "no deberia haber un dead letter de esta corrida (EmpleadoId {0}) en '{1}' del topic '{2}'",
+            empleadoId, SuscripcionSmokeTests, TopicDiaCalculado);
     }
 
     /// <summary>

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/Fixtures/DeadLetterMinimos.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/Fixtures/DeadLetterMinimos.cs
@@ -1,0 +1,11 @@
+namespace Bitakora.ControlAsistencia.ControlHoras.SmokeTests.Fixtures;
+
+// Issue #223 CA-2: formas minimas planas para filtrar dead letters por el identificador de
+// correlacion de esta corrida, sin depender de la deserializacion custom de los value objects
+// ricos de los contratos (ADR-0025). Los payloads viajan planos por el bus, asi que el
+// serializador por defecto basta para deserializar solo el identificador.
+public sealed record ProgramacionTurnoDiarioSolicitadaMinimo(Guid SolicitudId);
+
+public sealed record DiaCalculadoMinimo(InformacionEmpleadoMinimo? InformacionEmpleado);
+
+public sealed record InformacionEmpleadoMinimo(string EmpleadoId);

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/Fixtures/ServiceBusFixture.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/Fixtures/ServiceBusFixture.cs
@@ -129,16 +129,61 @@ public class ServiceBusFixture : IAsyncLifetime
             $"del topic {topicName} en {timeout.TotalSeconds}s");
     }
 
+    private const int TamanoPaginaDeadLetter = 100;
+
+    // Issue #223 CA-1: recorre el DLQ completo con peek iterativo (patron oficial de Microsoft Learn,
+    // "message-browsing#maximum-number-of-messages"), en vez del tope fijo anterior de 10 mensajes.
+    // El peek no completa mensajes, asi que iterar el DLQ entero es no destructivo.
     public async Task<IReadOnlyList<ServiceBusReceivedMessage>> PeekDeadLetterMessagesAsync(
         string topicName,
-        string subscriptionName,
-        int maxMessages = 10)
+        string subscriptionName)
     {
         var options = new ServiceBusReceiverOptions { SubQueue = SubQueue.DeadLetter };
         await using var receiver = _client!.CreateReceiver(topicName, subscriptionName, options);
 
-        var messages = await receiver.PeekMessagesAsync(maxMessages);
-        return messages;
+        var mensajes = new List<ServiceBusReceivedMessage>();
+        long? desdeSecuencia = null;
+
+        while (true)
+        {
+            var pagina = await receiver.PeekMessagesAsync(
+                maxMessages: TamanoPaginaDeadLetter, fromSequenceNumber: desdeSecuencia);
+            if (pagina.Count == 0)
+                break;
+
+            mensajes.AddRange(pagina);
+            desdeSecuencia = pagina[^1].SequenceNumber + 1;
+        }
+
+        return mensajes;
+    }
+
+    // Issue #223 CA-2/CA-3: acota el assert a "hay un dead letter de ESTA corrida" en vez de
+    // "el DLQ esta globalmente vacio". T es una forma minima plana (ver DeadLetterMinimos.cs)
+    // que solo declara el identificador de correlacion, sin depender de la deserializacion
+    // custom de los value objects ricos del contrato (ADR-0025).
+    public async Task<bool> ExisteDeadLetterDeEstaCorridaAsync<T>(
+        string topicName,
+        string subscriptionName,
+        Func<T, bool> match)
+    {
+        var mensajes = await PeekDeadLetterMessagesAsync(topicName, subscriptionName);
+
+        foreach (var mensaje in mensajes)
+        {
+            try
+            {
+                var deserializado = JsonSerializer.Deserialize<T>(mensaje.Body.ToString(), _jsonOptions);
+                if (deserializado is not null && match(deserializado))
+                    return true;
+            }
+            catch (JsonException)
+            {
+                continue;
+            }
+        }
+
+        return false;
     }
 
     public async ValueTask DisposeAsync()

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/RegistrarMarcacionFunction/RegistrarMarcacionSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/RegistrarMarcacionFunction/RegistrarMarcacionSmokeTests.cs
@@ -310,13 +310,14 @@ public class RegistrarMarcacionSmokeTests(
         diaCalculado.HorasDiscriminadas.MinutosPorConcepto.Should().BeEmpty(
             "una entrada sola deja la franja anomala, sin minutos por concepto");
 
-        // Assert: ausencia de dead letters en la suscripcion smoke-tests del topic dia-calculado.
-        var deadLetters = await serviceBus.PeekDeadLetterMessagesAsync(
-            TopicDiaCalculado, SuscripcionSmokeTests);
+        // Assert: ausencia de dead letter de ESTA corrida en la suscripcion smoke-tests del topic
+        // dia-calculado (issue #223: acotado por EmpleadoId, no "DLQ globalmente vacio").
+        var existeDeadLetter = await serviceBus.ExisteDeadLetterDeEstaCorridaAsync<DiaCalculadoMinimo>(
+            TopicDiaCalculado, SuscripcionSmokeTests, e => e.InformacionEmpleado?.EmpleadoId == empleadoId);
 
-        deadLetters.Should().BeEmpty(
-            "no deberia haber mensajes en dead letter de '{0}' del topic '{1}'",
-            SuscripcionSmokeTests, TopicDiaCalculado);
+        existeDeadLetter.Should().BeFalse(
+            "no deberia haber un dead letter de esta corrida (EmpleadoId {0}) en '{1}' del topic '{2}'",
+            empleadoId, SuscripcionSmokeTests, TopicDiaCalculado);
     }
 
     // HU-181 CA-5: camino feliz completo (turno + entrada + salida) -> el DiaCalculado publicado
@@ -439,12 +440,13 @@ public class RegistrarMarcacionSmokeTests(
             .Should().BeGreaterThan(0,
                 "el desglose real discriminado lleva horas ordinarias diurnas (no un payload vacio)");
 
-        // Assert: ausencia de dead letters en la suscripcion smoke-tests del topic dia-calculado.
-        var deadLetters = await serviceBus.PeekDeadLetterMessagesAsync(
-            TopicDiaCalculado, SuscripcionSmokeTests);
+        // Assert: ausencia de dead letter de ESTA corrida en la suscripcion smoke-tests del topic
+        // dia-calculado (issue #223: acotado por EmpleadoId, no "DLQ globalmente vacio").
+        var existeDeadLetter = await serviceBus.ExisteDeadLetterDeEstaCorridaAsync<DiaCalculadoMinimo>(
+            TopicDiaCalculado, SuscripcionSmokeTests, e => e.InformacionEmpleado?.EmpleadoId == empleadoId);
 
-        deadLetters.Should().BeEmpty(
-            "no deberia haber mensajes en dead letter de '{0}' del topic '{1}'",
-            SuscripcionSmokeTests, TopicDiaCalculado);
+        existeDeadLetter.Should().BeFalse(
+            "no deberia haber un dead letter de esta corrida (EmpleadoId {0}) en '{1}' del topic '{2}'",
+            empleadoId, SuscripcionSmokeTests, TopicDiaCalculado);
     }
 }

--- a/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/Fixtures/DeadLetterMinimos.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/Fixtures/DeadLetterMinimos.cs
@@ -1,0 +1,6 @@
+namespace Bitakora.ControlAsistencia.Programacion.SmokeTests.Fixtures;
+
+// Issue #223 CA-2: forma minima plana para filtrar dead letters de ProgramacionTurnoDiarioSolicitada
+// por SolicitudId, sin depender de la deserializacion custom de los value objects ricos del
+// contrato (ADR-0025). El payload viaja plano por el bus, asi que el serializador por defecto basta.
+public sealed record ProgramacionTurnoDiarioSolicitadaMinimo(Guid SolicitudId);

--- a/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/Fixtures/ServiceBusFixture.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/Fixtures/ServiceBusFixture.cs
@@ -102,16 +102,62 @@ public class ServiceBusFixture : IAsyncLifetime
             $"del topic {topicName} en {timeout.TotalSeconds}s");
     }
 
+    private const int TamanoPaginaDeadLetter = 100;
+
+    // Issue #223 CA-1: recorre el DLQ completo con peek iterativo (patron oficial de Microsoft Learn,
+    // "message-browsing#maximum-number-of-messages"), en vez del tope fijo anterior de 10 mensajes.
+    // El peek no completa mensajes, asi que iterar el DLQ entero es no destructivo.
     public async Task<IReadOnlyList<ServiceBusReceivedMessage>> PeekDeadLetterMessagesAsync(
         string topicName,
-        string subscriptionName,
-        int maxMessages = 10)
+        string subscriptionName)
     {
         var options = new ServiceBusReceiverOptions { SubQueue = SubQueue.DeadLetter };
         await using var receiver = _client!.CreateReceiver(topicName, subscriptionName, options);
 
-        var messages = await receiver.PeekMessagesAsync(maxMessages);
-        return messages;
+        var mensajes = new List<ServiceBusReceivedMessage>();
+        long? desdeSecuencia = null;
+
+        while (true)
+        {
+            var pagina = await receiver.PeekMessagesAsync(
+                maxMessages: TamanoPaginaDeadLetter, fromSequenceNumber: desdeSecuencia);
+            if (pagina.Count == 0)
+                break;
+
+            mensajes.AddRange(pagina);
+            desdeSecuencia = pagina[^1].SequenceNumber + 1;
+        }
+
+        return mensajes;
+    }
+
+    // Issue #223 CA-2/CA-3: acota el assert a "hay un dead letter de ESTA corrida" en vez de
+    // "el DLQ esta globalmente vacio". T es una forma minima plana (ver DeadLetterMinimos.cs)
+    // que solo declara el identificador de correlacion, sin depender de la deserializacion
+    // custom de los value objects ricos del contrato (ADR-0025).
+    public async Task<bool> ExisteDeadLetterDeEstaCorridaAsync<T>(
+        string topicName,
+        string subscriptionName,
+        Func<T, bool> match)
+    {
+        var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+        var mensajes = await PeekDeadLetterMessagesAsync(topicName, subscriptionName);
+
+        foreach (var mensaje in mensajes)
+        {
+            try
+            {
+                var deserializado = JsonSerializer.Deserialize<T>(mensaje.Body.ToString(), options);
+                if (deserializado is not null && match(deserializado))
+                    return true;
+            }
+            catch (JsonException)
+            {
+                continue;
+            }
+        }
+
+        return false;
     }
 
     public async ValueTask DisposeAsync()

--- a/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoSmokeTests.cs
@@ -107,15 +107,17 @@ public class SolicitarProgramacionTurnoSmokeTests(ApiFixture api, ServiceBusFixt
         evento1.DetalleTurno.Nombre.Should().Be("[TEST] Turno Smoke SB");
         evento1.DetalleTurno.FranjasOrdinarias.Should().HaveCount(1);
 
-        // Assert: verificar ausencia de dead letters en la suscripcion del consumidor real
+        // Assert: verificar ausencia de dead letter de ESTA corrida en la suscripcion del consumidor real
+        // (issue #223: acotado por SolicitudId, no "DLQ globalmente vacio" - residuales de otras
+        // corridas no deben tumbar este test).
         await Task.Delay(TimeSpan.FromSeconds(5), ct);
 
-        var deadLetters = await serviceBus.PeekDeadLetterMessagesAsync(
-            TopicSalida, SuscripcionConsumidor);
+        var existeDeadLetter = await serviceBus.ExisteDeadLetterDeEstaCorridaAsync<ProgramacionTurnoDiarioSolicitadaMinimo>(
+            TopicSalida, SuscripcionConsumidor, e => e.SolicitudId == solicitudId);
 
-        deadLetters.Should().BeEmpty(
-            "no deberia haber mensajes en dead letter de '{0}' - si los hay, el consumidor fallo al procesar el evento",
-            SuscripcionConsumidor);
+        existeDeadLetter.Should().BeFalse(
+            "no deberia haber un dead letter de esta corrida (SolicitudId {0}) en '{1}' - si lo hay, el consumidor fallo al procesar el evento",
+            solicitudId, SuscripcionConsumidor);
     }
 
     [Fact]


### PR DESCRIPTION
## Resumen

Pipeline tooling completado:
- Writer: implementacion de la tarea
- Reviewer: revision de calidad

## Decisiones del pipeline

<details>
<summary>Writer -- 6m 43s</summary>

# Stage 1 (writer) - Issue #223

## Resumen

Acotados los 5 asserts de dead-letter de los smoke tests de Service Bus a "hay un
dead-letter de ESTA corrida" (opcion B del issue), en vez de "el DLQ del consumidor
esta globalmente vacio". Un dead-letter residual de una corrida anterior, un warmup,
o un race deploy->smoke ya no puede tumbar el test.

## Cambios

### `Fixtures/ServiceBusFixture.cs` (Programacion y ControlHoras, duplicado por dominio)

- `PeekDeadLetterMessagesAsync(topic, sub)`: ya no tiene el parametro `maxMessages = 10`.
  Ahora recorre el DLQ completo con peek iterativo (paginas de 100, avanzando
  `fromSequenceNumber` tras cada pagina hasta que el receiver devuelve una pagina vacia).
  Patron tomado del ejemplo oficial de Microsoft Learn
  (https://learn.microsoft.com/azure/service-bus-messaging/message-browsing#maximum-number-of-messages).
  El peek no completa mensajes, asi que iterar el DLQ entero sigue siendo no destructivo.
- Nuevo metodo `ExisteDeadLetterDeEstaCorridaAsync<T>(topic, sub, Func<T, bool> match)`:
  usa `PeekDeadLetterMessagesAsync` internamente, deserializa cada mensaje a la forma
  minima `T` (case-insensitive) y devuelve `true` si algun mensaje cumple el predicado.
  Los `JsonException` de mensajes que no calzan con `T` se ignoran (no deberia romper
  el assert por dead-letters de otro tipo de evento en el mismo topic).

### Nuevo: `Fixtures/DeadLetterMinimos.cs` (Programacion y ControlHoras)

Records minimos planos usados solo para el predicado del DLQ, sin depender de la
deserializacion custom de los value objects ricos del contrato (ADR-0025):

- `ProgramacionTurnoDiarioSolicitadaMinimo(Guid SolicitudId)` - en ambos dominios
  (la suscripcion `control-horas-escucha-programacion` la peekean tanto el smoke de
  Programacion como el de ControlHoras).
- `DiaCalculadoMinimo(InformacionEmpleadoMinimo? InformacionEmpleado)` +
  `InformacionEmpleadoMinimo(string EmpleadoId)` - solo en ControlHoras (unico dominio
  que peekea el topic `dia-calculado`).

### Los 5 asserts reescritos

| Archivo | Linea original | Filtro |
|---|---|---|
| `SolicitarProgramacionTurnoSmokeTests.cs` | 116 | `SolicitudId` |
| `AsignarTurnoViaSbSmokeTests.cs` | 120 | `SolicitudId` |
| `AsignarTurnoViaSbSmokeTests.cs` | 128 | `EmpleadoId` |
| `RegistrarMarcacionSmokeTests.cs` | 317 | `EmpleadoId` |
| `RegistrarMarcacionSmokeTests.cs` | 446 | `EmpleadoId` |

Cada uno paso de `deadLetters.Should().BeEmpty()` (sobre el DLQ global) a
`existeDeadLetter.Should().BeFalse()` (acotado al identificador de esta corrida,
ya disponible en cada test via `solicitudId`/`empleadoId`).

## Decisiones tomadas (ya definidas en el issue, ejecutadas sin cambios)

- **Opcion B** (assert acotado) sobre opcion A (purge-before-act del DLQ del
  consumidor): no se agrego ninguna purga destructiva del DLQ.
- **Rule of Three**: el helper y los records minimos se duplican en los 2
  `Fixtures/` en vez de extraerse a un proyecto compartido (2 usos, no 3).
- Se mantiene el nombre `PeekDeadLetterMessagesAsync` (solo cambia su
  comportamiento interno), tal como pide CA-1 del issue.

## Verificacion

- `dotnet build ControlAsistencias.slnx`: compila sin errores (warnings
  preexistentes no relacionados: `NU1902` de OpenTelemetry.Api, `CS0414` en
  `CatalogoTurnos`).
- `dotnet test` sobre ambos proyectos SmokeTests: verde. Los tests que requieren
  ServiceBus/Postgres se omiten en este entorno local (no hay
  `appsettings.local.json` ni variables de entorno configuradas) - comportamiento
  esperado, no una regresion introducida por este cambio.
- Sin caracteres Unicode decorativos en los archivos `.cs` tocados (verificado con
  grep sobre el rango `U+2500`-`U+257F`).

## Fuera de alcance (documentado en el issue, no resuelto aqui)

- El smoke de Programacion sigue peekeando `control-horas-escucha-programacion`,
  una suscripcion de ControlHoras (acoplamiento cross-domain). La opcion B lo
  vuelve hermetico pero no elimina el acoplamiento; el issue #223 explicitamente
  no expande el alcance para resolverlo.

## Commit

`60f2f0b` - fix(smoke-tests): acotar asserts de dead-letter a la corrida actual (issue #223)

Nota: `.claude/settings.json` aparecia modificado en el working tree antes de
iniciar esta tarea (no es parte de este cambio); se dejo fuera del commit.

</details>

<details>
<summary>Reviewer -- 5m 21s</summary>

# Stage 2 - Reviewer - Issue #223

Acotar los asserts de dead-letter de los smoke tests de Service Bus a la corrida actual.

## Veredicto

**APROBADO sin correcciones.** El codigo del writer cumple los 5 criterios de aceptacion,
compila limpio (0 warnings / 0 errores en ambos proyectos de smoke tests) y no requirio
ningun cambio del reviewer. El commit del writer (`60f2f0b`) toca exclusivamente archivos
bajo `tests/` — sin rutas prohibidas (`src/`, `docs/adr/`, `commands/`, `agents/`, `hooks/`).

## Verificacion de criterios de aceptacion

- **CA-1 (peek iterativo hasta agotar el cursor):** OK. `PeekDeadLetterMessagesAsync` en ambos
  `Fixtures/ServiceBusFixture.cs` recorre el DLQ completo paginando con
  `PeekMessagesAsync(maxMessages, fromSequenceNumber)` y avanzando `desdeSecuencia = pagina[^1].SequenceNumber + 1`
  hasta que una pagina vuelve vacia. Reemplaza el tope fijo de 10. Patron oficial de Microsoft
  Learn ("message-browsing"). El peek no completa mensajes -> no destructivo, coherente con no
  borrar evidencia forense. Sin riesgo de bucle infinito (la ultima pagina parcial o multiplo
  exacto termina con una llamada que devuelve 0).

- **CA-2 (record plano solo con el identificador):** OK. `DeadLetterMinimos.cs` por dominio:
  - Programacion: `ProgramacionTurnoDiarioSolicitadaMinimo(Guid SolicitudId)`.
  - ControlHoras: mismo + `DiaCalculadoMinimo(InformacionEmpleadoMinimo? InformacionEmpleado)` /
    `InformacionEmpleadoMinimo(string EmpleadoId)`.
  Formas planas que no dependen de la serializacion custom de los VOs ricos (ADR-0025). La
  deserializacion usa `PropertyNameCaseInsensitive = true`, cubriendo tanto el payload camelCase
  de Wolverine como PascalCase. Contrastado contra los contratos reales:
  `DiaCalculado.InformacionEmpleado?` (nullable) con `EmpleadoId` string, y
  `ProgramacionTurnoDiarioSolicitada.SolicitudId` Guid — los tipos calzan exactamente.

- **CA-3 (mapeo de los 5 asserts):** OK, verificado assert por assert.
  - `SolicitarProgramacionTurnoSmokeTests` (linea 115): filtra por `SolicitudId`.
  - `AsignarTurnoViaSbSmokeTests` (linea 118): `SolicitudId`; (linea 127): `EmpleadoId`.
  - `RegistrarMarcacionSmokeTests` (lineas 315 y 445): `EmpleadoId`.
  Los identificadores del predicado son los mismos IDs por corrida ya generados en cada test
  (`solicitudId` Guid, `empleadoId` string via `Guid.CreateVersion7()`), reutilizados — no se
  inventan valores nuevos.

- **CA-4 (sin `BeEmpty` global; se conserva purge-before-act):** OK. `git grep` confirma 0
  ocurrencias de `deadLetters.Should().BeEmpty(...)`. La verificacion es ahora
  `existeDeadLetter.Should().BeFalse(...)` acotada a la corrida. Se conserva la purga previa de
  `smoke-tests` en `dia-calculado` (ADR-0016) y NO se agrega purga destructiva del DLQ del
  consumidor (opcion A descartada).

- **CA-5 (build + nombres de test + sin Unicode):** OK. `dotnet build` de ambos proyectos:
  compilacion correcta, 0 warnings, 0 errores. Nombres de metodo de test intactos (ADR-0022):
  `--list-tests` muestra los mismos nombres. `git grep` de U+2500 en `tests/`: ninguno.

## Calidad de codigo

- **Reutilizacion de patrones existentes:** el nuevo helper `ExisteDeadLetterDeEstaCorridaAsync<T>`
  replica el patron de `WaitForMessageAsync<T>` (generico + `Func<T, bool> match` + `catch (JsonException)`),
  familiar en ambos fixtures. Naming en espanol, claro y consistente
  (`TamanoPaginaDeadLetter`, `desdeSecuencia`, `pagina`, `mensajes`).
- **Duplicacion controlada (ADR-0024 / Rule of Three):** el cambio se aplica identico en los dos
  `ServiceBusFixture.cs`. Con 2 usos NO se extrae a un proyecto compartido — consistente con el
  criterio de #219/#220 y con lo pedido en el issue.
- **Divergencia menor observada (aceptada, no corregida):** en el fixture de ControlHoras el helper
  reutiliza el campo `_jsonOptions`; en Programacion crea `new JsonSerializerOptions { PropertyNameCaseInsensitive = true }`
  local. Cada fixture es internamente consistente con su propio estilo previo
  (`WaitForMessageAsync` de Programacion ya creaba las opciones localmente y ControlHoras ya tenia
  el campo). Homogeneizarlo seria churn sin ganancia funcional y contradiria el criterio de no
  sobre-refactorizar; se deja como esta. Ambas rutas son funcionalmente equivalentes (case-insensitive).
- **Robustez:** el predicado usa `?.` (`e.InformacionEmpleado?.EmpleadoId`) evitando NRE cuando
  `DiaCalculado.InformacionEmpleado` es null (caso valido del contrato). Mensajes ajenos o no-JSON
  en el DLQ caen en `catch (JsonException)` o producen defaults que no matchean -> el assert no
  se rompe por basura residual, que es justamente el objetivo del issue.

## Acoplamiento cross-domain (fuera de alcance, confirmado)

El smoke de Programacion sigue peekeando `control-horas-escucha-programacion` (suscripcion de
ControlHoras). La opcion B lo vuelve hermetico (acotado por `SolicitudId`) pero no elimina el
acoplamiento — el issue lo declara explicitamente fuera de alcance. Sin accion aqui.

## Comandos ejecutados

- `dotnet build tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/` -> OK (0/0).
- `dotnet build tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/` -> OK (0/0).
- `dotnet test --project ...ControlHoras.SmokeTests --list-tests` -> tests descubiertos, nombres intactos.
- No se ejecutaron contra dev (sin `appsettings.local.json` -> `Assert.SkipWhen`). No es responsabilidad
  del reviewer correr la suite contra el entorno desplegado.

## Correcciones aplicadas

Ninguna al codigo. Este stage solo agrega este resumen.

</details>

## Commits

60f2f0b fix(smoke-tests): acotar asserts de dead-letter a la corrida actual (issue #223)

Closes #223