### PR TITLE
Agregar un .dockerignore para acotar el contexto de build de la imagen del worker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -27,7 +27,10 @@ pipeline-state/
 **/node_modules/
 
 # Estado local y credenciales (MEF-ADR-0025 extendido al contexto de build: no llegan a la
-# imagen publicada, pero si a la capa del COPY en la etapa build, que vive en el cache del builder)
+# imagen publicada, pero si a la capa del COPY en la etapa build, que vive en el cache del builder).
+# Al ampliar este bloque, ojo con el sufijo: se excluye ".local.json", NO "appsettings.*.json".
+# appsettings.json y appsettings.Development.json del worker SI son input del build y se publican
+# en la imagen; excluirlos la romperia en silencio.
 **/.terraform/
 **/*.tfvars
 **/*.tfstate
@@ -42,5 +45,8 @@ pipeline-state/
 .vscode/
 **/.DS_Store
 
-# El Dockerfile lo lee "docker build -f" del host, no del contexto
+# Un Dockerfile en la RAIZ del contexto (hoy no existe ninguno): "docker build -f" lo lee del
+# host, no del contexto. Docker evalua estos patrones contra la ruta relativa a la raiz del
+# contexto y no contra el nombre de archivo, asi que esta linea NO alcanza al Dockerfile del
+# worker -- y no debe alcanzarlo: vive bajo src/, junto al proyecto que compila.
 Dockerfile*

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,46 @@
+# Docker NO lee .gitignore: cada patron va explicito aqui.
+# Criterio: lista de EXCLUSIONES, nunca allowlist ("*" + reinclusiones "!") -- el build
+# necesita global.json y los .csproj/.cs de src/*.Projections y src/*.ReadModels, y una
+# allowlist los dejaria fuera en silencio ante cualquier input nuevo.
+# Base: samples/aspnetapp/.dockerignore de dotnet/dotnet-docker (Microsoft).
+
+# Artefactos de compilacion. Critico, no cosmetico: obj/project.assets.json del host lleva
+# rutas absolutas (~/.nuget/packages, ~/.dotnet/sdk/<version>) y el "COPY . ." posterior al
+# "dotnet restore" lo sobrescribiria con uno que no resuelve dentro del contenedor.
+**/bin/
+**/obj/
+**/out/
+
+# Control de versiones
+.git/
+.gitignore
+.gitattributes
+
+# Nada de esto es input del build de la imagen
+docs/
+infra/
+tests/
+scripts/
+.github/
+.claude/
+pipeline-state/
+**/node_modules/
+
+# Estado local y credenciales (MEF-ADR-0025 extendido al contexto de build: no llegan a la
+# imagen publicada, pero si a la capa del COPY en la etapa build, que vive en el cache del builder)
+**/.terraform/
+**/*.tfvars
+**/*.tfstate
+**/*.tfstate.*
+**/tfplan
+**/local.settings.json
+**/appsettings.local.json
+
+# Editores / IDE / OS
+.vs/
+.idea/
+.vscode/
+**/.DS_Store
+
+# El Dockerfile lo lee "docker build -f" del host, no del contexto
+Dockerfile*


### PR DESCRIPTION
## Resumen

Pipeline tooling completado:
- Writer: implementacion de la tarea
- Reviewer: revision de calidad

## Decisiones del pipeline

<details>
<summary>Writer -- 3m 3s</summary>

# Stage 1 (tooling) — Issue #260: `.dockerignore` para el worker de proyecciones

## Que se hizo

Se creo `.dockerignore` en la raiz del repo (unico archivo nuevo, sin modificar el Dockerfile ni
`deploy-projections.yml`), con el contenido propuesto en el issue: lista de exclusiones explicitas,
sin allowlist.

## Verificacion de los criterios de aceptacion

- **CA-1** (lista de exclusiones, sin allowlist): OK. `grep` confirmo que no hay ninguna linea `!`
  de reinclusion ni patron `*` aislado.
- **CA-2** (patrones minimos): OK. Los 21 patrones exigidos por el issue estan presentes
  (`**/bin/`, `**/obj/`, `**/out/`, `.git/`, `docs/`, `infra/`, `tests/`, `scripts/`, `.github/`,
  `.claude/`, `pipeline-state/`, `**/node_modules/`, `**/.terraform/`, `**/*.tfvars`,
  `**/*.tfstate*`, `**/tfplan`, `**/local.settings.json`, `**/appsettings.local.json`, `.vs/`,
  `.idea/`, `.vscode/`, `**/.DS_Store`). Se confirmo que `global.json` y el codigo bajo
  `src/Bitakora.ControlAsistencia.Projections/` y `src/Bitakora.ControlAsistencia.ReadModels/` no
  quedan excluidos (solo sus `bin/`/`obj/`).
- **CA-3** (build con `bin/`/`obj/` locales presentes, sin limpiar): OK. El worktree no traia
  artefactos de build, asi que se corrio `dotnet build` sobre
  `src/Bitakora.ControlAsistencia.Projections/Bitakora.ControlAsistencia.Projections.csproj` para
  generarlos con rutas absolutas del host (confirmado en `obj/project.assets.json` ->
  `packageFolders: ["/Users/.../.nuget/packages/"]`). Con esos artefactos en disco,
  `docker build --no-cache -f src/Bitakora.ControlAsistencia.Projections/Dockerfile -t
  asist-projections:post .` termino con exit 0.
- **CA-4** (contexto < 20 MB): OK. Con `docker builder prune -f` previo, la linea
  `[internal] load build context` reporto **`transferring context: 232.34kB`** — muy por debajo del
  limite y del baseline de 1330 MB / 39.131 archivos del issue.
- **CA-5** (contenido publicado identico): OK. Se construyo tambien la imagen "pre" (moviendo
  `.dockerignore` fuera temporalmente y restaurandolo despues) y se comparo
  `docker run --rm --entrypoint ls <tag> -1 /app` entre `asist-projections:pre` y
  `asist-projections:post`: el `diff` fue vacio.

Las imagenes de prueba (`asist-projections:pre`/`:post`) se eliminaron del daemon local tras
verificar (`docker rmi`); no son parte del entregable. Los artefactos `bin/`/`obj/` generados por
`dotnet build` para la verificacion quedan en disco pero ya estaban cubiertos por `.gitignore`
(`[Bb]in/`, `[Oo]bj/`), asi que `git status` solo muestra `.dockerignore` como archivo nuevo.

## Nota sobre un dato del issue que no se pudo reproducir tal cual

El issue documenta el efecto 2 (build local roto por `project.assets.json` con rutas del host)
como "verificado, no hipotetico". En este entorno, construir la imagen **sin** `.dockerignore**
(con los mismos `bin/`/`obj/` del host presentes) tambien completo con exit 0 — no se reprodujo la
falla de resolucion de paquetes. Es consistente con que el ADR/issue la describe como un modo de
fallo dependiente del entorno (version exacta del SDK de la imagen base vs. la del host, contenido
del cache de NuGet, etc.), no como una falla garantizada en todo momento. Esto no cambia ninguno de
los CA: el `.dockerignore` sigue siendo la mitigacion correcta (evita que el `COPY . .` pise el
`project.assets.json` recien generado por el restore del contenedor, sea cual sea el entorno), y
CA-3/CA-4/CA-5 se verificaron igual con el archivo puesto.

## Fuera de alcance (deliberado, segun el issue)

- No se toco `Dockerfile` ni `deploy-projections.yml`.
- No se agrego ninguna verificacion automatizada (es `tipo:tooling` sin ciclo rojo/verde).
- El seguimiento en el harness (`projections-scaffolder` debe emitir este archivo para nuevos
  consumidores) queda pendiente de crear como issue en
  `augusto-romero-arango/eda-evsourcing-azure-harness` — no se creo en esta sesion porque el issue
  #260 ya deja documentado el candidato natural (#453) y la decision de si va ahi o como issue
  propio es del dueño del harness, no de esta fase.

## Archivos

- **Creado**: `.dockerignore` (raiz del repo)
- **Modificado**: ninguno

</details>

<details>
<summary>Reviewer -- 5m 52s</summary>

# Stage 2 - Reviewer - Issue #260 (.dockerignore para acotar el contexto de build)

**Veredicto: APROBADO.** Los 5 criterios de aceptacion se verificaron ejecutando builds
reales de Docker (server 28.5.1), no por inspeccion. Se corrigieron dos comentarios
imprecisos del archivo (commit `5c04f6e`); ningun patron cambio.

## Alcance de lo revisado

- Commit del writer: `5595585` — crea `.dockerignore` en la raiz (46 lineas, unico archivo).
- **Rutas prohibidas: ninguna tocada.** El writer no modifico `commands/`, `skills/`,
  `agents/`, `hooks/`, `.claude-plugin/`, `docs/adr/` ni `src/`. En particular **no toco el
  `Dockerfile`** ni `deploy-projections.yml`, como el issue exige explicitamente.
- No hay codigo C# en el cambio, asi que no aplica compilar ni correr la suite: el set de
  archivos que el compilador ve es identico (verificado abajo, CA-5 con diff vacio).

## Verificacion de criterios de aceptacion

Nota metodologica: la linea base del issue (1330 MB / 39.131 archivos) se midio en el repo
principal, que tiene `docs/presentaciones/**/node_modules` e `infra/**/.terraform` en disco.
Esta revision corre en el **worktree**, cuya linea base es 21,10 MB — mas chica, pero el
escenario critico (CA-3) se conserva intacto porque `bin/`+`obj/` de `Projections` y
`ReadModels` **si estan presentes**, incluido el `obj/project.assets.json` del host.

| CA | Resultado | Evidencia |
|---|---|---|
| CA-1 | **Cumple** | Lista de exclusiones explicitas. `grep` confirma que no hay ningun patron `*` global ni reinclusiones `!`. |
| CA-2 | **Cumple** | Los 22 patrones exigidos estan presentes. `**/*.tfstate*` se expresa como `**/*.tfstate` + `**/*.tfstate.*` (cobertura equivalente, redaccion del propio issue). |
| CA-3 | **Cumple** | `docker build --no-cache -f src/.../Dockerfile -t asist-projections:post .` → **exit 0**, con `bin/`/`obj/` locales sin limpiar. |
| CA-4 | **Cumple con margen amplio** | Contexto filtrado **0,62 MB / 114 archivos** vs 20,22 MB sin filtrar (cifra que reporto Docker en la linea `transferring context` del build de linea base). Limite exigido: 20 MB. |
| CA-5 | **Cumple** | `diff` de `docker run --rm --entrypoint ls <tag> -1 /app` entre la imagen **pre** (con el `.dockerignore` movido fuera) y la **post**: **vacio**, 72 entradas identicas. |

### Enumeracion exacta del contexto (verificacion dura de CA-2)

Primer intento con `--target build` fue **invalido** y lo descarto: ese listado mezcla el
`obj/` que genera el `dotnet restore` del propio contenedor con lo que llega por `COPY`.
La medicion valida usa un Dockerfile ad-hoc por stdin (`docker build -f - .`), que respeta
el `.dockerignore` de la raiz sin tocar el Dockerfile del repo:

- **114 archivos** en total. Unico directorio de nivel superior: `src/`.
- Archivos de raiz que viajan: `global.json` (**presente**, es el que fija el SDK),
  `.editorconfig`, `.mcp.json`, `.tmux.conf`, `CLAUDE.md`, `ControlAsistencias.slnx`,
  `dotnet-coverage.settings.xml`, `.dockerignore`.
- Cero coincidencias para `bin/`, `obj/`, `out/`, `node_modules`, `.terraform`, `tfstate`,
  `tfvars`, `tfplan`, `local.settings.json`, `appsettings.local.json`, `.DS_Store`.
- `.git` esta filtrado tambien aca, donde es un **archivo** y no un directorio (worktree):
  `filepath.Clean` normaliza `.git/` a `.git` y el patron alcanza ambas formas.

### El efecto 2 del issue quedo demostrado, no solo argumentado

Comparando los logs de los dos builds:

- Build **pre** (sin `.dockerignore`): el paso `dotnet build` vuelve a restaurar
  (`Restored ... in 133 ms`) porque el `COPY . .` sobrescribio el `project.assets.json` que
  habia generado el restore del contenedor con el del host.
- Build **post**: `All projects are up-to-date for restore` en `build` y en `publish`.

En este worktree se manifesto como trabajo redundante y no como fallo duro — el SDK
detecto el assets invalido y rehizo el restore. Lo digo explicito para no sobrevender la
evidencia: el mecanismo del issue es real y observable, y la variante que rompe el build
(SDK del host ausente en la imagen) sigue siendo un riesgo latente que este cambio elimina,
pero no la reproduje como error fatal.

## Correcciones aplicadas (commit `5c04f6e`, solo comentarios)

1. **`Dockerfile*` estaba mal documentado.** El comentario original ("El Dockerfile lo lee
   `docker build -f` del host, no del contexto") sugeria que la linea excluia el Dockerfile
   del worker. No lo hace: Docker evalua los patrones de `.dockerignore` contra la **ruta
   relativa a la raiz del contexto**, no contra el nombre de archivo, asi que `Dockerfile*`
   solo alcanza a un Dockerfile de raiz — que hoy no existe. Verificado: el contexto **si**
   incluye `src/Bitakora.ControlAsistencia.Projections/Dockerfile`, que es justo lo que
   CA-2 exige ("no excluye nada bajo `src/...Projections/` salvo `bin`/`obj`"). El patron se
   **mantiene** (cubre un futuro Dockerfile de raiz y replica el sample de Microsoft); lo que
   se corrigio es la afirmacion falsa sobre su alcance.
   Fuente: [Docker Docs, ".dockerignore files"](https://docs.docker.com/build/concepts/context/#dockerignore-files).
2. **El bloque de secretos no advertia su propio limite.** Se agrego que lo excluido es el
   sufijo `.local.json` y que `appsettings.json` y `appsettings.Development.json` del worker
   **si** son input del build — verificado: ambos aparecen en `/app` de la imagen publicada.
   Un `**/appsettings.*.json` bienintencionado en una edicion futura romperia la imagen en
   silencio, y ese es exactamente el modo de fallo que el issue queria evitar.

Reverificado tras la edicion: mismo set de 114 archivos en el contexto, build en exit 0,
diff de `/app` vacio, archivo 100% ASCII (sin `─` U+2500 ni decorativos Unicode).

## Revision de calidad (sin cambios, con justificacion)

- **`**/*.tfstate` + `**/*.tfstate.*` en lugar de `**/*.tfstate*`**: dos lineas donde CA-2
  pide una. La cobertura es equivalente y es la redaccion literal de las "Notas tecnicas"
  del issue. No lo colapse porque en este worktree no hay ningun `.tfstate` con el que
  comprobar empiricamente el patron colapsado, y no cambio por estetica algo verificado por
  otro algo sin verificar.
- **Archivos de raiz que siguen viajando** (`CLAUDE.md`, `.slnx`, `.mcp.json`, `.tmux.conf`,
  `dotnet-coverage.settings.xml`): el sample de Microsoft excluye `**/*.md`, pero el issue
  analizo el punto y decidio no excluirlos; suman pocos KB y CA-4 pasa con 30x de margen.
  Excluir el `.slnx` o el `.editorconfig` seria scope creep con riesgo asimetrico.
- **Coherencia con el issue**: el archivo es identico patron por patron a la propuesta de
  las "Notas tecnicas", que es lo que se queria — el implementer no improviso.

## Pendiente que este issue deliberadamente no cierra

El hueco del **harness** sigue abierto: `projections-scaffolder` no emite `.dockerignore`,
asi que todo BC nuevo que adopte `/scaffold-projections` nace con el mismo problema. Queda
por capturar en `augusto-romero-arango/eda-evsourcing-azure-harness` (candidato natural:
absorberlo en el **#453**, que ya define que agente es dueno de cada artefacto del
read-side). No es un defecto de este cambio; es el seguimiento que el propio issue declara.

**Estado de limpieza**: las 6 imagenes de verificacion (`asist-projections:{pre,post,post2,ctx}`,
`asist-ctxcheck:{tmp,tmp2}`) se eliminaron; no quedan artefactos de la revision en el daemon.
`git status` limpio.

</details>

## Commits

5c04f6e docs(issue-260): precisar en .dockerignore la semantica de rutas y el limite del bloque de secretos
5595585 feat(issue-260): agregar .dockerignore para acotar el contexto de build del worker

Closes #260