### PR TITLE
Publicar la imagen del worker de proyecciones al registry desde CI

### DIFF
--- a/.github/workflows/deploy-projections.yml
+++ b/.github/workflows/deploy-projections.yml
@@ -1,0 +1,122 @@
+# Publica la imagen del worker de proyecciones (Bitakora.ControlAsistencia.Projections)
+# en el ACR de dev y actualiza el Container App para que la ejecute (issue #236).
+#
+# Restricciones operativas (MEF-ADR-0034 seccion 8), verificadas antes de disenar este workflow:
+#   1. Orden frente al sembrado de secretos: la imagen real solo debe desplegarse DESPUES
+#      de que infra-cd.yml haya sembrado el secreto `marten-connection` en el Key Vault al
+#      menos una vez. Con el placeholder es inocuo que la Key Vault reference nazca sin
+#      resolver; con el worker real, arrancar sin la cadena de conexion es un fallo.
+#   2. Una revision viva no re-lee un secreto rotado: cambiar el valor de un secreto no se
+#      propaga a las revisiones en ejecucion. Por eso cada imagen se etiqueta con el SHA del
+#      commit: un tag nuevo siempre crea una revision nueva (revision-scope change segun
+#      "Revisions in Azure Container Apps" de Microsoft Learn), lo que garantiza que el
+#      contenedor arranque de cero y lea el secreto vigente.
+#
+# Desviacion declarada frente a MEF-ADR-0022: ese ADR exige que CI se autentique contra Azure
+# por OIDC (azure/login con client-id/tenant-id/subscription-id, sin secret de password). Este
+# workflow usa `creds: secrets.AZURE_CREDENTIALS` en su lugar, igual que deploy-control-horas.yml
+# y deploy-programacion.yml hacen hoy. Migrar a OIDC es un cambio transversal (federated
+# credentials del SP + los tres secrets + los cuatro workflows a la vez) que no pertenece a este
+# issue; se hara en un issue aparte que migre los cuatro workflows juntos.
+#
+# Rollback de imagen: la imagen NO la gobierna Terraform (issue #249 le puso
+# `lifecycle { ignore_changes = [template[0].container[0].image] }` al Container App), asi que
+# revertir jamas se hace tocando HCL ni corriendo `terraform apply`. Para volver a un estado
+# anterior:
+#   az containerapp update -n ca-asist-dev -g rg-controlasistencias-dev --image <loginServer>/<repo>:<sha-anterior>
+# o, si la revision anterior sigue activa/inactiva pero existe:
+#   az containerapp revision activate -n ca-asist-dev -g rg-controlasistencias-dev --revision <nombre-revision>
+
+name: Deploy Projections
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/Bitakora.ControlAsistencia.Projections/**'
+      - 'src/Bitakora.ControlAsistencia.ReadModels/**'
+  workflow_dispatch:
+
+env:
+  RESOURCE_GROUP: rg-controlasistencias-dev
+  CONTAINER_APP_NAME: ca-asist-dev
+  IMAGE_REPOSITORY: projections
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Restore
+        run: dotnet restore ControlAsistencias.slnx
+
+      - name: Build
+        run: dotnet build ControlAsistencias.slnx --no-restore --configuration Release
+
+      - name: Test
+        run: dotnet test tests/Bitakora.ControlAsistencia.Projections.Tests/ --no-build --configuration Release --ignore-exit-code 8
+
+  deploy:
+    needs: build-and-test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Azure Authentication
+        uses: azure/login@v3
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Resolver login server del ACR
+        run: |
+          login_server=$(az acr list -g "${{ env.RESOURCE_GROUP }}" --query "[0].loginServer" -o tsv)
+          if [ -z "$login_server" ]; then
+            echo "No se encontro ningun Container Registry en ${{ env.RESOURCE_GROUP }}"
+            exit 1
+          fi
+          echo "login_server=${login_server}" >> "$GITHUB_ENV"
+          # az acr login exige el nombre corto del registry, no el login server FQDN
+          # (Microsoft Learn, "Quickstart: Create a private container registry using the
+          # Azure CLI"). El nombre corto es el primer segmento del login server.
+          echo "acr_name=${login_server%%.*}" >> "$GITHUB_ENV"
+
+      - name: ACR login
+        run: az acr login --name "${{ env.acr_name }}"
+
+      - name: Build y push de la imagen
+        run: |
+          image="${{ env.login_server }}/${{ env.IMAGE_REPOSITORY }}:${{ github.sha }}"
+          docker build -f src/Bitakora.ControlAsistencia.Projections/Dockerfile -t "$image" .
+          docker push "$image"
+          echo "image=${image}" >> "$GITHUB_ENV"
+
+      - name: Actualizar Container App
+        run: |
+          az containerapp update \
+            -n "${{ env.CONTAINER_APP_NAME }}" \
+            -g "${{ env.RESOURCE_GROUP }}" \
+            --image "${{ env.image }}"
+
+      - name: Verificar imagen activa
+        run: |
+          active_image=$(az containerapp show \
+            -n "${{ env.CONTAINER_APP_NAME }}" \
+            -g "${{ env.RESOURCE_GROUP }}" \
+            --query "properties.template.containers[0].image" -o tsv)
+
+          echo "Imagen activa: ${active_image}"
+
+          if [ "$active_image" != "${{ env.image }}" ]; then
+            echo "La imagen activa no coincide con la publicada (${{ env.image }})"
+            exit 1
+          fi
+
+          if [[ "$active_image" == *"mcr.microsoft.com/k8se/quickstart"* ]]; then
+            echo "El Container App sigue corriendo el placeholder de demostracion"
+            exit 1
+          fi

--- a/.github/workflows/deploy-projections.yml
+++ b/.github/workflows/deploy-projections.yml
@@ -21,11 +21,17 @@
 #
 # Rollback de imagen: la imagen NO la gobierna Terraform (issue #249 le puso
 # `lifecycle { ignore_changes = [template[0].container[0].image] }` al Container App), asi que
-# revertir jamas se hace tocando HCL ni corriendo `terraform apply`. Para volver a un estado
-# anterior:
+# revertir jamas se hace tocando HCL ni corriendo `terraform apply`. Se hace re-publicando el
+# tag anterior:
 #   az containerapp update -n ca-asist-dev -g rg-controlasistencias-dev --image <loginServer>/<repo>:<sha-anterior>
-# o, si la revision anterior sigue activa/inactiva pero existe:
-#   az containerapp revision activate -n ca-asist-dev -g rg-controlasistencias-dev --revision <nombre-revision>
+# El tag por SHA sigue en el ACR, asi que este comando no necesita reconstruir nada.
+# `az containerapp revision activate` NO es un camino de rollback valido aqui: el Container App
+# corre en revision_mode = "Single" (infra/modules/container-app), y en ese modo solo una
+# revision puede estar activa a la vez y las viejas se desaprovisionan automaticamente
+# (Microsoft Learn, "Update and deploy changes in Azure Container Apps" -- Revision modes:
+# "New revisions are automatically provisioned, activated, and scaled ... Old revisions are
+# automatically deprovisioned"). Activar/desactivar revisiones a mano requiere pasar antes a
+# modo multiple con `az containerapp revision set-mode --mode multiple`.
 
 name: Deploy Projections
 
@@ -59,7 +65,7 @@ jobs:
         run: dotnet build ControlAsistencias.slnx --no-restore --configuration Release
 
       - name: Test
-        run: dotnet test tests/Bitakora.ControlAsistencia.Projections.Tests/ --no-build --configuration Release --ignore-exit-code 8
+        run: dotnet test --project tests/Bitakora.ControlAsistencia.Projections.Tests/ --no-build --configuration Release --ignore-exit-code 8
 
   deploy:
     needs: build-and-test
@@ -72,18 +78,28 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
-      - name: Resolver login server del ACR
+      - name: Resolver el ACR del resource group
         run: |
-          login_server=$(az acr list -g "${{ env.RESOURCE_GROUP }}" --query "[0].loginServer" -o tsv)
-          if [ -z "$login_server" ]; then
+          # El nombre del ACR lleva un sufijo aleatorio (random_string.container_registry_suffix),
+          # asi que no se puede fijar en el workflow: se resuelve en tiempo de ejecucion. Se leen
+          # los dos datos de la misma consulta porque `az acr login` quiere el nombre del recurso
+          # y no el login server FQDN (Microsoft Learn, "Quickstart: Create a private container
+          # registry using the Azure CLI": "Specify only the registry resource name when logging
+          # in with the Azure CLI. Don't use the fully qualified login server name"), mientras que
+          # el tag de la imagen si necesita el login server.
+          acr=$(az acr list -g "${{ env.RESOURCE_GROUP }}" \
+            --query "[0].{name: name, loginServer: loginServer}" -o json)
+
+          acr_name=$(jq -r '.name // empty' <<< "$acr")
+          login_server=$(jq -r '.loginServer // empty' <<< "$acr")
+
+          if [ -z "$acr_name" ] || [ -z "$login_server" ]; then
             echo "No se encontro ningun Container Registry en ${{ env.RESOURCE_GROUP }}"
             exit 1
           fi
+
+          echo "acr_name=${acr_name}" >> "$GITHUB_ENV"
           echo "login_server=${login_server}" >> "$GITHUB_ENV"
-          # az acr login exige el nombre corto del registry, no el login server FQDN
-          # (Microsoft Learn, "Quickstart: Create a private container registry using the
-          # Azure CLI"). El nombre corto es el primer segmento del login server.
-          echo "acr_name=${login_server%%.*}" >> "$GITHUB_ENV"
 
       - name: ACR login
         run: az acr login --name "${{ env.acr_name }}"
@@ -102,21 +118,56 @@ jobs:
             -g "${{ env.RESOURCE_GROUP }}" \
             --image "${{ env.image }}"
 
-      - name: Verificar imagen activa
+      - name: Verificar la revision activa
         run: |
-          active_image=$(az containerapp show \
+          # La verificacion se hace sobre la REVISION, no solo sobre el template del Container
+          # App: el template devuelve lo que acabamos de escribir con `update` (comprobarlo ahi
+          # seria una tautologia), mientras que la revision demuestra que Azure aprovisiono una
+          # revision nueva corriendo la imagen publicada. En revision_mode = "Single" la
+          # revision mas nueva es la unica activa, asi que latestRevisionName ES la que corre.
+          revision=$(az containerapp show \
             -n "${{ env.CONTAINER_APP_NAME }}" \
             -g "${{ env.RESOURCE_GROUP }}" \
-            --query "properties.template.containers[0].image" -o tsv)
+            --query "properties.latestRevisionName" -o tsv)
 
-          echo "Imagen activa: ${active_image}"
-
-          if [ "$active_image" != "${{ env.image }}" ]; then
-            echo "La imagen activa no coincide con la publicada (${{ env.image }})"
+          if [ -z "$revision" ]; then
+            echo "El Container App no reporta ninguna revision (properties.latestRevisionName vacio)"
             exit 1
           fi
 
-          if [[ "$active_image" == *"mcr.microsoft.com/k8se/quickstart"* ]]; then
-            echo "El Container App sigue corriendo el placeholder de demostracion"
+          revision_json=$(az containerapp revision show \
+            -n "${{ env.CONTAINER_APP_NAME }}" \
+            -g "${{ env.RESOURCE_GROUP }}" \
+            --revision "$revision" -o json)
+
+          revision_image=$(jq -r '.properties.template.containers[0].image' <<< "$revision_json")
+          revision_activa=$(jq -r '.properties.active' <<< "$revision_json")
+
+          echo "Revision:  ${revision}"
+          echo "Imagen:    ${revision_image}"
+          echo "Activa:    ${revision_activa}"
+          echo "Provision: $(jq -r '.properties.provisioningState // "sin reportar"' <<< "$revision_json")"
+          echo "Ejecucion: $(jq -r '.properties.runningState // "sin reportar"' <<< "$revision_json")"
+
+          # El placeholder se comprueba aparte de la igualdad: si alguien re-aplicara Terraform
+          # sin el ignore_changes de #249, este mensaje dice exactamente que paso en vez de un
+          # generico "no coincide".
+          if [[ "$revision_image" == *"mcr.microsoft.com/k8se/quickstart"* ]]; then
+            echo "La revision activa sigue corriendo el placeholder de demostracion"
             exit 1
           fi
+
+          if [ "$revision_image" != "${{ env.image }}" ]; then
+            echo "La imagen de la revision activa no coincide con la publicada (${{ env.image }})"
+            exit 1
+          fi
+
+          if [ "$revision_activa" != "true" ]; then
+            echo "La revision mas nueva (${revision}) no quedo activa"
+            exit 1
+          fi
+
+          # Nota operativa: un fallo de arranque del worker (secreto sin resolver, credenciales
+          # de Postgres, permisos DDL sobre el schema) NO lo detecta este job -- la revision se
+          # aprovisiona igual. Verlo requiere los logs del contenedor:
+          #   az containerapp logs show -n ca-asist-dev -g rg-controlasistencias-dev --follow


### PR DESCRIPTION
## Resumen

Pipeline tooling completado:
- Writer: implementacion de la tarea
- Reviewer: revision de calidad

## Decisiones del pipeline

<details>
<summary>Writer -- 2m 41s</summary>

# Stage 1 - Writer: Issue #236

## Que se hizo

Se creo `.github/workflows/deploy-projections.yml`, unico artefacto en el alcance del issue.

Patron espejado: `.github/workflows/deploy-control-horas.yml` (jobs `build-and-test` -> `deploy`,
`azure/login@v3` con `secrets.AZURE_CREDENTIALS`, filtro de paths en el trigger), con las
diferencias esperadas del issue: sin `Azure/functions-action` (se publica una imagen, no un
zip), sin job de smoke-tests (el worker no tiene ingress).

## Cobertura de criterios de aceptacion

- **CA-1**: trigger `push` a `main` filtrado por `src/Bitakora.ControlAsistencia.Projections/**`
  y `src/Bitakora.ControlAsistencia.ReadModels/**`, mas `workflow_dispatch`.
- **CA-2**: job `build-and-test` corre `dotnet build ControlAsistencias.slnx` y
  `dotnet test tests/Bitakora.ControlAsistencia.Projections.Tests/` antes de que `deploy` empiece
  (`needs: build-and-test`).
- **CA-3**: `docker build -f src/Bitakora.ControlAsistencia.Projections/Dockerfile -t "$image" .`
  con la raiz del repo como build context; el tag incluye `${{ github.sha }}`.
- **CA-4**: `azure/login@v3` con `creds: secrets.AZURE_CREDENTIALS`; login server resuelto en
  runtime con `az acr list -g rg-controlasistencias-dev --query "[0].loginServer" -o tsv`
  (comando exacto del issue); push tras `az acr login`.
- **CA-5**: `az containerapp update -n ca-asist-dev -g rg-controlasistencias-dev --image <tag>`
  seguido de verificacion con `az containerapp show --query "properties.template.containers[0].image"`
  que falla el job si la imagen activa no coincide con la publicada o si sigue siendo el
  placeholder `mcr.microsoft.com/k8se/quickstart`.
- **CA-6**: ningun secreto en logs, build args ni env vars del contenedor; el workflow no toca
  `secret` blocks ni `env` del Container App.
- **CA-7**: comentario de cabecera documenta las dos restricciones operativas de MEF-ADR-0034
  seccion 8, la desviacion declarada frente a MEF-ADR-0022, y el camino de rollback
  (`az containerapp update --image` / `az containerapp revision activate`, nunca HCL).

## Correccion durante la implementacion

Detecte y corregi un error antes de dar la tarea por terminada: `az acr login --name` no acepta
el login server FQDN, solo el nombre corto del registry (verificado contra Microsoft Learn,
"Quickstart: Create a private container registry using the Azure CLI" -- cita textual: *"Specify
only the registry resource name when logging in with the Azure CLI. Don't use the fully
qualified login server name."*). El CA-4 exige resolver el login server con el comando exacto
`az acr list ... --query "[0].loginServer"` (usado para el tag de la imagen), asi que derive el
nombre corto localmente con `${login_server%%.*}` en vez de agregar una segunda llamada a
`az acr list`.

## Verificacion

- `actionlint .github/workflows/deploy-projections.yml` -> sin hallazgos.
- No se modifico codigo C#; no aplica `dotnet build` del repo.

## Fuera de alcance (no tocado)

- `infra/` y `infra-cd.yml` (issue #249, ya cerrado segun el contexto del issue).
- Instrumentacion OpenTelemetry del worker (issue aparte, ya resuelto segun el historial de
  commits: `feat(hu-250)` / `refactor(hu-250)`).
- Migracion a OIDC de los cuatro workflows (issue aparte, declarado en el propio issue #236).

## Nota

No existe `.dockerignore` en la raiz del repo. No es requisito de ningun CA de este issue y esta
fuera del alcance de escritura permitido para tooling especificar cambios de repo-root fuera de
las carpetas listadas; no se creo.

</details>

<details>
<summary>Reviewer -- 8m 58s</summary>

# Stage 2 - Reviewer: Issue #236

Artefacto revisado: `.github/workflows/deploy-projections.yml` (unico archivo del diff del
writer). No se toco ninguna ruta prohibida: el writer se quedo dentro de `.github/workflows/`.

Veredicto: **aprobado con correcciones aplicadas**. Habia un defecto que rompia el workflow en
cada corrida, mas dos inexactitudes de verificacion/documentacion. Todo corregido en el commit
`7d527fa`.

## Defectos encontrados y corregidos

### 1. `dotnet test` fallaba siempre (bloqueante, CA-2 incumplido)

El writer escribio:

```yaml
run: dotnet test tests/Bitakora.ControlAsistencia.Projections.Tests/ --no-build ...
```

`global.json` de este repo fija `"test": { "runner": "Microsoft.Testing.Platform" }`. En ese
runner, pasar un directorio como argumento posicional es un error. Reproducido localmente con el
SDK 10.0.201 del repo:

```
$ dotnet test tests/Bitakora.ControlAsistencia.Projections.Tests/ --ignore-exit-code 8
La especificación de un directorio para 'dotnet test' debería ser a través de '--project' o '--solution'.
```

Consecuencia: el job `build-and-test` habria fallado en cada push, `deploy` nunca habria corrido
(`needs: build-and-test`) y la imagen real nunca se habria publicado -- exactamente el estado que
el issue #236 viene a resolver.

Corregido a `--project`, que es el idioma que ya usan `ci.yml` (linea 52) y
`deploy-control-horas.yml` (linea 31). Verificado: 23 tests en verde.

### 2. La verificacion del CA-5 era una tautologia, con un guard inalcanzable

El writer verificaba `az containerapp show --query "properties.template.containers[0].image"`.
Ese campo devuelve literalmente lo que el paso anterior acaba de escribir con
`az containerapp update --image`: la comparacion contra `$image` no puede fallar salvo que el
propio `update` haya fallado (y en ese caso el paso anterior ya habria roto el job). Y el guard
del placeholder quedaba como codigo muerto: si `active_image == $image`, y `$image` apunta al ACR
propio por construccion, nunca puede contener `mcr.microsoft.com/k8se/quickstart`.

El CA-5 pide verificar "que el Container App quedo corriendo una **revision nueva** cuya imagen
activa ya no es el placeholder". Ahora se verifica sobre la revision:

- `properties.latestRevisionName` del Container App (falla si viene vacio),
- `az containerapp revision show` de esa revision: imagen del contenedor y `properties.active`,
- se reportan `provisioningState` y `runningState` en el log del job.

Que `latestRevisionName` sea la revision que corre esta respaldado por el modo del recurso:
`revision_mode = "Single"` en `infra/modules/container-app/main.tf:142`, y en modo Single "Only
one revision can be active at a time" (Microsoft Learn, *ActiveRevisionsMode* /
*Update and deploy changes in Azure Container Apps*, seccion Revision modes).

El guard del placeholder se conservo -- ahora sobre un valor observado de forma independiente --
porque da un mensaje diagnostico especifico si alguien re-aplicara Terraform sin el
`ignore_changes` de #249.

### 3. El camino de rollback documentado no era ejecutable (CA-7)

La cabecera ofrecia `az containerapp revision activate` como alternativa de rollback. No aplica a
este Container App: corre en `revision_mode = "Single"`, donde solo una revision puede estar
activa y las viejas se desaprovisionan automaticamente (Microsoft Learn, *Update and deploy
changes in Azure Container Apps*, Revision modes: "New revisions are automatically provisioned,
activated, and scaled ... Old revisions are automatically deprovisioned"; la
activacion/desactivacion manual es una capacidad del modo multiple). Activar revisiones a mano
exigiria antes `az containerapp revision set-mode --mode multiple`.

La cabecera ahora documenta el rollback real (`az containerapp update --image <sha-anterior>`,
que no reconstruye nada porque el tag por SHA sigue en el ACR) y explica por que `revision
activate` no sirve aqui. Nota: el comentario de cabecera del modulo
`infra/modules/container-app/main.tf` repite la misma imprecision, pero `infra/` esta fuera del
alcance de escritura de esta etapa -- queda como observacion para el issue de infra.

### 4. Robustez: el nombre del ACR se lee, no se deriva

El writer derivaba el nombre del registry del login server con `${login_server%%.*}`. Correcto
para el ACR actual, pero fragil: en registries con DNL habilitado el login server incluye un hash
(`nombre-hash.azurecr.io`) y la derivacion produciria un nombre inexistente -- la propia doc que
el writer cita lo advierte ("Don't use the fully qualified login server name, such as
`registryname.azurecr.io` or `registryname-hash.azurecr.io` (for DNL-enabled registries)").
Ahora `name` y `loginServer` se leen de la misma consulta `az acr list`, sin inferir nada. El
comando sigue siendo el `az acr list -g <rg>` que prescribe el CA-4, solo con la proyeccion
ampliada.

## Lo que se reviso y quedo bien

- **CA-1**: trigger correcto. Acertado que el filtro de paths **no** incluya
  `infra/environments/dev/**` (a diferencia de `deploy-control-horas.yml`): tras #249 Terraform ya
  no gobierna la imagen, y un `apply` no debe disparar una republicacion. Tampoco incluye
  `Contracts/**`, coherente con que `Projections.csproj` solo referencia `ReadModels`.
- **CA-3**: verificado ejecutando el comando real del workflow. `docker build -f
  src/Bitakora.ControlAsistencia.Projections/Dockerfile -t <tag> .` construye desde la raiz del
  repo y resuelve el `ProjectReference` a `ReadModels`. Tag por SHA presente.
- **CA-4**: `azure/login@v3` con `creds: secrets.AZURE_CREDENTIALS`, espejando
  `deploy-control-horas.yml`; sin intento de migracion a OIDC ni mecanismo hibrido, como pedia el
  issue. Resource group hardcodeado (con precedente en el repo), ACR resuelto en runtime.
- **CA-6**: no hay `--build-arg`, ni `secrets.*` fuera de `AZURE_CREDENTIALS`, ni `--env` /
  `--secrets` en el `az containerapp update`. No toca `secret` blocks ni `env` del Container App.
- **CA-7**: cabecera completa con las dos restricciones operativas de MEF-ADR-0034 seccion 8 y la
  desviacion declarada frente a MEF-ADR-0022.
- Nombres de recursos verificados contra Terraform: `rg-controlasistencias-dev`
  (`prefix = "${var.project}-${var.environment}"` = `controlasistencias-dev`) y `ca-asist-dev`
  (`"ca-${local.prefix_short}"` con `project_short = asist`).
- `jq` ya tiene precedente en los workflows del repo (`smoke-tests.yml:14`) y viene preinstalado
  en los runners `ubuntu-latest`.

## Verificacion ejecutada

| Que | Resultado |
|---|---|
| `actionlint .github/workflows/deploy-projections.yml` (con shellcheck instalado) | limpio |
| Parseo YAML del workflow | OK |
| `dotnet restore` + `dotnet build ControlAsistencias.slnx -c Release` | 0 errores (3 warnings preexistentes) |
| `dotnet test --project tests/...Projections.Tests/ --no-build -c Release --ignore-exit-code 8` | 23/23 en verde |
| `docker build -f src/...Projections/Dockerfile -t projections:review-check .` | imagen construida (imagen local de prueba eliminada) |
| Simulacion de los bloques `jq` (caso normal, ACR ausente, `runningState` ausente) | comportamiento esperado |

No hay codigo C# nuevo: el diff es un unico workflow.

## Observaciones fuera del alcance de escritura de esta etapa

1. **No existe `.dockerignore` en la raiz del repo.** El build context es la raiz (lo exige el
   Dockerfile), asi que el daemon recibe `.git/`, `docs/`, `infra/` y cualquier `bin/`/`obj/`
   local. En CI el checkout es limpio, asi que no rompe nada -- es solo tiempo de subida de
   contexto. La raiz del repo esta fuera del alcance permitido para esta etapa; queda como mejora
   opcional.
2. **`infra/modules/container-app/main.tf`** documenta el mismo rollback via `revision activate`
   que corregi en el workflow. `infra/` esta fuera de alcance aqui.
3. **El worker si emite telemetria hoy.** El issue #236 afirma que
   `Bitakora.ControlAsistencia.Projections.csproj` "solo referencia Marten y
   Microsoft.Extensions.Hosting" y que no hay App Insights. Ya no es cierto: el issue #250 (commit
   `050295e`) agrego `Azure.Monitor.OpenTelemetry.Exporter` y `OpenTelemetry.Extensions.Hosting`.
   La verificacion post-deploy del primer arranque real puede apoyarse en App Insights, no solo en
   `az containerapp logs show`.
4. **Sin `concurrency` group.** Dos pushes seguidos al read-side podrian terminar dejando activa
   la imagen del SHA mas viejo. Los deploys del write-side tienen la misma exposicion y el repo no
   tiene precedente de `concurrency`, asi que no lo agregue para no divergir sin mandato del
   issue. Candidato a issue transversal junto con la migracion a OIDC.

## Recordatorio operativo antes del primer merge a `main`

El issue lo exige y no lo puede garantizar el workflow: #249 debe estar **aplicado** en `main`
(no solo mergeado) y `marten-connection` debe existir en el Key Vault antes de que este workflow
publique la primera imagen real:

```bash
az keyvault secret show --vault-name <kv-del-bc> --name marten-connection --query id -o tsv
```

</details>

## Commits

7d527fa fix(hu-236): corrige la invocacion de dotnet test y endurece la verificacion del deploy
9384c17 feat(hu-236): publica la imagen del worker de proyecciones desde CI

Closes #236