### PR TITLE
infra(dev): #246 Registrar el resource provider Microsoft.App en la suscripcion desde el provider de Terraform

### DIFF
--- a/infra/environments/dev/providers.tf
+++ b/infra/environments/dev/providers.tf
@@ -25,6 +25,13 @@ terraform {
 provider "azurerm" {
   subscription_id = var.subscription_id
 
+  # Microsoft.App no esta en el set "core" que el provider registra por defecto
+  # (resource_provider_registrations = "core"). Lo requiere el Container App
+  # Environment del worker de proyecciones (MEF-ADR-0034 seccion 8). Ver issue #246.
+  resource_providers_to_register = [
+    "Microsoft.App",
+  ]
+
   features {
     resource_group {
       prevent_deletion_if_contains_resources = true


### PR DESCRIPTION
## Infraestructura

Implementa los cambios de infraestructura del issue #246.

- **Ambiente**: dev
- **Estado**: HCL escrito y revisado localmente (sin plan ni apply local); pendiente de aplicar por CI
- **Pipeline**: iac-pipeline.sh

## Decisiones del pipeline

<details>
<summary>infra-writer -- 1m 17s</summary>

_(El agente no genero resumen)_

</details>

<details>
<summary>infra-reviewer -- 2m 53s</summary>

_(El agente no genero resumen)_

</details>

## Cambios Terraform

 infra/environments/dev/providers.tf | 7 +++++++
 1 file changed, 7 insertions(+)

## Commits

12ac50c infra(dev): registrar Microsoft.App via resource_providers_to_register

> **Apply pendiente en CI**: este PR no cierra el issue #246. El `terraform apply` lo ejecuta el workflow **Infra CD** al mergear este PR a `main` (MEF-ADR-0022); el issue se cierra automaticamente cuando ese apply termine exitosamente.