### PR TITLE
Habilitar las columnas de metadata de evento en el write-side de ambos dominios

### DIFF
--- a/src/Bitakora.ControlAsistencia.ControlHoras/Infraestructura/ComposicionServicios.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Infraestructura/ComposicionServicios.cs
@@ -11,7 +11,6 @@ using FluentValidation;
 using Marten;
 using Microsoft.Azure.Functions.Worker.OpenTelemetry;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using OpenTelemetry.Trace;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.Infraestructura;
@@ -72,6 +71,15 @@ public static class ComposicionServicios
                     jsonOptions.TypeInfoResolver = resolver;
                 });
             }
+
+            // Issue #232 (MEF-ADR-0034 seccion 7): Marten deja estas tres columnas de metadata de
+            // evento deshabilitadas por defecto -- sin este opt-in explicito, la columna ni
+            // siquiera se crea en la tabla de eventos, y ninguna proyeccion futura (Inline/Async)
+            // puede leer un CorrelationId/CausationId/header que nunca se persistio. Requisito del
+            // writer, independiente de que este dominio tenga o no un middleware de trazas activo.
+            options.Events.MetadataConfig.CorrelationIdEnabled = true;
+            options.Events.MetadataConfig.CausationIdEnabled = true;
+            options.Events.MetadataConfig.HeadersEnabled = true;
         });
 
         // Observabilidad: exporta las trazas del worker (Npgsql, Marten, Wolverine, handlers) a

--- a/src/Bitakora.ControlAsistencia.Programacion/Infraestructura/ComposicionServicios.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/Infraestructura/ComposicionServicios.cs
@@ -11,7 +11,6 @@ using Cosmos.MultiTenancy;
 using FluentValidation;
 using Marten;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 
 namespace Bitakora.ControlAsistencia.Programacion.Infraestructura;
 
@@ -66,6 +65,15 @@ public static class ComposicionServicios
                     jsonOptions.TypeInfoResolver = resolver;
                 });
             }
+
+            // Issue #232 (MEF-ADR-0034 seccion 7): Marten deja estas tres columnas de metadata de
+            // evento deshabilitadas por defecto -- sin este opt-in explicito, la columna ni
+            // siquiera se crea en la tabla de eventos, y ninguna proyeccion futura (Inline/Async)
+            // puede leer un CorrelationId/CausationId/header que nunca se persistio. Requisito del
+            // writer, independiente de que este dominio tenga o no un middleware de trazas activo.
+            options.Events.MetadataConfig.CorrelationIdEnabled = true;
+            options.Events.MetadataConfig.CausationIdEnabled = true;
+            options.Events.MetadataConfig.HeadersEnabled = true;
         });
 
         services.AddOpenTelemetry()

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/ComposicionServiciosTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/ComposicionServiciosTests.cs
@@ -10,11 +10,20 @@
 // Limite conocido: BuildServiceProvider(ValidateOnBuild) no valida registros por factory-lambda
 // (Wolverine/Marten registran varios), solo los de tipo mapeado -- de ahi la resolucion explicita
 // de ICommandRouter e IPrivateEventRouter en un scope, ademas del build general.
+//
+// Issue #232 (MEF-ADR-0034 seccion 7): Marten deja deshabilitadas por defecto las tres columnas
+// de metadata de evento (CorrelationId/CausationId/Headers) -- sin opt-in explicito la columna ni
+// siquiera se crea en la tabla de eventos. Este test verifica el opt-in sobre el IDocumentStore
+// resuelto del contenedor real (sin Postgres: el DocumentStore no abre conexion en bootstrap,
+// solo en la primera operacion real -- Marten 7+). La cadena de lectura es de solo lectura y sin
+// downcast: IDocumentStore.Options (IReadOnlyStoreOptions) -> Events (IReadOnlyEventStoreOptions)
+// -> MetadataConfig (IReadonlyMetadataConfig).
 
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.ControlHoras.Infraestructura;
 using Cosmos.EventDriven.Abstractions;
 using Cosmos.EventSourcing.Abstractions.Commands;
+using Marten;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.Tests.Infraestructura;
@@ -70,5 +79,19 @@ public class ComposicionServiciosTests
         var act = () => scope.ServiceProvider.GetRequiredService<IPrivateEventRouter>();
 
         act.Should().NotThrow();
+    }
+
+    [Fact]
+    public async Task AgregarServiciosControlHoras_HabilitaColumnasDeMetadataDeEvento_CuandoElContenedorEstaCompuesto()
+    {
+        await using var provider = ComponerServiceProvider();
+        await using var scope = provider.CreateAsyncScope();
+
+        var store = scope.ServiceProvider.GetRequiredService<IDocumentStore>();
+        var metadataConfig = store.Options.Events.MetadataConfig;
+
+        metadataConfig.CorrelationIdEnabled.Should().BeTrue();
+        metadataConfig.CausationIdEnabled.Should().BeTrue();
+        metadataConfig.HeadersEnabled.Should().BeTrue();
     }
 }

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/ComposicionServiciosTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/ComposicionServiciosTests.cs
@@ -19,8 +19,10 @@
 // downcast: IDocumentStore.Options (IReadOnlyStoreOptions) -> Events (IReadOnlyEventStoreOptions)
 // -> MetadataConfig (IReadonlyMetadataConfig).
 
+using System.Text;
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.ControlHoras.Infraestructura;
+using Bitakora.ControlAsistencia.ControlHoras.ValueObjects;
 using Cosmos.EventDriven.Abstractions;
 using Cosmos.EventSourcing.Abstractions.Commands;
 using Marten;
@@ -93,5 +95,31 @@ public class ComposicionServiciosTests
         metadataConfig.CorrelationIdEnabled.Should().BeTrue();
         metadataConfig.CausationIdEnabled.Should().BeTrue();
         metadataConfig.HeadersEnabled.Should().BeTrue();
+    }
+
+    // Issue #232 CA-5: las tres banderas de metadata comparten el mismo callback ConfigureMarten que
+    // registra el resolver de serializacion custom, asi que un edit futuro de ese bloque puede tumbar
+    // la serializacion sin que el test de metadata se ponga rojo. Los round-trip existentes
+    // (IntervaloTemporalSerializacionMartenTests) NO cubren este riesgo: usan
+    // ConfiguracionSerializacionControlHoras.CrearOpcionesMarten() -- una ruta paralela que no
+    // atraviesa el contenedor. Este test ejercita el ISerializer que el store realmente compuso.
+    // Importa porque el `if (options.Serializer() is SystemTextJsonSerializer)` del wiring omite el
+    // resolver EN SILENCIO si el serializador deja de ser STJ, e IntervaloTemporal (campos privados,
+    // sin propiedades publicas) no sobrevive STJ vanilla.
+    [Fact]
+    public async Task AgregarServiciosControlHoras_ConservaLaSerializacionCustom_CuandoTambienHabilitaMetadataDeEvento()
+    {
+        await using var provider = ComponerServiceProvider();
+        await using var scope = provider.CreateAsyncScope();
+        var serializador = scope.ServiceProvider.GetRequiredService<IDocumentStore>().Options.Serializer();
+        var original = IntervaloTemporal.Crear(
+            new MomentoDelDia(new TimeOnly(8, 0)),
+            new MomentoDelDia(new TimeOnly(17, 0)));
+
+        using var json = new MemoryStream(Encoding.UTF8.GetBytes(serializador.ToJson(original)));
+        var restaurado = serializador.FromJson<IntervaloTemporal>(json);
+
+        restaurado.Should().Be(original);
+        restaurado.ToString().Should().Be(original.ToString());
     }
 }

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/Infraestructura/ComposicionServiciosTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/Infraestructura/ComposicionServiciosTests.cs
@@ -10,10 +10,19 @@
 // Programacion no registra IPrivateEventRouter ni IQueryRouter hoy (ver Notas tecnicas del
 // issue #221): solo se resuelve explicitamente ICommandRouter, el unico router critico
 // efectivamente registrado en este dominio.
+//
+// Issue #232 (MEF-ADR-0034 seccion 7): Marten deja deshabilitadas por defecto las tres columnas
+// de metadata de evento (CorrelationId/CausationId/Headers) -- sin opt-in explicito la columna ni
+// siquiera se crea en la tabla de eventos. Este test verifica el opt-in sobre el IDocumentStore
+// resuelto del contenedor real (sin Postgres: el DocumentStore no abre conexion en bootstrap,
+// solo en la primera operacion real -- Marten 7+). La cadena de lectura es de solo lectura y sin
+// downcast: IDocumentStore.Options (IReadOnlyStoreOptions) -> Events (IReadOnlyEventStoreOptions)
+// -> MetadataConfig (IReadonlyMetadataConfig).
 
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.Programacion.Infraestructura;
 using Cosmos.EventSourcing.Abstractions.Commands;
+using Marten;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Bitakora.ControlAsistencia.Programacion.Tests.Infraestructura;
@@ -58,5 +67,19 @@ public class ComposicionServiciosTests
         var act = () => scope.ServiceProvider.GetRequiredService<ICommandRouter>();
 
         act.Should().NotThrow();
+    }
+
+    [Fact]
+    public async Task AgregarServiciosProgramacion_HabilitaColumnasDeMetadataDeEvento_CuandoElContenedorEstaCompuesto()
+    {
+        await using var provider = ComponerServiceProvider();
+        await using var scope = provider.CreateAsyncScope();
+
+        var store = scope.ServiceProvider.GetRequiredService<IDocumentStore>();
+        var metadataConfig = store.Options.Events.MetadataConfig;
+
+        metadataConfig.CorrelationIdEnabled.Should().BeTrue();
+        metadataConfig.CausationIdEnabled.Should().BeTrue();
+        metadataConfig.HeadersEnabled.Should().BeTrue();
     }
 }

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/Infraestructura/ComposicionServiciosTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/Infraestructura/ComposicionServiciosTests.cs
@@ -19,7 +19,9 @@
 // downcast: IDocumentStore.Options (IReadOnlyStoreOptions) -> Events (IReadOnlyEventStoreOptions)
 // -> MetadataConfig (IReadonlyMetadataConfig).
 
+using System.Text;
 using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Contracts.Programacion.ValueObjects;
 using Bitakora.ControlAsistencia.Programacion.Infraestructura;
 using Cosmos.EventSourcing.Abstractions.Commands;
 using Marten;
@@ -81,5 +83,28 @@ public class ComposicionServiciosTests
         metadataConfig.CorrelationIdEnabled.Should().BeTrue();
         metadataConfig.CausationIdEnabled.Should().BeTrue();
         metadataConfig.HeadersEnabled.Should().BeTrue();
+    }
+
+    // Issue #232 CA-5: las tres banderas de metadata comparten el mismo callback ConfigureMarten que
+    // registra el resolver de serializacion custom, asi que un edit futuro de ese bloque puede tumbar
+    // la serializacion sin que el test de metadata se ponga rojo. Los round-trip existentes
+    // (TurnoCreadoSerializacionTests) NO cubren este riesgo: replican las opciones de Marten a mano
+    // -- una ruta paralela que no atraviesa el contenedor. Este test ejercita el ISerializer que el
+    // store realmente compuso. Importa porque el `if (options.Serializer() is SystemTextJsonSerializer)`
+    // del wiring omite el resolver EN SILENCIO si el serializador deja de ser STJ, y SubFranja
+    // (campos privados, sin propiedades publicas) no sobrevive STJ vanilla.
+    [Fact]
+    public async Task AgregarServiciosProgramacion_ConservaLaSerializacionCustom_CuandoTambienHabilitaMetadataDeEvento()
+    {
+        await using var provider = ComponerServiceProvider();
+        await using var scope = provider.CreateAsyncScope();
+        var serializador = scope.ServiceProvider.GetRequiredService<IDocumentStore>().Options.Serializer();
+        var original = SubFranja.Crear(new TimeOnly(6, 0), new TimeOnly(16, 0));
+
+        using var json = new MemoryStream(Encoding.UTF8.GetBytes(serializador.ToJson(original)));
+        var restaurado = serializador.FromJson<SubFranja>(json);
+
+        restaurado.Should().Be(original);
+        restaurado.ToString().Should().Be(original.ToString());
     }
 }


### PR DESCRIPTION
## Resumen

Pipeline TDD completado:
- Fase roja: tests escritos con stubs
- Fase verde: implementación completa
- Fase refactor: revisión de calidad

## Decisiones del pipeline

<details>
<summary>Test Writer (fase roja) — 5m 49s</summary>

## ES Test Writer - Decisiones

### Naturaleza de la tarea

Issue #232 no introduce un command handler ni un aggregate nuevo: es una tarea de
configuracion de infraestructura Marten (write-side) verificable con tests de composicion
(mismo patron que el issue #221, MEF-ADR-0029). No aplica el DSL Given/When/Then de
`CommandHandlerAsyncTest<T>` porque no hay comando/evento involucrado; los tests viven en
la clase plana `ComposicionServiciosTests` ya existente en cada dominio, igual que sus
vecinos.

No califica como refactoring puro (seccion 2 de mis instrucciones): introduce
comportamiento observable nuevo (tres banderas booleanas que hoy son `false` por default
de Marten y deben pasar a `true`), con tests que hoy fallan y que un cambio de produccion
concreto hara pasar. Sigo el carril TDD normal.

### Tests creados

- `tests/Bitakora.ControlAsistencia.Programacion.Tests/Infraestructura/ComposicionServiciosTests.cs`: +1 test
  - `AgregarServiciosProgramacion_HabilitaColumnasDeMetadataDeEvento_CuandoElContenedorEstaCompuesto` - CA-1, CA-3
- `tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/ComposicionServiciosTests.cs`: +1 test
  - `AgregarServiciosControlHoras_HabilitaColumnasDeMetadataDeEvento_CuandoElContenedorEstaCompuesto` - CA-2, CA-4

Ambos tests resuelven `IDocumentStore` del scope del contenedor real (compuesto con
connection strings dummy, sin Postgres) y verifican:

```csharp
store.Options.Events.MetadataConfig.CorrelationIdEnabled.Should().BeTrue();
store.Options.Events.MetadataConfig.CausationIdEnabled.Should().BeTrue();
store.Options.Events.MetadataConfig.HeadersEnabled.Should().BeTrue();
```

Verificado por decompilacion contra Marten 9.2.1 (version real resuelta transitivamente via
`Cosmos.EventSourcing.CritterStack` 2.1.0, `Marten` no es `PackageReference` directo en
ninguno de los dos `.csproj`): la cadena `IDocumentStore.Options` (`IReadOnlyStoreOptions`)
-> `.Events` (`IReadOnlyEventStoreOptions`) -> `.MetadataConfig` (`IReadonlyMetadataConfig`,
con las tres props `bool` de solo lectura) existe tal cual describe el issue, sin downcast.
Tambien verifique que `AddMarten(...)` (invocado dentro de
`AgregarConfiguracionMartenComandos`, package `Cosmos.EventSourcing.CritterStack`) registra
`IDocumentStore` en el contenedor de forma estandar -- resoluble sin abrir conexion real
(Marten 7+: el store no se inicializa forzadamente en bootstrap).

Hoy ambos tests FALLAN: ninguno de los dos `ComposicionServicios.cs` habilita las tres
banderas (`grep -rn 'MetadataConfig' src/` no devuelve nada), asi que Marten las deja en su
default `false`. Es el estado rojo esperado.

### Estructura elegida

Extendi las clases `ComposicionServiciosTests` existentes (no cree archivos nuevos ni
nested classes): mismo patron que los tests de `ICommandRouter`/`IPrivateEventRouter` ya
presentes ahi (issue #221) -- comparten el mismo `ComponerServiceProvider()` helper y el
mismo estilo de resolucion via `CreateAsyncScope()`.

### Stubs creados

Ninguno. No hay tipos nuevos que stubbear: `IDocumentStore`, `IReadOnlyStoreOptions`,
`IReadOnlyEventStoreOptions` e `IReadonlyMetadataConfig` ya existen en el paquete Marten
que el proyecto ya referencia transitivamente. Solo agregue `using Marten;` a ambos
archivos de test.

No toque ningun archivo de `src/`: la habilitacion de las tres banderas en
`ComposicionServicios.AgregarServiciosProgramacion`/`AgregarServiciosControlHoras` es
implementacion real y le corresponde al implementer (fase verde).

### Decisiones de diseno

- Un solo test por dominio que verifica las tres banderas juntas (no uno por bandera):
  las tres se habilitan como una sola unidad de configuracion (mismo bloque
  `Events.MetadataConfig`), y el CA del issue las agrupa igual ("las tres banderas").
- No use el DSL `Given/When/Then/And<>` de `CommandHandlerAsyncTest` porque esta clase de
  test no hereda de esa base -- es un test de composicion de DI plano, igual que sus
  vecinos existentes en el mismo archivo (regla de estas instrucciones: el DSL aplica a
  handlers/eventos; este test verifica wiring, no comportamiento de un aggregate).

### Cobertura de criterios

| Criterio de aceptacion | Test(s) |
|---|---|
| CA-1: Programacion deja las 3 banderas en `true` | `AgregarServiciosProgramacion_HabilitaColumnasDeMetadataDeEvento_CuandoElContenedorEstaCompuesto` |
| CA-2: ControlHoras deja las 3 banderas en `true` | `AgregarServiciosControlHoras_HabilitaColumnasDeMetadataDeEvento_CuandoElContenedorEstaCompuesto` |
| CA-3: test de composicion de Programacion.Tests verifica sobre `IDocumentStore`, sin Postgres real | mismo test de CA-1 (resuelve `IDocumentStore` del `ServiceProvider` compuesto con connection strings dummy) |
| CA-4: test de composicion de ControlHoras.Tests verifica lo mismo | mismo test de CA-2 |
| CA-5: `dotnet test` pasa completo sin romper wiring existente (en particular la serializacion custom de ControlHoras via `ConfigureMarten`) | no cubierto por un test nuevo -- lo verifica el implementer al dejar pasar TODOS los tests existentes (incluidos los de serializacion) ademas de los 2 nuevos; no modifique ningun test existente |

### Desviaciones del plan del planner

Ninguna - las sugerencias del issue fueron aplicables tal cual. El planner ya identifico
correctamente que Programacion.Tests y ControlHoras.Tests ya tienen `ComposicionServiciosTests.cs`
(precedente del issue #221) y que la cadena de lectura `IDocumentStore.Options -> Events ->
MetadataConfig` es de solo lectura y sin downcast; ambos puntos los confirme por
decompilacion contra el paquete Marten real (9.2.1) antes de escribir los tests.

Una observacion menor sobre las notas tecnicas del issue: dice que "en Programacion no hay
ningun `ConfigureMarten` todavia", pero al leer el `ComposicionServicios.cs` actual de
Programacion ya existe un bloque `services.ConfigureMarten(...)` (usado para registrar
`SubFranja`/`FranjaOrdinaria`/`TurnoCreado.ConfigurarSerializacion`). No afecta a los tests
que escribi (no dependen de donde el implementer decida sumar las tres asignaciones), pero
lo dejo anotado para que el implementer no pierda tiempo buscando un hook que ya existe:
puede sumar las tres lineas al bloque `ConfigureMarten` ya presente en Programacion, igual
que en ControlHoras.

</details>

<details>
<summary>Implementer (fase verde) — 9m 10s</summary>

## ES Implementer - Decisiones

### Enfoque de implementacion
Cambio minimo y localizado: dentro del bloque `services.ConfigureMarten(options => { ... })` ya
existente en cada `ComposicionServicios.cs` (Programacion y ControlHoras), se agregaron las tres
asignaciones que exige MEF-ADR-0034 seccion 7:

```csharp
options.Events.MetadataConfig.CorrelationIdEnabled = true;
options.Events.MetadataConfig.CausationIdEnabled = true;
options.Events.MetadataConfig.HeadersEnabled = true;
```

No se agrego ningun `ConfigureMarten` nuevo en Programacion (la nota tecnica del issue advertia
que ese dominio no tenia ninguno todavia) porque, al leer el archivo, ya exigia uno para el
resolver de serializacion custom (`SubFranja`/`FranjaOrdinaria`/`TurnoCreado`). Se reuso ese mismo
bloque en vez de crear uno adicional -- un solo `ConfigureMarten` por dominio es mas claro que dos
callbacks separados operando sobre el mismo `StoreOptions`.

### Decisiones de diseno
- Se opto por el hook `services.ConfigureMarten(...)` (Marten), no el callback `options => { ... }`
  de `AgregarWolverineParaComandosServerless` (que es de Wolverine/`WolverineOptions`, no expone
  `StoreOptions` de forma directa) -- consistente con la "Propuesta revisable" del issue y con el
  precedente ya usado en ControlHoras.
- Ambos dominios quedaron con exactamente el mismo patron (mismo comentario, mismo orden de las
  tres asignaciones), para que la simetria writer-writer sea trivial de auditar visualmente.

### ADRs consultados
- MEF-ADR-0034 (harness): seccion 7 (columnas de metadata como requisito estructural del writer,
  independiente de OpenTelemetry), seccion 6 guarda 3 (config-test del worker que replicara esta
  configuracion, fuera del alcance de este issue), seccion 2 (named store del read-side reutiliza
  el mismo schema/connection string del write-side).
- MEF-ADR-0029 (harness, citado por el issue): test de composicion como fuente unica de verificacion
  del wiring de `ComposicionServicios{Dominio}.cs` -- ya materializado en este repo en los tests
  `ComposicionServiciosTests` de cada dominio (issue #221).
- ADR local 0007 (`docs/adr/0007-postgresql-compartido-schemas-por-dominio.md`): un schema de Marten
  por dominio (`programacion` y `control_horas`) -- confirma que la migracion de columnas de
  metadata ocurre por schema, no una sola vez para todo el BC.

### Desviaciones de ADRs
Ninguna desviacion -- todos los ADRs aplicados al pie de la letra. La forma canonica de MEF-ADR-0034
seccion 7 se copio literal.

### Desviaciones del plan del planner
Ninguna. Se siguio la "Propuesta revisable" del issue (usar `ConfigureMarten` por consistencia con
el precedente de ControlHoras) sin necesidad de preferir el otro hook: se verifico decompilando
`Cosmos.EventSourcing.CritterStack` 2.1.0 (`WolverineExtensions.AgregarWolverineParaComandosServerless`)
que el callback de Wolverine no expone `StoreOptions` en ningun punto -- delega la construccion de
Marten a `AgregarConfiguracionMartenComandos`, con su propio `Action<MartenRegistry>` interno vacio,
sin gancho para el consumidor. `ConfigureMarten` (registrado por Marten/`AddMarten` sobre el mismo
`IServiceCollection`) es el unico punto de extension directo a `StoreOptions` disponible aqui.

### Precedentes consultados
- `src/Bitakora.ControlAsistencia.ControlHoras/Infraestructura/ComposicionServicios.cs` (bloque
  `ConfigureMarten` preexistente, lineas 64-75 antes del cambio): alineado con MEF-ADR-0034 seccion 7
  una vez sumadas las tres asignaciones -- no se detecto ninguna violacion de ADR en el patron
  existente.

### Infraestructura modificada
Ninguna. Este issue no publica ni consume ningun evento nuevo (no hay `IPublicEventSender` /
`IPrivateEventSender` nuevo, ni un `[ServiceBusTrigger]` nuevo); solo altera configuracion interna
de Marten sobre el schema de eventos ya existente de cada dominio. No aplica ningun cambio en
`infra/environments/dev/main.tf`.

### Riesgo verificado (nota tecnica del issue): migracion de schema en dev
El issue pedia confirmar, no asumir, como se aplica el cambio de schema (las 3 columnas nuevas)
contra Postgres en dev. Verificado por decompilacion (`ilspycmd`) de
`Cosmos.EventSourcing.CritterStack` 2.1.0 y de Marten 9.12.0 (version resuelta en este repo):

- `MartenEventStoreExtensions.AgregarConfiguracionMartenComandos` (el metodo que arma el
  `StoreOptions` real para ambos dominios) NO fija `options.AutoCreateSchemaObjects` en ningun
  valor -- ni en este repo (`grep -rn "AutoCreateSchemaObjects" src/` no devuelve nada) ni en el
  paquete del harness.
- El default de Marten (`StoreOptions.AutoCreateSchemaObjects`, confirmado en el codigo decompilado
  de `Marten.dll` 9.12.0) es `AutoCreate.CreateOrUpdate` -- *"Whether or Marten should attempt to
  create any missing database schema objects at runtime. This property is 'CreateOrUpdate' by
  default for more efficient development"* (comentario XML del propio tipo).
- Conclusion: en dev, con `isDev: true` pasado a `AgregarServiciosProgramacion`/
  `AgregarServiciosControlHoras` (Program.cs de cada dominio) y sin ningun override de
  `AutoCreateSchemaObjects` en este repo, Marten migra el schema de eventos automaticamente en la
  primera operacion real contra Postgres (append/query) -- no hace falta ningun paso manual de DDL
  para que las tres columnas nuevas aparezcan en la tabla de eventos de `programacion` y
  `control_horas`. `isDevelopment` en `AgregarConfiguracionMartenComandos` solo controla
  `OpenTelemetryOptions.TrackConnections` vs `DisableNpgsqlLogging` -- no el modo de creacion de
  schema, que es independiente y ya viene en modo auto-migrable por el default de la libreria.
- Esto **no** aplica igual en un entorno productivo si algun dominio decidiera bajar
  `AutoCreateSchemaObjects` a un valor mas conservador (`CreateOnly`/`None`) -- hoy ningun dominio
  de este repo lo hace, asi que no hay accion pendiente, pero queda documentado por si un ADR futuro
  cambia ese default.

### Complejidad encontrada
Ninguna relevante. El cambio fue de una sola linea logica (tres asignaciones) replicada en dos
archivos ya estructuralmente identicos en el punto de insercion. El unico trabajo adicional fue de
verificacion (decompilacion de paquetes para resolver la "Propuesta revisable" y el "Riesgo a
verificar" del issue sin asumir nada), no de diseño.

### Resultado
- Tests pasando: 458/458 ejecutados (8 omitidos por falta de infra local -- Postgres/ServiceBus no
  configurados, comportamiento esperado y preexistente para smoke tests locales). 0 errores.
- CA-1 a CA-5: cumplidos.

</details>
<details>
<summary>Reviewer (fase refactor) — 9m 55s</summary>

## ES Reviewer - Revision

### Evaluacion general
- Calidad: **buena**
- Cambios realizados: **si** (2 tests agregados; ningun cambio en `src/`)

Baseline al arrancar: verde (458 correctos / 8 omitidos / 0 errores). Sin
`blockage-report.md`. Al cerrar: 468 total, **460 correctos, 8 omitidos, 0 errores**.
Los 8 omitidos son smoke tests sin infra local (`Assert.SkipWhen` por Postgres/ServiceBus
no configurados) - comportamiento esperado y preexistente.

El diff de produccion es minimo, correcto y aplica la forma canonica del ADR **verbatim**.
No toque `src/`: no habia nada que mejorar ahi.

### Cumplimiento de ADRs aplicables

| ADR | Cumplimiento | Observacion |
|---|---|---|
| MEF-ADR-0034 seccion 7: columnas de metadata como requisito del writer | ok | Las tres asignaciones aparecen literales en ambos dominios (`ComposicionServicios.cs:74-76` Programacion, `:80-82` ControlHoras), copiadas tal cual del snippet canonico del ADR. Verificado en runtime, no solo por lectura: el store compuesto reporta `Correlation=True Causation=True Headers=True`. |
| MEF-ADR-0034 seccion 6 guarda 3: replica exacta en el worker | ok (fuera de alcance) | El worker no existe todavia. Este diff crea el **lado de referencia** que la guarda 3 debera replicar; deja el issue del worker desbloqueado. Nada que verificar aqui. |
| MEF-ADR-0029: test de composicion como fuente unica del wiring | ok | Los tests nuevos extienden los `ComposicionServiciosTests` existentes e invocan el mismo `AgregarServicios{Dominio}` que `Program.cs`. Sin wiring duplicado. Se resuelve `IDocumentStore` desde un scope (`ValidateScopes = true` lo exige). |
| MEF-ADR-0003 / ADR-0007 local: un schema Marten por dominio | ok | Cada dominio configura su propio `StoreOptions` (`programacion` y `control_horas` como schema); la habilitacion se hizo dos veces, una por schema, como corresponde. No se intento centralizar (habria sido incorrecto). |
| MEF-ADR-0012: encapsulamiento / Tell-don't-Ask | n/a | Recorri los 7 antipatrones del checklist: el diff no agrega VOs, propiedades publicas de dominio, clases estaticas sobre datos crudos, `[JsonConstructor]`, `InternalsVisibleTo` ni eventos con marker de bus. `IReadonlyMetadataConfig` es tipo del framework Marten, no estado de dominio expuesto. |

El issue **si** traia seccion `## ADRs aplicables` completa y bien poblada. Nada que escalar al planner.

### Desviaciones de ADRs

**Ninguna desviacion - todos los ADRs aplicables se cumplen.**

El implementer declaro "ninguna desviacion" y lo confirmo: no encontre desviaciones
declaradas ni **no declaradas**. Dos puntos donde el implementer resolvio bien una
ambiguedad del planner, sin que constituyan desviacion:

1. El issue afirmaba que "en Programacion **no hay** ningun `ConfigureMarten` todavia".
   Es **incorrecto**: ya existia uno (resolver de `SubFranja`/`FranjaOrdinaria`/`TurnoCreado`).
   Tanto el test-writer como el implementer lo detectaron y reusaron el bloque existente en
   vez de agregar un segundo callback. Decision correcta: dos callbacks sobre el mismo
   `StoreOptions` habrian sido mas opacos.
2. La "Propuesta revisable" (`ConfigureMarten` vs el callback de
   `AgregarWolverineParaComandosServerless`) se resolvio a favor de `ConfigureMarten` con
   verificacion real (decompilacion), no por inercia del precedente.

### Precedentes consultados por el implementer

| Precedente | ADR aplicable | Veredicto |
|---|---|---|
| `ControlHoras/Infraestructura/ComposicionServicios.cs` (bloque `ConfigureMarten` preexistente) | MEF-ADR-0034 seccion 7 | **alineado**. Pero ver "Criticas": ese precedente contiene un `if` que puede omitir el resolver en silencio - no viola ningun ADR, y ahora queda cubierto por los tests que agregue. |

### Convenciones del pipeline (no ADRs)

| Convencion | Estado | Observacion |
|---|---|---|
| Cada test con `Then()` + `And<>()` | n/a | Tests de composicion de DI, no heredan de `CommandHandlerAsyncTest<T>`. El DSL aplica a handlers/aggregates. Correctamente clasificado por el test-writer. |
| Overloads correctos para stream IDs compuestos | n/a | Sin aggregates ni eventos en el diff. |
| Fakes manuales (no NSubstitute) | ok | Cero mocks: el test usa el contenedor DI real con connection strings dummy. |
| Feature folders (produccion y tests) | ok | `Infraestructura/` a nivel raiz en ambos lados; los tests espejan la ruta de produccion. |
| Smoke tests: SkipWhen, secrets, cobertura | n/a (con nota) | El diff no agrega smoke tests y no lo necesita: no hay efecto secundario nuevo (ni topic, ni evento, ni endpoint). Ver "Criticas" punto 3 sobre el rol de canario que los smoke tests existentes cumplen para la migracion. |
| Proyecciones read-side | n/a | Issue write-side puro; ningun artefacto de `ReadModels`/`Projections`. |
| Tests via ToString/comportamiento | ok | Los tests que agregue verifican por igualdad de valor y `ToString()`, no por getters de estado interno. |
| Sin numeros magicos | ok | Las horas de los VOs son datos de fixture, consistentes con los tests de serializacion vecinos. Los dummies de conexion ya estaban en constantes con nombre. |
| Condiciones en positivo | ok | El unico `if` del bloque (`is SystemTextJsonSerializer stj`) es afirmativo y es un type-pattern, no una guarda negada. |
| Caracter U+2500 prohibido | ok | 0 ocurrencias en los 4 archivos. |
| `dotnet format` | ok en el diff | Ningun aviso en los 4 archivos tocados. Quedan 6 avisos `IDE0005` **preexistentes** en archivos ajenos a la rama (ver "Criticas" punto 4). |

### Elegancia del codigo

El codigo de produccion ya era elegante y **no lo toque**. Dos decisiones que evalue y
deliberadamente dejé como estan:

- **Repetir `options.Events.MetadataConfig` tres veces** en vez de extraer un local
  (`var metadata = ...`). Compactarlo seria un micro-refactor tentador, pero MEF-ADR-0034
  seccion 7 fija esa cadena completa como forma canonica y la guarda 3 del futuro config-test
  del worker se va a comparar contra esta forma. La legibilidad literal contra el ADR vale
  mas que ahorrar dos repeticiones.
- **Duplicar las 3 lineas + comentario entre los dos dominios.** Estan en 2 lugares, debajo
  del umbral de la Rule of Three (ADR-0024 local), y extraerlas exigiria una biblioteca de
  infraestructura compartida que no existe - `Contracts` no puede alojarlas (ADR-0025: solo
  DTOs planos). Ademas MEF-ADR-0034 seccion 7 asigna explicitamente la responsabilidad al
  write-side **de cada dominio**. Correcto como esta; cuando aparezca un tercer dominio, ahi
  si se dispara la extraccion.

El comentario de 5 lineas replicado en 4 archivos es verboso en terminos absolutos, pero es
exactamente el estilo documentado del repo (los mismos archivos ya abren con encabezados
multi-parrafo que citan issue y root cause) y explica un *por que* genuinamente no obvio
(el opt-in de Marten). Sin hallazgo.

### Criticas y hallazgos

1. **[mayor - corregido] CA-5 estaba cubierto solo de forma indirecta, y el hueco era real.**
   CA-5 nombra explicitamente el riesgo: *"en particular la configuracion de serializacion
   custom de ControlHoras, que hoy tambien se registra via `ConfigureMarten`"*. El
   test-writer lo delego a "que pase toda la suite". Al revisarlo encontre que **ningun test
   del repo verifica el serializador que el contenedor realmente compone**: los round-trip
   existentes (`IntervaloTemporalSerializacionMartenTests`, `TurnoCreadoSerializacionTests`)
   usan `CrearOpcionesMarten()` u opciones replicadas a mano - rutas **paralelas** que no
   atraviesan `ComposicionServicios`. Como las banderas de metadata ahora viven en el mismo
   callback que el resolver, un edit futuro de ese bloque podia tumbar la serializacion
   dejando el test de metadata en verde. Agregue un test por dominio que ejercita el
   `ISerializer` del store compuesto. **Validado por sabotaje** (no asumido): al comentar
   `ConfigurarResolver`/`SubFranja.ConfigurarSerializacion`, solo el test nuevo se pone rojo
   y el de metadata sigue verde - prueba de que cubre un hueco real y no es falso verde.

2. **[menor - documentado, no corregido] El `if (options.Serializer() is SystemTextJsonSerializer stj)`
   omite el resolver en silencio.** Si el serializador dejara de ser STJ, el bloque entero se
   salta sin excepcion ni log, y tipos como `IntervaloTemporal`/`SubFranja` (campos privados,
   sin propiedades publicas) fallarian o llegarian lossy. Es **preexistente**, no introducido
   por este diff, y cambiarlo a un `else` que lance excederia el alcance del issue (rule 4).
   Queda cubierto por deteccion: los tests del punto 1 se ponen rojos si esa rama se salta.

3. **[menor - verificado] El riesgo de migracion que el issue exigia "no asumir" quedo confirmado
   empiricamente, no por lectura.** El implementer lo verifico por decompilacion; lo
   reverifique **en runtime** resolviendo el store del contenedor real:
   `AutoCreateSchemaObjects=CreateOrUpdate`, banderas en `True`, `MartenVersion=9.12.0`. Con
   `CreateOrUpdate` Marten agrega las columnas faltantes en la primera operacion real contra
   Postgres, sin DDL manual, y nunca dropea columnas (los eventos ya persistidos quedan con
   `NULL` en las nuevas). Confirmado ademas que el repo no override `AutoCreateSchemaObjects`
   en ningun lado. La verificacion de la migracion real en dev sigue siendo post-deploy: los
   smoke tests existentes de ambos dominios ya escriben eventos, asi que actuan como canario
   tal como el issue anticipaba - no hace falta un smoke test nuevo.

4. **[cosmetico - no corregido, deuda ajena] `dotnet format --verify-no-changes` sale con codigo 2**
   por 6 avisos `IDE0005` (usings innecesarios) en archivos que **esta rama no toca**
   (`SolicitarProgramacionTurno.cs`, `ConsolidadorDesgloseHorasPuenteTests.cs`, 2 smoke tests,
   2 tests de Programacion). Verifique que son preexistentes: el diff vs `main` son solo 4
   archivos, y ninguno de los 6 esta entre ellos. No los corregi por rule 4 (no refactorizar
   codigo ajeno a la HU): meterlos aqui ensuciaria un PR sobre columnas de metadata. **Vale un
   issue de limpieza aparte.** Nota positiva: el implementer si limpio los 2 `IDE0005` que
   existian en los archivos que si tocaba (`using Microsoft.Extensions.Hosting` en ambos
   `ComposicionServicios.cs`) - higiene correcta y en alcance.

5. **[cosmetico] Inconsistencia de version de Marten entre resumenes.** El test-writer documento
   Marten 9.2.1; el implementer, 9.12.0. La version real resuelta es **9.12.0** (confirmado en
   `project.assets.json` y en runtime). El test-writer verifico contra el paquete equivocado del
   cache local. No afecta al resultado (la cadena de lectura y el default de auto-create son
   iguales en ambas), pero conviene que las verificaciones por decompilacion confirmen la version
   resuelta antes de citarla.

### Refactorings aplicados

Ninguno en `src/`: el codigo de produccion estaba correcto, minimo y alineado al ADR. Los dos
micro-refactors candidatos (extraer local para `MetadataConfig`, deduplicar entre dominios) se
evaluaron y se descartaron con justificacion - ver "Elegancia del codigo". No refactorizar fue
aqui el resultado correcto.

### Cobertura de criterios de aceptacion

| Criterio | Estado | Test(s) |
|---|---|---|
| CA-1: `AgregarServiciosProgramacion` deja las 3 banderas en `true` | cubierto | `AgregarServiciosProgramacion_HabilitaColumnasDeMetadataDeEvento_CuandoElContenedorEstaCompuesto` |
| CA-2: `AgregarServiciosControlHoras` deja las mismas 3 banderas en `true` | cubierto | `AgregarServiciosControlHoras_HabilitaColumnasDeMetadataDeEvento_CuandoElContenedorEstaCompuesto` |
| CA-3: test de composicion de Programacion verifica sobre el `IDocumentStore` resuelto, sin Postgres | cubierto | mismo test de CA-1 (resuelve del contenedor real con connection strings dummy) |
| CA-4: idem para ControlHoras | cubierto | mismo test de CA-2 |
| CA-5: `dotnet test` pasa completo y el wiring existente no se rompe (en particular la serializacion custom de ControlHoras) | **cubierto (reforzado en esta fase)** | Suite completa verde (460/468, 8 omitidos por infra) + los 2 tests nuevos: `AgregarServiciosControlHoras_ConservaLaSerializacionCustom_CuandoTambienHabilitaMetadataDeEvento` y `AgregarServiciosProgramacion_ConservaLaSerializacionCustom_CuandoTambienHabilitaMetadataDeEvento`. Antes solo estaba cubierto por "la suite pasa". |

### Tests agregados

- `AgregarServiciosControlHoras_ConservaLaSerializacionCustom_CuandoTambienHabilitaMetadataDeEvento`
  (round-trip de `IntervaloTemporal` con el `ISerializer` del store compuesto).
- `AgregarServiciosProgramacion_ConservaLaSerializacionCustom_CuandoTambienHabilitaMetadataDeEvento`
  (round-trip de `SubFranja` idem).

Ambos son tests de **contrato de wiring** (verifican que la composicion preserva el resolver),
no de comportamiento de negocio: generarlos en fase refactor no viola TDD. Ambos verificados por
sabotaje para descartar falso verde. Nombres segun MEF-ADR-0016
(`<Sujeto>_<LoQuePasa>_Cuando<Condicion>`, sujeto = metodo bajo prueba, consistente con sus
vecinos).

No agregue tests de `IgualdadTestBase<T>` ni de round-trip por bus: el diff no introduce VOs
nuevos ni eventos con marker de bus.

### Commit

`6296169 test(issue-232): guardrail de composicion para la serializacion custom` (solo `tests/`).

</details>

## Cobertura

| Archivo | Cobertura | Umbral | Estado |
|---|---|---|---|
| ComposicionServicios.cs | - | no evaluado | - |
| ComposicionServicios.cs | - | no evaluado | - |
## Commits

6296169 test(issue-232): guardrail de composicion para la serializacion custom
a4d4c0b feat(issue-232): habilitar columnas de metadata de evento en el write-side
f071173 test(issue-232): tests de composicion para columnas de metadata de evento (fase roja)

Closes #232