### PR TITLE
Cubrir en el filtro de paths los inputs del build de los que la imagen depende

### DIFF
--- a/.github/workflows/deploy-projections.yml
+++ b/.github/workflows/deploy-projections.yml
@@ -38,9 +38,25 @@ name: Deploy Projections
 on:
   push:
     branches: [main]
+    # El filtro debe cubrir todo lo que determina la imagen construida, no solo el codigo del
+    # worker. El Dockerfile hace `COPY . .` con el contexto en la raiz del repo y compila
+    # dentro del contenedor, asi que `global.json` decide que SDK resuelve ese build: un
+    # cambio ahi puede romper o alterar la imagen sin tocar ningun .cs. Y el workflow se
+    # incluye a si mismo para que una correccion a este archivo se despliegue sola.
+    #
+    # Deliberadamente FUERA del filtro (no agregar por simetria con los deploy-*.yml del
+    # write-side):
+    #   - ControlAsistencias.slnx      -> el Dockerfile compila el .csproj directo, no la solucion.
+    #   - tests/...Projections.Tests/  -> un cambio de tests no altera la imagen, y cada
+    #                                     publicacion crea una revision nueva que reinicia el daemon.
+    #   - infra/environments/dev/      -> tras el issue #249 Terraform ya no gobierna la imagen
+    #                                     (`ignore_changes`), asi que un cambio de infra no
+    #                                     requiere republicarla.
     paths:
       - 'src/Bitakora.ControlAsistencia.Projections/**'
       - 'src/Bitakora.ControlAsistencia.ReadModels/**'
+      - 'global.json'
+      - '.github/workflows/deploy-projections.yml'
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## Problema

`Deploy Projections` filtra su trigger `push` por `src/...Projections/**` y `src/...ReadModels/**`. Desde que el workflow existe hubo exactamente dos cambios que afectaban al read-side, y **ninguno de los dos lo disparo**:

| PR | Que cambio | ¿Disparo? |
|---|---|---|
| #257 | Creo `deploy-projections.yml` | No — el workflow no esta en su propio filtro |
| #258 | Arreglo `global.json` para desbloquear el `docker build` | No — `global.json` no esta en el filtro |

Las dos veces hubo que disparar a mano con `workflow_dispatch`. No fue mala suerte: **el filtro no cubria sus propias dependencias**.

## Por que `global.json` pertenece al filtro

El Dockerfile del worker hace `COPY . .` con el contexto en la raiz del repo y **compila dentro del contenedor**. Eso hace que `global.json` decida que SDK resuelve ese build: un cambio ahi puede romper o alterar la imagen sin tocar ni un `.cs`. Es literalmente lo que paso en el PR #258 — el `docker build` fallaba con `exit code 155` por el `rollForward`, y arreglarlo no re-disparo nada.

## Correccion

```diff
     paths:
       - 'src/Bitakora.ControlAsistencia.Projections/**'
       - 'src/Bitakora.ControlAsistencia.ReadModels/**'
+      - 'global.json'
+      - '.github/workflows/deploy-projections.yml'
```

Mas un comentario que deja constancia de las tres exclusiones **deliberadas**, para que nadie las agregue despues buscando simetria con los `deploy-*.yml` del write-side:

- `ControlAsistencias.slnx` — el Dockerfile compila el `.csproj` directo, no la solucion.
- `tests/...Projections.Tests/**` — un cambio de tests no altera la imagen, y cada publicacion crea una revision nueva que reinicia el daemon.
- `infra/environments/dev/**` — tras el issue #249, Terraform ya no gobierna la imagen (`lifecycle { ignore_changes }`), asi que un cambio de infra no requiere republicarla. Esta es la asimetria con los deploys del write-side que **si** lo incluyen; aca es correcta.

### Alternativa descartada

Quitar el filtro y desplegar en cada push a `main`. Nunca perderia un cambio, pero cada publicacion crea una revision nueva y **reinicia el daemon**, asi que meteria churn en la eleccion de lider por advisory lock sin ninguna ganancia.

## Verificacion

- El YAML parsea con `yaml.safe_load`.
- El trigger queda con los cuatro paths; `workflow_dispatch` y `branches: [main]` intactos.
- Los dos jobs (`build-and-test`, `deploy`) sin cambios.
- El archivo es ASCII puro (`grep -P "[^\x00-\x7F]"` sin resultados).

## Consecuencia al mergear: este PR se prueba solo

Como el workflow ahora **se incluye a si mismo** en el filtro, mergear esto dispara `Deploy Projections` automaticamente. Eso reconstruye la imagen, publica un tag nuevo por SHA y crea una revision nueva del Container App — es decir, el fix se demuestra a si mismo en el propio merge, sin `workflow_dispatch` manual.

Consecuencia operativa a tener presente: **el daemon se reinicia** en ese deploy. Es inocuo hoy (no hay proyecciones registradas, no deserializa eventos), pero conviene saberlo.

## Nota

No lleva `Closes #<n>`: es un fix directo sin issue previo, a pedido explicito. Los otros dos hallazgos de la misma investigacion (falta un `.dockerignore`; los `deploy-*.yml` del write-side tienen el mismo hueco de `global.json`) se capturan como issues aparte y no se tocan aca.

🤖 Generated with [Claude Code](https://claude.com/claude-code)