### PR TITLE
Configurar el service.name del worker de proyecciones para que su telemetria sea identificable

### DIFF
--- a/src/Bitakora.ControlAsistencia.Projections/Infraestructura/ConfiguracionObservabilidadProjections.cs
+++ b/src/Bitakora.ControlAsistencia.Projections/Infraestructura/ConfiguracionObservabilidadProjections.cs
@@ -22,13 +22,13 @@ public static class ConfiguracionObservabilidadProjections
     internal const string VariableRatioSampling = "TELEMETRY_SAMPLING_RATIO";
     internal const double RatioSamplingPorDefecto = 0.2;
 
-    // Issue #263: nombre de servicio para el atributo de recurso OpenTelemetry `service.name`
-    // (fase roja -- valor pendiente de fijar por el implementer). Debe coincidir EXACTAMENTE con
-    // el nombre del ensamblado del worker: PatronFuentePropia (issue #250, arriba) ya nombra su
-    // ActivitySource con ese mismo string a mano, asi que ambas constantes deben derivar de una
-    // sola fuente de verdad -- fijado por guardrail en ConfiguracionObservabilidadProjectionsTests
-    // (CA-3). No lleva el ambiente: hay un App Insights por ambiente (un solo issue #263, punto 1).
-    internal const string NombreServicio = "";
+    // Issue #263: nombre de servicio para el atributo de recurso OpenTelemetry `service.name`.
+    // Debe coincidir EXACTAMENTE con el nombre del ensamblado del worker: PatronFuentePropia
+    // (issue #250, abajo) ya nombra su ActivitySource con ese mismo string, asi que ambas
+    // constantes derivan de una sola fuente de verdad -- fijado por guardrail en
+    // ConfiguracionObservabilidadProjectionsTests (CA-3). No lleva el ambiente: hay un App
+    // Insights por ambiente (un solo issue #263, punto 1).
+    internal const string NombreServicio = "Bitakora.ControlAsistencia.Projections";
 
     // CA-2: el source del propio ensamblado. El wildcard va SIN punto antes del asterisco --
     // divergencia deliberada frente a ControlHoras ("...ControlHoras.*"), verificada
@@ -37,8 +37,10 @@ public static class ConfiguracionObservabilidadProjections
     // "X.Hija". Como lo idiomatico al instrumentar es nombrar la fuente con el nombre del
     // ensamblado (`Assembly.GetName().Name`), con el punto los spans del propio worker se
     // descartarian EN SILENCIO -- el mismo tipo de wiring a medio terminar que este issue cierra.
-    // Fijado por guardrail en ConfiguracionObservabilidadProjectionsTests.
-    internal const string PatronFuentePropia = "Bitakora.ControlAsistencia.Projections*";
+    // Derivado de NombreServicio (concatenacion de constantes, resuelta en tiempo de compilacion)
+    // para que ambas constantes no puedan divergir -- fijado por guardrail en
+    // ConfiguracionObservabilidadProjectionsTests.
+    internal const string PatronFuentePropia = NombreServicio + "*";
 
     public static IServiceCollection ConfigurarObservabilidad(this IServiceCollection services)
     {
@@ -62,6 +64,7 @@ public static class ConfiguracionObservabilidadProjections
             Environment.GetEnvironmentVariable(VariableRatioSampling));
 
         services.AddOpenTelemetry()
+            .ConfigureResource(ConfigurarRecurso)
             .WithTracing(tracing => tracing
                 .SetSampler(new ParentBasedSampler(new TraceIdRatioBasedSampler(samplingRatio)))
                 .AddSource("Marten")
@@ -85,23 +88,28 @@ public static class ConfiguracionObservabilidadProjections
             ? ratio
             : RatioSamplingPorDefecto;
 
-    // Issue #263 (fase roja -- stub, pendiente de implementacion real).
+    // Issue #263: fija el atributo de recurso OpenTelemetry `service.name`, la unica pieza que le
+    // faltaba a este seam para que el worker deje de aparecer en Application Insights como
+    // `unknown_service:dotnet` (cloud_RoleName cae a `service.name` cuando `service.namespace` no
+    // esta seteado -- Microsoft Learn, "Configure Azure Monitor OpenTelemetry").
     //
     // Extraido como metodo interno testeable -- igual que ResolverRatioDeSampling arriba -- en vez
     // de wirear el AddService inline dentro del lambda de ConfigurarObservabilidad: eso permite
     // construir un ResourceBuilder propio en el test (CreateDefault, sin Postgres ni Container App)
     // y aseverar sobre Resource.Attributes, en vez de dejar el recurso sin cobertura.
     //
-    // Cuando se implemente: debe fijar unicamente `service.name = NombreServicio` via
-    // AddService(NombreServicio, autoGenerateServiceInstanceId: false) -- SIN serviceNamespace
-    // (CA-1: cloud_RoleName no debe llevar prefijo) y SIN autogenerar service.instance.id (el
-    // default true reemplazaria el hostname legible del contenedor por un GUID aleatorio distinto
-    // en cada arranque de revision; el exporter de Azure Monitor deriva cloud_RoleInstance de ese
-    // atributo y cae al hostname en su ausencia).
+    // SIN serviceNamespace (CA-1: cloud_RoleName no debe llevar prefijo) y SIN autogenerar
+    // service.instance.id (autoGenerateServiceInstanceId: false): el default true reemplazaria el
+    // hostname legible del contenedor por un GUID aleatorio distinto en cada arranque de revision;
+    // el exporter de Azure Monitor deriva cloud_RoleInstance de ese atributo y cae al hostname en
+    // su ausencia.
     //
-    // Consecuencia a documentar aqui cuando se complete: fijar el nombre en codigo deja
-    // OTEL_SERVICE_NAME inerte (ConfigureResource corre despues del ResourceBuilder.CreateDefault()
-    // que ya parsea esa variable, y Resource.Merge le da precedencia a lo que se fusiona despues).
+    // Consecuencia conocida: fijar el nombre en codigo deja OTEL_SERVICE_NAME inerte
+    // (ConfigureResource corre despues del ResourceBuilder.CreateDefault() que ya parsea esa
+    // variable, y Resource.Merge le da precedencia a lo que se fusiona despues -- verificado en
+    // CA-4/ConfigurarRecurso_ConservaElServiceNameDelCodigo_CuandoOtelServiceNameApuntaAOtroValor).
+    // Si alguna vez se necesita configurar el nombre por ambiente, el camino es un parametro nuevo
+    // en este metodo, no la variable de entorno.
     internal static void ConfigurarRecurso(ResourceBuilder recurso) =>
-        throw new NotImplementedException();
+        recurso.AddService(NombreServicio, autoGenerateServiceInstanceId: false);
 }

--- a/src/Bitakora.ControlAsistencia.Projections/Infraestructura/ConfiguracionObservabilidadProjections.cs
+++ b/src/Bitakora.ControlAsistencia.Projections/Infraestructura/ConfiguracionObservabilidadProjections.cs
@@ -26,8 +26,9 @@ public static class ConfiguracionObservabilidadProjections
     // Debe coincidir EXACTAMENTE con el nombre del ensamblado del worker: PatronFuentePropia
     // (issue #250, abajo) ya nombra su ActivitySource con ese mismo string, asi que ambas
     // constantes derivan de una sola fuente de verdad -- fijado por guardrail en
-    // ConfiguracionObservabilidadProjectionsTests (CA-3). No lleva el ambiente: hay un App
-    // Insights por ambiente (un solo issue #263, punto 1).
+    // ConfiguracionObservabilidadProjectionsTests. No lleva el ambiente: hay un Application Insights
+    // por ambiente, asi que cloud_RoleName nunca tiene que desambiguar ambientes dentro del mismo
+    // recurso (issue #263, punto 1 del refinamiento).
     internal const string NombreServicio = "Bitakora.ControlAsistencia.Projections";
 
     // CA-2: el source del propio ensamblado. El wildcard va SIN punto antes del asterisco --
@@ -91,14 +92,11 @@ public static class ConfiguracionObservabilidadProjections
     // Issue #263: fija el atributo de recurso OpenTelemetry `service.name`, la unica pieza que le
     // faltaba a este seam para que el worker deje de aparecer en Application Insights como
     // `unknown_service:dotnet` (cloud_RoleName cae a `service.name` cuando `service.namespace` no
-    // esta seteado -- Microsoft Learn, "Configure Azure Monitor OpenTelemetry").
+    // esta seteado -- Microsoft Learn, "Configure Azure Monitor OpenTelemetry"). Extraido como
+    // metodo interno -- igual que ResolverRatioDeSampling arriba -- para que el test pueda aislar la
+    // precedencia frente al entorno sobre un ResourceBuilder propio, sin construir el contenedor.
     //
-    // Extraido como metodo interno testeable -- igual que ResolverRatioDeSampling arriba -- en vez
-    // de wirear el AddService inline dentro del lambda de ConfigurarObservabilidad: eso permite
-    // construir un ResourceBuilder propio en el test (CreateDefault, sin Postgres ni Container App)
-    // y aseverar sobre Resource.Attributes, en vez de dejar el recurso sin cobertura.
-    //
-    // SIN serviceNamespace (CA-1: cloud_RoleName no debe llevar prefijo) y SIN autogenerar
+    // SIN serviceNamespace (cloud_RoleName no debe llevar prefijo) y SIN autogenerar
     // service.instance.id (autoGenerateServiceInstanceId: false): el default true reemplazaria el
     // hostname legible del contenedor por un GUID aleatorio distinto en cada arranque de revision;
     // el exporter de Azure Monitor deriva cloud_RoleInstance de ese atributo y cae al hostname en
@@ -107,7 +105,7 @@ public static class ConfiguracionObservabilidadProjections
     // Consecuencia conocida: fijar el nombre en codigo deja OTEL_SERVICE_NAME inerte
     // (ConfigureResource corre despues del ResourceBuilder.CreateDefault() que ya parsea esa
     // variable, y Resource.Merge le da precedencia a lo que se fusiona despues -- verificado en
-    // CA-4/ConfigurarRecurso_ConservaElServiceNameDelCodigo_CuandoOtelServiceNameApuntaAOtroValor).
+    // ConfigurarRecurso_ConservaElServiceNameDelCodigo_CuandoOtelServiceNameApuntaAOtroValor).
     // Si alguna vez se necesita configurar el nombre por ambiente, el camino es un parametro nuevo
     // en este metodo, no la variable de entorno.
     internal static void ConfigurarRecurso(ResourceBuilder recurso) =>

--- a/src/Bitakora.ControlAsistencia.Projections/Infraestructura/ConfiguracionObservabilidadProjections.cs
+++ b/src/Bitakora.ControlAsistencia.Projections/Infraestructura/ConfiguracionObservabilidadProjections.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using Azure.Monitor.OpenTelemetry.Exporter;
+using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 
 namespace Bitakora.ControlAsistencia.Projections.Infraestructura;
@@ -20,6 +21,14 @@ public static class ConfiguracionObservabilidadProjections
     // manualmente en el Container App y se baja despues -- no se sube el default en codigo.
     internal const string VariableRatioSampling = "TELEMETRY_SAMPLING_RATIO";
     internal const double RatioSamplingPorDefecto = 0.2;
+
+    // Issue #263: nombre de servicio para el atributo de recurso OpenTelemetry `service.name`
+    // (fase roja -- valor pendiente de fijar por el implementer). Debe coincidir EXACTAMENTE con
+    // el nombre del ensamblado del worker: PatronFuentePropia (issue #250, arriba) ya nombra su
+    // ActivitySource con ese mismo string a mano, asi que ambas constantes deben derivar de una
+    // sola fuente de verdad -- fijado por guardrail en ConfiguracionObservabilidadProjectionsTests
+    // (CA-3). No lleva el ambiente: hay un App Insights por ambiente (un solo issue #263, punto 1).
+    internal const string NombreServicio = "";
 
     // CA-2: el source del propio ensamblado. El wildcard va SIN punto antes del asterisco --
     // divergencia deliberada frente a ControlHoras ("...ControlHoras.*"), verificada
@@ -75,4 +84,24 @@ public static class ConfiguracionObservabilidadProjections
             out var ratio) && ratio is >= 0.0 and <= 1.0
             ? ratio
             : RatioSamplingPorDefecto;
+
+    // Issue #263 (fase roja -- stub, pendiente de implementacion real).
+    //
+    // Extraido como metodo interno testeable -- igual que ResolverRatioDeSampling arriba -- en vez
+    // de wirear el AddService inline dentro del lambda de ConfigurarObservabilidad: eso permite
+    // construir un ResourceBuilder propio en el test (CreateDefault, sin Postgres ni Container App)
+    // y aseverar sobre Resource.Attributes, en vez de dejar el recurso sin cobertura.
+    //
+    // Cuando se implemente: debe fijar unicamente `service.name = NombreServicio` via
+    // AddService(NombreServicio, autoGenerateServiceInstanceId: false) -- SIN serviceNamespace
+    // (CA-1: cloud_RoleName no debe llevar prefijo) y SIN autogenerar service.instance.id (el
+    // default true reemplazaria el hostname legible del contenedor por un GUID aleatorio distinto
+    // en cada arranque de revision; el exporter de Azure Monitor deriva cloud_RoleInstance de ese
+    // atributo y cae al hostname en su ausencia).
+    //
+    // Consecuencia a documentar aqui cuando se complete: fijar el nombre en codigo deja
+    // OTEL_SERVICE_NAME inerte (ConfigureResource corre despues del ResourceBuilder.CreateDefault()
+    // que ya parsea esa variable, y Resource.Merge le da precedencia a lo que se fusiona despues).
+    internal static void ConfigurarRecurso(ResourceBuilder recurso) =>
+        throw new NotImplementedException();
 }

--- a/tests/Bitakora.ControlAsistencia.Projections.Tests/Infraestructura/ConfiguracionObservabilidadProjectionsTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Projections.Tests/Infraestructura/ConfiguracionObservabilidadProjectionsTests.cs
@@ -1,4 +1,7 @@
 // Issue #250: instrumentar el worker de proyecciones con Application Insights.
+// Issue #263: fijar el recurso `service.name` para que el worker deje de aparecer en Application
+// Insights como `unknown_service:dotnet`. Guardrails al final de esta misma clase (CA-2 a CA-4) --
+// misma familia de tests, no una clase nueva.
 //
 // El worker corre sin ingress (MEF-ADR-0034 seccion 8): no hay endpoint HTTP que golpear para
 // diagnosticar el daemon HotCold, asi que la observabilidad depende exclusivamente de trazas
@@ -30,6 +33,7 @@ using AwesomeAssertions;
 using Bitakora.ControlAsistencia.Projections.Infraestructura;
 using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry;
+using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 
 namespace Bitakora.ControlAsistencia.Projections.Tests.Infraestructura;
@@ -193,5 +197,78 @@ public class ConfiguracionObservabilidadProjectionsTests
         var ratio = ConfiguracionObservabilidadProjections.ResolverRatioDeSampling("0.5");
 
         ratio.Should().Be(0.5);
+    }
+
+    // --- Recurso de OpenTelemetry: service.name (issue #263, CA-2 a CA-4) ---
+    //
+    // Estos tests invocan ConfigurarRecurso directamente sobre un ResourceBuilder propio -- no a
+    // traves de ConfigurarObservabilidad ni del ServiceProvider completo. Wirear el AddService
+    // inline en el lambda de tracing (como ya pasa con el sampler compuesto, ver limite 1 de la
+    // cabecera de este archivo) dejaria el recurso sin cobertura: TracerProvider no expone
+    // publicamente el Resource que termino usando. CreateDefault() (no CreateEmpty()) es
+    // deliberado: es lo que ConfigurarObservabilidad usaria en produccion via ConfigureResource, e
+    // incluye el fallback `unknown_service:` y el detector de OTEL_SERVICE_NAME/
+    // OTEL_RESOURCE_ATTRIBUTES (verificado contra el XML doc de OpenTelemetry 1.16.0) -- exactamente
+    // lo que CA-2 y CA-4 necesitan para demostrar que el nombre del codigo gana sobre ambos.
+
+    private const string AtributoServiceName = "service.name";
+    private const string AtributoServiceNamespace = "service.namespace";
+    private const string AtributoServiceInstanceId = "service.instance.id";
+    private const string VariableOtelServiceName = "OTEL_SERVICE_NAME";
+
+    [Fact]
+    public void ConfigurarRecurso_FijaServiceNameSinNamespaceNiInstanceId()
+    {
+        var recurso = ResourceBuilder.CreateDefault();
+
+        ConfiguracionObservabilidadProjections.ConfigurarRecurso(recurso);
+        var atributos = recurso.Build().Attributes.ToDictionary(a => a.Key, a => a.Value);
+
+        atributos.Should().ContainKey(AtributoServiceName)
+            .WhoseValue.Should().Be(ConfiguracionObservabilidadProjections.NombreServicio);
+        atributos.Should().NotContainKey(AtributoServiceNamespace);
+        atributos.Should().NotContainKey(AtributoServiceInstanceId);
+    }
+
+    // CA-3: el nombre de servicio no puede divergir del nombre del ensamblado del worker -- es el
+    // mismo criterio (idiomatico) por el que PatronFuentePropia (issue #250, arriba) nombra su
+    // ActivitySource. Si diverge, el proximo test (PatronFuentePropia_...) tambien lo detecta.
+    [Fact]
+    public void NombreServicio_CoincideConElNombreDelEnsambladoDelWorker()
+    {
+        var nombreDelEnsamblado = typeof(ConfiguracionObservabilidadProjections).Assembly.GetName().Name!;
+
+        ConfiguracionObservabilidadProjections.NombreServicio.Should().Be(nombreDelEnsamblado);
+    }
+
+    // CA-3: PatronFuentePropia (issue #250) hoy repite el nombre del ensamblado a mano. Este
+    // guardrail impide que NombreServicio y PatronFuentePropia diverjan con el tiempo -- si alguien
+    // cambia uno sin el otro, este test falla. La forma de hacerlo pasar de manera sostenible es
+    // derivar PatronFuentePropia de NombreServicio (p.ej. `NombreServicio + "*"`), no editar ambos
+    // strings a mano en cada cambio.
+    [Fact]
+    public void PatronFuentePropia_CoincideConNombreServicioMasAsterisco()
+    {
+        ConfiguracionObservabilidadProjections.PatronFuentePropia.Should()
+            .Be(ConfiguracionObservabilidadProjections.NombreServicio + "*");
+    }
+
+    // CA-4: precedencia sobre OTEL_SERVICE_NAME. ResourceBuilder.CreateDefault() ya parsea esa
+    // variable (XML doc de OpenTelemetry 1.16.0); si ConfigurarRecurso corriera ANTES de que el
+    // detector de entorno se aplicara, o si AddService no sobrescribiera el atributo, este test lo
+    // detectaria. Reusa el helper ConVariableDeEntorno de arriba (seguro con tests en paralelo).
+    [Fact]
+    public void ConfigurarRecurso_ConservaElServiceNameDelCodigo_CuandoOtelServiceNameApuntaAOtroValor()
+    {
+        ConVariableDeEntorno(VariableOtelServiceName, "un-nombre-distinto-desde-el-entorno", () =>
+        {
+            var recurso = ResourceBuilder.CreateDefault();
+
+            ConfiguracionObservabilidadProjections.ConfigurarRecurso(recurso);
+            var atributos = recurso.Build().Attributes.ToDictionary(a => a.Key, a => a.Value);
+
+            atributos.Should().ContainKey(AtributoServiceName)
+                .WhoseValue.Should().Be(ConfiguracionObservabilidadProjections.NombreServicio);
+        });
     }
 }

--- a/tests/Bitakora.ControlAsistencia.Projections.Tests/Infraestructura/ConfiguracionObservabilidadProjectionsTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Projections.Tests/Infraestructura/ConfiguracionObservabilidadProjectionsTests.cs
@@ -1,7 +1,8 @@
 // Issue #250: instrumentar el worker de proyecciones con Application Insights.
 // Issue #263: fijar el recurso `service.name` para que el worker deje de aparecer en Application
-// Insights como `unknown_service:dotnet`. Guardrails al final de esta misma clase (CA-2 a CA-4) --
-// misma familia de tests, no una clase nueva.
+// Insights como `unknown_service:dotnet`. Guardrails al final de esta misma clase (CA-1 a CA-4 de
+// ese issue) -- misma familia de tests, no una clase nueva. Ojo al leer los "CA-N" de este archivo:
+// los de la mitad de arriba son del issue #250 y los de la ultima seccion, del #263.
 //
 // El worker corre sin ingress (MEF-ADR-0034 seccion 8): no hay endpoint HTTP que golpear para
 // diagnosticar el daemon HotCold, asi que la observabilidad depende exclusivamente de trazas
@@ -47,6 +48,14 @@ public class ConfiguracionObservabilidadProjectionsTests
         "IngestionEndpoint=https://dummy.in.applicationinsights.azure.com/";
 
     private const string MartenConnectionStringDummy = "Host=localhost;Database=dummy";
+
+    // Atributos de recurso de la seccion "service.name" (issue #263). Nombres literales a proposito:
+    // son la clave de la convencion semantica de OpenTelemetry de la que el exporter de Azure Monitor
+    // deriva cloud_RoleName/cloud_RoleInstance -- si el SDK los renombrara, el test debe fallar.
+    private const string AtributoServiceName = "service.name";
+    private const string AtributoServiceNamespace = "service.namespace";
+    private const string AtributoServiceInstanceId = "service.instance.id";
+    private const string VariableOtelServiceName = "OTEL_SERVICE_NAME";
 
     private static ServiceProvider ComponerServiceProvider(
         Action<IServiceCollection>? seamsAdicionales = null)
@@ -199,22 +208,36 @@ public class ConfiguracionObservabilidadProjectionsTests
         ratio.Should().Be(0.5);
     }
 
-    // --- Recurso de OpenTelemetry: service.name (issue #263, CA-2 a CA-4) ---
+    // --- Recurso de OpenTelemetry: service.name (issue #263, CA-1 a CA-4) ---
     //
-    // Estos tests invocan ConfigurarRecurso directamente sobre un ResourceBuilder propio -- no a
-    // traves de ConfigurarObservabilidad ni del ServiceProvider completo. Wirear el AddService
-    // inline en el lambda de tracing (como ya pasa con el sampler compuesto, ver limite 1 de la
-    // cabecera de este archivo) dejaria el recurso sin cobertura: TracerProvider no expone
-    // publicamente el Resource que termino usando. CreateDefault() (no CreateEmpty()) es
-    // deliberado: es lo que ConfigurarObservabilidad usaria en produccion via ConfigureResource, e
-    // incluye el fallback `unknown_service:` y el detector de OTEL_SERVICE_NAME/
-    // OTEL_RESOURCE_ATTRIBUTES (verificado contra el XML doc de OpenTelemetry 1.16.0) -- exactamente
-    // lo que CA-2 y CA-4 necesitan para demostrar que el nombre del codigo gana sobre ambos.
+    // Dos niveles, deliberadamente:
+    //
+    // a) ConfigurarObservabilidad_* compone el seam completo y lee el Resource que el TracerProvider
+    //    del contenedor termino usando (ProviderExtensions.GetResource, API publica de OpenTelemetry
+    //    1.16.0 -- la misma via por la que el exporter de Azure Monitor deriva cloud_RoleName). Es lo
+    //    que cubre CA-1 de punta a punta: que el enganche .ConfigureResource(...) sobre el
+    //    IOpenTelemetryBuilder efectivamente alcance la senal de trazas, y no solo que
+    //    ConfigurarRecurso haga lo correcto si alguien lo llama.
+    // b) ConfigurarRecurso_* invoca el metodo sobre un ResourceBuilder propio, para aislar la
+    //    precedencia frente al entorno (CA-4) sin construir el contenedor. CreateDefault() (no
+    //    CreateEmpty()) es deliberado: es lo que el SDK usa en produccion e incluye el fallback
+    //    `unknown_service:` y el detector de OTEL_SERVICE_NAME/OTEL_RESOURCE_ATTRIBUTES (verificado
+    //    contra el XML doc de OpenTelemetry 1.16.0) -- exactamente lo que CA-4 necesita para
+    //    demostrar que el nombre del codigo gana sobre ambos.
 
-    private const string AtributoServiceName = "service.name";
-    private const string AtributoServiceNamespace = "service.namespace";
-    private const string AtributoServiceInstanceId = "service.instance.id";
-    private const string VariableOtelServiceName = "OTEL_SERVICE_NAME";
+    [Fact]
+    public void ConfigurarObservabilidad_FijaElServiceNameDelWorkerEnElRecursoDelTracerProvider()
+    {
+        using var provider = ComponerServiceProvider();
+
+        var atributos = provider.GetRequiredService<TracerProvider>()
+            .GetResource().Attributes.ToDictionary(a => a.Key, a => a.Value);
+
+        atributos.Should().ContainKey(AtributoServiceName)
+            .WhoseValue.Should().Be(ConfiguracionObservabilidadProjections.NombreServicio);
+        atributos.Should().NotContainKey(AtributoServiceNamespace);
+        atributos.Should().NotContainKey(AtributoServiceInstanceId);
+    }
 
     [Fact]
     public void ConfigurarRecurso_FijaServiceNameSinNamespaceNiInstanceId()
@@ -232,7 +255,7 @@ public class ConfiguracionObservabilidadProjectionsTests
 
     // CA-3: el nombre de servicio no puede divergir del nombre del ensamblado del worker -- es el
     // mismo criterio (idiomatico) por el que PatronFuentePropia (issue #250, arriba) nombra su
-    // ActivitySource. Si diverge, el proximo test (PatronFuentePropia_...) tambien lo detecta.
+    // ActivitySource, y de ahi que una sola constante alimente a los dos.
     [Fact]
     public void NombreServicio_CoincideConElNombreDelEnsambladoDelWorker()
     {
@@ -241,11 +264,11 @@ public class ConfiguracionObservabilidadProjectionsTests
         ConfiguracionObservabilidadProjections.NombreServicio.Should().Be(nombreDelEnsamblado);
     }
 
-    // CA-3: PatronFuentePropia (issue #250) hoy repite el nombre del ensamblado a mano. Este
-    // guardrail impide que NombreServicio y PatronFuentePropia diverjan con el tiempo -- si alguien
-    // cambia uno sin el otro, este test falla. La forma de hacerlo pasar de manera sostenible es
-    // derivar PatronFuentePropia de NombreServicio (p.ej. `NombreServicio + "*"`), no editar ambos
-    // strings a mano en cada cambio.
+    // CA-3: PatronFuentePropia se deriva hoy de NombreServicio (`NombreServicio + "*"`), asi que
+    // mientras esa derivacion siga en pie esta guarda no puede fallar -- y eso es justamente lo que
+    // fija: impide que alguien vuelva a escribir el literal a mano en una de las dos constantes y las
+    // deje divergir en silencio (el modo de falla que este issue corrige). Es el guardrail de la
+    // derivacion, no una asercion sobre el valor: ese lo cubre el test anterior contra el ensamblado.
     [Fact]
     public void PatronFuentePropia_CoincideConNombreServicioMasAsterisco()
     {


### PR DESCRIPTION
## Resumen

Pipeline TDD completado:
- Fase roja: tests escritos con stubs
- Fase verde: implementación completa
- Fase refactor: revisión de calidad

## Decisiones del pipeline

<details>
<summary>Test Writer (fase roja) — 8m 13s</summary>

## ES Test Writer - Decisiones

### Nota de alcance
Este issue no es un command handler de event sourcing: es un seam de composicion de
OpenTelemetry (`ConfiguracionObservabilidadProjections`) sobre el worker de proyecciones. No
aplica el DSL `CommandHandlerAsyncTest`/`Given`/`When`/`Then` del harness ES -- son tests xUnit +
AwesomeAssertions planos sobre un `ResourceBuilder` propio, en la misma clase de test existente
(`ConfiguracionObservabilidadProjectionsTests`, patron ya usado para `ResolverRatioDeSampling`).

### Tests creados
- `ConfiguracionObservabilidadProjectionsTests.cs`: 4 tests nuevos (agregados a la clase existente,
  tal como pide el issue en "Impacto en archivos" -- misma familia, no archivo nuevo)
  - `ConfigurarRecurso_FijaServiceNameSinNamespaceNiInstanceId` - CA-2: `service.name` presente e
    igual a `NombreServicio`; `service.namespace` y `service.instance.id` ausentes
  - `NombreServicio_CoincideConElNombreDelEnsambladoDelWorker` - CA-3 (parte 1): la constante debe
    coincidir con `Assembly.GetName().Name` del worker
  - `PatronFuentePropia_CoincideConNombreServicioMasAsterisco` - CA-3 (parte 2): guardrail de
    no-divergencia entre `PatronFuentePropia` (issue #250) y `NombreServicio` (issue #263)
  - `ConfigurarRecurso_ConservaElServiceNameDelCodigo_CuandoOtelServiceNameApuntaAOtroValor` - CA-4:
    precedencia del nombre fijado en codigo sobre `OTEL_SERVICE_NAME`

### Estructura elegida
- Los 4 tests se agregaron a la clase de test **existente** `ConfiguracionObservabilidadProjectionsTests`
  (no una clase nueva), reusando el helper privado `ConVariableDeEntorno` ya presente para CA-4.
- Los tests invocan `ConfigurarRecurso` directamente sobre un `ResourceBuilder.CreateDefault()`
  propio -- no a traves de `ConfigurarObservabilidad()` ni del `ServiceProvider` completo. Esto es
  deliberado y verificado empiricamente: `ServiceProviderOptions.ValidateOnBuild = true` (que ya
  usan los 4 tests de composicion existentes) fuerza la resolucion de `TracerProvider` durante
  `BuildServiceProvider`, lo que ejecutaria cualquier callback `ConfigureResource` registrado. Si
  hubiera wireado `ConfigurarRecurso` (que hoy lanza `NotImplementedException`) dentro de
  `ConfigurarObservabilidad`, los 4 tests de composicion existentes habrian empezado a fallar --
  justo la regresion que el issue pide evitar explicitamente ("Regresion a cuidar"). Por eso
  **no toque `ConfigurarObservabilidad`**: la unica adicion a esa clase es el metodo extraido
  `ConfigurarRecurso` (sin invocarlo desde el pipeline de tracing) y la constante `NombreServicio`.
  El wiring real de `ConfigureResource(ConfigurarRecurso)` dentro de `ConfigurarObservabilidad`
  queda para el implementer (CA-1), junto con el comentario sobre `OTEL_SERVICE_NAME` inerte.
- `ResourceBuilder.CreateDefault()` (no `CreateEmpty()`) en los 4 escenarios: verificado contra el
  XML doc de OpenTelemetry 1.16.0 que `CreateDefault()` ya parsea `OTEL_SERVICE_NAME` y
  `OTEL_RESOURCE_ATTRIBUTES` -- exactamente lo que CA-2/CA-4 necesitan para demostrar precedencia.

### Stubs creados
- `ConfiguracionObservabilidadProjections.NombreServicio` (const string) - valor stub `""`
  (deliberadamente vacio, NO el valor real `"Bitakora.ControlAsistencia.Projections"`): un `const`
  no puede lanzar `NotImplementedException`, asi que se opto por un placeholder que hace fallar
  los 2 guardrails de CA-3 por la razon correcta (valor no fijado) en vez de dejarlos pasar en
  falso por coincidencia con `PatronFuentePropia` (que ya tenia ese string hardcodeado del issue
  #250).
- `ConfiguracionObservabilidadProjections.ConfigurarRecurso(ResourceBuilder)` - stub que lanza
  `NotImplementedException`, con comentario detallando la firma esperada de `AddService`
  (`autoGenerateServiceInstanceId: false`, sin `serviceNamespace`) para guiar al implementer.

### Decisiones de diseno
- CA-2 se cubrio en **un solo test** con 3 aserciones (service.name / service.namespace ausente /
  service.instance.id ausente) tal como el propio texto del CA lo describe ("un test guardrail ...
  verifica los tres atributos") -- las 3 aserciones examinan el mismo `Resource` producido por una
  unica invocacion de `ConfigurarRecurso`, no 3 escenarios distintos.
- Se uso `.Should().ContainKey(...).WhoseValue.Should().Be(...)` sobre un `Dictionary<string,
  object>` construido con `Attributes.ToDictionary(...)` en vez de LINQ `.Single(...)` manual, para
  seguir el estilo AwesomeAssertions ya presente en el resto de la codebase (`ContainSingle`,
  `ContainKey` con patron `.Which`/`.WhoseValue`).
- Se verifico manualmente (no solo compilacion) que los 4 tests nuevos fallan (`dotnet test` con
  filtro sobre la clase) y que los 10 tests existentes de la misma clase siguen en verde -- esto
  para confirmar la ausencia de regresion que el issue exige explicitamente en "Regresion a
  cuidar" antes de hacer el commit. No se repitio la corrida despues; solo se uso `dotnet build`
  para las verificaciones subsiguientes.

### Cobertura de criterios
| Criterio de aceptacion | Test(s) |
|---|---|
| CA-1 (wiring en `ConfigurarObservabilidad`, sin `service.namespace`/`service.instance.id`, sampler intacto) | No testeable directamente por test-writer -- es la implementacion que hace pasar CA-2/CA-3/CA-4. El sampler intacto ya lo cubren los tests existentes de `ResolverRatioDeSampling`, sin tocar. |
| CA-2 (recurso con `service.name` = constante, sin namespace ni instance.id) | `ConfigurarRecurso_FijaServiceNameSinNamespaceNiInstanceId` |
| CA-3 (constante = nombre de ensamblado; `PatronFuentePropia` no diverge) | `NombreServicio_CoincideConElNombreDelEnsambladoDelWorker`, `PatronFuentePropia_CoincideConNombreServicioMasAsterisco` |
| CA-4 (precedencia sobre `OTEL_SERVICE_NAME`) | `ConfigurarRecurso_ConservaElServiceNameDelCodigo_CuandoOtelServiceNameApuntaAOtroValor` |
| CA-5 (verificacion manual post-merge en App Insights) | No automatizable, segun el propio issue -- queda para verificacion manual post-despliegue |

### Desviaciones del plan del planner

Ninguna - la superficie propuesta en "Notas tecnicas" del issue (`NombreServicio`,
`ConfigurarRecurso(ResourceBuilder)`, invocacion directa sobre `ResourceBuilder.CreateDefault()`,
reuso de `ConVariableDeEntorno`) se aplico tal cual. La unica decision de test-writer no explicitada
literalmente en el issue fue el valor stub de `NombreServicio` (`""` en vez del valor real), tomada
para mantener el principio "los tests deben fallar" sin depender de que `PatronFuentePropia`
coincidiera por casualidad con el valor correcto.

</details>

<details>
<summary>Implementer (fase verde) — 3m 59s</summary>

## ES Implementer - Decisiones

### Enfoque de implementacion

El issue trae la superficie completa ya decidida en "Notas tecnicas" y las tres decisiones cerradas
en el refinamiento, asi que la fase verde fue mecanica sobre `ConfiguracionObservabilidadProjections.cs`:

1. `NombreServicio` paso de `""` a `"Bitakora.ControlAsistencia.Projections"` (nombre del ensamblado,
   punto 1 de las decisiones cerradas del issue).
2. `PatronFuentePropia` se redefinio como `NombreServicio + "*"` (concatenacion de constantes,
   resuelta en tiempo de compilacion -- sigue siendo un `const string` valido) en vez de repetir el
   literal a mano, para que CA-3 (guardrail `PatronFuentePropia_CoincideConNombreServicioMasAsterisco`)
   no pueda quedar en verde con dos strings divergentes.
3. Se implemento `ConfigurarRecurso(ResourceBuilder recurso)` con
   `recurso.AddService(NombreServicio, autoGenerateServiceInstanceId: false)` -- exactamente la firma
   que las notas tecnicas del issue especificaron, sin `serviceNamespace` (CA-1) y sin autogenerar
   `service.instance.id` (evita el GUID aleatorio en `cloud_RoleInstance`).
4. Se engancho `ConfigureResource(ConfigurarRecurso)` en la cadena de `services.AddOpenTelemetry()`,
   antes de `.WithTracing(...)` -- el punto de enganche que las notas tecnicas sugerian ("aplica a
   todas las senales, no solo a trazas").
5. Se actualizaron los comentarios que estaban marcados "fase roja -- stub/pendiente" para reflejar
   el estado final, dejando la explicacion de la consecuencia (`OTEL_SERVICE_NAME` inerte) y la
   referencia al test que la verifica (CA-4).

### Decisiones de diseno

- No se creo ningun archivo nuevo ni se toco la clase de test: toda la superficie pedida por los
  4 tests nuevos (`ConfigurarRecurso_FijaServiceNameSinNamespaceNiInstanceId`,
  `NombreServicio_CoincideConElNombreDelEnsambladoDelWorker`,
  `PatronFuentePropia_CoincideConNombreServicioMasAsterisco`,
  `ConfigurarRecurso_ConservaElServiceNameDelCodigo_CuandoOtelServiceNameApuntaAOtroValor`) ya estaba
  descrita en el stub del test-writer; solo hizo falta llenar la implementacion real.
- Se derivo `PatronFuentePropia` de `NombreServicio` en vez de simplemente escribir el mismo literal
  dos veces: es la unica forma "sostenible" que el propio comentario del test senala para pasar CA-3
  sin volver a divergir en un cambio futuro.

### ADRs consultados

- CA-ADR-0009 (control de costos de Application Insights): verificado que el cambio no toca el
  sampler ni el ratio (`ResolverRatioDeSampling`/`RatioSamplingPorDefecto` intactos) -- solo agrega
  atributos de recurso via `ConfigureResource`, que es una capa distinta del sampler head-based.
- MEF-ADR-0029 (test de composicion del host): confirmado que el wiring correcto vive en el seam
  `ConfiguracionObservabilidadProjections` (no inline en `Program.cs`) y que la clase de test
  existente ya cumple el rol de "hermano" de este ADR para el worker -- no requirio cambios en
  `Program.cs` ni en `ComposicionServicios*`.
- MEF-ADR-0034 seccion 8 (worker sin ingress): no aplico ningun cambio de codigo derivado de esta
  seccion; solo confirma por que CA-5 queda como verificacion manual post-merge (no hay endpoint que
  golpear) y por que las trazas OpenTelemetry son la unica observabilidad del worker.
- MEF-ADR-0031 (readiness gate por SHA): leido solo para confirmar que `service.version` esta
  correctamente fuera de alcance de este issue (el mecanismo vive en `deploy-{kebab}.yml`, que no
  aplica a este worker) -- no genero ningun cambio de codigo.
- MEF-ADR-0016 (naming de metodos de test): no aplico cambios de produccion; los tests ya seguian
  la convencion `<Sujeto>_<LoQuePasa>_Cuando<Condicion>` al llegar de la fase roja.

### Desviaciones de ADRs

Ninguna desviacion -- todos los ADRs aplicados al pie de la letra.

### Precedentes consultados

- `PatronFuentePropia` (mismo archivo, issue #250): patron ya alineado con la doctrina del propio
  issue (constante `internal` fijada por guardrail). Se extendio el mismo patron para
  `NombreServicio`/`ConfigurarRecurso`, sin necesidad de reportar ninguna violacion.

### Infraestructura modificada

Ninguna. Este issue no publica ni consume eventos nuevos -- no toca `topics_config` de
`module "service_bus_interno"` ni ningun otro bloque de `infra/environments/dev/main.tf`. Tampoco
introduce secretos nuevos (CA-ADR-0026/MEF-ADR-0025): la connection string de Application Insights
ya la resuelve el exporter por convencion propia, sin cambios en este issue.

### Complejidad encontrada

Ninguna significativa. El unico ajuste no trivial fue confirmar que `PatronFuentePropia = NombreServicio + "*"`
sigue siendo una expresion constante valida en C# (concatenacion de `const string` en tiempo de
compilacion) para que ambos sigan siendo `internal const string` sin necesitar convertir alguno en
`static readonly`.

### Resultado

- Tests pasando: 495/495 en la solucion completa (487 correctos + 8 omitidos por falta de
  infraestructura real de smoke tests, sin relacion con este cambio; 0 errores).
- Tests de la clase objetivo (`ConfiguracionObservabilidadProjectionsTests`): 14/14 en verde,
  incluyendo los 4 nuevos de CA-2 a CA-4.

</details>
<details>
<summary>Reviewer (fase refactor) — 8m 50s</summary>

## ES Reviewer - Revision

### Evaluacion general
- Calidad: **buena** (el diff de las fases roja/verde ya era correcto y bien documentado; los cambios del review cierran un hueco de cobertura y alinean comentarios que quedaron desactualizados tras la fase verde)
- Cambios realizados: **si** (commit `8e1ef97`)
- Suite: **496 tests, 0 errores, 8 omitidos** (smoke tests sin infra real, preexistente). Baseline al inicio: 495/0/8.

### Cumplimiento de ADRs aplicables

| ADR | Cumplimiento | Observacion |
|---|---|---|
| CA-ADR-0009 (control de costos App Insights) | ok | El diff no toca el sampler: `SetSampler(new ParentBasedSampler(new TraceIdRatioBasedSampler(samplingRatio)))`, `RatioSamplingPorDefecto = 0.2` y `ResolverRatioDeSampling` quedan byte-identicos. `ConfigureResource` solo agrega atributos de recurso (capa distinta del sampler head-based de la Capa 2); no habilita ninguna senal nueva -- el pipeline sigue registrando unicamente `WithTracing`, asi que no hay riesgo de ingesta adicional. Los 5 tests de `ResolverRatioDeSampling` no requirieron cambio, la senal de no-desborde que el propio issue pedia cuidar. |
| MEF-ADR-0029 (test de composicion del host) | ok (reforzado) | El wiring vive en el seam `ConfiguracionObservabilidadProjections`, no inline en `Program.cs`, y el test de composicion existente es su hermano. **El review lo refuerza**: el nuevo test compone el `IServiceCollection` real y verifica el `Resource` que el `TracerProvider` del contenedor termino usando -- es exactamente la categoria "wiring del contenedor" que fija este ADR, aplicada al atributo de recurso. |
| MEF-ADR-0034 seccion 8 (worker sin ingress, `min_replicas >= 1`) | ok | Verificado contra la seccion 8: el worker corre como Container App sin ingress, asi que las trazas exportadas son su unica observabilidad -- lo que justifica el issue y vuelve manual a CA-5 (no hay endpoint que golpear, no admite smoke test). El diff no toca Terraform ni el Dockerfile, coherente con el alcance. |
| MEF-ADR-0031 (readiness gate por SHA) | ok (por exclusion) | Citado solo para justificar que `service.version` queda fuera: `-p:SourceRevisionId=${{ github.sha }}` existe unicamente en `deploy-control-horas.yml:53` y `deploy-programacion.yml:53`; el worker compila dentro del contenedor. El diff correctamente no fija `service.version` ni toca `deploy-projections.yml`. |
| MEF-ADR-0016 (naming de tests) | ok | Los 5 tests de la seccion nueva siguen `<Sujeto>_<LoQuePasa>[_Cuando<Condicion>]` con sujeto = metodo/constante bajo prueba (`ConfigurarRecurso`, `ConfigurarObservabilidad`, `NombreServicio`, `PatronFuentePropia`). El ADR permite omitir `_Cuando` cuando el escenario es trivial, que es el caso de los cuatro sin sufijo. Solo `[Fact]`, ningun `[Theory]`. |
| MEF-ADR-0014 (coverage gate) | ok | `src/.../Infraestructura/` es categoria excluida de medicion ("wiring puro", igual que fija MEF-ADR-0029 punto 5); el test vive en `tests/`. El cambio no distorsiona el gate. |
| MEF-ADR-0012 (encapsulamiento / Tell-don't-Ask) | ok / n/a | No hay aggregates, VOs ni eventos en el diff: es un seam de composicion. Recorrido explicito de los 7 antipatrones -- ninguno aplica: no hay propiedad publica nueva de VO, ni clase estatica operando sobre datos crudos de un objeto de dominio, ni getter para test, ni `InternalsVisibleTo`, ni `[JsonConstructor]`, ni `record` con coleccion, ni evento con marker de bus. Las constantes nuevas son `internal` (no `public`) y su unico consumidor externo es la clase de test del mismo seam, patron ya establecido por `VariableRatioSampling`/`RatioSamplingPorDefecto`. |

### Desviaciones de ADRs

**Ninguna desviacion -- todos los ADRs aplicables se cumplen.** El implementer no declaro desviaciones y la verificacion del diff no encontro ninguna sin declarar.

### Precedentes consultados por el implementer

| Precedente | ADR aplicable | Veredicto |
|---|---|---|
| `PatronFuentePropia` (mismo archivo, issue #250): constante `internal` fijada por guardrail | MEF-ADR-0012 (no exponer estado), MEF-ADR-0029 (wiring en el seam) | **alineado**. El precedente cumple: constante `internal`, no `public`, con guardrail propio. La extension a `NombreServicio` + `ConfigurarRecurso` es consistente. Ademas la fase verde lo **mejoro**: `PatronFuentePropia = NombreServicio + "*"` elimina el literal duplicado que el precedente tenia. |
| `ResolverRatioDeSampling` (mismo archivo): metodo `internal` extraido para testear sin mutar el entorno | MEF-ADR-0029 | **alineado**. Mismo criterio aplicado a `ConfigurarRecurso`. |

### Convenciones del pipeline (no ADRs)

| Convencion | Estado | Observacion |
|---|---|---|
| Cada test con `Then()` + `And<>()` | n/a | No hay tests de command handler en el diff (no hay `CommandHandlerAsyncTest<T>`): son tests de composicion/configuracion, categoria distinta (MEF-ADR-0029 punto 4). |
| Overloads correctos para stream IDs compuestos | n/a | Sin aggregates en el diff. |
| Fakes manuales (no NSubstitute) | ok | Sin mocks: se usa el `IServiceCollection` real y `ResourceBuilder` real. |
| Feature folders (produccion y tests) | ok | `src/.../Infraestructura/` con espejo exacto en `tests/.../Infraestructura/`. Un archivo por responsabilidad; los guardrails nuevos van en la clase existente del mismo seam (misma familia), no en una clase nueva. |
| Smoke tests: SkipWhen, secrets, cobertura | n/a | El worker no tiene ingress ni endpoint (MEF-ADR-0034 seccion 8): CA-5 es verificacion manual por KQL, declarada como tal en el issue. Ningun smoke test en el diff. |
| Proyecciones read-side: partial, inmutabilidad, read APIs, naming | n/a | El diff no toca read models, clases de proyeccion ni Functions GET -- es solo el seam de observabilidad del worker. |
| Tests via ToString/comportamiento | ok | Los tests aseveran sobre el resultado observable (`Resource.Attributes`, el valor de las constantes), no sobre estado privado. Ningun miembro se hizo `public` para el test. |
| Sin numeros magicos | ok | Los strings de atributos (`service.name`, `service.namespace`, `service.instance.id`) y `OTEL_SERVICE_NAME` son constantes con nombre; el review las movio al bloque de campos de la clase. |
| Condiciones en positivo (guardas if/else afirmativas) | n/a | No hay bifurcaciones nuevas. |
| Sin caracteres Unicode decorativos (U+2500) | ok | Verificado: ambos archivos son 100% ASCII. |
| `dotnet format --verify-no-changes` | ok | Limpio sobre los dos archivos del diff. Los `IDE0005` que reporta la solucion son preexistentes en Programacion/ControlHoras, fuera del alcance del issue (regla 4). |
| Warnings del compilador | ok | Ningun warning nuevo. Los 4 `NU1902` (`OpenTelemetry.Api` 1.14.0 en Programacion) son preexistentes y ajenos a este diff. |

### Elegancia del codigo

- **Legibilidad / exactitud (corregido)**: tres comentarios quedaron desalineados con el estado final tras la fase verde y afirmaban cosas ya falsas. Los comentarios que mienten son peores que la ausencia de comentario, sobre todo en un archivo cuyo valor principal *es* la documentacion de decisiones verificadas:
  1. `"TracerProvider no expone publicamente el Resource que termino usando"` -- **falso**: `OpenTelemetry.ProviderExtensions.GetResource(BaseProvider)` es publica en 1.16.0 (verificada empiricamente, ver "Tests agregados"). Esa afirmacion era la que justificaba dejar el enganche sin cobertura.
  2. `"PatronFuentePropia ... hoy repite el nombre del ensamblado a mano ... La forma de hacerlo pasar de manera sostenible es derivar..."` -- redaccion de fase roja: la fase verde ya aplico la derivacion. El implementer declaro explicitamente "no se toco la clase de test", de ahi el desfase.
  3. `"Si diverge, el proximo test (PatronFuentePropia_...) tambien lo detecta"` -- **falso** tras la derivacion: con `PatronFuentePropia = NombreServicio + "*"` esa guarda no puede fallar mientras la derivacion siga en pie. Sigue siendo valiosa (fija la derivacion, impide re-introducir el literal), pero su alcance real es otro y ahora el comentario lo dice.
- **Compacidad**: el comentario de `ConfigurarRecurso` tenia 22 lineas para una expresion de una linea, con un parrafo que solapaba textualmente con el comentario de la clase de test. Se compacto a 15 sin perder ninguna informacion sustantiva (mapeo a `cloud_RoleName`, `autoGenerateServiceInstanceId: false` y el GUID que evita, `OTEL_SERVICE_NAME` inerte). El resto de la densidad de comentarios se conserva a proposito: documenta hechos verificados contra el SDK que no son evidentes en el codigo.
- **Idiomatico / limpieza**: `ConfigurarRecurso` como expression-bodied member, `internal` en vez de `public`, concatenacion de `const` resuelta en compilacion -- todo idiomatico. Sin cruft, sin imports sobrantes, sin codigo comentado.
- **Ubicacion de miembros (corregido)**: las 4 constantes privadas de la clase de test estaban declaradas en el medio del archivo, entre metodos `[Fact]`. Se movieron al bloque de campos junto a las demas constantes, consistente con la convencion de C# y con el resto del archivo.
- **Robustez**: `ConVariableDeEntorno` restaura el valor original en `finally` -- correcto para tests en paralelo entre clases. El nuevo test no muta entorno.
- **Eficiencia**: n/a (no hay algoritmos; `ToDictionary` sobre un pu~nado de atributos).

### Criticas y hallazgos

1. **[mayor -- corregido] El enganche `ConfigureResource` no tenia cobertura, y el motivo registrado para no cubrirlo era tecnicamente incorrecto.** Los 4 tests de la fase roja verifican `ConfigurarRecurso` **aislado**; ninguno verificaba que `ConfigurarObservabilidad` lo enganchara al pipeline. CA-1 esta redactado sobre `ConfigurarObservabilidad`, no sobre `ConfigurarRecurso`. **Verificado por mutacion**: al borrar la linea `.ConfigureResource(ConfigurarRecurso)` de produccion, la suite completa seguia **verde** -- es decir, el defecto exacto que este issue corrige (recurso sin configurar -> `unknown_service:dotnet`) podia reintroducirse sin que ningun test se quejara. El agravante es que el motivo documentado ("`TracerProvider` no expone publicamente el Resource") es falso. Corregido con un test que compone el seam real y lee `GetResource()`; re-verificado por mutacion que ahora **si** se pone rojo.
2. **[menor -- corregido] Comentarios de fase roja no actualizados por la fase verde** (los tres puntos del bloque de elegancia). El implementer declaro "no se toco la clase de test" como decision de diseno, pero dos de esos comentarios describian el estado *antes* de su cambio.
3. **[cosmetico -- corregido] Colision de referencias "CA-N" entre issues.** El archivo mezcla los CA del #250 (ratio de sampling, patron de fuente) con los del #263 (atributos de recurso): habia dos "CA-3" distintos a 40 lineas de distancia y un "CA-4" en produccion que apuntaba al #263 mientras el "CA-4" de la cabecera del test apunta al #250. Se elimino la numeracion ambigua de los comentarios nuevos (los tests se citan por nombre, que no caduca) y se agrego una advertencia explicita en la cabecera.
4. **[cosmetico -- corregido] Frase mal formada en produccion**: `"hay un App Insights por ambiente (un solo issue #263, punto 1)"`. Reescrita con el argumento completo del refinamiento.
5. **[observacion -- no corregido, deliberado] Duplicacion de 3 lineas entre los dos tests de `ConfigurarRecurso`** (`CreateDefault` -> `ConfigurarRecurso` -> `Build().Attributes.ToDictionary(...)`). Se evaluo extraer un helper y **se descarto por MEF-ADR-0018 (Rule of Three)**: con dos ocurrencias la duplicacion es preferible a la abstraccion prematura, y aqui ademas mantiene cada test legible de arriba abajo sin salto de indireccion.
6. **[observacion -- sin accion, pertenece al harness] El valor de este issue debe alimentar al issue #457 del harness**, como el propio issue indica. Las tres piezas a heredar por el generador quedan confirmadas por esta revision: (a) `service.name` = nombre del ensamblado, (b) `autoGenerateServiceInstanceId: false` para no perder `cloud_RoleInstance` legible, (c) el guardrail de precedencia frente a `OTEL_SERVICE_NAME`. **Se suma una cuarta, que este review descubrio**: el guardrail debe ejercitar el enganche real via `ProviderExtensions.GetResource()`, no solo el metodo aislado -- sin eso el generador puede emitir un seam a medio cablear con la suite en verde, que es precisamente el modo de falla que #457 quiere prevenir.

### Refactorings aplicados

- **Test nuevo de composicion** `ConfigurarObservabilidad_FijaElServiceNameDelWorkerEnElRecursoDelTracerProvider` (hallazgo 1). Reusa el helper `ComponerServiceProvider()` existente, asi que no duplica wiring.
- **Comentarios corregidos** en `ConfiguracionObservabilidadProjections.cs` (la afirmacion sobre `Resource` sin cobertura, la frase mal formada del punto 1 del refinamiento, las referencias "CA-N" ambiguas) y en la clase de test (los dos comentarios de CA-3 que describian el estado pre-fase-verde). Compactacion del bloque de `ConfigurarRecurso` de 22 a 15 lineas sin perdida de contenido.
- **Constantes movidas** al bloque de campos de la clase de test.
- **No se toco**: `ResolverRatioDeSampling`, el sampler, los `AddSource`, los 5 tests de ratio ni los 4 de composicion existentes -- la se~nal de no-desborde que el issue pedia cuidar se mantiene intacta.

### Cobertura de criterios de aceptacion

| Criterio | Estado | Test(s) |
|---|---|---|
| CA-1: `ConfigurarObservabilidad` fija `service.name`; no fija `service.namespace` ni `service.instance.id`; no modifica sampler, ratio 0.2 ni `AddSource` | **cubierto** (era parcial antes del review) | `ConfigurarObservabilidad_FijaElServiceNameDelWorkerEnElRecursoDelTracerProvider` **(agregado en el review)** para el enganche y los tres atributos sobre el pipeline real; los 5 `ResolverRatioDeSampling_*` y `PatronFuentePropia_CapturaLaActividad_*` fijan que sampler/ratio/`AddSource` no cambiaron. |
| CA-2: guardrail de los tres atributos de servicio sobre el recurso que produce el seam | cubierto | `ConfigurarRecurso_FijaServiceNameSinNamespaceNiInstanceId` (nivel unitario) + el test de composicion nuevo (nivel end-to-end). |
| CA-3: la constante coincide con el nombre del ensamblado y `PatronFuentePropia` no puede divergir | cubierto | `NombreServicio_CoincideConElNombreDelEnsambladoDelWorker` + `PatronFuentePropia_CoincideConNombreServicioMasAsterisco`, reforzado en produccion por la derivacion `PatronFuentePropia = NombreServicio + "*"` (la divergencia deja de ser posible por construccion, no solo detectable). |
| CA-4: precedencia del codigo sobre `OTEL_SERVICE_NAME` | cubierto | `ConfigurarRecurso_ConservaElServiceNameDelCodigo_CuandoOtelServiceNameApuntaAOtroValor` (sobre `CreateDefault()`, que es lo que parsea la variable). |
| CA-5: verificacion manual post-merge por KQL sobre `controlasistencias-dev-ai` | **pendiente por diseno** | No automatizable (worker sin ingress, MEF-ADR-0034 seccion 8). Consulta a correr tras el despliegue: `union traces, dependencies, exceptions \| where timestamp > ago(1h) \| summarize count() by cloud_RoleName` -- se espera el worker bajo `Bitakora.ControlAsistencia.Projections` y cero registros nuevos bajo `unknown_service:dotnet`. |

### Tests agregados

- `ConfigurarObservabilidad_FijaElServiceNameDelWorkerEnElRecursoDelTracerProvider` -- guardrail de composicion que cierra CA-1 de punta a punta. Metodo: compone el seam real y lee el `Resource` efectivo del `TracerProvider` con `ProviderExtensions.GetResource()`, la misma via por la que el exporter de Azure Monitor deriva `cloud_RoleName`.
  - **Accesibilidad de la API verificada empiricamente**, no asumida: sonda compilada y ejecutada contra `OpenTelemetry` 1.16.0 antes de escribir el test (el XML doc del paquete no distingue accesibilidad, asi que documentarlo no bastaba).
  - **Poder de deteccion verificado por mutacion**: sin `.ConfigureResource(ConfigurarRecurso)` el test falla (1 error, 27 correctos) y con el enganche pasa. No es un test tautologico.
- Tests de contrato de igualdad (`IgualdadTestBase<T>`) y de round-trip de serializacion: **n/a** -- el diff no introduce `IEquatable<T>`, `ConfigurarSerializacion` ni eventos con marker de bus (`IPrivateEvent`/`IPublicEvent`), asi que ninguno de esos guardrails aplica.

</details>

## Cobertura

| Archivo | Cobertura | Umbral | Estado |
|---|---|---|---|
| ConfiguracionObservabilidadProjections.cs | - | no evaluado | - |
## Commits

8e1ef97 refactor(hu-263): cerrar el hueco de cobertura del enganche de ConfigureResource
a75cfbe feat(issue-263): fijar service.name del worker de proyecciones (fase verde)
6d5da15 test(hu-263): tests para service.name del worker de proyecciones (fase roja)

Closes #263