### PR TITLE
Adoptar el prefijo CA-ADR- en los ADRs del proyecto

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,26 +140,26 @@ Si tu trabajo toca uno de estos temas, consulta el ADR correspondiente antes de 
 
 | Tema | ADR |
 |---|---|
-| **Encapsulamiento, Tell-don't-Ask, ocultación de estado interno (aplica por igual a aggregates y a value objects)** | ADR-0015 |
-| Serialización, value objects con ctor privado, records vs sealed class, `ConfigurarSerializacion`, proscripción de `[JsonConstructor]` | ADR-0015 |
-| Manejo de errores en event sourcing, eventos de fallo, no-throw en `Apply()` | ADR-0007 |
-| Naming de eventos, versionado | ADR-0005 |
-| Naming de funciones Azure (HTTP y Service Bus) | ADR-0008 |
-| Topics y subscriptions de Service Bus, un topic por evento | ADR-0004 |
-| Estrategia de testing con event sourcing, DSL de tests | ADR-0006 |
-| Contracts: eventos públicos y value objects compartidos | ADR-0002 |
-| Mensajes en `.resx` por aggregate/handler | ADR-0012 |
+| **Encapsulamiento, Tell-don't-Ask, ocultación de estado interno (aplica por igual a aggregates y a value objects)** | MEF-ADR-0012 |
+| Serialización, value objects con ctor privado, records vs sealed class, `ConfigurarSerializacion`, proscripción de `[JsonConstructor]` | MEF-ADR-0012 |
+| Manejo de errores en event sourcing, eventos de fallo, no-throw en `Apply()` | MEF-ADR-0004 |
+| Naming de eventos, versionado | MEF-ADR-0005 |
+| Naming de funciones Azure (HTTP y Service Bus) | MEF-ADR-0006 |
+| Topics y subscriptions de Service Bus, un topic por evento | MEF-ADR-0001 |
+| Estrategia de testing con event sourcing, DSL de tests | MEF-ADR-0002 |
+| Contracts: eventos públicos y value objects compartidos | CA-ADR-0002 |
+| Mensajes en `.resx` por aggregate/handler | MEF-ADR-0009 |
 | Definition of Ready | MEF-ADR-0011 |
-| Smoke tests contra entorno dev | ADR-0016 |
+| Smoke tests contra entorno dev | MEF-ADR-0013 |
 | Worker de proyecciones read-side, proyecciones Marten (read models), Functions HTTP GET de consulta | MEF-ADR-0034, MEF-ADR-0035 |
-| Snapshots de Marten (excepción) | ADR-0021 |
-| Convención de nombres para métodos de test (`<Sujeto>_<LoQuePasa>_Cuando<Condicion>`) | ADR-0022 |
-| Archivo señal de refactor puro vive en `pipeline-state/` (fuera de `.claude/`) | ADR-0023 |
-| Extracción vs duplicación, Rule of Three, evolución del código | ADR-0024 |
-| El modelo de dominio rico vive en el dominio y no cruza el bus; Contracts solo DTOs planos | ADR-0025 |
-| Custodia de secretos: connection strings en Key Vault, referencias `@Microsoft.KeyVault(...)`, `AzureWebJobsStorage` por identidad administrada | ADR-0026 |
-| Estrategia de tenancy mono-tenant, `ITenantResolver` de valores fijos | ADR-0027 |
-| Biblioteca `{Dominio}.Dominio` como frontera entre write-side y read-side; a qué proyecto referencia el worker de proyecciones para ver tipos de evento del aggregate | ADR-0028 |
+| Snapshots de Marten (excepción) | MEF-ADR-0015 |
+| Convención de nombres para métodos de test (`<Sujeto>_<LoQuePasa>_Cuando<Condicion>`) | MEF-ADR-0016 |
+| Archivo señal de refactor puro vive en `pipeline-state/` (fuera de `.claude/`) | MEF-ADR-0017 |
+| Extracción vs duplicación, Rule of Three, evolución del código | MEF-ADR-0018 |
+| El modelo de dominio rico vive en el dominio y no cruza el bus; Contracts solo DTOs planos | CA-ADR-0025 |
+| Custodia de secretos: connection strings en Key Vault, referencias `@Microsoft.KeyVault(...)`, `AzureWebJobsStorage` por identidad administrada | CA-ADR-0026 |
+| Estrategia de tenancy mono-tenant, `ITenantResolver` de valores fijos | CA-ADR-0027 |
+| Biblioteca `{Dominio}.Dominio` como frontera entre write-side y read-side; a qué proyecto referencia el worker de proyecciones para ver tipos de evento del aggregate | CA-ADR-0028 |
 
 Si una regla no aparece en ADRs pero la descubres repetida en varios lugares del proyecto, **propón un ADR** antes de replicarla en agentes.
 

--- a/docs/adr/ca-adr-0001-function-app-por-dominio.md
+++ b/docs/adr/ca-adr-0001-function-app-por-dominio.md
@@ -1,4 +1,4 @@
-# ADR-0001: Function App por dominio
+# CA-ADR-0001: Function App por dominio
 
 ## Estado
 

--- a/docs/adr/ca-adr-0002-contracts-eventos-y-value-objects.md
+++ b/docs/adr/ca-adr-0002-contracts-eventos-y-value-objects.md
@@ -1,4 +1,4 @@
-# ADR-0002: Proyecto Contracts para eventos y value objects compartidos
+# CA-ADR-0002: Proyecto Contracts para eventos y value objects compartidos
 
 ## Estado
 
@@ -47,5 +47,5 @@ unicamente este proyecto.
 **Negativas**
 
 - Cambios breaking en un contrato (renombrar un campo, cambiar un tipo) requieren coordinar
-  la actualizacion de todos los consumidores antes de desplegar. Ver ADR-0005 para la
+  la actualizacion de todos los consumidores antes de desplegar. Ver MEF-ADR-0005 para la
   estrategia de versionado que mitiga este riesgo.

--- a/docs/adr/ca-adr-0003-tests-separados-por-dominio.md
+++ b/docs/adr/ca-adr-0003-tests-separados-por-dominio.md
@@ -1,4 +1,4 @@
-# ADR-0003: Proyectos de tests separados por dominio
+# CA-ADR-0003: Proyectos de tests separados por dominio
 
 ## Estado
 

--- a/docs/adr/ca-adr-0004-service-bus-topics-por-dominio.md
+++ b/docs/adr/ca-adr-0004-service-bus-topics-por-dominio.md
@@ -1,4 +1,4 @@
-# ADR-0004: Service Bus - un topic por dominio productor
+# CA-ADR-0004: Service Bus - un topic por dominio productor
 
 ## Estado
 
@@ -26,7 +26,7 @@ requeriria modificar el productor.
 ## Decision
 
 Se usa un topic de Service Bus por dominio productor. El naming de los recursos sigue la
-convencion definida en ADR-0005:
+convencion definida en MEF-ADR-0005:
 
 - Topics: `eventos-{dominio-en-kebab}` (e.g. `eventos-marcaciones`, `eventos-empleados`)
 - Subscriptions: `{consumidor}-escucha-{productor}` (e.g. `liquidacion-escucha-marcaciones`)

--- a/docs/adr/ca-adr-0007-postgresql-compartido-schemas-por-dominio.md
+++ b/docs/adr/ca-adr-0007-postgresql-compartido-schemas-por-dominio.md
@@ -1,4 +1,4 @@
-# ADR-0007: PostgreSQL compartido con schemas separados por dominio
+# CA-ADR-0007: PostgreSQL compartido con schemas separados por dominio
 
 ## Estado
 
@@ -6,7 +6,7 @@ Aceptado
 
 ## Contexto
 
-Marten (el event store adoptado en ADR-0006) requiere una base de datos PostgreSQL. Hay que
+Marten (el event store adoptado en MEF-ADR-0003) requiere una base de datos PostgreSQL. Hay que
 decidir como organizar esa base de datos dado que el sistema tiene multiples dominios, cada
 uno con su propia Function App.
 

--- a/docs/adr/ca-adr-0009-control-costos-application-insights.md
+++ b/docs/adr/ca-adr-0009-control-costos-application-insights.md
@@ -1,4 +1,4 @@
-# ADR-0009: Control de costos de Application Insights
+# CA-ADR-0009: Control de costos de Application Insights
 
 ## Estado
 

--- a/docs/adr/ca-adr-0017-configuracion-service-bus-prefetch-lock.md
+++ b/docs/adr/ca-adr-0017-configuracion-service-bus-prefetch-lock.md
@@ -1,4 +1,4 @@
-# ADR-0017: Configuracion de prefetchCount y manejo de MessageLockLost en Service Bus
+# CA-ADR-0017: Configuracion de prefetchCount y manejo de MessageLockLost en Service Bus
 
 ## Estado
 
@@ -8,7 +8,7 @@ Aceptado
 
 Un incidente el 2026-04-10 genero multiples errores `ServiceBusException: MessageLockLost` en la
 funcion `AsignarTurnoCuandoProgramacionTurnoDiarioSolicitada` (dominio ControlHoras). La alerta
-de pico de excepciones (ADR-0009) detecto 8 fallos en 22 segundos.
+de pico de excepciones (CA-ADR-0009) detecto 8 fallos en 22 segundos.
 
 La causa raiz fue la combinacion de tres factores:
 
@@ -73,7 +73,7 @@ Si en el futuro se sube prefetchCount, se debera revisar lock_duration proporcio
 ### Positivas
 
 - Elimina la posibilidad de `MessageLockLost` por mensajes esperando en buffer de prefetch.
-- Las alertas de excepciones (ADR-0009) reflejan errores reales, no cascadas de infraestructura.
+- Las alertas de excepciones (CA-ADR-0009) reflejan errores reales, no cascadas de infraestructura.
 - Impacto en throughput despreciable (~0.3s por 100 mensajes con procesamiento secuencial).
 
 ### Negativas

--- a/docs/adr/ca-adr-0019-kql-ad-hoc-con-guardrails.md
+++ b/docs/adr/ca-adr-0019-kql-ad-hoc-con-guardrails.md
@@ -1,4 +1,4 @@
-# ADR-0019: KQL ad-hoc con guardrails
+# CA-ADR-0019: KQL ad-hoc con guardrails
 
 **Fecha**: 2026-04-13
 **Estado**: Aceptado
@@ -7,7 +7,7 @@
 
 ## Contexto
 
-ADR-0009 establecio un daily cap de 0.5GB en App Insights y restringio las consultas a 5 queries
+CA-ADR-0009 establecio un daily cap de 0.5GB en App Insights y restringio las consultas a 5 queries
 KQL predefinidas en `scripts/appinsights-query.sh`. Esto fue una reaccion correcta al incidente
 de $350 USD en 3 dias por logging excesivo.
 
@@ -18,7 +18,7 @@ procesaron en la ultima hora?"). Esta limitacion degrada la capacidad diagnostic
 proporcional en control de costos -- una query ad-hoc con `take 20` y ventana de 1h tiene impacto
 marginal vs el daily cap de 0.5GB.
 
-Las 4 capas defensivas de ADR-0009 (log levels, sampling, daily cap, alertas) siguen intactas.
+Las 4 capas defensivas de CA-ADR-0009 (log levels, sampling, daily cap, alertas) siguen intactas.
 Esta decision solo relaja la restriccion de "solo queries predefinidas".
 
 ## Decision
@@ -33,7 +33,7 @@ con guardrails automaticos inyectados por el script:
    `| where timestamp > ago(1h)` como filtro. Las queries predefinidas usan 24h; la ventana
    reducida de 1h limita el volumen de datos escaneados.
 
-3. **Warning visible**: se imprime `ADVERTENCIA: query ad-hoc. Daily cap: 0.5GB. Ver ADR-0009.`
+3. **Warning visible**: se imprime `ADVERTENCIA: query ad-hoc. Daily cap: 0.5GB. Ver CA-ADR-0009.`
    en stderr antes de ejecutar. Esto es visible tanto para humanos como para agentes.
 
 4. **Audit log**: cada ejecucion se registra en `scripts/.kql-audit.log` con timestamp y query
@@ -50,7 +50,7 @@ El agente `bug-investigator` puede usar hasta 3 queries custom por sesion, solo 
   queries predefinidas son insuficientes.
 - Los guardrails automaticos evitan queries costosas sin depender de la disciplina del invocador.
 - El audit log permite detectar patrones de uso excesivo o abuso.
-- Las 4 capas defensivas de ADR-0009 permanecen intactas.
+- Las 4 capas defensivas de CA-ADR-0009 permanecen intactas.
 
 **Negativas**
 

--- a/docs/adr/ca-adr-0020-version-dotnet-plan-hosting-azure-functions.md
+++ b/docs/adr/ca-adr-0020-version-dotnet-plan-hosting-azure-functions.md
@@ -1,4 +1,4 @@
-# ADR-0020: Versión de .NET y plan de hosting Azure Functions
+# CA-ADR-0020: Versión de .NET y plan de hosting Azure Functions
 
 ## Estado
 
@@ -6,7 +6,7 @@ Aceptado
 
 ## Contexto
 
-El proyecto usa Azure Functions isolated worker como plataforma de despliegue (ver ADR-0001). Al migrar a .NET 10 en abril 2026 se descubrió que **el plan Consumption Y1 no soporta .NET 10**: la Function App responde con 503 y nunca arranca porque las imágenes de contenedor de Y1 no incluyen el runtime .NET 10.
+El proyecto usa Azure Functions isolated worker como plataforma de despliegue (ver CA-ADR-0001). Al migrar a .NET 10 en abril 2026 se descubrió que **el plan Consumption Y1 no soporta .NET 10**: la Function App responde con 503 y nunca arranca porque las imágenes de contenedor de Y1 no incluyen el runtime .NET 10.
 
 Los diagnósticos iniciales apuntaron incorrectamente al código (errores tipo "malformed content", "sync trigger failed") cuando el problema real era combinado: plan de hosting inadecuado, variables de entorno faltantes y flags de publish incorrectos. Sin una decisión documentada, cada nuevo dominio corre riesgo de replicar el error.
 
@@ -66,7 +66,7 @@ Sin `-r linux-x64 --self-contained false` el artefacto no corre correctamente en
 
 ## Referencias
 
-- ADR-0001: Function App por dominio
+- CA-ADR-0001: Function App por dominio
 - Módulo Terraform: `infra/modules/service-plan/main.tf` (SKU default B1)
 - Módulo Terraform: `infra/modules/function-app/main.tf` (app_settings)
 - Agente `domain-scaffolder`: genera workflows con los flags correctos

--- a/docs/adr/ca-adr-0025-el-modelo-de-dominio-rico-no-cruza-el-bus.md
+++ b/docs/adr/ca-adr-0025-el-modelo-de-dominio-rico-no-cruza-el-bus.md
@@ -1,4 +1,4 @@
-# ADR-0025: El modelo de dominio rico no cruza el bus
+# CA-ADR-0025: El modelo de dominio rico no cruza el bus
 
 ## Estado
 
@@ -24,7 +24,7 @@ serializa nativamente sin resolver custom. `#184` poblo su trazabilidad. Tras am
 `IPublicEvent` referencia ya el modelo rico**: solo lo consume el propio dominio.
 
 Quedaba la deuda de ubicacion: tipos de dominio interno alojados en `Contracts`, el proyecto que
-ADR-0002 reserva para el vocabulario que cruza entre dominios.
+CA-ADR-0002 reserva para el vocabulario que cruza entre dominios.
 
 ## Decision
 
@@ -57,6 +57,6 @@ antes de publicar (patron `Discriminar()` de `DesgloseHoras`).
   por defecto debe pasar; los tipos ricos fallarian con `NotSupportedException`).
 - `DetalleRetardo` se renombro a `Retardo` (termino del glosario) al salir de `Contracts`: ya no
   necesita el prefijo `Detalle` que sugeria un DTO de contrato.
-- Refuerza ADR-0002 (Contracts = vocabulario cross-domain plano) y convive con el ADR de
+- Refuerza CA-ADR-0002 (Contracts = vocabulario cross-domain plano) y convive con el ADR de
   serializacion (value objects con ctor privado + `ConfigurarSerializacion`), que ahora se entiende
   como mecanismo exclusivo del event store interno.

--- a/docs/adr/ca-adr-0026-custodia-de-secretos.md
+++ b/docs/adr/ca-adr-0026-custodia-de-secretos.md
@@ -1,4 +1,4 @@
-# ADR-0026: Custodia de secretos (connection strings en Key Vault)
+# CA-ADR-0026: Custodia de secretos (connection strings en Key Vault)
 
 ## Estado
 
@@ -6,16 +6,16 @@ Aceptado
 
 ## Contexto
 
-El harness (Mefisto) aceptó el 2026-07-01 el **ADR-0025 "Custodia de secretos"** (`docs/adr/0025-custodia-de-secretos.md` del plugin `mefisto@augusto-romero-arango-harness`, resuelto vía `.claude/pipeline/.plugin-root`). Su doctrina raíz: **ningún secreto ni key debe viajar en texto plano en los app settings de una Function App, ni materializarse en el state de Terraform**. Todo secreto se custodia en el Key Vault del bounded context y se referencia con `@Microsoft.KeyVault(SecretUri=...)` versionless, o se resuelve por identidad administrada cuando el runtime lo exige antes de poder resolver referencias de Key Vault. ADR-0025 del harness generaliza su ADR-0024 decisión #6, que sólo cubría las cadenas de Azure Service Bus.
+El harness (Mefisto) aceptó el 2026-07-01 el **MEF-ADR-0025 "Custodia de secretos"** (`docs/adr/mef-adr-0025-custodia-de-secretos.md` del plugin `mefisto@augusto-romero-arango-harness`, resuelto vía `.claude/pipeline/.plugin-root`). Su doctrina raíz: **ningún secreto ni key debe viajar en texto plano en los app settings de una Function App, ni materializarse en el state de Terraform**. Todo secreto se custodia en el Key Vault del bounded context y se referencia con `@Microsoft.KeyVault(SecretUri=...)` versionless, o se resuelve por identidad administrada cuando el runtime lo exige antes de poder resolver referencias de Key Vault. MEF-ADR-0025 del harness generaliza su MEF-ADR-0024 decisión #6, que sólo cubría las cadenas de Azure Service Bus.
 
-Una auditoría de nuestro proyecto frente a esa doctrina encontró que **los cuatro secretos que ADR-0025 clasifica están hoy en texto plano** en `infra/environments/dev/main.tf`:
+Una auditoría de nuestro proyecto frente a esa doctrina encontró que **los cuatro secretos que MEF-ADR-0025 clasifica están hoy en texto plano** en `infra/environments/dev/main.tf`:
 
 - Cadena de Azure Service Bus (`SERVICE_BUS_CONNECTION`), desde `module.service_bus.default_primary_connection_string`.
 - Password de PostgreSQL embebido en `MartenConnectionString` (`...Password=${var.postgresql_admin_password}...`).
 - Connection string de Application Insights (`APPLICATIONINSIGHTS_CONNECTION_STRING`, incluye la instrumentation key), desde `module.monitoring.connection_string`.
 - Access key de la Storage Account del host (`AzureWebJobsStorage`), vía `storage_account_access_key` nativo del módulo `function-app`.
 
-Cualquiera con lectura del recurso Function App, o del state de Terraform donde el valor también se materializa, ve estos secretos en claro. Además, a diferencia del harness, **no tenemos provisionado ningún Key Vault ni módulo Terraform** para custodiarlos; ni siquiera adoptamos ADR-0024 decisión #6.
+Cualquiera con lectura del recurso Function App, o del state de Terraform donde el valor también se materializa, ve estos secretos en claro. Además, a diferencia del harness, **no tenemos provisionado ningún Key Vault ni módulo Terraform** para custodiarlos; ni siquiera adoptamos MEF-ADR-0024 decisión #6.
 
 Este ADR **no toca código ni infra**: registra formalmente la adopción de la doctrina del harness en el proyecto y fija el mapa concreto de secretos que los issues de infra implementan (#195 provisiona el vault; #196 conmuta las referencias; #197 migra el storage a identidad administrada).
 
@@ -23,7 +23,7 @@ Este ADR **no toca código ni infra**: registra formalmente la adopción de la d
 
 ### 1. Adoptamos la doctrina del harness por referencia, sin duplicarla
 
-Adoptamos **ADR-0025 del harness** como doctrina de manejo de secretos del proyecto. No reproducimos su contenido: es la fuente de verdad de la regla, y por convención de este proyecto los ADRs no duplican reglas de ADRs del harness (los consultan, aplican y documentan sus desviaciones). Este ADR registra únicamente **la adaptación propia**: el mapa concreto de secretos, las divergencias con el harness y los caveats de nuestra migración brownfield.
+Adoptamos **MEF-ADR-0025 del harness** como doctrina de manejo de secretos del proyecto. No reproducimos su contenido: es la fuente de verdad de la regla, y por convención de este proyecto los ADRs no duplican reglas de ADRs del harness (los consultan, aplican y documentan sus desviaciones). Este ADR registra únicamente **la adaptación propia**: el mapa concreto de secretos, las divergencias con el harness y los caveats de nuestra migración brownfield.
 
 El principio que adoptamos, enunciado: **un app setting nunca contiene el valor de un secreto** (cadena de conexión con password, access key, instrumentation key, token). Lleva una referencia `@Microsoft.KeyVault(SecretUri=...)` versionless, o el secreto se resuelve por identidad administrada. El principio aplica por igual al recurso desplegado y al **state de Terraform**: Terraform no materializa el valor de ningún secreto.
 
@@ -42,9 +42,9 @@ El nombre `marten-connection` se respeta tal cual el harness lo ancla en `agents
 
 El código de ambos dominios (`Program.cs`) lee `SERVICE_BUS_CONNECTION` y `MartenConnectionString` como variables de entorno por su nombre. Migrar la custodia **no requiere tocar C#**: las claves de app setting se conservan idénticas; sólo el **valor** pasa de literal a referencia `@Microsoft.KeyVault(SecretUri=...)`.
 
-### 4. Divergencia con la topología de ADR-0024 del harness
+### 4. Divergencia con la topología de MEF-ADR-0024 del harness
 
-**No adoptamos la topología de bus interno/externo de ADR-0024** (harness). Usamos un único namespace `sb-${prefix}` y un único app setting `SERVICE_BUS_CONNECTION`, sin bloque `serviceBus` en `.claude/harness.config.json`. Por eso nuestro mapa de secretos difiere de la implementación de referencia del harness (`infra-base-scaffolder`, que usa prefijos `sbint-` y app settings `SERVICE_BUS_CONNECTION_<ALIAS>`): tenemos **un** secreto `service-bus-connection`, no uno por alias de bus. Esa migración a la topología interno/externo queda **fuera del alcance** de este ADR y de los issues de custodia.
+**No adoptamos la topología de bus interno/externo de MEF-ADR-0024** (harness). Usamos un único namespace `sb-${prefix}` y un único app setting `SERVICE_BUS_CONNECTION`, sin bloque `serviceBus` en `.claude/harness.config.json`. Por eso nuestro mapa de secretos difiere de la implementación de referencia del harness (`infra-base-scaffolder`, que usa prefijos `sbint-` y app settings `SERVICE_BUS_CONNECTION_<ALIAS>`): tenemos **un** secreto `service-bus-connection`, no uno por alias de bus. Esa migración a la topología interno/externo queda **fuera del alcance** de este ADR y de los issues de custodia.
 
 ### 5. `AzureWebJobsStorage` va por identidad administrada, no por Key Vault
 
@@ -54,16 +54,16 @@ El runtime de Azure Functions necesita el storage del host **al arrancar**, ante
 
 El **valor** de cada secreto de Key Vault se coloca de forma administrativa fuera del ciclo de Terraform y del repo (`az keyvault secret set`), nunca por Terraform. El proyecto provisiona por Terraform únicamente (a) la referencia en app settings y (b) el rol **Key Vault Secrets User** de la managed identity de la Function App. Consecuencia operativa: entre provisionar el vault (#195) y conmutar las referencias (#196) hay una siembra manual obligatoria; conmutar antes de sembrar deja a las Function Apps sin poder resolver las referencias al arrancar.
 
-### 7. Application Insights NO se custodia en Key Vault (divergencia con ADR-0025)
+### 7. Application Insights NO se custodia en Key Vault (divergencia con MEF-ADR-0025)
 
-ADR-0025 del harness clasifica la connection string de Application Insights como secreto a custodiar en Key Vault (por incluir la instrumentation key). **Divergimos de esa clasificación**: se configura como **valor directo** (`module.monitoring.connection_string`), no como referencia `@Microsoft.KeyVault(...)`.
+MEF-ADR-0025 del harness clasifica la connection string de Application Insights como secreto a custodiar en Key Vault (por incluir la instrumentation key). **Divergimos de esa clasificación**: se configura como **valor directo** (`module.monitoring.connection_string`), no como referencia `@Microsoft.KeyVault(...)`.
 
 Razones, según la guía oficial de Microsoft:
 
 - La connection string de App Insights y su instrumentation key **no se consideran secretos**: son una clave de *ingesta* de telemetría (no de lectura de datos), recuperable con permiso `Reader` sobre el recurso. Microsoft indica explícitamente que **no hace falta** moverlas a Key Vault.
 - Referenciar `APPLICATIONINSIGHTS_CONNECTION_STRING` desde Key Vault **rompe la telemetría integrada del portal** de App Service / Azure Functions (Live Metrics, el blade del recurso): con una referencia, el portal no puede leer el valor y obliga a ir al recurso de App Insights directamente. Microsoft recomienda configurarla directamente.
 
-Se descubrió tras conmutarla a Key Vault en #196: la telemetría llega igual, pero se pierde la integración del portal sin ganar seguridad. Es candidata a subir como enmienda al ADR-0025 del harness. El secreto `app-insights-connection` queda sin uso en el vault (limpieza opcional; el valor no lo gestiona Terraform).
+Se descubrió tras conmutarla a Key Vault en #196: la telemetría llega igual, pero se pierde la integración del portal sin ganar seguridad. Es candidata a subir como enmienda al MEF-ADR-0025 del harness. El secreto `app-insights-connection` queda sin uso en el vault (limpieza opcional; el valor no lo gestiona Terraform).
 
 ## Consecuencias
 
@@ -82,16 +82,16 @@ Se descubrió tras conmutarla a Key Vault en #196: la telemetría llega igual, p
 
 **Fuera de alcance / trabajo diferido**
 
-- Migración a la topología de bus interno/externo de ADR-0024 del harness (decisión #4).
+- Migración a la topología de bus interno/externo de MEF-ADR-0024 del harness (decisión #4).
 - Migración de ASB, Postgres y App Insights a identidad administrada, cuando exista soporte viable.
 - Rotación automatizada de los secretos.
 
 ## Referencias
 
-- ADR-0025 del harness: "Custodia de secretos" — doctrina raíz que este ADR adopta por referencia.
-- ADR-0024 del harness, decisión #6: custodia de cadenas de ASB — instancia de la doctrina; documentamos que NO adoptamos su topología interno/externo.
-- ADR-0021 del harness: infraestructura base — unicidad global del nombre del Key Vault y `prevent_destroy`. (Nota: el número 0021 del harness NO guarda relación con la numeración local; las dos series son independientes.)
-- ADR-0022 del harness: autenticación de CI por OIDC — mismo espíritu identity-based que la ruta de identidad administrada para Storage.
+- MEF-ADR-0025 del harness: "Custodia de secretos" — doctrina raíz que este ADR adopta por referencia.
+- MEF-ADR-0024 del harness, decisión #6: custodia de cadenas de ASB — instancia de la doctrina; documentamos que NO adoptamos su topología interno/externo.
+- MEF-ADR-0021 del harness: infraestructura base — unicidad global del nombre del Key Vault y `prevent_destroy`. (Nota: el número 0021 del harness NO guarda relación con la numeración local; las dos series son independientes.)
+- MEF-ADR-0022 del harness: autenticación de CI por OIDC — mismo espíritu identity-based que la ruta de identidad administrada para Storage.
 - Implementación de referencia: `agents/infra-base-scaffolder.md` del plugin (módulos `key-vault` y `function-app`; nombres de secreto anclados y roles de datos de Storage).
 - Issues del proyecto: #195 (provisionar el Key Vault), #196 (conmutar referencias de ASB, Postgres y App Insights), #197 (identidad administrada para `AzureWebJobsStorage`).
 - "Use Key Vault references for App Service and Azure Functions". https://learn.microsoft.com/azure/app-service/app-service-key-vault-references
@@ -101,5 +101,5 @@ Se descubrió tras conmutarla a Key Vault en #196: la telemetría llega igual, p
 
 ## Control de cambios
 
-- 2026-07-01: creación. Adopta la doctrina de custodia de secretos del harness (su ADR-0025) y fija el mapa concreto de secretos del proyecto, la divergencia con la topología de ADR-0024 y los caveats de la migración brownfield. Numerado 0026 por ser el siguiente libre de la serie local (la serie local ya tenía 0025; el 0025 del harness es de otra serie).
-- 2026-07-03: enmienda (decisión #7). Application Insights sale de Key Vault y vuelve a valor directo (`module.monitoring.connection_string`); se documenta la divergencia con ADR-0025 del harness (la connection string de App Insights no es secreto y referenciarla desde Key Vault rompe la telemetría integrada del portal, según guía de Microsoft). Se actualiza el mapa de secretos (decisión #2) y las consecuencias. Descubierto durante la investigación del outage posterior a #196. El secreto `app-insights-connection` queda sin uso en el vault (limpieza opcional).
+- 2026-07-01: creación. Adopta la doctrina de custodia de secretos del harness (su MEF-ADR-0025) y fija el mapa concreto de secretos del proyecto, la divergencia con la topología de MEF-ADR-0024 y los caveats de la migración brownfield. Numerado 0026 por ser el siguiente libre de la serie local (la serie local ya tenía 0025; el 0025 del harness es de otra serie).
+- 2026-07-03: enmienda (decisión #7). Application Insights sale de Key Vault y vuelve a valor directo (`module.monitoring.connection_string`); se documenta la divergencia con MEF-ADR-0025 del harness (la connection string de App Insights no es secreto y referenciarla desde Key Vault rompe la telemetría integrada del portal, según guía de Microsoft). Se actualiza el mapa de secretos (decisión #2) y las consecuencias. Descubierto durante la investigación del outage posterior a #196. El secreto `app-insights-connection` queda sin uso en el vault (limpieza opcional).

--- a/docs/adr/ca-adr-0027-estrategia-tenancy-mono-tenant.md
+++ b/docs/adr/ca-adr-0027-estrategia-tenancy-mono-tenant.md
@@ -1,4 +1,4 @@
-# ADR-0027: Estrategia de tenancy mono-tenant
+# CA-ADR-0027: Estrategia de tenancy mono-tenant
 
 ## Estado
 
@@ -43,8 +43,8 @@ header-based de 2.x.**
 
 1. Clase `TenantResolverFijo : ITenantResolver` en `Infraestructura/` de cada dominio
    (`ControlHoras` y `Programacion`). Con solo 2 usos se acepta duplicar la clase en lugar de
-   extraerla a un proyecto compartido (Rule of Three, ADR-0024 del harness); tampoco vive en
-   `Contracts`, reservado a eventos publicos y value objects compartidos (ADR-0002).
+   extraerla a un proyecto compartido (Rule of Three, MEF-ADR-0018); tampoco vive en
+   `Contracts`, reservado a eventos publicos y value objects compartidos (CA-ADR-0002).
 2. `TenantId` resuelve al tenant por defecto de Marten: `JasperFx.StorageConstants.DefaultTenantId`
    (valor `"*DEFAULT*"`). Marten mapea ese valor a `Tenancy.Default` aun con
    `options.Policies.AllDocumentsAreMultiTenanted()` activo -- no se introduce un tenant nuevo, se
@@ -52,7 +52,7 @@ header-based de 2.x.**
 3. `UserId` es el literal fijo `"sin-identificar"`: el producto no distingue usuarios todavia: no
    hay autenticacion de llamador que popular este campo con un valor real.
 4. Ambos valores quedan como constantes `private`, expuestas solo via los getters publicos que pide
-   la interfaz -- sin superficie publica adicional (encapsulamiento, ADR-0012 del harness).
+   la interfaz -- sin superficie publica adicional (encapsulamiento, MEF-ADR-0012).
 5. Registro en DI con lifetime **Scoped** en ambos `Program.cs`, junto a los
    `AgregarWolverine*Router`/`AgregarWolverineEventSender` correspondientes: los routers/senders que
    lo inyectan son Scoped, y al ser un unico registro Scoped por request/activacion, el lado que

--- a/docs/adr/ca-adr-0028-biblioteca-de-dominio-frontera-write-read.md
+++ b/docs/adr/ca-adr-0028-biblioteca-de-dominio-frontera-write-read.md
@@ -1,4 +1,4 @@
-# ADR-0028: Biblioteca de dominio por dominio como frontera entre write-side y read-side
+# CA-ADR-0028: Biblioteca de dominio por dominio como frontera entre write-side y read-side
 
 ## Estado
 
@@ -27,7 +27,7 @@ aggregate**: `ProgramacionTurnoSolicitada` lo documenta explícitamente en su pr
 de event sourcing (privado)... No se publica al Service Bus"), y ninguno de los cinco implementa
 `IPublicEvent`/`IPrivateEvent` -- esa es la marca que distingue a los DTOs de `Contracts`
 (`DiaCalculado`, `ProgramacionTurnoDiarioSolicitada`), que sí cruzan el bus. Varios de estos eventos
-tienen constructor privado y exponen `ConfigurarSerializacion(resolver)` (ADR-0015 local), atados al
+tienen constructor privado y exponen `ConfigurarSerializacion(resolver)` (MEF-ADR-0012), atados al
 resolver custom de Marten que hoy registra
 `src/Bitakora.ControlAsistencia.ControlHoras/Infraestructura/ConfiguracionSerializacionControlHoras.cs`
 -- ese archivo también vive dentro del Function App.
@@ -58,22 +58,22 @@ se extrae una biblioteca de clases `Bitakora.ControlAsistencia.{Dominio}.Dominio
 - Los **eventos internos del aggregate** -- los que hoy viven en `Eventos/` dentro de cada Function
   App y que ni son `IPublicEvent` ni `IPrivateEvent` (esos siguen en `Contracts`, ver decisión #2).
 - Los **value objects del dominio** que esos eventos y aggregates usan y que no son vocabulario
-  compartido entre dominios (los que sí lo son quedan en `Contracts`, ADR-0002 local).
+  compartido entre dominios (los que sí lo son quedan en `Contracts`, CA-ADR-0002).
 
 Es el modelo de dominio rico del write-side, con su identidad string (`ControlDiarioAggregateRoot`
 usa `"{EmpleadoId}:{Fecha:yyyy-MM-dd}"`, `CatalogoTurnos` usa `evento.TurnoId.ToString()`) y sus tipos
-de constructor privado + `ConfigurarSerializacion` (ADR-0015 local) intactos.
+de constructor privado + `ConfigurarSerializacion` (MEF-ADR-0012) intactos.
 
 ### 2. Tres bibliotecas, tres propósitos, sin solape
 
 | Biblioteca | Contenido | Depende de Marten | Cruza el bus |
 |---|---|---|---|
-| `Contracts` | DTOs planos y value objects **compartidos entre dominios** (ADR-0002 local) | No (verificado: su único `PackageReference`, `Cosmos.EventDriven.Abstractions` 2.1.0, no arrastra Marten ni transitivamente -- comprobado contra `project.assets.json`, no por inspección visual) | Sí -- es exactamente lo que puede viajar en `IPublicEvent`/`IPrivateEvent` |
-| `{Dominio}.Dominio` (este ADR) | Aggregates, eventos internos del aggregate, value objects propios del dominio | No como paquete propio, pero sus tipos exigen el resolver custom de Marten para (de)serializarse (ADR-0015 local) | No -- son el modelo rico que ADR-0025 local prohíbe exponer al bus |
+| `Contracts` | DTOs planos y value objects **compartidos entre dominios** (CA-ADR-0002) | No (verificado: su único `PackageReference`, `Cosmos.EventDriven.Abstractions` 2.1.0, no arrastra Marten ni transitivamente -- comprobado contra `project.assets.json`, no por inspección visual) | Sí -- es exactamente lo que puede viajar en `IPublicEvent`/`IPrivateEvent` |
+| `{Dominio}.Dominio` (este ADR) | Aggregates, eventos internos del aggregate, value objects propios del dominio | No como paquete propio, pero sus tipos exigen el resolver custom de Marten para (de)serializarse (MEF-ADR-0012) | No -- son el modelo rico que CA-ADR-0025 prohíbe exponer al bus |
 | `ReadModels` (MEF-ADR-0034 sección 5) | Records de vista que las proyecciones producen | No, ni transitivamente (mandato explícito de MEF-ADR-0034 sección 5) | No -- solo los consume el propio read-side |
 
 No hay solape: `Contracts` es vocabulario cross-domain que cruza el bus; `{Dominio}.Dominio` es el
-modelo rico que un solo dominio posee y que ADR-0025 local ya prohíbe publicar; `ReadModels` es la
+modelo rico que un solo dominio posee y que CA-ADR-0025 ya prohíbe publicar; `ReadModels` es la
 vista derivada, sin comportamiento ni Marten. Cada una resuelve una necesidad distinta y ninguna
 sustituye a otra.
 
@@ -88,7 +88,7 @@ ReadModels  <---------------------  Projections worker (<RootNamespace>.Projecti
 ```
 
 - **Function App (write-side) de un dominio** referencia `{Dominio}.Dominio` (el suyo, nunca el de
-  otro dominio -- los dominios siguen siendo autónomos, ADR-0001 local) y `Contracts` (para el
+  otro dominio -- los dominios siguen siendo autónomos, CA-ADR-0001) y `Contracts` (para el
   vocabulario compartido y para publicar/consumir eventos públicos/privados). Esto no cambia frente a
   hoy; solo se explicita que el modelo rico que antes vivía inline en el Function App ahora vive en un
   `.csproj` separado que el Function App referencia.
@@ -132,17 +132,17 @@ worker.
 
 **Descartada.** Violaría dos ADRs locales ya aceptados:
 
-- **ADR-0002 local**: `Contracts` es vocabulario **compartido entre dominios** que cruza el bus; los
+- **CA-ADR-0002**: `Contracts` es vocabulario **compartido entre dominios** que cruza el bus; los
   eventos del aggregate no cruzan el bus (`ProgramacionTurnoSolicitada` lo documenta explícitamente:
   "No se publica al Service Bus") y no son compartidos -- cada uno pertenece a un solo dominio.
-- **ADR-0025 local**: fija que "el modelo de dominio rico vive en su dominio y nunca cruza el bus"
+- **CA-ADR-0025**: fija que "el modelo de dominio rico vive en su dominio y nunca cruza el bus"
   precisamente porque moverlo a `Contracts` reintrodujo, en el pasado (`DiaCalculado`, corregido en
   `#183`/`#184`), un bug de serialización lossy: el canal de publicación a Service Bus usa el
-  serializador **por defecto** (sin el resolver custom de ADR-0015 local), así que un tipo con
+  serializador **por defecto** (sin el resolver custom de MEF-ADR-0012), así que un tipo con
   constructor privado como `TurnoCreado` -- que hoy expone `ConfigurarSerializacion` precisamente
   porque necesita ese resolver -- se serializaría de forma corrupta hacia cualquier consumidor externo
   si viviera en `Contracts`. Repetir ese movimiento con los eventos del aggregate reproduciría el mismo
-  bug que ADR-0025 local ya pagó el costo de corregir.
+  bug que CA-ADR-0025 ya pagó el costo de corregir.
 
 ## Consecuencias
 
@@ -150,7 +150,7 @@ worker.
 
 - El worker de proyecciones tiene una vía de acceso a los tipos de evento sin arrastrar dependencias
   ajenas a su propósito (Azure Functions SDK, Wolverine, ASP.NET Core).
-- Se preserva la frontera que ADR-0002/ADR-0025 locales ya fijaron: `Contracts` sigue siendo
+- Se preserva la frontera que CA-ADR-0002/CA-ADR-0025 ya fijaron: `Contracts` sigue siendo
   exclusivamente vocabulario plano cross-domain: nada de esta decisión le agrega superficie.
 - El modelo de dominio rico queda en un único lugar con dos consumidores legítimos (Function App propio
   y worker de proyecciones), en vez de duplicarse o de forzar un acoplamiento incorrecto.
@@ -187,13 +187,13 @@ worker.
 
 ## Referencias
 
-- ADR-0001 local ("Function App por dominio"): fija la autonomía de dominio que esta decisión respeta
+- CA-ADR-0001 ("Function App por dominio"): fija la autonomía de dominio que esta decisión respeta
   (`{Dominio}.Dominio` nunca referencia el de otro dominio).
-- ADR-0002 local ("Proyecto Contracts para eventos y value objects compartidos"): delimita la frontera
+- CA-ADR-0002 ("Proyecto Contracts para eventos y value objects compartidos"): delimita la frontera
   de `Contracts` frente a `{Dominio}.Dominio` (decisión #2).
-- ADR-0015 local (encapsulamiento, `ConfigurarSerializacion`, constructor privado): los tipos que se
+- MEF-ADR-0012 (encapsulamiento, `ConfigurarSerializacion`, constructor privado): los tipos que se
   mudan a `{Dominio}.Dominio` siguen este patrón sin cambios.
-- ADR-0025 local ("El modelo de dominio rico no cruza el bus"): razón directa por la que la Alt 2 se
+- CA-ADR-0025 ("El modelo de dominio rico no cruza el bus"): razón directa por la que la Alt 2 se
   descartó; premisa que este ADR cita y refuerza.
 - MEF-ADR-0034 del harness ("Worker de proyecciones y read models por Bounded Context"), sección 5:
   fija que `ReadModels` no lleva Marten ni transitivamente y que las clases de proyección viven en el

--- a/src/Bitakora.ControlAsistencia.ControlHoras/Infraestructura/ComposicionServicios.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Infraestructura/ComposicionServicios.cs
@@ -49,7 +49,7 @@ public static class ComposicionServicios
         // Issue #219: Cosmos.Event* 2.x dejo de auto-registrar un ITenantResolver por defecto (se movio a
         // Cosmos.MultiTenancy.CritterStack), pero los routers/senders de Wolverine lo siguen exigiendo por
         // constructor. Este proyecto es mono-tenant: se registra un resolver de valores fijos en vez de los
-        // resolvers header-based de 2.x. Ver docs/adr/0027-estrategia-tenancy-mono-tenant.md.
+        // resolvers header-based de 2.x. Ver docs/adr/ca-adr-0027-estrategia-tenancy-mono-tenant.md.
         services.AddScoped<ITenantResolver, TenantResolverFijo>();
         // AgregarWolverineCommandRouter se conserva: RegistrarMarcacion (HTTP) lo sigue usando.
         services.AgregarWolverineCommandRouter();

--- a/src/Bitakora.ControlAsistencia.ControlHoras/Infraestructura/TenantResolverFijo.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Infraestructura/TenantResolverFijo.cs
@@ -10,7 +10,7 @@ namespace Bitakora.ControlAsistencia.ControlHoras.Infraestructura;
 // Este proyecto es mono-tenant: se registra un ITenantResolver con valores fijos en vez de los
 // resolvers header-based de 2.x (AgregarTenantResolverHibrido/ProxyTenantResolver), que exigirian
 // headers TenantId/user_id inexistentes en este flujo HTTP.
-// Ver docs/adr/0027-estrategia-tenancy-mono-tenant.md y
+// Ver docs/adr/ca-adr-0027-estrategia-tenancy-mono-tenant.md y
 // docs/bitacora/field-notes/2026-07-18-1905-bug-investigation.md.
 public sealed class TenantResolverFijo : ITenantResolver
 {

--- a/src/Bitakora.ControlAsistencia.Programacion/Infraestructura/ComposicionServicios.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/Infraestructura/ComposicionServicios.cs
@@ -46,7 +46,7 @@ public static class ComposicionServicios
         // Issue #219: Cosmos.Event* 2.x dejo de auto-registrar un ITenantResolver por defecto (se movio a
         // Cosmos.MultiTenancy.CritterStack), pero los routers/senders de Wolverine lo siguen exigiendo por
         // constructor. Este proyecto es mono-tenant: se registra un resolver de valores fijos en vez de los
-        // resolvers header-based de 2.x. Ver docs/adr/0027-estrategia-tenancy-mono-tenant.md.
+        // resolvers header-based de 2.x. Ver docs/adr/ca-adr-0027-estrategia-tenancy-mono-tenant.md.
         services.AddScoped<ITenantResolver, TenantResolverFijo>();
         services.AgregarWolverineCommandRouter();
         services.AgregarWolverineEventSender();

--- a/src/Bitakora.ControlAsistencia.Programacion/Infraestructura/TenantResolverFijo.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/Infraestructura/TenantResolverFijo.cs
@@ -10,7 +10,7 @@ namespace Bitakora.ControlAsistencia.Programacion.Infraestructura;
 // Este proyecto es mono-tenant: se registra un ITenantResolver con valores fijos en vez de los
 // resolvers header-based de 2.x (AgregarTenantResolverHibrido/ProxyTenantResolver), que exigirian
 // headers TenantId/user_id inexistentes en este flujo HTTP.
-// Ver docs/adr/0027-estrategia-tenancy-mono-tenant.md y
+// Ver docs/adr/ca-adr-0027-estrategia-tenancy-mono-tenant.md y
 // docs/bitacora/field-notes/2026-07-18-1905-bug-investigation.md.
 public sealed class TenantResolverFijo : ITenantResolver
 {


### PR DESCRIPTION
Adopta el esquema de identificacion de ADRs que fija **MEF-ADR-0030** del marco, con el codigo corto `CA-` que ese mismo ADR sugiere para Control de Asistencias.

## Decision de ruta: los ADRs se quedan en `docs/adr/`

Al investigar se encontro que **MEF-ADR-0030 descarta explicitamente** mover los ADRs del consumidor a otra carpeta. Su Alt 2 es, textualmente, *"mover los ADRs del consumidor a una ruta distinta (`docs/adr-proyecto/`) en vez de prefijo"*, y cita el guard de `_pipeline-common.sh` como la convencion que se considero: **descartada**, porque resuelve la colision en disco pero no la colision en prosa. La decision del marco es el prefijo, y su decision #4 lo hace opt-in para el consumidor.

## Que cambia

| | |
|---|---|
| **13 ADRs renombrados** | `docs/adr/NNNN-slug.md` -> `docs/adr/ca-adr-NNNN-slug.md`; prefijo minuscula en filename, ID canonico en mayuscula en el titulo (MEF-ADR-0030 decision #3) |
| **Indice tematico de `CLAUDE.md` corregido** | 15 de sus 19 filas apuntaban al marco con numeracion **anterior** a la migracion `MEF-ADR-` |
| **Deriva heredada en `ca-adr-0028`** | sus 5 citas a "ADR-0015 local" son del marco, no locales |
| **Rutas citadas desde codigo** | 4 comentarios en `.cs` actualizados para no quedar muertos |

### El indice estaba desalineado, no solo sin prefijo

Cada fila se resolvio **por tema**, que es lo que el issue #231 ya pedia. Ejemplos verificados contra los titulos reales de los `MEF-ADR-*`:

| Fila | Decia | Es |
|---|---|---|
| Encapsulamiento, Tell-don't-Ask / serializacion, ctor privado | `ADR-0015` | **MEF-ADR-0012** (Heuristicas de modelado de objetos de dominio) |
| Manejo de errores en event sourcing | `ADR-0007` | **MEF-ADR-0004** |
| Naming de funciones Azure | `ADR-0008` | **MEF-ADR-0006** |
| Un topic por evento | `ADR-0004` | **MEF-ADR-0001** |
| Estrategia de testing con event sourcing | `ADR-0006` | **MEF-ADR-0002** |
| Mensajes en `.resx` | `ADR-0012` | **MEF-ADR-0009** |
| Smoke tests contra dev | `ADR-0016` | **MEF-ADR-0013** |
| Snapshots de Marten | `ADR-0021` | **MEF-ADR-0015** |
| Rule of Three, evolucion del codigo | `ADR-0024` | **MEF-ADR-0018** |

Las filas que si son locales quedaron como `CA-ADR-0002`, `CA-ADR-0025`, `CA-ADR-0026`, `CA-ADR-0027`, `CA-ADR-0028`. Continua el trabajo que #230 empezo al corregir dos filas a `MEF-ADR-`.

Nota de contexto: `ca-adr-0026` (escrito 2026-07-01) ya citaba numeros del harness que **si** coinciden, porque MEF-ADR-0030 decision #3 conservo la numeracion al prefijar (`ADR-0001..0027` -> `MEF-ADR-0001..0027`). El indice de `CLAUDE.md` habia quedado en una numeracion aun anterior.

## Fuera de alcance (deliberado)

- **Los ~90 comentarios `ADR-NNNN` en `.cs`**: MEF-ADR-0030 decision #4 declara valido seguir citandolos como `ADR-XXXX` a secas. Se migran en un issue aparte porque varios exigen decision de mapeo (p. ej. `ADR-0013` no corresponde por tema a `MEF-ADR-0013`).
- **Las field notes de `docs/bitacora/`**: registro historico de lo que se afirmo en su momento. Sus rutas de ADR ya estaban muertas **antes** de este PR (citan ADRs del marco que nunca existieron localmente) -- son evidencia de la deriva, no un error a corregir.
- **Sumar al indice las filas de los ADRs locales que hoy no aparecen** (`0001`, `0003`, `0004`, `0007`, `0009`, `0017`, `0019`, `0020`).

## Hallazgo para un issue aparte

La fila del indice describe *"un topic por evento"* mientras el ADR local `ca-adr-0004` se titula *"un topic por dominio productor"*: temas distintos. El codigo (`ComposicionServicios.cs`) comenta "un topic por evento", asi que en la practica rige **MEF-ADR-0001** y `ca-adr-0004` parece superado. Es una contradiccion de doctrina, no de numeracion, y no se resuelve aqui.

## Verificacion

- `dotnet build ControlAsistencias.slnx`: **0 errores** (5 advertencias preexistentes).
- `dotnet test`: **468 total, 0 errores**, 462 correctos, 6 omitidos -- los omitidos son smoke tests que no alcanzan el Postgres de dev por firewall de IP, ajenos a este cambio.
- Sin rutas `docs/adr/NNNN-` muertas fuera de la bitacora.

## Por que el PR se abre a mano

El gate `validate_consumer_scope_changes` de `_pipeline-common.sh` bloquea todo cambio bajo `docs/adr/`, asi que este trabajo no puede correr por pipeline. Ese guard refleja la Alt 2 que MEF-ADR-0030 descarto; se reporta al marco por separado.

Closes #242