### PR TITLE
Instrumentar el worker de proyecciones con Application Insights

### DIFF
--- a/src/Bitakora.ControlAsistencia.Projections/Bitakora.ControlAsistencia.Projections.csproj
+++ b/src/Bitakora.ControlAsistencia.Projections/Bitakora.ControlAsistencia.Projections.csproj
@@ -11,10 +11,19 @@
   <ItemGroup>
     <PackageReference Include="Marten" Version="9.12.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
+    <!-- Issue #250: mismas versiones que ControlHoras (patron de referencia). Se usa el exporter,
+         no el distro Azure.Monitor.OpenTelemetry.AspNetCore, porque este worker no es ASP.NET Core
+         y no recibe requests. Ver ConfiguracionObservabilidadProjections. -->
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.8.1" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Bitakora.ControlAsistencia.ReadModels\Bitakora.ControlAsistencia.ReadModels.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Bitakora.ControlAsistencia.Projections.Tests" />
   </ItemGroup>
 
 </Project>

--- a/src/Bitakora.ControlAsistencia.Projections/Infraestructura/ConfiguracionObservabilidadProjections.cs
+++ b/src/Bitakora.ControlAsistencia.Projections/Infraestructura/ConfiguracionObservabilidadProjections.cs
@@ -21,6 +21,16 @@ public static class ConfiguracionObservabilidadProjections
     internal const string VariableRatioSampling = "TELEMETRY_SAMPLING_RATIO";
     internal const double RatioSamplingPorDefecto = 0.2;
 
+    // CA-2: el source del propio ensamblado. El wildcard va SIN punto antes del asterisco --
+    // divergencia deliberada frente a ControlHoras ("...ControlHoras.*"), verificada
+    // empiricamente contra OpenTelemetry 1.16.0: el patron "X.*" se ancla como ^X\..*$ y NO
+    // captura una ActivitySource nombrada exactamente "X", mientras "X*" captura tanto "X" como
+    // "X.Hija". Como lo idiomatico al instrumentar es nombrar la fuente con el nombre del
+    // ensamblado (`Assembly.GetName().Name`), con el punto los spans del propio worker se
+    // descartarian EN SILENCIO -- el mismo tipo de wiring a medio terminar que este issue cierra.
+    // Fijado por guardrail en ConfiguracionObservabilidadProjectionsTests.
+    internal const string PatronFuentePropia = "Bitakora.ControlAsistencia.Projections*";
+
     public static IServiceCollection ConfigurarObservabilidad(this IServiceCollection services)
     {
         // Observabilidad: exporta las trazas del worker (Npgsql, Marten) a Application Insights via
@@ -47,7 +57,7 @@ public static class ConfiguracionObservabilidadProjections
                 .SetSampler(new ParentBasedSampler(new TraceIdRatioBasedSampler(samplingRatio)))
                 .AddSource("Marten")
                 .AddSource("Npgsql")
-                .AddSource("Bitakora.ControlAsistencia.Projections.*"))
+                .AddSource(PatronFuentePropia))
             .UseAzureMonitorExporter();
 
         return services;

--- a/src/Bitakora.ControlAsistencia.Projections/Infraestructura/ConfiguracionObservabilidadProjections.cs
+++ b/src/Bitakora.ControlAsistencia.Projections/Infraestructura/ConfiguracionObservabilidadProjections.cs
@@ -1,4 +1,6 @@
-using Microsoft.Extensions.DependencyInjection;
+using System.Globalization;
+using Azure.Monitor.OpenTelemetry.Exporter;
+using OpenTelemetry.Trace;
 
 namespace Bitakora.ControlAsistencia.Projections.Infraestructura;
 
@@ -9,8 +11,6 @@ namespace Bitakora.ControlAsistencia.Projections.Infraestructura;
 /// seam). El worker corre sin ingress (MEF-ADR-0034 seccion 8), asi que la unica observabilidad
 /// posible es trazas exportadas a Application Insights via OpenTelemetry: no hay endpoint HTTP que
 /// las herramientas de diagnostico del marco puedan golpear.
-///
-/// STUB (fase roja del pipeline TDD): implementacion pendiente del implementer.
 /// </summary>
 public static class ConfiguracionObservabilidadProjections
 {
@@ -23,15 +23,46 @@ public static class ConfiguracionObservabilidadProjections
 
     public static IServiceCollection ConfigurarObservabilidad(this IServiceCollection services)
     {
-        throw new NotImplementedException();
+        // Observabilidad: exporta las trazas del worker (Npgsql, Marten) a Application Insights via
+        // OpenTelemetry. El worker no es ASP.NET Core ni Azure Functions (Microsoft.NET.Sdk.Worker,
+        // Host.CreateApplicationBuilder), no recibe requests y corre sin ingress (MEF-ADR-0034
+        // seccion 8): se usa el exporter, no el distro Azure.Monitor.OpenTelemetry.AspNetCore, ni
+        // Microsoft.Azure.Functions.Worker.OpenTelemetry / UseFunctionsWorkerDefaults (no hay host de
+        // Functions). Mismo argumento que ControlHoras/ComposicionServicios.cs, con mas fuerza aqui.
+        // El exporter resuelve APPLICATIONINSIGHTS_CONNECTION_STRING del entorno por convencion
+        // propia (no se lee ni se pasa a mano): la inyecta el Container App via Key Vault reference
+        // (MEF-ADR-0025/CA-ADR-0026, issue #234).
+        //
+        // CA-ADR-0009 Capa 2 (control de costos): sampler head-based ParentBasedSampler +
+        // TraceIdRatioBasedSampler, ratio configurable via TELEMETRY_SAMPLING_RATIO (default 0.2).
+        // Este worker corre 24/7 con min_replicas = 1 (a diferencia de las Function Apps, que
+        // escalan a cero), asi que puede generar volumen sostenido mayor -- el sampler debe estar
+        // desde el dia uno. Para un diagnostico puntual se sube a 1.0 manualmente en el Container
+        // App y se baja despues; el daily cap (Capa 3) y la alerta de spike (Capa 4) siguen activos.
+        var samplingRatio = ResolverRatioDeSampling(
+            Environment.GetEnvironmentVariable(VariableRatioSampling));
+
+        services.AddOpenTelemetry()
+            .WithTracing(tracing => tracing
+                .SetSampler(new ParentBasedSampler(new TraceIdRatioBasedSampler(samplingRatio)))
+                .AddSource("Marten")
+                .AddSource("Npgsql")
+                .AddSource("Bitakora.ControlAsistencia.Projections.*"))
+            .UseAzureMonitorExporter();
+
+        return services;
     }
 
     // Extraido como metodo interno testeable en vez de leer Environment.GetEnvironmentVariable
     // inline (a diferencia de ControlHoras/ComposicionServicios.cs): permite verificar el parsing
     // del ratio (CA-3: default 0.2 ante ausencia/valor invalido/fuera de rango) sin mutar variables
     // de entorno de proceso en los tests, que corren en paralelo entre clases.
-    internal static double ResolverRatioDeSampling(string? valorConfigurado)
-    {
-        throw new NotImplementedException();
-    }
+    internal static double ResolverRatioDeSampling(string? valorConfigurado) =>
+        double.TryParse(
+            valorConfigurado,
+            NumberStyles.Float,
+            CultureInfo.InvariantCulture,
+            out var ratio) && ratio is >= 0.0 and <= 1.0
+            ? ratio
+            : RatioSamplingPorDefecto;
 }

--- a/src/Bitakora.ControlAsistencia.Projections/Infraestructura/ConfiguracionObservabilidadProjections.cs
+++ b/src/Bitakora.ControlAsistencia.Projections/Infraestructura/ConfiguracionObservabilidadProjections.cs
@@ -1,0 +1,37 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Bitakora.ControlAsistencia.Projections.Infraestructura;
+
+/// <summary>
+/// Seam de composicion de observabilidad del worker de proyecciones (issue #250). Program.cs
+/// invoca este metodo -- no wirea OpenTelemetry inline -- igual que ya hace con
+/// <see cref="ConfiguracionMartenProjections.ConfigurarEventos"/> (MEF-ADR-0029, hermano de este
+/// seam). El worker corre sin ingress (MEF-ADR-0034 seccion 8), asi que la unica observabilidad
+/// posible es trazas exportadas a Application Insights via OpenTelemetry: no hay endpoint HTTP que
+/// las herramientas de diagnostico del marco puedan golpear.
+///
+/// STUB (fase roja del pipeline TDD): implementacion pendiente del implementer.
+/// </summary>
+public static class ConfiguracionObservabilidadProjections
+{
+    // CA-3 / CA-ADR-0009 Capa 2 (control de costos): sampler head-based
+    // ParentBasedSampler(TraceIdRatioBasedSampler(ratio)), ratio leido de esta variable de entorno.
+    // Default 0.2 cuando la variable falta o es invalida. Para un diagnostico puntual se sube a 1.0
+    // manualmente en el Container App y se baja despues -- no se sube el default en codigo.
+    internal const string VariableRatioSampling = "TELEMETRY_SAMPLING_RATIO";
+    internal const double RatioSamplingPorDefecto = 0.2;
+
+    public static IServiceCollection ConfigurarObservabilidad(this IServiceCollection services)
+    {
+        throw new NotImplementedException();
+    }
+
+    // Extraido como metodo interno testeable en vez de leer Environment.GetEnvironmentVariable
+    // inline (a diferencia de ControlHoras/ComposicionServicios.cs): permite verificar el parsing
+    // del ratio (CA-3: default 0.2 ante ausencia/valor invalido/fuera de rango) sin mutar variables
+    // de entorno de proceso en los tests, que corren en paralelo entre clases.
+    internal static double ResolverRatioDeSampling(string? valorConfigurado)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/Bitakora.ControlAsistencia.Projections/Program.cs
+++ b/src/Bitakora.ControlAsistencia.Projections/Program.cs
@@ -8,5 +8,7 @@ var builder = Host.CreateApplicationBuilder(args);
 var martenConnectionString = Environment.GetEnvironmentVariable("MartenConnectionString")!;
 
 builder.Services.ConfigurarEventos(martenConnectionString);
+// Issue #250: seam de observabilidad propio (MEF-ADR-0029), hermano de ConfigurarEventos.
+builder.Services.ConfigurarObservabilidad();
 
 await builder.Build().RunAsync();

--- a/tests/Bitakora.ControlAsistencia.Projections.Tests/Infraestructura/ConfiguracionObservabilidadProjectionsTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Projections.Tests/Infraestructura/ConfiguracionObservabilidadProjectionsTests.cs
@@ -11,36 +11,73 @@
 // El parsing del ratio de sampling (CA-3, CA-ADR-0009 Capa 2) se extrajo a un metodo interno
 // testeable (ResolverRatioDeSampling) en vez de leerse inline de Environment.GetEnvironmentVariable
 // dentro del seam: permite verificar el default (0.2) ante ausencia/valor invalido/fuera de rango
-// sin mutar variables de entorno del proceso, evitando interferencia con otras clases de test que
-// puedan correr en paralelo.
+// sin depender del entorno del proceso de test.
+//
+// Limites conocidos de esta clase (documentados, no huecos accidentales):
+//
+// 1. Que el ratio resuelto llegue efectivamente al ParentBasedSampler/TraceIdRatioBasedSampler no
+//    se verifica: el sampler compuesto vive dentro de TracerProviderSdk, que OpenTelemetry no
+//    expone publicamente. Ejercitarlo end-to-end exigiria muestrear actividades reales contra un
+//    ratio fraccionario -- probabilistico y flaky. Queda cubierto por revision de codigo.
+// 2. Que Program.cs invoque el seam (CA-4) tampoco: Program.cs son top-level statements y el
+//    worker no tiene equivalente a WebApplicationFactory (limite que MEF-ADR-0029 ya reconoce).
+//    Lo mas cerca que llega esta clase es componer juntos los dos seams del worker
+//    (ConfigurarEventos + ConfigurarObservabilidad), que es lo que Program.cs encadena; el enlace
+//    literal queda cubierto por revision de codigo (CA-4) y por el arranque real post-deploy
+//    (MEF-ADR-0013).
+using System.Diagnostics;
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.Projections.Infraestructura;
 using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry;
 using OpenTelemetry.Trace;
 
 namespace Bitakora.ControlAsistencia.Projections.Tests.Infraestructura;
 
 public class ConfiguracionObservabilidadProjectionsTests
 {
-    private const string ConnectionStringDummy =
+    private const string VariableConnectionString = "APPLICATIONINSIGHTS_CONNECTION_STRING";
+
+    private const string ConnectionStringAppInsightsDummy =
         "InstrumentationKey=00000000-0000-0000-0000-000000000000;" +
         "IngestionEndpoint=https://dummy.in.applicationinsights.azure.com/";
 
-    private static ServiceProvider ComponerServiceProvider()
+    private const string MartenConnectionStringDummy = "Host=localhost;Database=dummy";
+
+    private static ServiceProvider ComponerServiceProvider(
+        Action<IServiceCollection>? seamsAdicionales = null)
     {
         var services = new ServiceCollection();
         services.AddLogging();
 
         services.ConfigurarObservabilidad();
+        seamsAdicionales?.Invoke(services);
 
         return services.BuildServiceProvider(
             new ServiceProviderOptions { ValidateOnBuild = true, ValidateScopes = true });
     }
 
+    // Fija el valor de la variable de entorno mientras corre la accion y lo restaura despues
+    // (null la elimina). Sin esto, el escenario "connection string ausente" no seria determinista:
+    // dependeria de que el entorno del proceso de test no la tenga seteada, y CI si podria tenerla.
+    private static void ConVariableDeEntorno(string nombre, string? valor, Action accion)
+    {
+        var original = Environment.GetEnvironmentVariable(nombre);
+        Environment.SetEnvironmentVariable(nombre, valor);
+        try
+        {
+            accion();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(nombre, original);
+        }
+    }
+
     // --- Composicion del seam (CA-2, CA-4, CA-5) ---
 
     [Fact]
-    public void ConfigurarObservabilidad_ComponeElContenedorSinExcepciones_ConValidateOnBuild()
+    public void ConfigurarObservabilidad_ComponeElGrafoCompleto_CuandoSeValidaAlConstruir()
     {
         var act = () => ComponerServiceProvider().Dispose();
 
@@ -48,37 +85,72 @@ public class ConfiguracionObservabilidadProjectionsTests
     }
 
     [Fact]
-    public void ConfigurarObservabilidad_ResuelveTracerProviderDelContenedor()
+    public void ConfigurarObservabilidad_ResuelveTracerProviderDelContenedor_CuandoLaConnectionStringEstaAusente()
     {
-        using var provider = ComponerServiceProvider();
-
-        var tracerProvider = provider.GetService<TracerProvider>();
-
-        tracerProvider.Should().NotBeNull();
-    }
-
-    [Fact]
-    public void ConfigurarObservabilidad_ResuelveTracerProviderDelContenedor_CuandoLaConnectionStringEstaPresente()
-    {
-        var original = Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING");
-        try
+        // Escenario de arranque local y de una revision cuya Key Vault reference aun no resolvio
+        // (MEF-ADR-0034 seccion 8, secreto sembrado despues del apply): el exporter no debe tumbar
+        // la composicion del worker por falta de connection string -- solo falla al exportar.
+        ConVariableDeEntorno(VariableConnectionString, null, () =>
         {
-            // Replica el escenario real (MEF-ADR-0025/CA-ADR-0026): el Container App inyecta esta
-            // variable via Key Vault reference; este test no la lee a mano, solo verifica que el
-            // exporter no revienta la composicion cuando el runtime ya la puso en el entorno.
-            Environment.SetEnvironmentVariable(
-                "APPLICATIONINSIGHTS_CONNECTION_STRING", ConnectionStringDummy);
-
             using var provider = ComponerServiceProvider();
 
             var tracerProvider = provider.GetService<TracerProvider>();
 
             tracerProvider.Should().NotBeNull();
-        }
-        finally
+        });
+    }
+
+    [Fact]
+    public void ConfigurarObservabilidad_ResuelveTracerProviderDelContenedor_CuandoLaConnectionStringEstaPresente()
+    {
+        // Replica el escenario real (MEF-ADR-0025/CA-ADR-0026): el Container App inyecta esta
+        // variable via Key Vault reference; el seam no la lee ni la pasa a mano -- la resuelve el
+        // exporter por convencion propia.
+        ConVariableDeEntorno(VariableConnectionString, ConnectionStringAppInsightsDummy, () =>
         {
-            Environment.SetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING", original);
-        }
+            using var provider = ComponerServiceProvider();
+
+            var tracerProvider = provider.GetService<TracerProvider>();
+
+            tracerProvider.Should().NotBeNull();
+        });
+    }
+
+    // Los dos seams del worker se registran sobre el mismo IServiceCollection, en el mismo orden en
+    // que Program.cs los encadena. Sin esta guarda, cada seam queda verde por separado y un choque
+    // entre ambos (registro duplicado, dependencia que uno espera del otro) solo aparece al
+    // arrancar el proceso real. Sigue sin necesitar Postgres: Marten 7+ no abre conexion durante el
+    // bootstrapping del IHost.
+    [Fact]
+    public void ConfigurarObservabilidad_ResuelveTracerProviderDelContenedor_CuandoSeComponeJuntoAlSeamDeEventos()
+    {
+        using var provider = ComponerServiceProvider(
+            services => services.ConfigurarEventos(MartenConnectionStringDummy));
+
+        provider.GetService<TracerProvider>().Should().NotBeNull();
+        provider.GetService<IProgramacionProjectionStore>().Should().NotBeNull();
+        provider.GetService<IControlHorasProjectionStore>().Should().NotBeNull();
+    }
+
+    // El patron de la fuente propia (CA-2) va sin punto antes del asterisco a proposito. Verificado
+    // contra OpenTelemetry 1.16.0: "X.*" se ancla como ^X\..*$ y descarta una ActivitySource
+    // nombrada exactamente "X", que es como se nombra al instrumentar con el nombre del ensamblado.
+    // Esta guarda evita que alguien "restaure la paridad" con ControlHoras ("...ControlHoras.*") y
+    // deje los spans del worker sin capturar EN SILENCIO. Construye su propio TracerProvider en vez
+    // de usar el del contenedor porque ese lleva el sampler de ratio 0.2 (CA-3), que volveria la
+    // asercion probabilistica; aca el sampler por defecto la vuelve determinista.
+    [Fact]
+    public void PatronFuentePropia_CapturaLaActividad_CuandoLaFuenteSeLlamaComoElEnsambladoDelWorker()
+    {
+        var nombreDelEnsamblado = typeof(ConfiguracionObservabilidadProjections).Assembly.GetName().Name!;
+        using var provider = Sdk.CreateTracerProviderBuilder()
+            .AddSource(ConfiguracionObservabilidadProjections.PatronFuentePropia)
+            .Build();
+        using var fuente = new ActivitySource(nombreDelEnsamblado);
+
+        using var actividad = fuente.StartActivity("operacion-de-prueba");
+
+        actividad.Should().NotBeNull();
     }
 
     // --- Parsing del ratio de sampling (CA-3, CA-6, CA-ADR-0009 Capa 2) ---
@@ -122,10 +194,4 @@ public class ConfiguracionObservabilidadProjectionsTests
 
         ratio.Should().Be(0.5);
     }
-
-    // --- Seam de nivel BC (CA-4): Program.cs debe invocar ConfigurarObservabilidad junto a
-    // ConfigurarEventos. Esta guarda documenta el requisito -- MEF-ADR-0029 no puede testear
-    // Program.cs directamente (top-level statements, sin equivalente a WebApplicationFactory para
-    // el worker), asi que el enlace real entre Program.cs y este seam queda cubierto por el smoke
-    // test post-deploy (MEF-ADR-0013) y por revision de codigo (CA-4), no por este test unitario.
 }

--- a/tests/Bitakora.ControlAsistencia.Projections.Tests/Infraestructura/ConfiguracionObservabilidadProjectionsTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Projections.Tests/Infraestructura/ConfiguracionObservabilidadProjectionsTests.cs
@@ -1,0 +1,131 @@
+// Issue #250: instrumentar el worker de proyecciones con Application Insights.
+//
+// El worker corre sin ingress (MEF-ADR-0034 seccion 8): no hay endpoint HTTP que golpear para
+// diagnosticar el daemon HotCold, asi que la observabilidad depende exclusivamente de trazas
+// OpenTelemetry exportadas a Application Insights. Este test de composicion es hermano del que
+// exige MEF-ADR-0029: construye el mismo IServiceCollection que Program.cs compone (via el seam
+// ConfiguracionObservabilidadProjections.ConfigurarObservabilidad, CA-4) y verifica que el
+// TracerProvider se resuelve del contenedor (CA-2, CA-5), sin necesidad de Postgres real ni de
+// un Container App desplegado.
+//
+// El parsing del ratio de sampling (CA-3, CA-ADR-0009 Capa 2) se extrajo a un metodo interno
+// testeable (ResolverRatioDeSampling) en vez de leerse inline de Environment.GetEnvironmentVariable
+// dentro del seam: permite verificar el default (0.2) ante ausencia/valor invalido/fuera de rango
+// sin mutar variables de entorno del proceso, evitando interferencia con otras clases de test que
+// puedan correr en paralelo.
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Projections.Infraestructura;
+using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry.Trace;
+
+namespace Bitakora.ControlAsistencia.Projections.Tests.Infraestructura;
+
+public class ConfiguracionObservabilidadProjectionsTests
+{
+    private const string ConnectionStringDummy =
+        "InstrumentationKey=00000000-0000-0000-0000-000000000000;" +
+        "IngestionEndpoint=https://dummy.in.applicationinsights.azure.com/";
+
+    private static ServiceProvider ComponerServiceProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.ConfigurarObservabilidad();
+
+        return services.BuildServiceProvider(
+            new ServiceProviderOptions { ValidateOnBuild = true, ValidateScopes = true });
+    }
+
+    // --- Composicion del seam (CA-2, CA-4, CA-5) ---
+
+    [Fact]
+    public void ConfigurarObservabilidad_ComponeElContenedorSinExcepciones_ConValidateOnBuild()
+    {
+        var act = () => ComponerServiceProvider().Dispose();
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void ConfigurarObservabilidad_ResuelveTracerProviderDelContenedor()
+    {
+        using var provider = ComponerServiceProvider();
+
+        var tracerProvider = provider.GetService<TracerProvider>();
+
+        tracerProvider.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void ConfigurarObservabilidad_ResuelveTracerProviderDelContenedor_CuandoLaConnectionStringEstaPresente()
+    {
+        var original = Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING");
+        try
+        {
+            // Replica el escenario real (MEF-ADR-0025/CA-ADR-0026): el Container App inyecta esta
+            // variable via Key Vault reference; este test no la lee a mano, solo verifica que el
+            // exporter no revienta la composicion cuando el runtime ya la puso en el entorno.
+            Environment.SetEnvironmentVariable(
+                "APPLICATIONINSIGHTS_CONNECTION_STRING", ConnectionStringDummy);
+
+            using var provider = ComponerServiceProvider();
+
+            var tracerProvider = provider.GetService<TracerProvider>();
+
+            tracerProvider.Should().NotBeNull();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING", original);
+        }
+    }
+
+    // --- Parsing del ratio de sampling (CA-3, CA-6, CA-ADR-0009 Capa 2) ---
+
+    [Fact]
+    public void ResolverRatioDeSampling_DevuelveElRatioPorDefecto_CuandoValorEsNull()
+    {
+        var ratio = ConfiguracionObservabilidadProjections.ResolverRatioDeSampling(null);
+
+        ratio.Should().Be(ConfiguracionObservabilidadProjections.RatioSamplingPorDefecto);
+    }
+
+    [Fact]
+    public void ResolverRatioDeSampling_DevuelveElRatioPorDefecto_CuandoValorNoEsNumerico()
+    {
+        var ratio = ConfiguracionObservabilidadProjections.ResolverRatioDeSampling("no-es-un-numero");
+
+        ratio.Should().Be(ConfiguracionObservabilidadProjections.RatioSamplingPorDefecto);
+    }
+
+    [Fact]
+    public void ResolverRatioDeSampling_DevuelveElRatioPorDefecto_CuandoValorEstaPorEncimaDeUno()
+    {
+        var ratio = ConfiguracionObservabilidadProjections.ResolverRatioDeSampling("1.5");
+
+        ratio.Should().Be(ConfiguracionObservabilidadProjections.RatioSamplingPorDefecto);
+    }
+
+    [Fact]
+    public void ResolverRatioDeSampling_DevuelveElRatioPorDefecto_CuandoValorEsNegativo()
+    {
+        var ratio = ConfiguracionObservabilidadProjections.ResolverRatioDeSampling("-0.3");
+
+        ratio.Should().Be(ConfiguracionObservabilidadProjections.RatioSamplingPorDefecto);
+    }
+
+    [Fact]
+    public void ResolverRatioDeSampling_DevuelveElValorConfigurado_CuandoEsValido()
+    {
+        var ratio = ConfiguracionObservabilidadProjections.ResolverRatioDeSampling("0.5");
+
+        ratio.Should().Be(0.5);
+    }
+
+    // --- Seam de nivel BC (CA-4): Program.cs debe invocar ConfigurarObservabilidad junto a
+    // ConfigurarEventos. Esta guarda documenta el requisito -- MEF-ADR-0029 no puede testear
+    // Program.cs directamente (top-level statements, sin equivalente a WebApplicationFactory para
+    // el worker), asi que el enlace real entre Program.cs y este seam queda cubierto por el smoke
+    // test post-deploy (MEF-ADR-0013) y por revision de codigo (CA-4), no por este test unitario.
+}


### PR DESCRIPTION
## Resumen

Pipeline TDD completado:
- Fase roja: tests escritos con stubs
- Fase verde: implementación completa
- Fase refactor: revisión de calidad

## Decisiones del pipeline

<details>
<summary>Test Writer (fase roja) — 7m 13s</summary>

## ES Test Writer - Decisiones

### Naturaleza de la tarea
Issue #250 no es un command handler de event sourcing: es wiring de observabilidad (OpenTelemetry
-> Application Insights) sobre el worker de proyecciones. No hay aggregate, comando ni evento
involucrado, asi que el DSL Given/When/Then de `Cosmos.EventSourcing.Testing.Utilities`
(`CommandHandlerAsyncTest<T>`) no aplica. La categoria de test correcta es la de **composicion del
contenedor DI** (MEF-ADR-0029), ya precedente en este mismo proyecto Projections.Tests
(`ConfiguracionMartenProjectionsTests.cs`) y en `ControlHoras.Tests`/`Programacion.Tests`
(`ComposicionServiciosTests.cs`). No es refactoring puro (seccion 2): el issue agrega
comportamiento nuevo (CA-1 a CA-6) que hoy no existe -- no se creo archivo `refactor-signal.md`.

### Tests creados
`ConfiguracionObservabilidadProjectionsTests.cs`: 8 tests
- `ConfigurarObservabilidad_ComponeElContenedorSinExcepciones_ConValidateOnBuild` - CA-2/CA-5, grafo
  completo resoluble con `ValidateOnBuild + ValidateScopes` (patron MEF-ADR-0029).
- `ConfigurarObservabilidad_ResuelveTracerProviderDelContenedor` - CA-2/CA-5, sin
  `APPLICATIONINSIGHTS_CONNECTION_STRING` seteada (verificado empiricamente: `UseAzureMonitorExporter()`
  no lanza al resolver `TracerProvider` sin esa variable).
- `ConfigurarObservabilidad_ResuelveTracerProviderDelContenedor_CuandoLaConnectionStringEstaPresente`
  - CA-2, mismo escenario con la variable seteada (dummy), replicando el caso real de produccion
    (Key Vault reference, MEF-ADR-0025/CA-ADR-0026).
- `ResolverRatioDeSampling_DevuelveElRatioPorDefecto_CuandoValorEsNull` - CA-3.
- `ResolverRatioDeSampling_DevuelveElRatioPorDefecto_CuandoValorNoEsNumerico` - CA-3.
- `ResolverRatioDeSampling_DevuelveElRatioPorDefecto_CuandoValorEstaPorEncimaDeUno` - CA-3 (rango).
- `ResolverRatioDeSampling_DevuelveElRatioPorDefecto_CuandoValorEsNegativo` - CA-3 (rango).
- `ResolverRatioDeSampling_DevuelveElValorConfigurado_CuandoEsValido` - CA-3, ratio custom (0.5).

### Estructura elegida
- Una sola clase de test (no nested classes): un unico seam (`ConfigurarObservabilidad`) mas un
  metodo auxiliar interno (`ResolverRatioDeSampling`) que este mismo seam consume.
- Helper `ComponerServiceProvider()` siguiendo el patron de `ComposicionServiciosTests.cs`
  (ControlHoras/Programacion): `ValidateOnBuild = true, ValidateScopes = true`.

### Stubs creados
- `ConfiguracionObservabilidadProjections.ConfigurarObservabilidad(this IServiceCollection)` -
  extension method stub (`throw new NotImplementedException()`), seam propio de composicion
  (CA-4), en `src/Bitakora.ControlAsistencia.Projections/Infraestructura/`.
- `ConfiguracionObservabilidadProjections.ResolverRatioDeSampling(string?)` - metodo `internal`
  stub, extraido para hacer testeable el parsing del ratio (CA-3) sin mutar variables de entorno
  de proceso en el test de DI.
- Constantes `internal const string VariableRatioSampling` y
  `internal const double RatioSamplingPorDefecto = 0.2` (documentan CA-3/CA-6 con puntero a
  CA-ADR-0009).
- Paquetes agregados al `.csproj` del worker: `Azure.Monitor.OpenTelemetry.Exporter` 1.8.1 y
  `OpenTelemetry.Extensions.Hosting` 1.16.0 (mismas versiones que `ControlHoras`, CA-1).
- `InternalsVisibleTo` agregado al `.csproj` de `Bitakora.ControlAsistencia.Projections` apuntando
  a `Bitakora.ControlAsistencia.Projections.Tests` (precedente: mismo patron ya usado por
  `Bitakora.ControlAsistencia.Programacion.csproj`), necesario para que el test acceda a
  `ResolverRatioDeSampling` y las dos constantes `internal`.

### Decisiones de diseno
- **Verificacion empirica previa a diseñar el test** (para no rumiar): compile un mini-programa
  standalone (`/tmp/otel-probe`, descartado tras la prueba) que construye
  `AddOpenTelemetry().WithTracing(...).UseAzureMonitorExporter()` y resuelve `TracerProvider` sin
  la variable `APPLICATIONINSIGHTS_CONNECTION_STRING` presente: no lanza excepcion (el exporter
  solo falla al exportar realmente, no al componer el pipeline). Esto simplifica el test principal
  (no requiere env var dummy) y motivo agregar un segundo test explicito con la variable presente
  para cubrir el escenario real de produccion sin depender de comportamiento no documentado.
- **Extraccion de `ResolverRatioDeSampling` como metodo interno testeable**: `ControlHoras`
  resuelve el ratio inline dentro de `AgregarServiciosControlHoras` (sin test dedicado). Para este
  issue, CA-3 exige verificar explicitamente el default 0.2 ante variable ausente/invalida/fuera de
  rango -- mutar `Environment.SetEnvironmentVariable("TELEMETRY_SAMPLING_RATIO", ...)` en tests que
  corren en paralelo entre clases es fragil. Extraer el parsing a un metodo puro
  `internal static double ResolverRatioDeSampling(string?)` permite testear las 4 ramas de forma
  determinista y sin efectos secundarios sobre el proceso de test.
- **Program.cs NO se modifico en esta fase.** El seam se invoca directamente desde el test
  (`services.ConfigurarObservabilidad()`), igual que `ConfiguracionMartenProjectionsTests` invoca
  `ConfigurarProgramacion`/`ConfigurarControlHoras` directamente sin pasar por `ConfigurarEventos`.
  Modificar `Program.cs` para invocar el seam real es parte de la implementacion (CA-4, cerrar la
  fase verde) y no es necesario para que los tests compilen ni para que fallen en fase roja
  (el stub que hoy existe en el seam lanza `NotImplementedException`, asi que conectarlo desde
  `Program.cs` ya haria fallar el arranque real del worker). El implementer conecta
  `builder.Services.ConfigurarObservabilidad();` en `Program.cs` junto a `ConfigurarEventos`.
- **No se creo ningun `.resx`/clase `Mensajes`**: no hay eventos de fallo de aggregate ni
  excepciones de negocio con mensaje custom en este issue -- es wiring puro de DI/OTel, sin reglas
  de dominio que fallen. Seccion 6b no aplica.
- **No se testeo el contenido literal del `.csproj`** (CA-1: ausencia de
  `Microsoft.Azure.Functions.Worker.OpenTelemetry`/`Azure.Monitor.OpenTelemetry.AspNetCore`): no es
  un patron de test unitario existente en el repo: se deja a revision de codigo (reviewer, stage 3).
- **No se testeo el enlace real `Program.cs` -> seam**: MEF-ADR-0029 ya documenta esta limitacion
  (top-level statements sin equivalente a `WebApplicationFactory` para el worker); el enlace real
  queda cubierto por smoke test post-deploy (MEF-ADR-0013) y revision de codigo (CA-4).

### Cobertura de criterios
| Criterio de aceptacion | Test(s) |
|---|---|
| CA-1: paquetes correctos en `.csproj`, sin los prohibidos | Verificado al escribir el `.csproj` (agregado manual); ausencia de paquetes prohibidos queda a revision de codigo, no hay test unitario para contenido de `.csproj` |
| CA-2: `AddOpenTelemetry().WithTracing(...)` con los tres `AddSource` + `.UseAzureMonitorExporter()`, connection string leida de env var | `ConfigurarObservabilidad_ComponeElContenedorSinExcepciones_ConValidateOnBuild`, `ConfigurarObservabilidad_ResuelveTracerProviderDelContenedor`, `ConfigurarObservabilidad_ResuelveTracerProviderDelContenedor_CuandoLaConnectionStringEstaPresente` |
| CA-3: sampler `ParentBasedSampler(TraceIdRatioBasedSampler(ratio))`, default 0.2 | `ResolverRatioDeSampling_DevuelveElRatioPorDefecto_CuandoValorEsNull`, `..._CuandoValorNoEsNumerico`, `..._CuandoValorEstaPorEncimaDeUno`, `..._CuandoValorEsNegativo`, `ResolverRatioDeSampling_DevuelveElValorConfigurado_CuandoEsValido` |
| CA-4: seam propio de composicion, invocado desde `Program.cs` | Seam creado como stub (`ConfigurarObservabilidad`); enlace con `Program.cs` es responsabilidad del implementer (ver "Decisiones de diseno") |
| CA-5: test de composicion sin Postgres real, verifica `TracerProvider` resuelto | `ConfigurarObservabilidad_ResuelveTracerProviderDelContenedor` y su variante con connection string presente |
| CA-6: ratio por defecto documentado con puntero a CA-ADR-0009 | Comentario en `ConfiguracionObservabilidadProjections.cs` junto a `RatioSamplingPorDefecto` |

### Desviaciones del plan del planner
Ninguna estructural. Una adicion de diseno no listada explicitamente en el issue: extraer
`ResolverRatioDeSampling` como metodo `internal` separado (ver "Decisiones de diseno"). El issue no
prohibe esta forma -- CA-3 describe el comportamiento observable (default 0.2 ante ausencia/valor
invalido), no la forma interna del codigo -- y es necesaria para poder testear las 4 ramas de forma
determinista sin mutar variables de entorno del proceso. El implementer puede mantener esta
extraccion o inlinearla en la fase verde siempre que preserve la semantica que los tests fijan: si
la inlinea, debe adaptar los tests de `ResolverRatioDeSampling` a como quede expuesto el
comportamiento (o mantenerlo si conserva la firma).

</details>

<details>
<summary>Implementer (fase verde) — 3m 10s</summary>

## ES Implementer - Decisiones

### Enfoque de implementacion

El test-writer ya habia dejado el `.csproj` del worker con los paquetes correctos
(`Azure.Monitor.OpenTelemetry.Exporter` 1.8.1, `OpenTelemetry.Extensions.Hosting` 1.16.0,
mismas versiones que `ControlHoras`) y el stub `ConfiguracionObservabilidadProjections` con
las constantes `VariableRatioSampling`/`RatioSamplingPorDefecto` ya declaradas. El trabajo de
esta fase fue:

1. Implementar `ResolverRatioDeSampling(string?)`: replica exactamente el `double.TryParse`
   inline que ya usa `ControlHoras/ComposicionServicios.cs` (rango `[0.0, 1.0]`, default 0.2
   ante null/no-numerico/fuera de rango), pero extraido a metodo estatico interno para que el
   test-writer pudiera verificarlo sin mutar variables de entorno del proceso.
2. Implementar `ConfigurarObservabilidad(this IServiceCollection)`: `AddOpenTelemetry()
   .WithTracing(...)` con `SetSampler(ParentBasedSampler(TraceIdRatioBasedSampler(ratio)))`,
   `AddSource("Marten")`, `AddSource("Npgsql")` y la fuente propia del ensamblado
   (`"Bitakora.ControlAsistencia.Projections.*"`), cerrando con `.UseAzureMonitorExporter()`.
   Sin `.UseFunctionsWorkerDefaults()` ni `AddSource("Wolverine")` (el worker no usa Wolverine
   ni Azure Functions -- es un `Microsoft.NET.Sdk.Worker` puro con `HostApplicationBuilder`).
3. Invocar el seam nuevo desde `Program.cs`, una linea junto a `ConfigurarEventos`, igual que
   pide CA-4.

### Decisiones de diseno

- Se agrego el `using Azure.Monitor.OpenTelemetry.Exporter;` que faltaba para resolver
  `UseAzureMonitorExporter()` (extension method sobre `OpenTelemetryBuilder`); sin ese using
  el build fallaba con CS1061. El resto del stub (usings, constantes, firma de metodos) ya
  estaba correcto tal cual lo dejo el test-writer.
- No se agrego `AddSource("Wolverine")`: el worker de proyecciones no referencia
  `Cosmos.EventDriven.CritterStack` ni ningun `IMessageBus` de Wolverine (solo Marten +
  Hosting), a diferencia de `ControlHoras`. Agregar esa fuente no tendria ningun span que
  capturar y seria ruido sin justificacion en el dominio de este worker.
- El sampler ratio se resuelve una sola vez, en el momento de invocar `ConfigurarObservabilidad`
  (mismo momento que `ControlHoras` lo hace en `AgregarServiciosControlHoras`), leyendo
  `Environment.GetEnvironmentVariable(VariableRatioSampling)` directamente -- no via
  `IConfiguration`, para mantener paridad exacta con el patron de referencia.

### ADRs consultados

- CA-ADR-0009 (control de costos de Application Insights): sampler head-based, ratio default
  0.2, documentado en comentario junto al codigo (CA-6).
- MEF-ADR-0025 / CA-ADR-0026 (custodia de secretos): no se toco Terraform ni se leyo la
  connection string a mano; el exporter la resuelve por convencion de nombre de variable de
  entorno, ya inyectada por el Container App (issue #234).
- MEF-ADR-0029 (verificacion por test de composicion sobre el seam real): el seam
  `ConfigurarObservabilidad` es el mismo invocado por `Program.cs` y por el test.
- MEF-ADR-0034 secciones 2 y 8 (worker sin ingress, daemon HotCold): confirma por que la
  unica observabilidad posible es via trazas OpenTelemetry, sin apoyo de endpoints HTTP.

### Desviaciones de ADRs

Ninguna desviacion -- todos los ADRs aplicados al pie de la letra.

### Desviaciones del plan del planner

Ninguna -- se uso el nombre y ubicacion propuestos por el issue
(`ConfiguracionObservabilidadProjections.ConfigurarObservabilidad` en
`src/Bitakora.ControlAsistencia.Projections/Infraestructura/`), ya materializados por el
test-writer.

### Precedentes consultados

- `src/Bitakora.ControlAsistencia.ControlHoras/Infraestructura/ComposicionServicios.cs`
  (bloque de observabilidad): patron de referencia explicito del issue. Alineado con
  CA-ADR-0009; se replico el sampler y el comentario de razonamiento, ajustando solo lo que
  no aplica a un `Microsoft.NET.Sdk.Worker` (sin `UseFunctionsWorkerDefaults`, sin
  `AddSource("Wolverine")`).

### Infraestructura modificada

Ninguna. `infra/environments/dev/main.tf` ya inyecta `APPLICATIONINSIGHTS_CONNECTION_STRING`
via Key Vault reference al Container App del worker (issue #234, verificado en linea 333);
este issue solo consume la variable ya presente en el entorno, sin secretos nuevos.

### Complejidad encontrada

- Unico ajuste sobre el stub del test-writer: faltaba el `using
  Azure.Monitor.OpenTelemetry.Exporter;` para resolver `UseAzureMonitorExporter()` (CS1061).
  Se agrego sin tocar la firma publica ni el comportamiento esperado por los tests.

### Resultado

- Tests pasando: 21/21 (proyecto `Bitakora.ControlAsistencia.Projections.Tests`)
- Suite completa de la solucion: 481 correctos / 8 omitidos (requieren Postgres/ServiceBus
  locales, esperado) / 0 errores, 489 total.

</details>
<details>
<summary>Reviewer (fase refactor) — 13m 4s</summary>

## ES Reviewer - Revision

### Evaluacion general
- Calidad: **buena** (el diff de la fase verde ya era un espejo fiel del patron de referencia; se corrigio un defecto de robustez con impacto en CA-2 y se endurecio el config-test)
- Cambios realizados: **si** (commit `050295e`)
- Suite: 491 total / 483 correctos / 8 omitidos (smoke tests sin Postgres/ServiceBus local, esperado) / **0 errores**
- `dotnet build`: 0 warnings. `dotnet format --verify-no-changes`: 0 hallazgos en los archivos del diff.

### Cumplimiento de ADRs aplicables

| ADR | Cumplimiento | Observacion |
|---|---|---|
| CA-ADR-0009 (control de costos App Insights) | ok | Sampler head-based `ParentBasedSampler(TraceIdRatioBasedSampler(ratio))` con ratio de `TELEMETRY_SAMPLING_RATIO` y default `0.2` -- exactamente el mecanismo de la Capa 2 tras la actualizacion 2026-06-18 del ADR, y el valor que su tabla "Valores por ambiente" fija para dev. Capas 3 y 4 intactas (no se tocan). Comentario junto al codigo con el puntero al ADR y la nota de subir a `1.0` para diagnostico puntual (CA-6). |
| MEF-ADR-0025 / CA-ADR-0026 (custodia de secretos) | ok | Cero secretos, app settings o cambios de Terraform. El exporter resuelve `APPLICATIONINSIGHTS_CONNECTION_STRING` por convencion propia; verificado que `infra/environments/dev/main.tf:333` ya la inyecta como Key Vault reference con identidad `UserAssigned`. La connection string no se lee ni se pasa por parametro en ningun punto del seam. |
| MEF-ADR-0029 (test de composicion sobre el seam real) | ok | El wiring vive en un metodo de extension unico que `Program.cs` y el test invocan -- fuente unica de verdad, sin duplicacion (Alt 2 del ADR, descartada, no se reintroduce). El test valida con `BuildServiceProvider(ValidateOnBuild = true, ValidateScopes = true)` y resuelve explicitamente `TracerProvider`, que es el analogo aqui de la resolucion explicita de routers del ADR. Se **reforzo**: ahora tambien compone los dos seams del worker juntos (ver "Refactorings"). |
| MEF-ADR-0034 secciones 2 y 8 (worker sin ingress, daemon HotCold) | ok | La justificacion de "por que trazas y no endpoints de diagnostico" esta documentada en el seam y en el test. No se agrego ingress, ni `host.json`, ni `UseFunctionsWorkerDefaults` (no hay host de Functions). El escenario de la seccion 8 -- secreto sembrado despues del `apply`, revision con Key Vault reference aun sin resolver -- quedo cubierto por el test de connection string ausente. |
| MEF-ADR-0034 seccion 9 (coverage gate, MEF-ADR-0014) | ok | El archivo nuevo vive en `src/.../Infraestructura/` -- categoria *"`Infraestructura/` wiring puro"*, ya excluida de medicion -- y el test en `tests/`, fuera del alcance del gate. No distorsiona el gate ni exige cobertura adicional. |
| MEF-ADR-0016 (naming de tests) | **desviacion NO declarada -- corregida** | Ver seccion siguiente. |
| MEF-ADR-0012 (encapsulamiento / serializacion) | n/a (checklist recorrido) | Recorri los 7 antipatrones explicitamente: el diff no introduce VOs, aggregates, `record` con colecciones, `ConfigurarSerializacion`, `[JsonConstructor]`, clases estaticas sobre datos crudos de un VO, ni eventos con marker de bus. El `InternalsVisibleTo` agregado es del worker hacia **su propio proyecto de tests** (precedente: `Programacion.csproj`, `Contracts.csproj`), no el caso proscrito por el ADR (Contracts -> dominio para conversion de VOs). |

El issue **si** traia la seccion `## ADRs aplicables` correctamente poblada. No hay que escalar nada al planner por este concepto.

### Desviaciones de ADRs

**Desviaciones declaradas por el implementer**: ninguna. Su resumen de fase verde dice "Ninguna desviacion -- todos los ADRs aplicados al pie de la letra", y lo verifique contra cada ADR: es exacto en cuanto a los cuatro ADRs que el issue lista.

**Desviaciones detectadas por el reviewer (NO declaradas por el implementer)**:

#### Desviacion: MEF-ADR-0016 (convencion de naming de tests)
- **Regla del ADR**: patron unico `<Sujeto>_<LoQuePasa>[_Cuando<Condicion>]`; el tercer segmento, cuando existe, es una condicion prefijada con `Cuando`.
- **Desviacion encontrada en el diff**: `ConfiguracionObservabilidadProjectionsTests.cs` -- `ConfigurarObservabilidad_ComponeElContenedorSinExcepciones_ConValidateOnBuild`: el tercer segmento (`ConValidateOnBuild`) no es un `Cuando<Condicion>`, es un detalle del como. El precedente directo del repo lo hace bien (`AgregarServiciosControlHoras_ComponeElGrafoCompleto_CuandoLasConnectionStringsSonDummy`).
- **Accion tomada**: **corregida en refactor** -> `ConfigurarObservabilidad_ComponeElGrafoCompleto_CuandoSeValidaAlConstruir`. Los otros 7 nombres ya cumplian el patron.
- **Status**: resuelta; no requiere evaluacion del usuario.

### Precedentes consultados por el implementer

| Precedente | ADR aplicable | Veredicto |
|---|---|---|
| `ControlHoras/Infraestructura/ComposicionServicios.cs` (bloque de observabilidad) | CA-ADR-0009 | **alineado en lo esencial, con un defecto propio que NO debia replicarse**: el sampler, el ratio, el default y la eleccion exporter-sobre-distro estan correctos y se replicaron bien. Pero su `AddSource("Bitakora.ControlAsistencia.ControlHoras.*")` tiene un bug de wildcard (detalle abajo) que el diff habia heredado por espejo. Corregido solo en el worker (alcance de este issue); ver "Criticas" para el issue transversal recomendado. |
| `ConfiguracionMartenProjectionsTests.cs` (patron del config-test) | MEF-ADR-0029 / MEF-ADR-0034 seccion 6 | alineado. Ademas **aporto una leccion que el diff no habia tomado**: ese precedente cierra con una guarda de nivel BC (`ConfigurarEventos_RegistraElNamedStoreDeCadaDominioDelBc`) precisamente porque los tests por seam individual quedan verdes aunque nadie encadene la llamada. Apliqué el mismo razonamiento al worker (ver "Refactorings", guarda de composicion conjunta). |
| `Programacion.csproj` (`InternalsVisibleTo`) | -- | alineado; patron estandar src -> tests, ya presente tambien en `Contracts.csproj`. |

### Convenciones del pipeline (no ADRs)

| Convencion | Estado | Observacion |
|---|---|---|
| Cada test con `Then()` + `And<>()` | n/a | No hay aggregate, comando ni evento: es wiring de observabilidad. El DSL `CommandHandlerAsyncTest<T>` no aplica (categoria "test de composicion", MEF-ADR-0029 punto 4). Los tests si afirman resultado observable + estado del contenedor, que es el analogo aqui. |
| Overloads correctos para stream IDs compuestos | n/a | Sin streams ni aggregates en el diff. |
| Fakes manuales (no NSubstitute) | ok | Cero mocks; el contenedor real y `Environment` son las unicas colaboraciones, ambas reales. |
| Feature folders (produccion y tests) | ok | `src/.../Infraestructura/` con espejo exacto en `tests/.../Infraestructura/`, consistente con `ComposicionServiciosTests.cs` de ControlHoras y Programacion (ambos en `Infraestructura/`). |
| Smoke tests: SkipWhen, secrets, cobertura | n/a | El worker corre sin ingress: no hay endpoint que golpear, y el efecto real solo se observa con la imagen real (issue #236). El issue fija explicitamente la verificacion local por CA-5. No aplica el checklist de smoke tests -- y **no** corresponde marcarlo como hueco de cobertura por efecto: el unico efecto secundario del diff es el registro en el contenedor DI, que si esta verificado. |
| Proyecciones read-side: partial, inmutabilidad, read APIs, naming | n/a | El diff no toca read models, clases de proyeccion ni Functions GET. Verificado que no se altero ninguna `Configurar{Dominio}` ni el ciclo de vida `Async`/`HotCold`. |
| Tests via ToString/comportamiento | ok | No se expuso ningun getter de estado interno para el test. `ResolverRatioDeSampling` es un metodo puro de parsing (Extract Method sobre wiring de infraestructura), no un getter de estado de un objeto de dominio -- evaluado explicitamente y aceptado. |
| Sin numeros magicos | ok | `0.2` -> `RatioSamplingPorDefecto`; el patron de fuente -> `PatronFuentePropia` (extraido en esta fase). Los `0.5`/`1.5`/`-0.3` de los tests son datos de escenario. |
| Condiciones en positivo (guardas if/else afirmativas) | ok | El unico condicional es el ternario de `ResolverRatioDeSampling`, en positivo (`TryParse(...) && ratio is >= 0.0 and <= 1.0 ? ratio : default`). Sin `if` negados. |

### Elegancia del codigo

El codigo de la fase verde ya era compacto, idiomatico (expresion-bodied member, pattern matching de rango `is >= 0.0 and <= 1.0`, extension method) y muy bien comentado -- los comentarios explican *por que*, con punteros a ADR e issue, no *que*. Hallazgos y mejoras:

- **Compacidad**: se elimino la duplicacion del literal `"APPLICATIONINSIGHTS_CONNECTION_STRING"` (3 apariciones en el test) y del bloque `try/finally` de set/restore de variable de entorno, extraido al helper `ConVariableDeEntorno`.
- **Legibilidad**: `ConnectionStringDummy` no decia de que servicio era la cadena -> `ConnectionStringAppInsightsDummy` (el precedente de ControlHoras ya distingue `MartenConnectionStringDummy`/`ServiceBusConnectionStringDummy`).
- **Limpieza**: el archivo de test terminaba con un comentario de seccion (`// --- Seam de nivel BC (CA-4) ...`) sin ningun test debajo -- se lee como un test olvidado. Consolidado en el bloque de "limites conocidos" de la cabecera, donde tiene contexto.
- **Robustez**: el defecto del wildcard (abajo) y el escenario no determinista de connection string ausente.
- **Eficiencia**: n/a, no hay algoritmos ni bucles en el diff.

### Criticas y hallazgos

1. **[MAYOR - corregido] El `AddSource` del propio ensamblado no capturaba el propio ensamblado (CA-2).**
   El diff usaba `AddSource("Bitakora.ControlAsistencia.Projections.*")`, espejo de ControlHoras. **Verificado empiricamente** contra OpenTelemetry 1.16.0 (la version que el `.csproj` fija), con un probe descartado tras la prueba:

   | Patron registrado | `ActivitySource("X")` | `ActivitySource("X.Hija")` |
   |---|---|---|
   | `"X.*"` | **no capturada** | capturada |
   | `"X*"` | capturada | capturada |

   El wildcard con punto se ancla como `^X\..*$`. Como lo idiomatico al instrumentar es nombrar la fuente con el nombre del ensamblado (`Assembly.GetName().Name`), la primera `ActivitySource` que alguien agregue al worker habria emitido spans **descartados en silencio** -- exactamente el tipo de wiring a medio terminar que este issue existe para cerrar. Corregido a `PatronFuentePropia = "Bitakora.ControlAsistencia.Projections*"` y fijado con el guardrail `PatronFuentePropia_CapturaLaActividad_CuandoLaFuenteSeLlamaComoElEnsambladoDelWorker`, cuya eficacia verifique por mutacion (revirtiendo el patron a `.*`, el test se pone rojo).

2. **[MENOR - corregido] El escenario "connection string ausente" no controlaba su precondicion.**
   `ConfigurarObservabilidad_ResuelveTracerProviderDelContenedor` no aseguraba que la variable estuviera ausente: en un entorno que la tenga seteada (CI, o una maquina con la variable exportada) el test ejercitaba silenciosamente el escenario *contrario* al que su nombre y su intencion declaran -- y el escenario ausente, el mas critico (arranque local, y revision cuya Key Vault reference aun no resolvio, MEF-ADR-0034 seccion 8), nunca se probaba. Corregido con `ConVariableDeEntorno(..., null, ...)` y nombre explicito `_CuandoLaConnectionStringEstaAusente`.

3. **[MENOR - corregido] Faltaba la guarda de composicion conjunta de los dos seams (CA-5).**
   CA-5 pide un test que "construye el host del worker". Los tests solo invocaban `ConfigurarObservabilidad` en aislamiento, asi que un choque entre los dos seams del worker (registro duplicado, dependencia que uno espera del otro) habria aparecido recien al arrancar el proceso real. Es el mismo hueco que el precedente `ConfiguracionMartenProjectionsTests` cierra con su guarda de nivel BC. Agregado.

4. **[OBSERVACION - no corregible aqui, fuera de alcance] El mismo bug de wildcard existe en ControlHoras y merece issue transversal.**
   `ControlHoras/Infraestructura/ComposicionServicios.cs` usa `AddSource("Bitakora.ControlAsistencia.ControlHoras.*")`. No lo toque: esta fuera del diff (regla de no refactorizar codigo ajeno a la HU) y ControlHoras si tiene fuentes descendientes reales que el patron actual captura, asi que el impacto es menor alla. **Recomiendo un issue** que unifique ambos a la forma sin punto. Es tambien la razon por la que documente la divergencia en el codigo: para que no se lea como inconsistencia accidental y alguien la "arregle" de vuelta.

5. **[OBSERVACION - no accionable en este issue] `Programacion` arrastra una vulnerabilidad conocida por usar el distro.**
   `dotnet build` emite `NU1902` en `Programacion` (src y tests): `Azure.Monitor.OpenTelemetry.AspNetCore` 1.4.0 arrastra `OpenTelemetry.Api` 1.14.0 con vulnerabilidad de gravedad moderada (GHSA-g94r-2vxg-569j). Verifique que el worker **no** hereda el problema (`dotnet list package --vulnerable --include-transitive`: sin paquetes vulnerables), lo que refuerza empiricamente la decision del issue de usar el exporter y no el distro. Warnings preexistentes, ajenos al diff; candidato a issue de mantenimiento.

6. **[OBSERVACION] `TELEMETRY_SAMPLING_RATIO` no esta declarada en Terraform para el Container App.**
   Correcto y deliberado (el issue prohibe tocar Terraform), y el default `0.2` del codigo coincide con el valor de dev de la tabla de CA-ADR-0009. Nota para cuando exista prod: esa tabla fija `0.1`, lo que exigira declarar la variable en el Container App de ese entorno.

7. **[LIMITE CONOCIDO - documentado, no cerrado]** Que el ratio resuelto llegue efectivamente al sampler no se verifica: el sampler compuesto vive en `TracerProviderSdk`, que OpenTelemetry no expone publicamente, y ejercitarlo end-to-end contra un ratio fraccionario seria probabilistico (flaky). Evalue el costo/beneficio y decidi documentarlo en la cabecera del test en vez de agregar un test fragil -- mismo criterio con que MEF-ADR-0029 y el precedente de ControlHoras documentan los limites de `ValidateOnBuild`. Queda cubierto por revision de codigo.

### Refactorings aplicados

Commit `050295e`. Cada cambio se verifico con `dotnet test` (verde en todos los pasos):

1. **Produccion** -- extraccion de `internal const string PatronFuentePropia` con el wildcard corregido (sin punto) y comentario que documenta la evidencia empirica y por que divergimos de ControlHoras. Justificacion: cumplimiento real de CA-2 (hallazgo 1).
2. **Test** -- helper `ConVariableDeEntorno(nombre, valor, accion)`: elimina la duplicacion del `try/finally` y del literal de la variable, y vuelve determinista el escenario ausente (hallazgo 2).
3. **Test** -- guarda nueva `ConfigurarObservabilidad_ResuelveTracerProviderDelContenedor_CuandoSeComponeJuntoAlSeamDeEventos` (hallazgo 3).
4. **Test** -- guardrail nuevo `PatronFuentePropia_CapturaLaActividad_CuandoLaFuenteSeLlamaComoElEnsambladoDelWorker`, con verificacion por mutacion de su eficacia (hallazgo 1).
5. **Test** -- renombre por MEF-ADR-0016 (`_ConValidateOnBuild` -> `_CuandoSeValidaAlConstruir`) y `ConnectionStringDummy` -> `ConnectionStringAppInsightsDummy`.
6. **Test** -- comentario de seccion colgante del final consolidado en la cabecera como "limites conocidos", con los punteros a MEF-ADR-0029, CA-4 y MEF-ADR-0013.

No se modifico `Program.cs`, el `.csproj` ni Terraform: estaban correctos.

### Cobertura de criterios de aceptacion

| Criterio | Estado | Test(s) |
|---|---|---|
| CA-1: `.csproj` suma `Azure.Monitor.OpenTelemetry.Exporter` 1.8.1 y `OpenTelemetry.Extensions.Hosting` 1.16.0; no suma los prohibidos | cubierto (por revision) | Verificado contra `ControlHoras.csproj` (lineas 14 y 26): mismas versiones exactas, sin segunda linea de version. Confirmada la **ausencia** de `Microsoft.Azure.Functions.Worker.OpenTelemetry` y `Azure.Monitor.OpenTelemetry.AspNetCore` en el worker. Sin test unitario (no hay patron de test sobre contenido de `.csproj` en el repo). |
| CA-2: `AddOpenTelemetry().WithTracing(...)` con los tres `AddSource` + `.UseAzureMonitorExporter()`; connection string del entorno | cubierto | `ConfigurarObservabilidad_ComponeElGrafoCompleto_CuandoSeValidaAlConstruir`, `..._ResuelveTracerProviderDelContenedor_CuandoLaConnectionStringEstaAusente`, `..._CuandoLaConnectionStringEstaPresente`, `PatronFuentePropia_CapturaLaActividad_CuandoLaFuenteSeLlamaComoElEnsambladoDelWorker` (este ultimo cierra el defecto del hallazgo 1) |
| CA-3: `ParentBasedSampler(TraceIdRatioBasedSampler(ratio))`, ratio de `TELEMETRY_SAMPLING_RATIO`, default `0.2` | cubierto | `ResolverRatioDeSampling_DevuelveElRatioPorDefecto_CuandoValorEsNull`, `..._CuandoValorNoEsNumerico`, `..._CuandoValorEstaPorEncimaDeUno`, `..._CuandoValorEsNegativo`, `ResolverRatioDeSampling_DevuelveElValorConfigurado_CuandoEsValido`. Composicion del sampler: revision de codigo (limite 7). |
| CA-4: seam de composicion propio, invocado desde `Program.cs` | cubierto | Seam `ConfiguracionObservabilidadProjections.ConfigurarObservabilidad` en `src/.../Infraestructura/` (nombre y ubicacion de la propuesta del issue, sin desviacion). Invocacion en `Program.cs:12`, junto a `ConfigurarEventos`. Aproximacion mas cercana en test: `..._CuandoSeComponeJuntoAlSeamDeEventos`; el enlace literal por revision de codigo (limite 2 documentado). |
| CA-5: test de composicion sin Postgres real que resuelve el `TracerProvider` | cubierto | `ConfigurarObservabilidad_ResuelveTracerProviderDelContenedor_CuandoLaConnectionStringEstaAusente` / `..._CuandoLaConnectionStringEstaPresente` / `..._CuandoSeComponeJuntoAlSeamDeEventos` (este ultimo con los named stores de ambos dominios, cadena dummy, sin Postgres) |
| CA-6: ratio por defecto documentado con puntero a CA-ADR-0009 y nota de subir a 1.0 | cubierto (por revision) | Comentario sobre `RatioSamplingPorDefecto` y bloque dentro de `ConfigurarObservabilidad`, ambos con el puntero al ADR, la Capa 2 y la instruccion de subir a `1.0` puntualmente y bajarlo despues |

### Tests agregados

- `ConfigurarObservabilidad_ResuelveTracerProviderDelContenedor_CuandoSeComponeJuntoAlSeamDeEventos` -- composicion conjunta de los dos seams del worker, como los encadena `Program.cs` (CA-5); resuelve `TracerProvider` y los named stores de ambos dominios con `ValidateOnBuild`/`ValidateScopes`.
- `PatronFuentePropia_CapturaLaActividad_CuandoLaFuenteSeLlamaComoElEnsambladoDelWorker` -- guardrail del wildcard corregido (CA-2), determinista (sampler por defecto, no el de ratio 0.2) y verificado por mutacion.
- Tests de contrato de igualdad (`IgualdadTestBase<T>`) y de round-trip de serializacion: **no aplican**. El diff no introduce ningun `IEquatable<T>`, ningun `ConfigurarSerializacion` ni ningun evento con marker de bus (`IPrivateEvent`/`IPublicEvent`), asi que ni el round-trip de Marten ni el guardrail de portabilidad por el bus tienen sujeto aqui.

Total del proyecto de tests del worker: 21 -> 23 tests, todos verdes.

</details>

## Cobertura

| Archivo | Cobertura | Umbral | Estado |
|---|---|---|---|
| Program.cs | - | excluido | - |
| ConfiguracionObservabilidadProjections.cs | - | no evaluado | - |
## Commits

050295e refactor(hu-250): corrige el patron de fuente propia de OTel y endurece el config-test
d3ac155 feat(hu-250): instrumentar el worker de proyecciones con OpenTelemetry (fase verde)
e225acd test(hu-250): tests de composicion para observabilidad OTel del worker de proyecciones (fase roja)

Closes #250