### PR TITLE
infra(dev): #249 Ceder a CI la propiedad de la imagen del Container App del worker

### DIFF
--- a/infra/environments/dev/variables.tf
+++ b/infra/environments/dev/variables.tf
@@ -33,12 +33,21 @@ variable "postgresql_admin_password" {
   sensitive   = true
 }
 
-# Worker de proyecciones (opt-in, MEF-ADR-0034 seccion 8; issue #234). Placeholder publico
-# hasta que un pipeline de CI de imagen (fuera de alcance de este issue) construya y empuje
-# la imagen real a module.container_registry.login_server; en ese momento, sobreescribe
-# este default via terraform.tfvars o TF_VAR_projections_worker_image.
+# Worker de proyecciones (opt-in, MEF-ADR-0034 seccion 8; issue #234). Este default es
+# SOLO BOOTSTRAP: alimenta unicamente la creacion inicial (`create`) del Container App
+# (issue #249). A partir del primer `az containerapp update --image` que el pipeline de
+# imagen real corra contra module.container_registry.login_server (issue #236), este
+# valor deja de reflejar la imagen activa -- el `lifecycle.ignore_changes` del modulo
+# container-app (template[0].container[0].image) hace que `terraform plan` deje de
+# comparar el estado remoto contra este default, precisamente para no proponer revertir
+# la imagen real al placeholder. NO se sobreescribe via terraform.tfvars ni via
+# TF_VAR_projections_worker_image (esa era la nota original, descartada en #249: ver el
+# camino (b) descartado ahi, con el hallazgo de que *.tfvars esta en .gitignore y de que
+# infra-cd.yml no tiene workflow_dispatch/inputs). El rollback de imagen se hace con
+# `az containerapp update --image` o `az containerapp revision activate`, nunca
+# revirtiendo este HCL.
 variable "projections_worker_image" {
-  description = "Imagen del worker de proyecciones (Bitakora.ControlAsistencia.Projections)"
+  description = "Imagen de bootstrap del worker de proyecciones (Bitakora.ControlAsistencia.Projections); solo gobierna el create inicial, ver la nota de arriba"
   type        = string
   default     = "mcr.microsoft.com/k8se/quickstart:latest"
 }

--- a/infra/modules/container-app/main.tf
+++ b/infra/modules/container-app/main.tf
@@ -1,3 +1,32 @@
+# ------------------------------------------------------------------------------------
+# GOBIERNO DE LA IMAGEN: la imagen de este Container App la gobierna CI, no Terraform
+# (issue #249). `var.image` alimenta UNICAMENTE la creacion inicial (bootstrap con el
+# placeholder publico de var.projections_worker_image, ver la nota de esa variable en
+# infra/environments/dev/variables.tf); a partir de ahi el pipeline de aplicacion (el
+# que corre `az containerapp update --image ...` en cada push a `main` sobre la imagen
+# real) es el unico dueno del atributo `image`. El bloque `lifecycle` de abajo declara
+# `ignore_changes = [template[0].container[0].image]` para que Terraform deje de
+# proponer revertir la imagen desplegada por CI al placeholder del HCL (HashiCorp,
+# Terraform, "The lifecycle Meta-Argument" -- seccion ignore_changes: "Terraform
+# considers the arguments corresponding to the given attribute names when planning a
+# create operation, but are ignored when planning an update operation").
+#
+# RESTRICCION CONOCIDA: `lifecycle` no admite expresiones dinamicas -- no se puede
+# condicionar `ignore_changes` a una variable ni hacerlo opt-in por flag. Esto significa
+# que la semantica "la imagen la publica CI" aplica a CUALQUIER Container App que este
+# modulo instancie en el futuro, no solo al worker de proyecciones. Hoy el modulo tiene
+# un unico consumidor (module.container_app del entorno dev, el worker de proyecciones)
+# y esa semantica es exactamente la suya. Si en el futuro se necesita un Container App
+# cuya imagen SI gobierne Terraform (por ejemplo, sin pipeline de CI propio), hay que
+# separar ese caso en un modulo distinto ANTES de instanciarlo con este.
+#
+# ROLLBACK DE IMAGEN: con Terraform fuera del gobierno de la imagen, el rollback NO se
+# hace revirtiendo HCL ni corriendo `terraform apply`. Se hace con:
+#   az containerapp update -n <nombre> -g <resource-group> --image <acr>/<repo>:<sha-anterior>
+# o activando una revision previa con `az containerapp revision activate` (Microsoft
+# Learn, "Revisions in Azure Container Apps").
+# ------------------------------------------------------------------------------------
+
 variable "name" {
   description = "Nombre del Container App (2-32 chars, minusculas/numeros/guiones, empieza con letra y termina alfanumerico -- Microsoft.App/containerApps, scope resource group; verificado contra Microsoft Learn, 'Naming rules and restrictions for Azure resources')"
   type        = string
@@ -185,6 +214,16 @@ resource "azurerm_container_app" "this" {
       condition     = var.max_replicas >= var.min_replicas
       error_message = "max_replicas (${var.max_replicas}) no puede ser menor que min_replicas (${var.min_replicas})."
     }
+
+    # La imagen la gobierna CI, no Terraform (issue #249, ver la nota de cabecera del
+    # modulo). `var.image` solo alimenta el `create` inicial (bootstrap con placeholder);
+    # a partir de ahi `az containerapp update --image` de CI es el dueno del atributo, y
+    # sin este ignore_changes cada `plan` posterior propondria revertirlo al placeholder
+    # del HCL. Aplica a cualquier consumidor futuro del modulo (lifecycle no admite
+    # expresiones dinamicas ni opt-in por flag) -- ver la restriccion documentada arriba.
+    ignore_changes = [
+      template[0].container[0].image
+    ]
   }
 }
 


### PR DESCRIPTION
## Infraestructura

Implementa los cambios de infraestructura del issue #249.

- **Ambiente**: dev
- **Estado**: HCL escrito y revisado localmente (sin plan ni apply local); pendiente de aplicar por CI
- **Pipeline**: iac-pipeline.sh

## Decisiones del pipeline

<details>
<summary>infra-writer -- 1m 49s</summary>

_(El agente no genero resumen)_

</details>

<details>
<summary>infra-reviewer -- 3m 14s</summary>

_(El agente no genero resumen)_

</details>

## Cambios Terraform

 infra/environments/dev/variables.tf | 19 +++++++++++++-----
 infra/modules/container-app/main.tf | 39 +++++++++++++++++++++++++++++++++++++
 2 files changed, 53 insertions(+), 5 deletions(-)

## Commits

9d2951c infra(dev): ceder a CI la propiedad de la imagen del Container App del worker

> **Apply pendiente en CI**: este PR no cierra el issue #249. El `terraform apply` lo ejecuta el workflow **Infra CD** al mergear este PR a `main` (MEF-ADR-0022); el issue se cierra automaticamente cuando ese apply termine exitosamente.