### PR TITLE
Relajar rollForward del SDK a latestFeature para desbloquear el build en Docker

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
     "sdk": {
         "version": "10.0.201",
-        "rollForward": "latestPatch"
+        "rollForward": "latestFeature"
     },
     "test": {
         "runner": "Microsoft.Testing.Platform"


### PR DESCRIPTION
## Problema

El primer `workflow_dispatch` de `Deploy Projections` (el workflow que agregó el PR #257, issue #236) falló en el paso **Build y push de la imagen** con `exit code: 155` — [run 30486690113](https://github.com/augusto-romero-arango/Bitakora.ControlAsistencia/actions/runs/30486690113).

```
Requested SDK version: 10.0.201
global.json file: /src/global.json
Install the [10.0.201] .NET SDK or update [/src/global.json] to match an installed SDK.
10.0.302 [/usr/share/dotnet/sdk]
```

`global.json` pineaba el SDK con `"version": "10.0.201"` y `"rollForward": "latestPatch"`. Según [la documentación de `global.json`](https://learn.microsoft.com/en-us/dotnet/core/tools/global-json#rollforward), `latestPatch` usa "the latest installed patch level that matches the requested major, minor, **and feature band**". La banda pedida es `2xx`; `mcr.microsoft.com/dotnet/sdk:10.0` trae `10.0.302`, que es banda `3xx` → no hay match y el SDK se rechaza.

### Por qué fallaba en el `build` y no en el `restore`

Es el orden de capas del `Dockerfile` del worker:

| Capa | Qué hace | ¿`global.json` en el contexto? |
|---|---|---|
| 3/8, 4/8 | `COPY` de los dos `.csproj` | no |
| 5/8 | `dotnet restore` → pasa | **no** → resuelve el SDK sin pin |
| 6/8 | `COPY . .` | **entra aquí** |
| 8/8 | `dotnet build` → falla | sí → aplica el pin y revienta |

El `restore` pasaba por accidente: corre antes de que `global.json` exista en el contexto de build. Esa capa intermedia es deliberada (el comentario del `Dockerfile` explica que preserva el cache cuando cambia un `.cs`), y es justamente lo que enmascaraba el problema hasta el `build`.

El job `build-and-test` del mismo workflow nunca falló, porque `actions/setup-dotnet@v5` instala un SDK que sí satisface el pin. El defecto era exclusivo del build dentro de Docker.

## Corrección

Una línea: `rollForward` pasa de `latestPatch` a `latestFeature`, que permite avanzar a una feature band superior manteniendo `major.minor`. El pin sigue acotado a `10.0.x`, pero deja de romperse cada vez que Microsoft publica una banda nueva en la imagen base.

Se descartaron dos alternativas:

- **Subir el `version` pineado a un `10.0.3xx`** — arregla hoy y vuelve a romper con la banda `4xx`.
- **Pinear la imagen base a un tag con `10.0.2xx`** — mantiene el pin estricto pero acopla el `Dockerfile` a un digest concreto y hay que moverlo a mano en cada actualización.

## Verificación

- `docker build -f src/Bitakora.ControlAsistencia.Projections/Dockerfile .` completa de punta a punta en local (antes moría en la capa 8/8).
- `dotnet build ControlAsistencias.slnx`: 0 errores.
- `dotnet test --solution ControlAsistencias.slnx`: **485 correctos, 0 errores, 6 omitidos**. Los omitidos son smoke tests que no alcanzan Postgres desde local por el firewall de Azure — preexistente y ajeno a este cambio.
- Sin efecto en desarrollo local: `10.0.201` sigue siendo la banda más alta instalada, así que el SDK resuelto no cambia.

## Notas

- **No lleva `Closes #<n>`**: es un hotfix directo sobre `main` sin issue previo, a pedido explícito. Si preferís trazabilidad por issue, se puede abrir uno y enlazarlo antes del merge.
- El Container App **sigue en el placeholder** (`mcr.microsoft.com/k8se/quickstart:latest`, revisión `ca-asist-dev--3yhu3le`). El run falló antes del push, así que no quedó imagen huérfana en el ACR ni revisión que revertir. Tras mergear esto hay que volver a disparar `Deploy Projections` a mano — el filtro de paths del trigger (`src/...Projections/**`, `src/...ReadModels/**`) no matchea un cambio en `global.json`.
- Recordatorio del issue #236: ese deploy es el primer arranque real del daemon, y un fallo de arranque no lo detecta el workflow. Hay que mirar `az containerapp logs show -n ca-asist-dev -g rg-controlasistencias-dev --follow`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)