### PR TITLE
Habilitar la adopcion de proyecciones en la configuracion del harness

### DIFF
--- a/.claude/harness.config.json
+++ b/.claude/harness.config.json
@@ -6,9 +6,12 @@
   "terraformStateStorage": "stcatfstatedev",
   "githubServicePrincipalName": "github-controlasistencias-ci",
   "appInsightsApp": "controlasistencias-dev-ai",
-  "domainLabels": ["asistencia", "programacion", "contracts", "controlhoras"],
+  "domainLabels": ["asistencia", "programacion", "contracts", "control-horas"],
   "boundedContext": {
     "name": "ControlAsistencias",
-    "domains": ["programacion", "controlhoras"]
+    "domains": ["programacion", "control-horas"]
+  },
+  "projections": {
+    "enabled": true
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ Sistema de control de asistencias y cálculo de horas según legislación labora
 Este proyecto consume el plugin `mefisto@augusto-romero-arango-harness` desde el marketplace privado registrado en `.claude/settings.json`. Los skills, agentes, scripts y ADRs del marco arquitectónico vienen del plugin, no del repo del proyecto.
 
 - **Repositorio del harness**: https://github.com/augusto-romero-arango/eda-evsourcing-azure-harness
-- **Skills disponibles**: `/mefisto:implement`, `:scaffold`, `:infra`, `:tooling`, `:bug`, `:draft`, `:merge`, `:parallel`, `:sequential`, `:show-flow`, `:work-status`, `:health-check`, `:eraser-diagram`, `:fix-review`.
+- **Skills disponibles**: `/mefisto:implement`, `:scaffold`, `:scaffold-projections`, `:infra`, `:tooling`, `:bug`, `:draft`, `:merge`, `:parallel`, `:sequential`, `:show-flow`, `:work-status`, `:health-check`, `:eraser-diagram`, `:fix-review`.
 - **Actualizar**: `/plugin update mefisto`.
 
 #### Setup para nuevos desarrolladores

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,7 @@ Los skills son comandos `/…` que orquestan trabajo. Cada uno documenta su prop
 | `/parallel` | Corre varios issues en worktrees aislados sin merge automático |
 | `/sequential` | Cadena de issues con merge automático entre PRs |
 | `/scaffold` | Crea el scaffold de un nuevo dominio (proyecto + tests + Terraform + workflow) |
+| `/scaffold-projections` | Genera el worker de proyecciones, `ReadModels` y su config-test base (opt-in vía `projections.enabled`) |
 | `/bug` | Investiga un síntoma; enruta a `bug-investigator` o `tooling-investigator` |
 | `/fix-review` | Resuelve comentarios pendientes de un PR en revisión |
 | `/health-check` | Dashboard del entorno desplegado (excepciones, dead letters, requests) |
@@ -93,8 +94,11 @@ Invocables directamente con `claude --agent <nombre>` cuando necesites iterar fu
 | `eda-modeler` | Formaliza flujos y aggregates en `docs/eda/` |
 | `historiador` | Consolida field notes en la bitácora del día |
 | `domain-scaffolder` | Crea scaffold de un nuevo dominio (invocado por `/scaffold`) |
+| `projections-scaffolder` | Crea el worker de proyecciones read-side (invocado por `/scaffold-projections`) |
 | `test-writer` | Fase roja del pipeline TDD (invocado por `/implement`) |
 | `implementer` | Fase verde del pipeline TDD (invocado por `/implement`) |
+| `projection-test-writer` | Fase roja del pipeline TDD read-side: tests de proyecciones Marten |
+| `projection-implementer` | Fase verde del pipeline TDD read-side: proyecciones Marten y Functions de consulta |
 | `reviewer` | Revisión antes de crear PR |
 | `smoke-test-writer` | Smoke tests contra entorno dev |
 | `infra-writer` / `infra-reviewer` / `infra-applier` / `infra-bootstrap` | Etapas del pipeline IaC |
@@ -110,7 +114,7 @@ Invocables directamente con `claude --agent <nombre>` cuando necesites iterar fu
 - **Labels obligatorios**: `tipo:X` + `dom:X` + `estado:{borrador|listo}`. Los asigna el planner.
 - **Dependencias**: cada issue las declara en su sección `## Dependencias`. No se usan issues contenedor/epic.
 - **Bloqueados**: label `bloqueado` cuando dependen de otro no cerrado. El pipeline lo quita al verificar dependencias.
-- **Definition of Ready**: ver `docs/adr/0014-definition-of-ready.md` — los skills de pipeline lo validan antes de ejecutar.
+- **Definition of Ready**: ver MEF-ADR-0011 (Definition of Ready, del marco) — los skills de pipeline lo validan antes de ejecutar.
 
 Setup inicial de labels: `./scripts/setup-github-labels.sh`. Al crear un dominio nuevo, recuerda `gh label create dom:<nombre>`.
 
@@ -145,8 +149,9 @@ Si tu trabajo toca uno de estos temas, consulta el ADR correspondiente antes de 
 | Estrategia de testing con event sourcing, DSL de tests | ADR-0006 |
 | Contracts: eventos públicos y value objects compartidos | ADR-0002 |
 | Mensajes en `.resx` por aggregate/handler | ADR-0012 |
-| Definition of Ready | ADR-0014 |
+| Definition of Ready | MEF-ADR-0011 |
 | Smoke tests contra entorno dev | ADR-0016 |
+| Worker de proyecciones read-side, proyecciones Marten (read models), Functions HTTP GET de consulta | MEF-ADR-0034, MEF-ADR-0035 |
 | Snapshots de Marten (excepción) | ADR-0021 |
 | Convención de nombres para métodos de test (`<Sujeto>_<LoQuePasa>_Cuando<Condicion>`) | ADR-0022 |
 | Archivo señal de refactor puro vive en `pipeline-state/` (fuera de `.claude/`) | ADR-0023 |


### PR DESCRIPTION
## Resumen

Pipeline tooling completado:
- Writer: implementacion de la tarea
- Reviewer: revision de calidad

## Decisiones del pipeline

<details>
<summary>Writer -- 5m 26s</summary>

# Stage 1 (writer) — Issue #230: habilitar la adopción de proyecciones en la configuración del harness

## Qué se hizo

### CA-1 — Token `projections.enabled`
`.claude/harness.config.json` ahora declara:
```json
"projections": { "enabled": true }
```
Verificado: `jq -r '.projections.enabled' .claude/harness.config.json` → `true`.

### CA-2 — Label `tipo:projection`
Creado en GitHub con `gh label create "tipo:projection" --color "0052CC" --description "Proyeccion Marten y query read-side"` (mismo esquema que `scripts/setup-github-labels.sh` del plugin). Confirmado con `gh label list --search projection`.

### CA-3 — `domainLabels` alineado con `dom:control-horas`
`domainLabels` pasó de `controlhoras` a `control-horas`. **Además** se actualizó `boundedContext.domains` (no listado explícitamente en el issue, pero necesario): `_pipeline-common.sh::load_harness_config` valida que `boundedContext.domains` sea subconjunto de `domainLabels`; dejar `controlhoras` ahí mientras `domainLabels` decía `control-horas` habría hecho abortar `load_harness_config` en todo pipeline que la invoque. Verificado cargando la función real del plugin (`source _pipeline-common.sh && load_harness_config`): carga sin error, `HARNESS_DOMAIN_LABELS` y `HARNESS_BC_DOMAINS` devuelven `control-horas`. Confirmé además que `boundedContext.domains` no se usa en el repo para derivar nombres de carpeta/namespace (los proyectos `src/Bitakora.ControlAsistencia.ControlHoras` no se tocaron).

### CA-4 — Catálogo de skills y agentes en `CLAUDE.md`
- Sumada fila `/scaffold-projections` a la tabla "Catálogo de skills".
- Sumadas filas `projections-scaffolder`, `projection-test-writer`, `projection-implementer` a la tabla "Agentes disponibles", junto a sus equivalentes write-side (`domain-scaffolder`, `test-writer`, `implementer`).

No se tocó la lista corta "Skills disponibles" de la sección "Harness integrado" (línea ~23): el issue solo pide sumar la entrada al "catálogo de skills" (la tabla), y esa lista corta ya tenía una inconsistencia preexistente con la tabla (incluye `:merge`, que la tabla no lista) — no es parte del alcance de este issue reconciliarla.

### CA-5 — Índice temático de ADRs
- Nueva fila: "Worker de proyecciones read-side, proyecciones Marten (read models), Functions HTTP GET de consulta" → `MEF-ADR-0034, MEF-ADR-0035`.
- Fila "Definition of Ready" corregida: `ADR-0014` → `MEF-ADR-0011`. Verificado que `docs/adr/0014-definition-of-ready.md` no existe en `docs/adr/` (ese directorio pertenece al plugin y lista `mef-adr-0011-definition-of-ready.md`, no un 0014).
- También corregida la referencia gemela en la sección "Issues" (`### Issues` → viñeta "Definition of Ready"), que apuntaba al mismo archivo inexistente y quedaría rota si solo se arreglaba la tabla.

No se tocó el resto de la tabla de ADRs (hay más filas cuya numeración `ADR-XXXX` no corresponde 1:1 con la numeración `MEF-ADR-XXXX` del framework ni con los archivos locales de `docs/adr/`). Ese es un problema preexistente más amplio, fuera del alcance de este issue; solo se corrigió la referencia rota que el issue señala explícitamente.

### CA-6 — `/scaffold-projections` ya no aborta
Extraje y corrí *solo* el bloque bash de la "Pre-condición 2" del skill (`commands/scaffold-projections.md` del plugin 0.19.0) sin invocar el agente ni generar nada. Con el token en `true`, el bloque no aborta (`RAW='true'`).

## Verificaciones adicionales
- `jq empty .claude/harness.config.json` → JSON válido.
- `load_harness_config` (función real del plugin, no reimplementada) corre limpio sobre la config final.
- `gh label list --search projection` confirma el label creado con color y descripción correctos.

## Alcance no tocado (fuera de permiso o fuera de issue)
- No se modificó nada bajo `commands/`, `skills/`, `agents/`, `docs/adr/` (pertenecen al plugin).
- No se generó ningún archivo del worker de proyecciones (`src/*.Projections`, `src/*.ReadModels`): eso es responsabilidad de `/scaffold-projections` en un issue posterior, no de este.

## Commit
`f898d40` — `tooling(harness): habilitar adopcion de proyecciones en la config del harness` (incluye `Closes #230`).

</details>

<details>
<summary>Reviewer -- 5m 28s</summary>

# Stage 2 (reviewer) — Issue #230: habilitar la adopción de proyecciones en la configuración del harness

**Veredicto: aprobado.** Los 6 criterios de aceptación se cumplen y quedaron verificados ejecutando el contrato real del plugin (`mefisto@0.19.0`), no reimplementándolo. Se aplicó **1 corrección** de consistencia interna.

## Verificación de criterios

| CA | Estado | Cómo se verificó |
|---|---|---|
| CA-1 | OK | `jq -r '.projections.enabled'` → `true` (booleano, no string). `jq empty` confirma JSON válido. |
| CA-2 | OK | `gh label list --search projection` → `tipo:projection` / `Proyeccion Marten y query read-side` / `#0052CC`. Coincide **carácter por carácter** con la línea 42 de `scripts/setup-github-labels.sh` del plugin. |
| CA-3 | OK | `domainLabels` = `["asistencia","programacion","contracts","control-horas"]`, alineado con el label real `dom:control-horas`. |
| CA-4 | OK | `/scaffold-projections` en la tabla de skills; `projections-scaffolder`, `projection-test-writer` y `projection-implementer` en la de agentes. |
| CA-5 | OK | Nueva fila → `MEF-ADR-0034, MEF-ADR-0035`; `grep '0014' CLAUDE.md` → **0 resultados**. |
| CA-6 | OK | Se corrió el bloque bash de la Pre-condición 2 de `commands/scaffold-projections.md` textualmente: `RAW='true'` → no aborta. |

Verificación de integración de extremo a extremo: `source _pipeline-common.sh && load_harness_config` corre limpio y exporta `HARNESS_PROJECTIONS_ENABLED=true`.

## Confirmación del punto más riesgoso del diff

El writer modificó `boundedContext.domains` (`controlhoras` → `control-horas`) sin que ningún CA lo pidiera. **Lo verifiqué de forma independiente y el cambio era obligatorio, no scope creep:**

- `_pipeline-common.sh:157-171` valida que **cada** elemento de `boundedContext.domains` esté en `domainLabels` y hace `return 1` si no. Cambiar solo `domainLabels` (lo que pide CA-3 al pie de la letra) habría hecho **abortar `load_harness_config` en todo pipeline del harness** — una regresión total.
- Confirmé además que `HARNESS_BC_DOMAINS` solo se consume para validación y para el reporte de `/onboard`: **nunca** se usa para derivar rutas ni namespaces. Por eso `src/Bitakora.ControlAsistencia.ControlHoras/` (PascalCase, sin guion) sigue siendo correcto y no debía tocarse.
- Efecto colateral positivo: `domainLabels` apuntaba a un `dom:controlhoras` **que no existe** en GitHub; el label real siempre fue `dom:control-horas`. El cambio corrige un defecto latente en `/onboard` y en `setup-github-labels.sh`.

También verifiqué las tres referencias a ADRs que introduce el diff, en lugar de confiar en el issue: `mef-adr-0011-definition-of-ready.md` (titulado "Definition of Ready por tipo de issue", y su tabla **sí** tiene la columna `projection`), `mef-adr-0034-worker-proyecciones-read-models.md` y `mef-adr-0035-doctrina-proyeccion-query-read-side.md` existen en el plugin.

## Corrección aplicada (commit `719d4b7`)

**`CLAUDE.md` se contradecía a sí mismo sobre la existencia del skill.** El writer sumó `/scaffold-projections` a la tabla "Catálogo de skills" (CA-4) pero dejó sin tocar la lista corta "Skills disponibles" de la sección "Harness integrado" (línea 23) — que es la **primera** lista de skills que lee un agente o un dev nuevo.

El writer lo justificó como fuera de alcance argumentando que esa lista ya tenía una inconsistencia previa (incluye `:merge`, ausente de la tabla). No comparto el razonamiento: verifiqué que `commands/merge.md` **sí existe** en el plugin, así que la lista corta está correcta y es la *tabla* la que tiene el hueco de `merge` — un defecto preexistente distinto que no justifica introducir uno nuevo. La intención de CA-4 es descubribilidad de la cadena read-side, y se incumplía en el lugar más visible del documento. Costo del arreglo: un token en una lista.

Ubiqué `:scaffold-projections` después de `:scaffold` para agrupar los dos skills de scaffolding y espejar el orden de la tabla.

## Hallazgo para un issue aparte (no corregido, deliberadamente)

El índice temático de ADRs de `CLAUDE.md` tiene un **defecto sistémico preexistente**: la fila de DoR que este issue arregló era *un caso* de un patrón mucho más amplio. `docs/adr/` del proyecto contiene solo 12 ADRs (`0001-0004, 0007, 0009, 0017, 0019, 0020, 0025-0027`), pero el índice cita ~11 filas con numeración `ADR-XXXX` a secas cuyo tema en realidad vive en los ADRs **del marco**, bajo otro número:

- **Referencias colgantes** (el archivo no existe en `docs/adr/`): `ADR-0005` (naming de eventos → `MEF-ADR-0005`), `ADR-0006` (testing ES → `MEF-ADR-0002`), `ADR-0008` (naming funciones Azure → `MEF-ADR-0006`), `ADR-0012` (`.resx` → `MEF-ADR-0009`), `ADR-0015` (encapsulamiento/serialización → `MEF-ADR-0012`), `ADR-0016` (smoke tests → `MEF-ADR-0013`), `ADR-0021` (snapshots → `MEF-ADR-0015`), `ADR-0022` (naming tests → `MEF-ADR-0016`), `ADR-0023` (señal de refactor → `MEF-ADR-0017`), `ADR-0024` (extracción vs duplicación → `MEF-ADR-0018`).
- **Colisiones activas, más peligrosas que un enlace roto** — apuntan a un archivo *real* del proyecto sobre un tema *distinto*: la fila "Manejo de errores en event sourcing → ADR-0007" resuelve a `docs/adr/0007-postgresql-compartido-schemas-por-dominio.md`; la fila "un topic **por evento** → ADR-0004" resuelve a `docs/adr/0004-service-bus-topics-por-dominio.md` (por dominio, la doctrina opuesta).

No lo corregí por disciplina de alcance: son ~11 filas, es una migración documental con criterio propio, y **MEF-ADR-0030 (sección "Decisión #4")** fija explícitamente que renumerar los ADRs del consumidor es opt-in y "tarea del lado consumidor". Meterlo en un PR titulado "habilitar la adopción de proyecciones" mezclaría dos trabajos sin relación. **Recomiendo un issue `tipo:tooling` dedicado**, adoptando el prefijo `CA-ADR-` que ese mismo ADR sugiere para este proyecto.

Segundo hallazgo menor, también preexistente: `CLAUDE.md` dice "Setup inicial de labels: `./scripts/setup-github-labels.sh`", pero `scripts/` del consumidor solo contiene `.env.template` — ese script vive en el plugin y se invoca plugin-relative. Candidato para el mismo issue de limpieza.

## Calidad

- **Reutilización de patrones**: correcta. El bloque `projections` usa el mismo estilo multilínea de 2 espacios que `boundedContext` en el mismo archivo, y se ubica al final sin reordenar claves existentes. El label replica el esquema canónico del plugin en vez de inventar color o descripción.
- **Naming**: `control-horas` (kebab) es correcto para labels y config; `ControlHoras` (Pascal) sigue siendo correcto para proyectos .NET. La distinción se respetó. El nombre de la storage account `stcontrolhoras...` en `infra/` tampoco debe llevar guion (Azure no los admite) — correcto dejarlo.
- **Legibilidad**: las filas nuevas de las tablas quedaron junto a sus equivalentes write-side (`domain-scaffolder`/`projections-scaffolder`, `test-writer`/`projection-test-writer`), lo que hace evidente el paralelismo de las dos cadenas.
- **Sin residuos**: `grep controlhoras` solo devuelve field notes históricas de `docs/bitacora/` (registro inmutable, correcto no tocarlas) y el nombre de la storage account.

## Alcance y guardas

- Rutas modificadas: `.claude/harness.config.json`, `CLAUDE.md`. Ambas dentro del alcance permitido.
- **Ninguna ruta prohibida tocada**: `git diff --name-only main...HEAD | grep -E '^(commands/|skills/|agents/|hooks/|\.claude-plugin/|docs/adr/|src/)'` → sin resultados.
- Verifiqué además que el repo del plugin (`~/.claude/plugins/marketplaces/…`) quedó con `git status` **limpio**: el writer no modificó el marco.
- **Compilación/tests: no aplica.** El diff no toca ni un archivo `.cs` (`git diff --name-only` sobre `src/` y `tests/` → vacío); son solo un `.json` de config y un `.md`. No corrí `dotnet build`/`dotnet test` porque nada del diff puede afectarlos.
- No se hizo `git push` ni `gh pr create` (responsabilidad del pipeline).

## Commits

- `f898d40` — writer: habilitar adopción de proyecciones en la config del harness (`Closes #230`)
- `719d4b7` — reviewer: sumar `:scaffold-projections` a la lista de skills de "Harness integrado"

</details>

## Commits

719d4b7 tooling(harness): sumar :scaffold-projections a la lista de skills de Harness integrado
f898d40 tooling(harness): habilitar adopcion de proyecciones en la config del harness

Closes #230