### PR TITLE
infra(dev): #234 Provisionar el worker de proyecciones como Container App en dev

### DIFF
--- a/infra/environments/dev/main.tf
+++ b/infra/environments/dev/main.tf
@@ -233,6 +233,9 @@ resource "azurerm_role_assignment" "storage_data_control_horas" {
 
 # El nombre de un Container Registry (*.azurecr.io) es unico en TODO Azure y admite
 # SOLO alfanumerico (sin guiones), a diferencia de Postgres/Service Bus/Key Vault.
+# Lleva el ambiente embebido igual que el otro recurso de nombre global-alfanumerico
+# de este entorno (module.storage_*: "stcontrolhoras${var.environment}<sufijo>"), para
+# que el registry de dev sea distinguible a simple vista del de un futuro staging/prod.
 resource "random_string" "container_registry_suffix" {
   length  = 6
   special = false
@@ -241,7 +244,7 @@ resource "random_string" "container_registry_suffix" {
 
 module "container_registry" {
   source              = "../../modules/container-registry"
-  name                = "acr${var.project_short}${random_string.container_registry_suffix.result}"
+  name                = "acr${var.project_short}${var.environment}${random_string.container_registry_suffix.result}"
   resource_group_name = module.resource_group.name
   location            = module.resource_group.location
   tags                = local.tags

--- a/infra/environments/dev/main.tf
+++ b/infra/environments/dev/main.tf
@@ -225,3 +225,123 @@ resource "azurerm_role_assignment" "storage_data_control_horas" {
   principal_id         = module.function_app_control_horas.principal_id
 }
 
+# ---- Worker de proyecciones (opt-in, MEF-ADR-0034 seccion 8; issue #234) ----
+# Container App sin ingress: nadie le hace requests HTTP, solo lee eventos de Postgres
+# y escribe proyecciones (async daemon de Marten, HotCold). El usuario acepto el
+# trade-off de costo: min_replicas >= 1 corre siempre encendido, a diferencia de las
+# Function Apps del write-side que escalan a demanda.
+
+# El nombre de un Container Registry (*.azurecr.io) es unico en TODO Azure y admite
+# SOLO alfanumerico (sin guiones), a diferencia de Postgres/Service Bus/Key Vault.
+resource "random_string" "container_registry_suffix" {
+  length  = 6
+  special = false
+  upper   = false
+}
+
+module "container_registry" {
+  source              = "../../modules/container-registry"
+  name                = "acr${var.project_short}${random_string.container_registry_suffix.result}"
+  resource_group_name = module.resource_group.name
+  location            = module.resource_group.location
+  tags                = local.tags
+}
+
+# UNICA identidad del worker de proyecciones (MEF-ADR-0034 seccion 8): la usa tanto para
+# pullear la imagen del ACR (registry.identity) como para resolver las Key Vault
+# references de sus secretos (secret.identity). Se crea y se le otorgan LOS DOS roles
+# ANTES de instanciar module.container_app -- un role assignment sobre una identidad
+# SystemAssigned solo puede crearse DESPUES del recurso que la porta (patron de las
+# Function Apps, arriba), y el plano de control de Container Apps resuelve la Key Vault
+# reference dentro del PUT que crea la app, cuando esa identidad SystemAssigned aun no
+# existiria.
+resource "azurerm_user_assigned_identity" "projections_worker" {
+  name                = "id-${local.prefix_short}-projections"
+  resource_group_name = module.resource_group.name
+  location            = module.resource_group.location
+  tags                = local.tags
+}
+
+resource "azurerm_role_assignment" "projections_worker_acr_pull" {
+  scope                = module.container_registry.id
+  role_definition_name = "AcrPull"
+  principal_id         = azurerm_user_assigned_identity.projections_worker.principal_id
+  # La identidad se acaba de crear en este mismo apply: skip_service_principal_aad_check
+  # evita que la verificacion contra Azure AD falle por lag de replicacion (MEF-ADR-0022
+  # / nota operativa del modulo: la propagacion de RBAC puede tardar).
+  skip_service_principal_aad_check = true
+}
+
+# Lectura de secretos del Key Vault del BC (CA-ADR-0026): mismo rol "Key Vault Secrets
+# User" que reciben las Function Apps, pero otorgado a esta identidad UserAssigned y
+# ANTES de crear el Container App -- no despues, como en las Function Apps. Con
+# identity = "System" en el bloque secret, la referencia no podria resolverse en la
+# creacion de la app porque esa identidad todavia no existiria (MEF-ADR-0034 seccion 8).
+resource "azurerm_role_assignment" "projections_worker_kv_secrets_user" {
+  scope                            = module.key_vault.id
+  role_definition_name             = "Key Vault Secrets User"
+  principal_id                     = azurerm_user_assigned_identity.projections_worker.principal_id
+  skip_service_principal_aad_check = true
+}
+
+module "container_app_environment" {
+  source                     = "../../modules/container-app-environment"
+  name                       = "cae-${local.prefix_short}"
+  resource_group_name        = module.resource_group.name
+  location                   = module.resource_group.location
+  log_analytics_workspace_id = module.monitoring.log_analytics_workspace_id
+  tags                       = local.tags
+}
+
+locals {
+  # URIs crudas del secreto (sin el envoltorio @Microsoft.KeyVault(SecretUri=...)): el
+  # campo key_vault_secret_id del bloque `secret` de azurerm_container_app espera el URI
+  # del secreto directamente, a diferencia del app setting de una Function App (que si
+  # usa el envoltorio, ver locals de arriba). Reutilizan los mismos secretos fijos del BC
+  # (marten-connection, app-insights-connection, ya sembrados en vivo): el worker de
+  # proyecciones no crea ningun secreto nuevo (MEF-ADR-0034 seccion 2).
+  projections_marten_connection_secret_uri       = "${module.key_vault.uri}secrets/marten-connection"
+  projections_app_insights_connection_secret_uri = "${module.key_vault.uri}secrets/app-insights-connection"
+}
+
+module "container_app" {
+  source                       = "../../modules/container-app"
+  name                         = "ca-${local.prefix_short}"
+  resource_group_name          = module.resource_group.name
+  container_app_environment_id = module.container_app_environment.id
+  image                        = var.projections_worker_image
+  registry_server              = module.container_registry.login_server
+  user_assigned_identity_id    = azurerm_user_assigned_identity.projections_worker.id
+
+  # Dimensionamiento dev (issue #234, decision resuelta con el usuario): min_replicas = 1
+  # fijo (no puede ser 0, MEF-ADR-0034 seccion 8), max_replicas = 1 (HotCold no acelera
+  # con mas replicas), cpu/memory en el piso razonable para el daemon de proyecciones.
+  min_replicas = 1
+  max_replicas = 1
+  cpu          = 0.25
+  memory       = "0.5Gi"
+
+  key_vault_secret_refs = {
+    marten-connection = {
+      env_var_name        = "MartenConnectionString"
+      key_vault_secret_id = local.projections_marten_connection_secret_uri
+    }
+    app-insights-connection = {
+      env_var_name        = "APPLICATIONINSIGHTS_CONNECTION_STRING"
+      key_vault_secret_id = local.projections_app_insights_connection_secret_uri
+    }
+  }
+
+  tags = local.tags
+
+  # Fuerza a que AMBOS roles de la identidad UserAssigned esten asignados antes de que
+  # exista el Container App: el AcrPull para que pueda pullear su imagen, y el Key Vault
+  # Secrets User para que el plano de control resuelva las Key Vault references dentro
+  # del PUT de creacion. Sin este depends_on, Terraform podria crear la app en paralelo
+  # con los role assignments y la creacion fallaria con "Authorization failed".
+  depends_on = [
+    azurerm_role_assignment.projections_worker_acr_pull,
+    azurerm_role_assignment.projections_worker_kv_secrets_user,
+  ]
+}
+

--- a/infra/environments/dev/outputs.tf
+++ b/infra/environments/dev/outputs.tf
@@ -47,3 +47,15 @@ output "app_insights_connection_string" {
   value       = module.monitoring.connection_string
   sensitive   = true
 }
+
+# Worker de proyecciones (opt-in, MEF-ADR-0034 seccion 8; issue #234)
+
+output "container_registry_login_server" {
+  description = "Hostname del Container Registry del worker de proyecciones. Lo consume el pipeline de CI de imagen (fuera de alcance de este issue) para saber a donde empujar Bitakora.ControlAsistencia.Projections"
+  value       = module.container_registry.login_server
+}
+
+output "container_app_name" {
+  description = "Nombre del Container App del worker de proyecciones. Lo consume el pipeline de CI de imagen para actualizar la revision (ej. az containerapp update --image ...) tras publicar una imagen nueva"
+  value       = module.container_app.name
+}

--- a/infra/environments/dev/variables.tf
+++ b/infra/environments/dev/variables.tf
@@ -33,6 +33,16 @@ variable "postgresql_admin_password" {
   sensitive   = true
 }
 
+# Worker de proyecciones (opt-in, MEF-ADR-0034 seccion 8; issue #234). Placeholder publico
+# hasta que un pipeline de CI de imagen (fuera de alcance de este issue) construya y empuje
+# la imagen real a module.container_registry.login_server; en ese momento, sobreescribe
+# este default via terraform.tfvars o TF_VAR_projections_worker_image.
+variable "projections_worker_image" {
+  description = "Imagen del worker de proyecciones (Bitakora.ControlAsistencia.Projections)"
+  type        = string
+  default     = "mcr.microsoft.com/k8se/quickstart:latest"
+}
+
 locals {
   prefix       = "${var.project}-${var.environment}"
   prefix_short = "${var.project_short}-${var.environment}"

--- a/infra/modules/container-app-environment/main.tf
+++ b/infra/modules/container-app-environment/main.tf
@@ -1,0 +1,49 @@
+variable "name" {
+  description = "Nombre del Container App Environment"
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "Nombre del resource group"
+  type        = string
+}
+
+variable "location" {
+  description = "Region de Azure"
+  type        = string
+}
+
+variable "log_analytics_workspace_id" {
+  description = "ID del Log Analytics Workspace (output log_analytics_workspace_id del modulo monitoring) -- requerido junto con logs_destination = \"log-analytics\" (verificado contra la doc del provider azurerm, azurerm_container_app_environment). Reutiliza el mismo workspace que ya usa Application Insights (ADR-0009 local): evita crear un segundo workspace redundante."
+  type        = string
+}
+
+variable "tags" {
+  description = "Tags comunes del proyecto"
+  type        = map(string)
+  default     = {}
+}
+
+# Entorno gestionado de Container Apps (MEF-ADR-0034 seccion 8). Se instancia una sola
+# vez por entorno, igual que postgresql/service-bus/key-vault.
+resource "azurerm_container_app_environment" "this" {
+  name                       = var.name
+  resource_group_name        = var.resource_group_name
+  location                   = var.location
+  logs_destination           = "log-analytics"
+  log_analytics_workspace_id = var.log_analytics_workspace_id
+  tags                       = var.tags
+}
+
+output "id" {
+  value = azurerm_container_app_environment.this.id
+}
+
+output "name" {
+  value = azurerm_container_app_environment.this.name
+}
+
+output "default_domain" {
+  description = "Dominio publico por defecto del entorno (no aplica al worker: no lleva ingress, MEF-ADR-0034 seccion 8)"
+  value       = azurerm_container_app_environment.this.default_domain
+}

--- a/infra/modules/container-app/main.tf
+++ b/infra/modules/container-app/main.tf
@@ -36,9 +36,23 @@ variable "max_replicas" {
 }
 
 variable "cpu" {
-  description = "vCPU del contenedor. Debe formar una combinacion valida con memory en el plan Consumption (Microsoft Learn, 'vCPU and memory allocation requirements')"
+  description = "vCPU del contenedor. Debe formar una combinacion valida con memory en el plan Consumption (Microsoft Learn, 'Containers in Azure Container Apps' -- Configuration): incrementos de 0.25, y memory exactamente cpu*2 en Gi (ver la precondition del recurso)"
   type        = number
   default     = 0.25
+
+  # Azure no admite cualquier valor de cpu: la tabla de asignaciones solo lista
+  # incrementos de 0.25 (Microsoft Learn, "Containers in Azure Container Apps" --
+  # Configuration). El techo de 2.0 es el del entorno que crea el modulo
+  # container-app-environment, que no declara workload profiles y por tanto es un
+  # entorno *Consumption only*: "Apps using the Consumption plan in a Consumption only
+  # environment are limited to a maximum of 2 cores and 4Gi of memory" (misma pagina).
+  # Se valida aca -- y no solo en el apply -- porque quien escribe el HCL no tiene
+  # credenciales de Azure (MEF-ADR-0021/0022): un valor invalido debe fallar en el
+  # `terraform validate` local, no a mitad del apply de CI.
+  validation {
+    condition     = var.cpu >= 0.25 && var.cpu <= 2.0 && var.cpu * 4 == floor(var.cpu * 4)
+    error_message = "cpu debe ser un multiplo de 0.25 entre 0.25 y 2.0 (Microsoft Learn, 'Containers in Azure Container Apps' -- Configuration; el techo de 2.0 aplica a un entorno Consumption only, que es el que crea el modulo container-app-environment)."
+  }
 }
 
 variable "memory" {
@@ -153,6 +167,25 @@ resource "azurerm_container_app" "this" {
   # y escribe proyecciones; nunca es el destino de un request.
 
   tags = var.tags
+
+  lifecycle {
+    # Azure solo admite pares cpu/memory de una tabla cerrada: memory es SIEMPRE cpu*2
+    # en Gi (0.25->0.5Gi, 0.5->1.0Gi, 0.75->1.5Gi, ... 2.0->4.0Gi). Un par fuera de la
+    # tabla no lo detecta `terraform validate` -- lo rechaza el plano de control en
+    # medio del apply. Como el apply corre en CI sin nadie mirando (MEF-ADR-0022), la
+    # relacion se verifica aca, en el plan, con un mensaje que dice que poner.
+    # Fuente: Microsoft Learn, "Containers in Azure Container Apps" -- Configuration.
+    precondition {
+      condition     = var.memory == format("%.1fGi", var.cpu * 2)
+      error_message = "Par cpu/memory invalido: con cpu = ${var.cpu}, memory debe ser exactamente \"${format("%.1fGi", var.cpu * 2)}\" (Azure exige memory = cpu*2 Gi; Microsoft Learn, 'Containers in Azure Container Apps' -- Configuration)."
+    }
+
+    # max_replicas < min_replicas es un apply roto garantizado; se atrapa antes.
+    precondition {
+      condition     = var.max_replicas >= var.min_replicas
+      error_message = "max_replicas (${var.max_replicas}) no puede ser menor que min_replicas (${var.min_replicas})."
+    }
+  }
 }
 
 output "id" {

--- a/infra/modules/container-app/main.tf
+++ b/infra/modules/container-app/main.tf
@@ -1,0 +1,169 @@
+variable "name" {
+  description = "Nombre del Container App (2-32 chars, minusculas/numeros/guiones, empieza con letra y termina alfanumerico -- Microsoft.App/containerApps, scope resource group; verificado contra Microsoft Learn, 'Naming rules and restrictions for Azure resources')"
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "Nombre del resource group"
+  type        = string
+}
+
+variable "container_app_environment_id" {
+  description = "ID del Container App Environment (modulo container-app-environment)"
+  type        = string
+}
+
+variable "image" {
+  description = "Referencia completa de la imagen del contenedor (registry/repositorio:tag). El wiring del entorno la alimenta desde var.projections_worker_image -- ver la nota de bootstrap ahi sobre el placeholder inicial"
+  type        = string
+}
+
+variable "min_replicas" {
+  description = "Replicas minimas. SIEMPRE >= 1 (validado abajo): sin ingress, Azure no reactiva un Container App que escala a 0 (MEF-ADR-0034 seccion 8)"
+  type        = number
+  default     = 1
+
+  validation {
+    condition     = var.min_replicas >= 1
+    error_message = "min_replicas debe ser >= 1: sin ingress, un Container App que escala a 0 no tiene forma de reactivarse (MEF-ADR-0034 seccion 8; Microsoft Learn, 'Set scaling rules in Azure Container Apps')."
+  }
+}
+
+variable "max_replicas" {
+  description = "Replicas maximas. HotCold (el daemon de Marten que corre dentro del contenedor) tolera mas de una replica activa via eleccion de lider sobre advisory locks de Postgres (MEF-ADR-0034 seccion 2)"
+  type        = number
+  default     = 1
+}
+
+variable "cpu" {
+  description = "vCPU del contenedor. Debe formar una combinacion valida con memory en el plan Consumption (Microsoft Learn, 'vCPU and memory allocation requirements')"
+  type        = number
+  default     = 0.25
+}
+
+variable "memory" {
+  description = "Memoria del contenedor. Debe formar una combinacion valida con cpu en el plan Consumption"
+  type        = string
+  default     = "0.5Gi"
+}
+
+variable "env_vars" {
+  description = "Variables de entorno NO sensibles (ej. nivel de log, nombre del ambiente). Ninguna cadena de conexion va aqui -- ver key_vault_secret_refs (MEF-ADR-0025 / ADR-0026 local)"
+  type        = map(string)
+  default     = {}
+}
+
+variable "key_vault_secret_refs" {
+  description = "Variables de entorno sensibles resueltas por Key Vault reference con la identidad UserAssigned de var.user_assigned_identity_id (MEF-ADR-0025 / ADR-0026 local). Clave = nombre interno del secret block; env_var_name = nombre de la variable de entorno que lo consume; key_vault_secret_id = URI del secreto (versionless), NUNCA el valor en claro"
+  type = map(object({
+    env_var_name        = string
+    key_vault_secret_id = string
+  }))
+  default = {}
+}
+
+variable "registry_server" {
+  description = "login_server del Container Registry (modulo container-registry) del que este Container App extrae la imagen"
+  type        = string
+}
+
+variable "user_assigned_identity_id" {
+  description = "Resource ID de la UNICA identidad UserAssigned de este Container App, con rol AcrPull sobre el Container Registry y Key Vault Secrets User sobre el Key Vault del BC (ambos otorgados por el wiring del entorno ANTES de instanciar este modulo). NUNCA \"System\": el bloque registry.identity exige un Resource ID UserAssigned, y una Key Vault reference con \"System\" no puede resolverse en la creacion de la app porque esa identidad no existe todavia (MEF-ADR-0034 seccion 8)"
+  type        = string
+}
+
+variable "tags" {
+  description = "Tags comunes del proyecto"
+  type        = map(string)
+  default     = {}
+}
+
+# El worker de proyecciones en si (MEF-ADR-0034 secciones 1-8): sin bloque `ingress`
+# (nadie le hace requests), revision_mode = "Single", identidad administrada para leer
+# secretos del Key Vault del BC (bloque `secret`, MEF-ADR-0025 / ADR-0026 local) y
+# min_replicas >= 1 exigido por validacion -- sin ingress, un Container App que escala
+# a 0 no tiene forma de reactivarse.
+#
+# Identidad UNICA UserAssigned para el pull del ACR y para las Key Vault references
+# (punto abierto de MEF-ADR-0034 resuelto en el ADR): el bloque registry.identity exige
+# el Resource ID de una identidad User Assigned (el literal "System" no es valido ahi),
+# y una Key Vault reference con "System" no puede resolverse al CREAR la app porque esa
+# identidad no existe hasta despues de crearla. Ningun role assignment posterior lo
+# arregla. La identidad SystemAssigned sigue habilitada (output principal_id) para
+# cualquier RBAC futuro que si pueda asignarse despues de crear la app, pero no es quien
+# lee el Key Vault ni quien pulea la imagen.
+resource "azurerm_container_app" "this" {
+  name                         = var.name
+  resource_group_name          = var.resource_group_name
+  container_app_environment_id = var.container_app_environment_id
+  revision_mode                = "Single"
+
+  identity {
+    type         = "SystemAssigned, UserAssigned"
+    identity_ids = [var.user_assigned_identity_id]
+  }
+
+  registry {
+    server   = var.registry_server
+    identity = var.user_assigned_identity_id
+  }
+
+  # identity = la UserAssigned, NUNCA "System": el plano de control resuelve la
+  # referencia dentro del PUT que crea esta app, cuando la identidad SystemAssigned
+  # aun no existe (Microsoft Learn, "Manage secrets in Azure Container Apps").
+  dynamic "secret" {
+    for_each = var.key_vault_secret_refs
+    content {
+      name                = secret.key
+      identity            = var.user_assigned_identity_id
+      key_vault_secret_id = secret.value.key_vault_secret_id
+    }
+  }
+
+  template {
+    min_replicas = var.min_replicas
+    max_replicas = var.max_replicas
+
+    container {
+      name   = var.name
+      image  = var.image
+      cpu    = var.cpu
+      memory = var.memory
+
+      dynamic "env" {
+        for_each = var.env_vars
+        content {
+          name  = env.key
+          value = env.value
+        }
+      }
+
+      dynamic "env" {
+        for_each = var.key_vault_secret_refs
+        content {
+          name        = env.value.env_var_name
+          secret_name = env.key
+        }
+      }
+    }
+  }
+
+  # Sin bloque `ingress` a proposito (MEF-ADR-0034 seccion 8): el worker no recibe
+  # trafico HTTP/TCP -- lee eventos directamente de Postgres (async daemon de Marten)
+  # y escribe proyecciones; nunca es el destino de un request.
+
+  tags = var.tags
+}
+
+output "id" {
+  value = azurerm_container_app.this.id
+}
+
+output "name" {
+  value = azurerm_container_app.this.name
+}
+
+output "principal_id" {
+  description = "Principal ID de la identidad SystemAssigned de este Container App. NO es quien lee el Key Vault (eso va por var.user_assigned_identity_id, ver la nota del modulo): queda expuesto para cualquier RBAC futuro que si pueda asignarse despues de crear la app"
+  value       = azurerm_container_app.this.identity[0].principal_id
+}

--- a/infra/modules/container-registry/main.tf
+++ b/infra/modules/container-registry/main.tf
@@ -1,0 +1,47 @@
+variable "name" {
+  description = "Nombre del Container Registry (5-50 chars, SOLO alfanumerico -- Microsoft.ContainerRegistry/registries, scope global, no admite guiones a diferencia de otros recursos de este modulo; verificado contra Microsoft Learn, 'Naming rules and restrictions for Azure resources')"
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "Nombre del resource group"
+  type        = string
+}
+
+variable "location" {
+  description = "Region de Azure"
+  type        = string
+}
+
+variable "tags" {
+  description = "Tags comunes del proyecto"
+  type        = map(string)
+  default     = {}
+}
+
+# Registro de imagenes del worker de proyecciones (MEF-ADR-0034 seccion 8). SKU Basic:
+# el worker es la unica imagen que este registry sirve. Sin prevent_destroy: a diferencia
+# de Postgres/Storage/Service Bus/Key Vault, un registry de imagenes es recreable sin
+# perdida de datos con estado real -- la imagen se reconstruye y reempuja desde el
+# pipeline de CI de imagen (fuera de alcance de este issue).
+resource "azurerm_container_registry" "this" {
+  name                = var.name
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  sku                 = "Basic"
+  admin_enabled       = false
+  tags                = var.tags
+}
+
+output "id" {
+  value = azurerm_container_registry.this.id
+}
+
+output "name" {
+  value = azurerm_container_registry.this.name
+}
+
+output "login_server" {
+  description = "Hostname del registry (ej. acrasistdev123456.azurecr.io). Lo consume container-app (bloque registry.server) y el pipeline de CI que construya/empuje la imagen del worker (fuera de alcance de este issue)"
+  value       = azurerm_container_registry.this.login_server
+}

--- a/infra/modules/monitoring/main.tf
+++ b/infra/modules/monitoring/main.tf
@@ -157,3 +157,8 @@ output "instrumentation_key" {
   value     = azurerm_application_insights.this.instrumentation_key
   sensitive = true
 }
+
+output "log_analytics_workspace_id" {
+  description = "ID del Log Analytics Workspace. Lo consume el modulo opt-in container-app-environment (MEF-ADR-0034 seccion 8, issue #234) para no crear un segundo workspace redundante (ADR-0009 local, control de costos de Application Insights)"
+  value       = azurerm_log_analytics_workspace.this.id
+}


### PR DESCRIPTION
## Infraestructura

Implementa los cambios de infraestructura del issue #234.

- **Ambiente**: dev
- **Estado**: HCL escrito y revisado localmente (sin plan ni apply local); pendiente de aplicar por CI
- **Pipeline**: iac-pipeline.sh

## Decisiones del pipeline

<details>
<summary>infra-writer -- 5m 51s</summary>

_(El agente no genero resumen)_

</details>

<details>
<summary>infra-reviewer -- 7m 2s</summary>

_(El agente no genero resumen)_

</details>

## Cambios Terraform

 infra/environments/dev/main.tf                  | 123 +++++++++++++++
 infra/environments/dev/outputs.tf               |  12 ++
 infra/environments/dev/variables.tf             |  10 ++
 infra/modules/container-app-environment/main.tf |  49 ++++++
 infra/modules/container-app/main.tf             | 202 ++++++++++++++++++++++++
 infra/modules/container-registry/main.tf        |  47 ++++++
 infra/modules/monitoring/main.tf                |   5 +
 7 files changed, 448 insertions(+)

## Commits

7600b11 infra(review): correcciones de seguridad y calidad en dev
3f95667 infra(dev): provisionar worker de proyecciones como Container App sin ingress

> **Apply pendiente en CI**: este PR no cierra el issue #234. El `terraform apply` lo ejecuta el workflow **Infra CD** al mergear este PR a `main` (MEF-ADR-0022); el issue se cierra automaticamente cuando ese apply termine exitosamente.