### PR TITLE
Replicar la stream identity del write-side en los named stores del worker

### DIFF
--- a/src/Bitakora.ControlAsistencia.Projections/Infraestructura/ConfiguracionMartenProjectionsControlHoras.cs
+++ b/src/Bitakora.ControlAsistencia.Projections/Infraestructura/ConfiguracionMartenProjectionsControlHoras.cs
@@ -1,4 +1,4 @@
-using JasperFx.Events; // StreamIdentity
+using JasperFx.Events; // StreamIdentity (NO Marten.Events, mismo gotcha que DaemonMode)
 using JasperFx.Events.Daemon; // DaemonMode (NO Marten.Events.Daemon: compila pero deja DaemonMode sin resolver)
 using Marten;
 
@@ -36,15 +36,14 @@ public static class ConfiguracionMartenProjectionsControlHoras
                 opts.Connection(martenConnectionString);
                 opts.DatabaseSchemaName = SchemaDelDominio; // mismo schema que el write-side (MEF-ADR-0003)
 
-                // Issue #253: replica de la identidad de stream del write-side. El default de
-                // Marten es AsGuid cuando nadie lo configura (Marten docs, "Event Store
-                // Configuration" -> "Stream Identity": "If not set, Marten defaults to
-                // StreamIdentity.AsGuid", https://martendb.io/events/configuration.html#stream-identity),
-                // pero este dominio nunca usa el Guid crudo como stream key:
-                // ControlDiarioAggregateRoot.ComputarStreamId devuelve
-                // "{EmpleadoId}:{Fecha:yyyy-MM-dd}", un valor que ni por accidente es un Guid. Sin
-                // esta linea el daemon interroga el event store (stream_id varchar) como si fuera
-                // uuid y no encuentra ningun stream.
+                // Replica de la identidad de stream que el write-side ya declara
+                // (Cosmos.EventSourcing.CritterStack 2.1.0, AgregarConfiguracionMartenComandos:
+                // Events.StreamIdentity = AsString): el stream key de este dominio lo computa
+                // ControlDiarioAggregateRoot.ComputarStreamId como "{EmpleadoId}:{Fecha:yyyy-MM-dd}",
+                // un valor que ni por accidente es un Guid. Sin esta linea Marten aplica su default
+                // AsGuid ("Event Store Configuration" -> "Stream Identity" en
+                // https://martendb.io/events/configuration.html#stream-identity) y el daemon leeria
+                // el event store (stream_id varchar) como uuid, sin encontrar ningun stream (#253).
                 opts.Events.StreamIdentity = StreamIdentity.AsString;
 
                 // Replica de la configuracion de metadata del write-side (MEF-ADR-0034 seccion 6

--- a/src/Bitakora.ControlAsistencia.Projections/Infraestructura/ConfiguracionMartenProjectionsControlHoras.cs
+++ b/src/Bitakora.ControlAsistencia.Projections/Infraestructura/ConfiguracionMartenProjectionsControlHoras.cs
@@ -1,3 +1,4 @@
+using JasperFx.Events; // StreamIdentity
 using JasperFx.Events.Daemon; // DaemonMode (NO Marten.Events.Daemon: compila pero deja DaemonMode sin resolver)
 using Marten;
 
@@ -34,6 +35,17 @@ public static class ConfiguracionMartenProjectionsControlHoras
             {
                 opts.Connection(martenConnectionString);
                 opts.DatabaseSchemaName = SchemaDelDominio; // mismo schema que el write-side (MEF-ADR-0003)
+
+                // Issue #253: replica de la identidad de stream del write-side. El default de
+                // Marten es AsGuid cuando nadie lo configura (Marten docs, "Event Store
+                // Configuration" -> "Stream Identity": "If not set, Marten defaults to
+                // StreamIdentity.AsGuid", https://martendb.io/events/configuration.html#stream-identity),
+                // pero este dominio nunca usa el Guid crudo como stream key:
+                // ControlDiarioAggregateRoot.ComputarStreamId devuelve
+                // "{EmpleadoId}:{Fecha:yyyy-MM-dd}", un valor que ni por accidente es un Guid. Sin
+                // esta linea el daemon interroga el event store (stream_id varchar) como si fuera
+                // uuid y no encuentra ningun stream.
+                opts.Events.StreamIdentity = StreamIdentity.AsString;
 
                 // Replica de la configuracion de metadata del write-side (MEF-ADR-0034 seccion 6
                 // punto 3, seccion 7): el config-test verifica exactamente estas tres. La

--- a/src/Bitakora.ControlAsistencia.Projections/Infraestructura/ConfiguracionMartenProjectionsProgramacion.cs
+++ b/src/Bitakora.ControlAsistencia.Projections/Infraestructura/ConfiguracionMartenProjectionsProgramacion.cs
@@ -1,4 +1,4 @@
-using JasperFx.Events; // StreamIdentity
+using JasperFx.Events; // StreamIdentity (NO Marten.Events, mismo gotcha que DaemonMode)
 using JasperFx.Events.Daemon; // DaemonMode (NO Marten.Events.Daemon: compila pero deja DaemonMode sin resolver)
 using Marten;
 
@@ -36,14 +36,14 @@ public static class ConfiguracionMartenProjectionsProgramacion
                 opts.Connection(martenConnectionString);
                 opts.DatabaseSchemaName = SchemaDelDominio; // mismo schema que el write-side (MEF-ADR-0003)
 
-                // Issue #253: replica de la identidad de stream del write-side. El default de
-                // Marten es AsGuid cuando nadie lo configura (Marten docs, "Event Store
-                // Configuration" -> "Stream Identity": "If not set, Marten defaults to
-                // StreamIdentity.AsGuid", https://martendb.io/events/configuration.html#stream-identity),
-                // pero este dominio nunca usa el Guid crudo como stream key: SolicitudProgramacion
-                // AggregateRoot.Id = e.Id.ToString() y CatalogoTurnos usan siempre la
-                // representacion string del identificador. Sin esta linea el daemon interroga el
-                // event store (stream_id varchar) como si fuera uuid y no encuentra ningun stream.
+                // Replica de la identidad de stream que el write-side ya declara
+                // (Cosmos.EventSourcing.CritterStack 2.1.0, AgregarConfiguracionMartenComandos:
+                // Events.StreamIdentity = AsString): los stream keys de este dominio son siempre
+                // strings -- e.Id.ToString() en la raiz de solicitud, evento.TurnoId.ToString() en
+                // el catalogo de turnos. Sin esta linea Marten aplica su default AsGuid ("Event
+                // Store Configuration" -> "Stream Identity" en
+                // https://martendb.io/events/configuration.html#stream-identity) y el daemon leeria
+                // el event store (stream_id varchar) como uuid, sin encontrar ningun stream (#253).
                 opts.Events.StreamIdentity = StreamIdentity.AsString;
 
                 // Replica de la configuracion de metadata del write-side (MEF-ADR-0034 seccion 6

--- a/src/Bitakora.ControlAsistencia.Projections/Infraestructura/ConfiguracionMartenProjectionsProgramacion.cs
+++ b/src/Bitakora.ControlAsistencia.Projections/Infraestructura/ConfiguracionMartenProjectionsProgramacion.cs
@@ -1,3 +1,4 @@
+using JasperFx.Events; // StreamIdentity
 using JasperFx.Events.Daemon; // DaemonMode (NO Marten.Events.Daemon: compila pero deja DaemonMode sin resolver)
 using Marten;
 
@@ -34,6 +35,16 @@ public static class ConfiguracionMartenProjectionsProgramacion
             {
                 opts.Connection(martenConnectionString);
                 opts.DatabaseSchemaName = SchemaDelDominio; // mismo schema que el write-side (MEF-ADR-0003)
+
+                // Issue #253: replica de la identidad de stream del write-side. El default de
+                // Marten es AsGuid cuando nadie lo configura (Marten docs, "Event Store
+                // Configuration" -> "Stream Identity": "If not set, Marten defaults to
+                // StreamIdentity.AsGuid", https://martendb.io/events/configuration.html#stream-identity),
+                // pero este dominio nunca usa el Guid crudo como stream key: SolicitudProgramacion
+                // AggregateRoot.Id = e.Id.ToString() y CatalogoTurnos usan siempre la
+                // representacion string del identificador. Sin esta linea el daemon interroga el
+                // event store (stream_id varchar) como si fuera uuid y no encuentra ningun stream.
+                opts.Events.StreamIdentity = StreamIdentity.AsString;
 
                 // Replica de la configuracion de metadata del write-side (MEF-ADR-0034 seccion 6
                 // punto 3, seccion 7): el config-test verifica exactamente estas tres. La

--- a/tests/Bitakora.ControlAsistencia.Projections.Tests/ConfiguracionMartenProjectionsTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Projections.Tests/ConfiguracionMartenProjectionsTests.cs
@@ -77,6 +77,17 @@ public class ConfiguracionMartenProjectionsTests
         provider.AssertDaemonHotCold<IProgramacionProjectionStore>();
     }
 
+    // Issue #253 (CA-1, CA-3, CA-4): el named store de Programacion debe leer el event store con
+    // la misma identidad de stream que su write-side (SolicitudProgramacionAggregateRoot.Id =
+    // e.Id.ToString(), CatalogoTurnos con TurnoId.ToString()), no con el default AsGuid de Marten.
+    [Fact]
+    public void ConfigurarProgramacion_DeclaraLaStreamIdentityComoString()
+    {
+        using var provider = ProviderDeProgramacion();
+
+        provider.GetRequiredService<IProgramacionProjectionStore>().AssertStreamIdentityAsString();
+    }
+
     // --- ControlHoras (CA-2, CA-3, CA-6, CA-7) ---
 
     [Fact]
@@ -119,6 +130,18 @@ public class ConfiguracionMartenProjectionsTests
         using var provider = ProviderDeControlHoras();
 
         provider.AssertDaemonHotCold<IControlHorasProjectionStore>();
+    }
+
+    // Issue #253 (CA-2, CA-3, CA-4): el named store de ControlHoras debe leer el event store con
+    // la misma identidad de stream que su write-side (ControlDiarioAggregateRoot.ComputarStreamId
+    // devuelve "{EmpleadoId}:{Fecha:yyyy-MM-dd}", nunca un Guid), no con el default AsGuid de
+    // Marten.
+    [Fact]
+    public void ConfigurarControlHoras_DeclaraLaStreamIdentityComoString()
+    {
+        using var provider = ProviderDeControlHoras();
+
+        provider.GetRequiredService<IControlHorasProjectionStore>().AssertStreamIdentityAsString();
     }
 
     // --- Seam de nivel BC (CA-4) ---

--- a/tests/Bitakora.ControlAsistencia.Projections.Tests/ConfiguracionMartenProjectionsTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Projections.Tests/ConfiguracionMartenProjectionsTests.cs
@@ -10,9 +10,9 @@ namespace Bitakora.ControlAsistencia.Projections.Tests;
 // .ConfigurarEventos, que es wiring puro para Program.cs y queda fuera de esta medicion -- con una
 // cadena de conexion dummy, sin necesidad de Postgres real (Marten 7+ no abre la conexion durante
 // el bootstrapping del IHost). Cada dominio se cubre con las mismas guardas: el named store
-// resuelve del contenedor, apunta al schema del write-side, replica su metadata de evento, no
-// tiene ninguna proyeccion Inline y corre su daemon en HotCold. La superficie de Marten que cada
-// una interroga vive en AssertsProyecciones.
+// resuelve del contenedor, apunta al schema del write-side, replica su metadata de evento y su
+// identidad de stream, no tiene ninguna proyeccion Inline y corre su daemon en HotCold. La
+// superficie de Marten que cada una interroga vive en AssertsProyecciones.
 public class ConfiguracionMartenProjectionsTests
 {
     private const string ConnectionStringDummy = "Host=localhost;Database=dummy";
@@ -77,9 +77,6 @@ public class ConfiguracionMartenProjectionsTests
         provider.AssertDaemonHotCold<IProgramacionProjectionStore>();
     }
 
-    // Issue #253 (CA-1, CA-3, CA-4): el named store de Programacion debe leer el event store con
-    // la misma identidad de stream que su write-side (SolicitudProgramacionAggregateRoot.Id =
-    // e.Id.ToString(), CatalogoTurnos con TurnoId.ToString()), no con el default AsGuid de Marten.
     [Fact]
     public void ConfigurarProgramacion_DeclaraLaStreamIdentityComoString()
     {
@@ -132,10 +129,6 @@ public class ConfiguracionMartenProjectionsTests
         provider.AssertDaemonHotCold<IControlHorasProjectionStore>();
     }
 
-    // Issue #253 (CA-2, CA-3, CA-4): el named store de ControlHoras debe leer el event store con
-    // la misma identidad de stream que su write-side (ControlDiarioAggregateRoot.ComputarStreamId
-    // devuelve "{EmpleadoId}:{Fecha:yyyy-MM-dd}", nunca un Guid), no con el default AsGuid de
-    // Marten.
     [Fact]
     public void ConfigurarControlHoras_DeclaraLaStreamIdentityComoString()
     {

--- a/tests/Bitakora.ControlAsistencia.Projections.Tests/Infraestructura/AssertsProyecciones.cs
+++ b/tests/Bitakora.ControlAsistencia.Projections.Tests/Infraestructura/AssertsProyecciones.cs
@@ -1,4 +1,5 @@
 using AwesomeAssertions;
+using JasperFx.Events;
 using JasperFx.Events.Daemon;
 using JasperFx.Events.Projections;
 using Marten;
@@ -69,4 +70,25 @@ public static class AssertsProyecciones
         var opciones = (StoreOptions)provider.GetRequiredService<TStore>().Options;
         opciones.Projections.AsyncMode.Should().Be(DaemonMode.HotCold);
     }
+
+    /// <summary>
+    /// Issue #253: el named store del worker debe leer el event store con la misma identidad de
+    /// stream que el write-side de ese mismo dominio ya declara -- gap que MEF-ADR-0034 seccion 6
+    /// todavia no enumera junto a las otras tres guardas (hallazgo a proponer como enmienda de esa
+    /// seccion). El write-side de este BC usa siempre stream keys de tipo string (
+    /// SolicitudProgramacionAggregateRoot.Id = e.Id.ToString(),
+    /// ControlDiarioAggregateRoot.ComputarStreamId), nunca el Guid crudo, asi que el unico valor
+    /// correcto para el named store del worker es AsString.
+    ///
+    /// A diferencia de AsyncMode (AssertDaemonHotCold) y de Projections() (AssertSinProyecciones
+    /// Inline), que solo se exponen en la superficie mutable (StoreOptions), StreamIdentity si
+    /// esta declarada en la superficie de solo lectura que devuelve IDocumentStore.Options:
+    /// IReadOnlyEventStoreOptions.StreamIdentity (Marten.Events, get-only) -- verificado por
+    /// decompilacion contra Marten 9.12.0 / JasperFx.Events 2.18.1, sin necesidad de castear a
+    /// StoreOptions. El default de Marten es AsGuid cuando nadie lo configura (Marten docs,
+    /// "Event Store Configuration" -> "Stream Identity": "If not set, Marten defaults to
+    /// StreamIdentity.AsGuid"), https://martendb.io/events/configuration.html#stream-identity.
+    /// </summary>
+    public static void AssertStreamIdentityAsString(this IDocumentStore store) =>
+        store.Options.Events.StreamIdentity.Should().Be(StreamIdentity.AsString);
 }

--- a/tests/Bitakora.ControlAsistencia.Projections.Tests/Infraestructura/AssertsProyecciones.cs
+++ b/tests/Bitakora.ControlAsistencia.Projections.Tests/Infraestructura/AssertsProyecciones.cs
@@ -72,22 +72,22 @@ public static class AssertsProyecciones
     }
 
     /// <summary>
-    /// Issue #253: el named store del worker debe leer el event store con la misma identidad de
-    /// stream que el write-side de ese mismo dominio ya declara -- gap que MEF-ADR-0034 seccion 6
-    /// todavia no enumera junto a las otras tres guardas (hallazgo a proponer como enmienda de esa
-    /// seccion). El write-side de este BC usa siempre stream keys de tipo string (
-    /// SolicitudProgramacionAggregateRoot.Id = e.Id.ToString(),
-    /// ControlDiarioAggregateRoot.ComputarStreamId), nunca el Guid crudo, asi que el unico valor
-    /// correcto para el named store del worker es AsString.
+    /// El named store lee el event store con la misma identidad de stream que el write-side ya
+    /// declara (Cosmos.EventSourcing.CritterStack 2.1.0: Events.StreamIdentity = AsString): los
+    /// stream keys de este BC son siempre strings -- e.Id.ToString() en la raiz de solicitud,
+    /// ComputarStreamId -> "{EmpleadoId}:{Fecha:yyyy-MM-dd}" en control diario --, nunca el Guid
+    /// crudo. Con el default de Marten (AsGuid cuando nadie lo configura, docs "Event Store
+    /// Configuration" -> "Stream Identity": https://martendb.io/events/configuration.html#stream-identity)
+    /// el daemon leeria stream_id varchar como si fuera uuid y no encontraria ningun stream.
     ///
-    /// A diferencia de AsyncMode (AssertDaemonHotCold) y de Projections() (AssertSinProyecciones
-    /// Inline), que solo se exponen en la superficie mutable (StoreOptions), StreamIdentity si
-    /// esta declarada en la superficie de solo lectura que devuelve IDocumentStore.Options:
-    /// IReadOnlyEventStoreOptions.StreamIdentity (Marten.Events, get-only) -- verificado por
-    /// decompilacion contra Marten 9.12.0 / JasperFx.Events 2.18.1, sin necesidad de castear a
-    /// StoreOptions. El default de Marten es AsGuid cuando nadie lo configura (Marten docs,
-    /// "Event Store Configuration" -> "Stream Identity": "If not set, Marten defaults to
-    /// StreamIdentity.AsGuid"), https://martendb.io/events/configuration.html#stream-identity.
+    /// A diferencia de AsyncMode (AssertDaemonHotCold), que solo existe en la superficie mutable,
+    /// StreamIdentity si esta declarada en la de solo lectura que devuelve IDocumentStore.Options
+    /// (Marten.Events.IReadOnlyEventStoreOptions.StreamIdentity, get-only -- verificado por
+    /// decompilacion contra Marten 9.12.0 / JasperFx.Events 2.18.1), asi que aqui no hace falta
+    /// castear a StoreOptions.
+    ///
+    /// MEF-ADR-0034 seccion 6 todavia no enumera esta guarda junto a las otras tres: candidata a
+    /// enmienda de esa seccion en el harness (issue #253).
     /// </summary>
     public static void AssertStreamIdentityAsString(this IDocumentStore store) =>
         store.Options.Events.StreamIdentity.Should().Be(StreamIdentity.AsString);


### PR DESCRIPTION
## Resumen

Pipeline TDD completado:
- Fase roja: tests escritos con stubs
- Fase verde: implementación completa
- Fase refactor: revisión de calidad

## Decisiones del pipeline

<details>
<summary>Projection Test Writer (fase roja) — 0m 0s</summary>

# Fase roja read-side -- issue #253: Replicar la stream identity del write-side en los named stores del worker

## Naturaleza del issue

Issue puro de config-test del worker. Sin read model, sin clase de proyeccion, sin Function GET
-- coincide con lo que la propia HU declara en "Necesidad de lectura" y "Capas de test esperadas":
la unica capa que aplica es el config-test de `ConfiguracionMartenProjectionsTests` (MEF-ADR-0034
seccion 6). No se tocó nada de `src/`.

## Tests creados

Dos guardas nuevas en `tests/Bitakora.ControlAsistencia.Projections.Tests/ConfiguracionMartenProjectionsTests.cs`,
hermanas de las cinco existentes por dominio, siguiendo MEF-ADR-0016:

- `ConfigurarProgramacion_DeclaraLaStreamIdentityComoString` (CA-1, CA-4)
- `ConfigurarControlHoras_DeclaraLaStreamIdentityComoString` (CA-2, CA-4)

Ambas invocan `Configurar{Dominio}` directamente con la cadena dummy (mismo patron que las
guardas existentes, sin Postgres real) y delegan la verificacion en un helper nuevo.

## Helper nuevo (CA-3)

`AssertStreamIdentityAsString(this IDocumentStore store)` en
`tests/Bitakora.ControlAsistencia.Projections.Tests/Infraestructura/AssertsProyecciones.cs`,
hermano de `AssertOpcionesDeEvento`/`AssertSchema`/`AssertSinProyeccionesInline`/`AssertDaemonHotCold`.

Verifica `store.Options.Events.StreamIdentity == StreamIdentity.AsString`.

Superficie de Marten resuelta **por decompilacion** (no por asuncion), contra los paquetes
pinneados de este worker:

- `Marten` `9.12.0` (`src/Bitakora.ControlAsistencia.Projections.csproj`).
- `JasperFx.Events` `2.18.1` (resuelto via `project.assets.json` del worker).

Hallazgos verificados con `ilspycmd` sobre ambos ensamblados:

- `JasperFx.Events.StreamIdentity` es el enum correcto (`AsGuid = 0` default, `AsString = 1`).
  **No** vive en `Marten.Events.Daemon` ni en otro namespace de Marten -- riesgo que la propia
  HU señalaba por precedente (`DaemonMode`), descartado aqui por decompilacion directa.
- `IDocumentStore.Options` es `IReadOnlyStoreOptions`; su miembro `Events` es
  `IReadOnlyEventStoreOptions`, que expone `StreamIdentity` como propiedad **get-only** en la
  superficie de solo lectura. A diferencia de `AsyncMode` (`AssertDaemonHotCold`) y de
  `Projections()` (`AssertSinProyeccionesInline`), que CA-3 anticipaba como posible precedente de
  casteo a `StoreOptions`, **no hizo falta castear**: `store.Options.Events.StreamIdentity` basta.
  Documentado en el doc-comment del helper para que quien lo lea despues no repita la
  investigacion.

No fue necesario ningun stub de compilacion: el seam (`Configurar{Dominio}`), el marker
(`I{Dominio}ProjectionStore`) y el helper class (`AssertsProyecciones`) ya existian en el
worktree, completos, de issues anteriores (#235). Este issue solo añade una linea de produccion
por dominio (fuera de mi alcance, la escribe `projection-implementer`) mas el helper y las dos
guardas de test.

## Por que el rojo es real

Ninguno de los dos named stores (`ConfiguracionMartenProjectionsProgramacion.cs`,
`ConfiguracionMartenProjectionsControlHoras.cs`) declara `opts.Events.StreamIdentity` hoy, asi
que Marten aplica su default (`StreamIdentity.AsGuid`, confirmado por decompilacion del
constructor de `EventGraph`). Las dos guardas nuevas esperan `AsString` y fallan contra el
codigo actual -- exactamente el rojo que pide el issue, sin tocar produccion.

## Cobertura de criterios de aceptacion

- CA-1 / CA-2 (produccion): fuera de mi alcance, quedan para `projection-implementer`.
- CA-3: helper `AssertStreamIdentityAsString` creado en `AssertsProyecciones.cs`.
- CA-4: dos guardas nuevas, una por dominio, con el naming exacto sugerido por el issue.
- CA-5: las once guardas existentes no se tocaron (solo se insertaron metodos nuevos, sin tocar
  ninguna linea de las guardas previas). Verificado con `dotnet build` de la solucion completa:
  compila limpio.

## Verificacion de compilacion

`dotnet build` (proyecto de tests y solucion completa): compilacion correcta, 0 errores.
No se corrio `dotnet test` (regla del rol: se sabe que el resultado sera rojo).

## Desviaciones del plan del planner

Ninguna. El issue ya anticipaba con precision el helper, el naming de las guardas y el riesgo de
namespace/superficie de Marten; solo hizo falta resolver esos dos puntos por compilacion/decompilacion
tal como el propio issue pedia ("A resolver por compilacion").

## Hallazgo para reportar (no resuelto aqui, per alcance del issue)

El issue ya lo señala: MEF-ADR-0034 seccion 6 solo enumera tres guardas (partial, ciclo de vida
Async, replica de metadata) y no nombra esta cuarta (identidad de stream). Vale la pena un draft
en el repo del harness para sumarla a la doctrina, como ya se hizo con los gaps hermanos de
serializacion (#238/#252). No lo resuelvo yo -- lo dejo consignado para quien continue el
pipeline.

</details>

<details>
<summary>Projection Implementer (fase verde) — 0m 0s</summary>

# Stage 2 -- projection-implementer (issue #253)

## Enfoque

El issue es de configuracion pura del read-side: no crea read model, clase de
proyeccion ni Function. El unico trabajo de produccion es sumar
`opts.Events.StreamIdentity = StreamIdentity.AsString;` dentro del
`AddMartenStore<...>` que ya registra cada named store del worker
(`ConfiguracionMartenProjectionsProgramacion.ConfigurarProgramacion` y
`ConfiguracionMartenProjectionsControlHoras.ConfigurarControlHoras`), replicando
del lado lectura la identidad de stream que el write-side de cada dominio ya usa
(stream keys string: `SolicitudProgramacionAggregateRoot.Id = e.Id.ToString()`,
`CatalogoTurnos.TurnoId.ToString()`, `ControlDiarioAggregateRoot.ComputarStreamId`).

No toque el seam de nivel BC (`ConfiguracionMartenProjections.ConfigurarEventos`)
ni el write-side de ningun dominio -- fuera del alcance declarado explicitamente
en el issue.

## Decisiones de diseno

- El `using JasperFx.Events;` para `StreamIdentity` se resolvio siguiendo el
  mismo namespace que ya usa `AssertsProyecciones.cs` (el test-writer ya lo
  habia verificado por decompilacion contra Marten 9.12.0 / JasperFx.Events
  2.18.1). Confirmado ademas por build limpio: `StreamIdentity` vive en
  `JasperFx.Events`, no en `Marten.Events` -- mismo patron de gotcha ya
  documentado en el archivo para `DaemonMode` (`JasperFx.Events.Daemon`, no
  `Marten.Events.Daemon`).
- La linea nueva se coloco inmediatamente despues de `DatabaseSchemaName` y
  antes del bloque de metadata de evento, con un comentario que explica el
  "por que" (default `AsGuid` de Marten citado con la URL de la doc oficial) y
  cita la evidencia concreta del write-side de cada dominio -- mismo estilo que
  los comentarios ya existentes en ambos archivos.
- No fue necesario tocar `AssertsProyecciones.cs` ni
  `ConfiguracionMartenProjectionsTests.cs`: ya los dejo completos
  `projection-test-writer` (CA-3 y CA-4), y como implementer nunca modifico
  tests.

## ADRs consultados

- MEF-ADR-0034 secciones 2, 6 y 7 (replica de configuracion write-side ->
  read-side, guardas del config-test, metadata de evento).
- MEF-ADR-0029 (fuente unica compartida entre composicion y test: el
  config-test invoca el mismo seam `Configurar{Dominio}` que `Program.cs`).
- MEF-ADR-0003 (pin de Marten 9.12.0; la superficie exacta de `StoreOptions`
  se verifico por compilacion, no se asumio).
- Skill `projections` (precargado) + recurso de Nivel 3 `modelos-marten.md`
  para el arbol de decision N1/N2 -- no aplica en este issue porque no hay
  ninguna proyeccion concreta que crear.

## Desviaciones

Ninguna. El cambio de produccion es exactamente el sugerido en el issue: dos
lineas (una por named store) mas su comentario, dentro del `AddMartenStore`
que `domain-scaffolder`/issue #235 ya habia dejado registrado. No fue
necesaria ninguna guarda de `partial` (el seam ya tenia modificadores de
acceso desde el issue #235) ni ningun ajuste a `ComposicionServicios{Dominio}`
(este issue no crea Functions).

## Hallazgo a reportar (no resuelto aqui, por alcance explicito del issue)

Tal como anota el issue, el gap de "identidad de stream no nombrada en
MEF-ADR-0034 seccion 6" es candidato a enmienda de esa seccion en el repo del
harness (mefisto), hermano de los gaps de serializacion (#238/#252). No lo
resolvi aqui: implicaria editar el ADR fuera de este repo consumidor.

## Resultado

- `dotnet build` sobre `ControlAsistencias.slnx`: compilacion correcta, 0
  errores (solo warnings preexistentes `NU1902` de `OpenTelemetry.Api`, no
  relacionados).
- `dotnet test --project tests/Bitakora.ControlAsistencia.Projections.Tests/...`:
  13/13 correctas (las 11 guardas existentes + las 2 nuevas de CA-4:
  `ConfigurarProgramacion_DeclaraLaStreamIdentityComoString` y
  `ConfigurarControlHoras_DeclaraLaStreamIdentityComoString`).
- `dotnet test --solution ControlAsistencias.slnx`: 473 correctas, 8 omitidas
  (smoke tests que exigen Postgres/Service Bus locales, preexistente), 0
  errores -- write-side de ambos dominios intacto.
- Formateo: no se detecto MCP de JetBrains disponible en este entorno: use
  `dotnet format ControlAsistencias.slnx --include <archivos>`; el diff no
  cambio despues de ejecutarlo (ya cumplia el estilo del archivo).
- Commit `95bc98e`: `feat(hu-253): replicar stream identity AsString en named
  stores del worker (fase verde)`.

</details>
<details>
<summary>Reviewer (fase refactor) — 0m 0s</summary>

_(El agente no generó resumen)_

</details>

## Cobertura

| Archivo | Cobertura | Umbral | Estado |
|---|---|---|---|
| ConfiguracionMartenProjectionsControlHoras.cs | - | no evaluado | - |
| ConfiguracionMartenProjectionsProgramacion.cs | - | no evaluado | - |
## Commits

eff0c09 refactor(hu-253): precisar la evidencia del write-side en la guarda de stream identity
95bc98e feat(hu-253): replicar stream identity AsString en named stores del worker (fase verde)
0055b7b test(hu-253): guardas de stream identity para named stores del worker (fase roja)

Closes #253