### PR TITLE
Alinear la cadena de disparo de los deploys del write-side con la plantilla vigente del harness

### DIFF
--- a/.github/workflows/deploy-control-horas.yml
+++ b/.github/workflows/deploy-control-horas.yml
@@ -6,14 +6,95 @@ on:
     paths:
       - 'src/Bitakora.ControlAsistencia.ControlHoras/**'
       - 'src/Bitakora.ControlAsistencia.Contracts/**'
-      - 'infra/environments/dev/**'
+      # global.json (issue #454 del harness): quien lo lee NO es actions/setup-dotnet -- el
+      # job de abajo le pasa 'dotnet-version' explicito, no 'global-json-file', asi que la
+      # action solo instala el SDK del canal pedido. Lo leen el muxer del CLI y el resolver
+      # de SDK de MSBuild al correr 'dotnet restore/build', y por eso su 'version' +
+      # 'rollForward' deciden con cual de los SDK instalados se compila este dominio. El modo
+      # de fallo no es rotura -- eso lo atrapa el CI del PR antes del merge -- sino staleness
+      # silenciosa: sin esta ruta, un push a main que solo toque global.json no dispara nada
+      # y la Function App sigue sirviendo el binario construido con el SDK anterior, sin aviso.
+      - 'global.json'
+      # Este propio workflow (issue #454 del harness): sin esta ruta, un cambio en como se
+      # construye/despliega este dominio (incluida esta misma migracion) nunca dispara solo --
+      # hay que lanzarlo a mano con workflow_dispatch cada vez.
+      - '.github/workflows/deploy-control-horas.yml'
+      # Exclusiones deliberadas de esta lista -- no las agregues buscando simetria:
+      # - ControlAsistencias.slnx: lo usa build-and-test (el gate de test), no el job deploy,
+      #   que compila el .csproj de este dominio directo. Un cambio al .slnx por ESTE dominio
+      #   ya viene acompanado de cambios en src/.../ControlHoras/** (que disparan igual), y
+      #   uno por OTRO dominio no altera el binario de este.
+      # - infra/**: su trigger vive en infra-cd.yml y este workflow se encadena detras via el
+      #   workflow_run de abajo, para que el codigo nunca se despliegue antes del apply de
+      #   infra (MEF-ADR-0022). Devolverlo aqui rompe ese orden.
+      # - tests/**: un cambio de tests no altera el binario publicado de este dominio.
+      # - .dockerignore: acota el contexto de build de imagenes Docker (issue #260); este
+      #   workflow no construye ninguna imagen (dotnet publish directo, sin Docker), asi que
+      #   no es un input de lo que despliega.
+  workflow_run:
+    # 'Infra CD - Terraform Apply' es el nombre real del workflow en este repo
+    # (.github/workflows/infra-cd.yml), verificado contra la API de Actions -- no el literal
+    # 'Infra CD' de la plantilla del harness, que aqui no dispara nada.
+    workflows: ['Infra CD - Terraform Apply']
+    types: [completed]
   workflow_dispatch:
 
 jobs:
+  # El apply de infra (infra-cd.yml, MEF-ADR-0022) y el deploy de codigo pueden correr en
+  # el mismo push a main. Encadenar por workflow_run (en vez de un 'push' que dispare
+  # ambos) garantiza el orden infra -> deploy (MEF-ADR-0022, "Orden: infra antes que deploy
+  # de codigo"). Pero workflow_run por si solo redesplegaria el dominio tras CADA apply de
+  # infra (seguro por idempotencia, pero costoso); este job filtra por si el PR que se acaba
+  # de mergear toco este dominio (src/Bitakora.ControlAsistencia.ControlHoras/**) y salta el
+  # redeploy si no. Se resuelve via la API de PRs asociados al commit (no depende de la
+  # estrategia de merge: squash, merge o rebase).
+  determinar-alcance:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      debe_desplegar: ${{ steps.check.outputs.debe_desplegar }}
+    steps:
+      - id: check
+        name: Decidir si corresponde desplegar este dominio
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # push directo (src/**) o workflow_dispatch: siempre despliega.
+          if [ "${{ github.event_name }}" != "workflow_run" ]; then
+            echo "debe_desplegar=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # 'Infra CD - Terraform Apply' solo corre en push a main (el plan de PR vive en
+          # infra-ci.yml, otro workflow), pero se filtra igual por conclusion y rama por
+          # defensividad -- si algun dia se unifican los dos archivos de infra como hizo el
+          # harness, esta guarda evita reaccionar a una corrida que no sea un apply exitoso.
+          if [ "${{ github.event.workflow_run.conclusion }}" != "success" ] || \
+             [ "${{ github.event.workflow_run.head_branch }}" != "main" ]; then
+            echo "debe_desplegar=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # ...y el PR mergeado toco este dominio.
+          PR_NUM=$(gh api "repos/${{ github.repository }}/commits/${{ github.event.workflow_run.head_sha }}/pulls" --jq '.[0].number // empty')
+          if [ -z "$PR_NUM" ]; then
+            echo "debe_desplegar=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if gh api "repos/${{ github.repository }}/pulls/${PR_NUM}/files" --paginate --jq '.[].filename' | grep -qE '^src/Bitakora\.ControlAsistencia\.ControlHoras/'; then
+            echo "debe_desplegar=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "debe_desplegar=false" >> "$GITHUB_OUTPUT"
+          fi
+
   build-and-test:
+    needs: determinar-alcance
+    if: needs.determinar-alcance.outputs.debe_desplegar == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - uses: actions/setup-dotnet@v5
         with:
@@ -32,10 +113,15 @@ jobs:
           done
 
   deploy:
-    needs: build-and-test
+    needs: [determinar-alcance, build-and-test]
+    if: needs.determinar-alcance.outputs.debe_desplegar == 'true'
     runs-on: ubuntu-latest
+    outputs:
+      sha: ${{ github.event.workflow_run.head_sha || github.sha }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - uses: actions/setup-dotnet@v5
         with:
@@ -50,7 +136,7 @@ jobs:
             --configuration Release \
             --no-restore \
             -r linux-x64 \
-            -p:SourceRevisionId=${{ github.sha }}
+            -p:SourceRevisionId=${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Publish
         run: |
@@ -84,7 +170,7 @@ jobs:
     with:
       base_url: https://func-asist-dev-control-horas.azurewebsites.net
       test_project: tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/
-      expected_sha: ${{ github.sha }}
+      expected_sha: ${{ needs.deploy.outputs.sha }}
     secrets:
       SERVICEBUS_CONNECTION_STRING: ${{ secrets.SERVICEBUS_CONNECTION_STRING }}
       POSTGRES_CONNECTION_STRING: ${{ secrets.POSTGRES_CONNECTION_STRING }}

--- a/.github/workflows/deploy-control-horas.yml
+++ b/.github/workflows/deploy-control-horas.yml
@@ -6,8 +6,8 @@ on:
     paths:
       - 'src/Bitakora.ControlAsistencia.ControlHoras/**'
       - 'src/Bitakora.ControlAsistencia.Contracts/**'
-      # global.json (issue #454 del harness): quien lo lee NO es actions/setup-dotnet -- el
-      # job de abajo le pasa 'dotnet-version' explicito, no 'global-json-file', asi que la
+      # global.json (issue #454 del harness): quien lo lee NO es actions/setup-dotnet -- los
+      # jobs de abajo le pasan 'dotnet-version' explicito, no 'global-json-file', asi que la
       # action solo instala el SDK del canal pedido. Lo leen el muxer del CLI y el resolver
       # de SDK de MSBuild al correr 'dotnet restore/build', y por eso su 'version' +
       # 'rollForward' deciden con cual de los SDK instalados se compila este dominio. El modo
@@ -58,11 +58,30 @@ jobs:
     steps:
       - id: check
         name: Decidir si corresponde desplegar este dominio
+        # Los datos del evento entran por 'env' y NO interpolados como ${{ }} dentro del
+        # 'run'. Un ${{ }} en el cuerpo del script se sustituye como TEXTO antes de que bash
+        # lo parsee, asi que un dato controlable por quien dispara la corrida se vuelve
+        # codigo. 'head_branch' es justamente eso: git acepta ", $, ;, & y ` en un nombre de
+        # rama (solo prohibe espacio, ~, ^, :, ?, *, [ y \), asi que una rama como
+        #   main"$IFS]&&<comando>&&test$IFS"x
+        # -- un ref valido -- ejecuta <comando> Y ADEMAS deja la guarda de abajo en verdadero,
+        # con el token de escritura y los secrets que este disparador expone. Pasarlo por
+        # 'env' lo mantiene siempre como valor, nunca como sintaxis; es la mitigacion que
+        # prescribe el hardening de GitHub Actions para datos del evento.
+        # Hoy el vector es latente, no explotable: 'Infra CD - Terraform Apply' solo corre en
+        # push a main, asi que head_branch siempre vale 'main'. Se vuelve alcanzable en el
+        # mismo escenario para el que la guarda existe -- que infra-cd.yml gane un trigger de
+        # pull_request --, que es la razon de blindarlo junto con ella y no despues.
         env:
           GH_TOKEN: ${{ github.token }}
+          EVENTO: ${{ github.event_name }}
+          RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          RUN_RAMA: ${{ github.event.workflow_run.head_branch }}
+          RUN_SHA: ${{ github.event.workflow_run.head_sha }}
+          REPO: ${{ github.repository }}
         run: |
           # push directo (src/**) o workflow_dispatch: siempre despliega.
-          if [ "${{ github.event_name }}" != "workflow_run" ]; then
+          if [ "$EVENTO" != "workflow_run" ]; then
             echo "debe_desplegar=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -70,18 +89,17 @@ jobs:
           # infra-ci.yml, otro workflow), pero se filtra igual por conclusion y rama por
           # defensividad -- si algun dia se unifican los dos archivos de infra como hizo el
           # harness, esta guarda evita reaccionar a una corrida que no sea un apply exitoso.
-          if [ "${{ github.event.workflow_run.conclusion }}" != "success" ] || \
-             [ "${{ github.event.workflow_run.head_branch }}" != "main" ]; then
+          if [ "$RUN_CONCLUSION" != "success" ] || [ "$RUN_RAMA" != "main" ]; then
             echo "debe_desplegar=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           # ...y el PR mergeado toco este dominio.
-          PR_NUM=$(gh api "repos/${{ github.repository }}/commits/${{ github.event.workflow_run.head_sha }}/pulls" --jq '.[0].number // empty')
+          PR_NUM=$(gh api "repos/${REPO}/commits/${RUN_SHA}/pulls" --jq '.[0].number // empty')
           if [ -z "$PR_NUM" ]; then
             echo "debe_desplegar=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          if gh api "repos/${{ github.repository }}/pulls/${PR_NUM}/files" --paginate --jq '.[].filename' | grep -qE '^src/Bitakora\.ControlAsistencia\.ControlHoras/'; then
+          if gh api "repos/${REPO}/pulls/${PR_NUM}/files" --paginate --jq '.[].filename' | grep -qE '^src/Bitakora\.ControlAsistencia\.ControlHoras/'; then
             echo "debe_desplegar=true" >> "$GITHUB_OUTPUT"
           else
             echo "debe_desplegar=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/deploy-programacion.yml
+++ b/.github/workflows/deploy-programacion.yml
@@ -6,14 +6,95 @@ on:
     paths:
       - 'src/Bitakora.ControlAsistencia.Programacion/**'
       - 'src/Bitakora.ControlAsistencia.Contracts/**'
-      - 'infra/environments/dev/**'
+      # global.json (issue #454 del harness): quien lo lee NO es actions/setup-dotnet -- el
+      # job de abajo le pasa 'dotnet-version' explicito, no 'global-json-file', asi que la
+      # action solo instala el SDK del canal pedido. Lo leen el muxer del CLI y el resolver
+      # de SDK de MSBuild al correr 'dotnet restore/build', y por eso su 'version' +
+      # 'rollForward' deciden con cual de los SDK instalados se compila este dominio. El modo
+      # de fallo no es rotura -- eso lo atrapa el CI del PR antes del merge -- sino staleness
+      # silenciosa: sin esta ruta, un push a main que solo toque global.json no dispara nada
+      # y la Function App sigue sirviendo el binario construido con el SDK anterior, sin aviso.
+      - 'global.json'
+      # Este propio workflow (issue #454 del harness): sin esta ruta, un cambio en como se
+      # construye/despliega este dominio (incluida esta misma migracion) nunca dispara solo --
+      # hay que lanzarlo a mano con workflow_dispatch cada vez.
+      - '.github/workflows/deploy-programacion.yml'
+      # Exclusiones deliberadas de esta lista -- no las agregues buscando simetria:
+      # - ControlAsistencias.slnx: lo usa build-and-test (el gate de test), no el job deploy,
+      #   que compila el .csproj de este dominio directo. Un cambio al .slnx por ESTE dominio
+      #   ya viene acompanado de cambios en src/.../Programacion/** (que disparan igual), y uno
+      #   por OTRO dominio no altera el binario de este.
+      # - infra/**: su trigger vive en infra-cd.yml y este workflow se encadena detras via el
+      #   workflow_run de abajo, para que el codigo nunca se despliegue antes del apply de
+      #   infra (MEF-ADR-0022). Devolverlo aqui rompe ese orden.
+      # - tests/**: un cambio de tests no altera el binario publicado de este dominio.
+      # - .dockerignore: acota el contexto de build de imagenes Docker (issue #260); este
+      #   workflow no construye ninguna imagen (dotnet publish directo, sin Docker), asi que
+      #   no es un input de lo que despliega.
+  workflow_run:
+    # 'Infra CD - Terraform Apply' es el nombre real del workflow en este repo
+    # (.github/workflows/infra-cd.yml), verificado contra la API de Actions -- no el literal
+    # 'Infra CD' de la plantilla del harness, que aqui no dispara nada.
+    workflows: ['Infra CD - Terraform Apply']
+    types: [completed]
   workflow_dispatch:
 
 jobs:
+  # El apply de infra (infra-cd.yml, MEF-ADR-0022) y el deploy de codigo pueden correr en
+  # el mismo push a main. Encadenar por workflow_run (en vez de un 'push' que dispare
+  # ambos) garantiza el orden infra -> deploy (MEF-ADR-0022, "Orden: infra antes que deploy
+  # de codigo"). Pero workflow_run por si solo redesplegaria el dominio tras CADA apply de
+  # infra (seguro por idempotencia, pero costoso); este job filtra por si el PR que se acaba
+  # de mergear toco este dominio (src/Bitakora.ControlAsistencia.Programacion/**) y salta el
+  # redeploy si no. Se resuelve via la API de PRs asociados al commit (no depende de la
+  # estrategia de merge: squash, merge o rebase).
+  determinar-alcance:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      debe_desplegar: ${{ steps.check.outputs.debe_desplegar }}
+    steps:
+      - id: check
+        name: Decidir si corresponde desplegar este dominio
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # push directo (src/**) o workflow_dispatch: siempre despliega.
+          if [ "${{ github.event_name }}" != "workflow_run" ]; then
+            echo "debe_desplegar=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # 'Infra CD - Terraform Apply' solo corre en push a main (el plan de PR vive en
+          # infra-ci.yml, otro workflow), pero se filtra igual por conclusion y rama por
+          # defensividad -- si algun dia se unifican los dos archivos de infra como hizo el
+          # harness, esta guarda evita reaccionar a una corrida que no sea un apply exitoso.
+          if [ "${{ github.event.workflow_run.conclusion }}" != "success" ] || \
+             [ "${{ github.event.workflow_run.head_branch }}" != "main" ]; then
+            echo "debe_desplegar=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # ...y el PR mergeado toco este dominio.
+          PR_NUM=$(gh api "repos/${{ github.repository }}/commits/${{ github.event.workflow_run.head_sha }}/pulls" --jq '.[0].number // empty')
+          if [ -z "$PR_NUM" ]; then
+            echo "debe_desplegar=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if gh api "repos/${{ github.repository }}/pulls/${PR_NUM}/files" --paginate --jq '.[].filename' | grep -qE '^src/Bitakora\.ControlAsistencia\.Programacion/'; then
+            echo "debe_desplegar=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "debe_desplegar=false" >> "$GITHUB_OUTPUT"
+          fi
+
   build-and-test:
+    needs: determinar-alcance
+    if: needs.determinar-alcance.outputs.debe_desplegar == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - uses: actions/setup-dotnet@v5
         with:
@@ -32,10 +113,15 @@ jobs:
           done
 
   deploy:
-    needs: build-and-test
+    needs: [determinar-alcance, build-and-test]
+    if: needs.determinar-alcance.outputs.debe_desplegar == 'true'
     runs-on: ubuntu-latest
+    outputs:
+      sha: ${{ github.event.workflow_run.head_sha || github.sha }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - uses: actions/setup-dotnet@v5
         with:
@@ -50,7 +136,7 @@ jobs:
             --configuration Release \
             --no-restore \
             -r linux-x64 \
-            -p:SourceRevisionId=${{ github.sha }}
+            -p:SourceRevisionId=${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Publish
         run: |
@@ -82,7 +168,8 @@ jobs:
     needs: deploy
     uses: ./.github/workflows/smoke-tests-dominio.yml
     with:
+      base_url: https://func-asist-dev-programacion.azurewebsites.net
       test_project: tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/
-      expected_sha: ${{ github.sha }}
+      expected_sha: ${{ needs.deploy.outputs.sha }}
     secrets:
       SERVICEBUS_CONNECTION_STRING: ${{ secrets.SERVICEBUS_CONNECTION_STRING }}

--- a/.github/workflows/deploy-programacion.yml
+++ b/.github/workflows/deploy-programacion.yml
@@ -6,8 +6,8 @@ on:
     paths:
       - 'src/Bitakora.ControlAsistencia.Programacion/**'
       - 'src/Bitakora.ControlAsistencia.Contracts/**'
-      # global.json (issue #454 del harness): quien lo lee NO es actions/setup-dotnet -- el
-      # job de abajo le pasa 'dotnet-version' explicito, no 'global-json-file', asi que la
+      # global.json (issue #454 del harness): quien lo lee NO es actions/setup-dotnet -- los
+      # jobs de abajo le pasan 'dotnet-version' explicito, no 'global-json-file', asi que la
       # action solo instala el SDK del canal pedido. Lo leen el muxer del CLI y el resolver
       # de SDK de MSBuild al correr 'dotnet restore/build', y por eso su 'version' +
       # 'rollForward' deciden con cual de los SDK instalados se compila este dominio. El modo
@@ -58,11 +58,30 @@ jobs:
     steps:
       - id: check
         name: Decidir si corresponde desplegar este dominio
+        # Los datos del evento entran por 'env' y NO interpolados como ${{ }} dentro del
+        # 'run'. Un ${{ }} en el cuerpo del script se sustituye como TEXTO antes de que bash
+        # lo parsee, asi que un dato controlable por quien dispara la corrida se vuelve
+        # codigo. 'head_branch' es justamente eso: git acepta ", $, ;, & y ` en un nombre de
+        # rama (solo prohibe espacio, ~, ^, :, ?, *, [ y \), asi que una rama como
+        #   main"$IFS]&&<comando>&&test$IFS"x
+        # -- un ref valido -- ejecuta <comando> Y ADEMAS deja la guarda de abajo en verdadero,
+        # con el token de escritura y los secrets que este disparador expone. Pasarlo por
+        # 'env' lo mantiene siempre como valor, nunca como sintaxis; es la mitigacion que
+        # prescribe el hardening de GitHub Actions para datos del evento.
+        # Hoy el vector es latente, no explotable: 'Infra CD - Terraform Apply' solo corre en
+        # push a main, asi que head_branch siempre vale 'main'. Se vuelve alcanzable en el
+        # mismo escenario para el que la guarda existe -- que infra-cd.yml gane un trigger de
+        # pull_request --, que es la razon de blindarlo junto con ella y no despues.
         env:
           GH_TOKEN: ${{ github.token }}
+          EVENTO: ${{ github.event_name }}
+          RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          RUN_RAMA: ${{ github.event.workflow_run.head_branch }}
+          RUN_SHA: ${{ github.event.workflow_run.head_sha }}
+          REPO: ${{ github.repository }}
         run: |
           # push directo (src/**) o workflow_dispatch: siempre despliega.
-          if [ "${{ github.event_name }}" != "workflow_run" ]; then
+          if [ "$EVENTO" != "workflow_run" ]; then
             echo "debe_desplegar=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -70,18 +89,17 @@ jobs:
           # infra-ci.yml, otro workflow), pero se filtra igual por conclusion y rama por
           # defensividad -- si algun dia se unifican los dos archivos de infra como hizo el
           # harness, esta guarda evita reaccionar a una corrida que no sea un apply exitoso.
-          if [ "${{ github.event.workflow_run.conclusion }}" != "success" ] || \
-             [ "${{ github.event.workflow_run.head_branch }}" != "main" ]; then
+          if [ "$RUN_CONCLUSION" != "success" ] || [ "$RUN_RAMA" != "main" ]; then
             echo "debe_desplegar=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           # ...y el PR mergeado toco este dominio.
-          PR_NUM=$(gh api "repos/${{ github.repository }}/commits/${{ github.event.workflow_run.head_sha }}/pulls" --jq '.[0].number // empty')
+          PR_NUM=$(gh api "repos/${REPO}/commits/${RUN_SHA}/pulls" --jq '.[0].number // empty')
           if [ -z "$PR_NUM" ]; then
             echo "debe_desplegar=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          if gh api "repos/${{ github.repository }}/pulls/${PR_NUM}/files" --paginate --jq '.[].filename' | grep -qE '^src/Bitakora\.ControlAsistencia\.Programacion/'; then
+          if gh api "repos/${REPO}/pulls/${PR_NUM}/files" --paginate --jq '.[].filename' | grep -qE '^src/Bitakora\.ControlAsistencia\.Programacion/'; then
             echo "debe_desplegar=true" >> "$GITHUB_OUTPUT"
           else
             echo "debe_desplegar=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Resumen

Pipeline tooling completado:
- Writer: implementacion de la tarea
- Reviewer: revision de calidad

## Decisiones del pipeline

<details>
<summary>Writer -- 3m 46s</summary>

# Issue #262 - Resumen de implementacion (stage-1-writer)

## Alcance

Tarea de tooling puro (YAML de GitHub Actions), sin ciclo rojo/verde. Se parcharon a mano
los dos workflows existentes -- no se regeneraron con `domain-scaffolder` (aborta si el
proyecto del dominio ya existe; ver el body del issue).

## Archivos modificados

- `.github/workflows/deploy-programacion.yml`
- `.github/workflows/deploy-control-horas.yml`

## Fuente de la plantilla

Se leyo `agents/domain-scaffolder.md` del harness **en su rama `main`** (via
`gh api repos/augusto-romero-arango/eda-evsourcing-azure-harness/contents/agents/domain-scaffolder.md?ref=main`),
no el cache local del plugin (`0.19.0`, sin el fix del issue #454 del harness). El Paso 5
(lineas 2351-2547 del archivo descargado) es el molde literal transcrito.

## CAs cubiertos

- **CA-1**: el bloque `paths` del `push` quedo con exactamente 4 rutas en cada workflow --
  `src/Bitakora.ControlAsistencia.{Dominio}/**`, `src/Bitakora.ControlAsistencia.Contracts/**`,
  `global.json`, `.github/workflows/deploy-{dominio}.yml`. `infra/environments/dev/**` se
  retiro. Comentarios adyacentes documentan las inclusiones (global.json, auto-referencia) y
  las 4 exclusiones deliberadas -- `ControlAsistencias.slnx`, `infra/**`, `tests/**`,
  `.dockerignore` -- con su razon, siguiendo el espiritu del PR #259 (`deploy-projections.yml`).
- **CA-2**: `workflow_run.workflows` quedo como `['Infra CD - Terraform Apply']` -- el
  `name:` real de `.github/workflows/infra-cd.yml`, verificado leyendo el archivo (no el
  literal `'Infra CD'` de la plantilla). `types: [completed]` y `workflow_dispatch` se
  conservan. Un comentario inline explica la diferencia frente al literal del harness.
- **CA-3**: los dos workflows ganaron el job `determinar-alcance` (`permissions: contents:
  read` + `pull-requests: read`, output `debe_desplegar`) con las tres ramas de decision de
  la plantilla. `build-and-test` y `deploy` declaran `needs` sobre el y quedan gateados con
  `if: needs.determinar-alcance.outputs.debe_desplegar == 'true'`.
- **CA-4**: los `actions/checkout` de `build-and-test` y `deploy` usan
  `ref: ${{ github.event.workflow_run.head_sha || github.sha }}`; el paso `Build` del job
  `deploy` hornea `-p:SourceRevisionId=` con esa misma expresion; `deploy` la expone una
  sola vez como `outputs.sha`; `smoke-tests` pasa `expected_sha: ${{ needs.deploy.outputs.sha }}`
  en vez de `${{ github.sha }}`.
- **CA-5**: `deploy-programacion.yml` ahora pasa `base_url:
  https://func-asist-dev-programacion.azurewebsites.net` explicito al reutilizable
  (antes lo omitia y dependia del default de `smoke-tests-dominio.yml`).
- **CA-6**: `actionlint .github/workflows/deploy-programacion.yml
  .github/workflows/deploy-control-horas.yml` -> exit code 0.

## Divergencias deliberadamente NO tocadas (per issue, fuera de alcance)

- Autenticacion: se mantuvo `azure/login` con `creds: secrets.AZURE_CREDENTIALS` (NO se migro
  a OIDC/client-id-tenant-id-subscription-id). Por lo tanto tampoco se agrego
  `permissions: id-token: write` al job `deploy` -- solo tendria sentido con OIDC.
- `actions/checkout@v6` se mantuvo (la plantilla usa `@v7`; los 8 workflows del repo usan
  `@v6`, alinear versiones de actions es un frente transversal propio).
- `POSTGRES_CONNECTION_STRING` en el `smoke-tests` de Programacion sigue ausente (el
  `ApiFixture` de Programacion no lo consume).
- `infra-cd.yml` no se toco (solo se leyo su `name:` para el CA-2).

## Consecuencias aceptadas (para citar en el PR, no para "arreglar")

1. Doble deploy en el caso mixto (PR que toca `infra/**` y `src/.../{Dominio}/**`): dispara
   por `push` y por `workflow_run`. Seguro por idempotencia; el encadenado corre ultimo.
2. Un PR de infra que NO toca `src/{Dominio}/` ya no redespliega ese dominio (antes si, via
   `infra/environments/dev/**` en el filtro). Caso residual: recreacion de Function App sin
   tocar `src/{Dominio}/` deja la app sin codigo hasta un `workflow_dispatch` manual.
3. El `workflow_run` no se puede validar end-to-end desde la rama del PR (GitHub solo lo
   dispara si el workflow existe en la rama default) -- la verificacion es post-merge; en el
   PR solo se valida `actionlint` y lectura del YAML.

## Verificacion

- `actionlint .github/workflows/deploy-programacion.yml .github/workflows/deploy-control-horas.yml`:
  exit code 0.
- Sin caracteres Unicode decorativos prohibidos (grep de U+2500 sobre ambos archivos: limpio).
- No se modifico codigo C#, por lo que no aplica `dotnet build`.

## Pendiente para quien revise / cree el PR

- El body del PR debe incluir `Closes #262` y citar las 3 "Consecuencias aceptadas" de
  arriba para que el reviewer no las reporte como hallazgos.
- El issue #261 queda propuesto para cierre como *not planned* con referencia a este issue
  (decision ya tomada en el refinamiento, documentada en el body del #262). Esta tarea no
  cierra issues ni comenta en GitHub -- eso es responsabilidad del pipeline/usuario.

</details>

<details>
<summary>Reviewer -- 7m 47s</summary>

# Etapa 2 - Reviewer - Issue #262

Alinear la cadena de disparo de los deploys del write-side con la plantilla vigente del harness.

## Veredicto

**Aprobado con una correccion de seguridad aplicada.** El trabajo del writer es una
transcripcion fiel de la plantilla del harness (`agents/domain-scaffolder.md`, Paso 5, rama
`main` -- se descargo y se diffeo, no se uso el cache local `0.19.0`), con las cuatro
divergencias correctas y deliberadas: nombre real del workflow de infra, `checkout@v6` en vez
de `@v7`, sin el `permissions: id-token: write` de OIDC, y el `grep -qE` con los puntos
escapados. Los 6 CAs se cumplen. Corregi un defecto de seguridad real y dos imprecisiones.

## Verificacion de los criterios de aceptacion

Todo verificado por parseo del YAML, no por lectura.

| CA | Estado | Evidencia |
|---|---|---|
| CA-1 | Cumple | Exactamente 4 rutas en cada archivo; `infra/environments/dev/**` retirado (`infra en paths? False`); comentario documenta las 4 exclusiones deliberadas (`.slnx`, `infra/**`, `tests/**`, `.dockerignore`) con su razon |
| CA-2 | Cumple | `workflows: ['Infra CD - Terraform Apply']` + `types: [completed]`; comprobado por igualdad de cadenas contra el `name:` de `infra-cd.yml` -> `True` en ambos; `workflow_dispatch` conservado; comentario explica la divergencia del literal `'Infra CD'` |
| CA-3 | Cumple | `determinar-alcance` con `contents: read` + `pull-requests: read`, output `debe_desplegar`, y las 3 ramas; `build-and-test` y `deploy` con `needs` + `if` correctos |
| CA-4 | Cumple | Los 2 `checkout` de cada archivo con `ref:` de la expresion compuesta; `SourceRevisionId` con la misma; `deploy.outputs.sha` una sola vez; `expected_sha: ${{ needs.deploy.outputs.sha }}` |
| CA-5 | Cumple | `base_url` explicito en Programacion; ControlHoras ya lo tenia |
| CA-6 | Cumple | `actionlint` sobre los dos archivos -> **exit 0** |

Ademas verifique el comportamiento de la guarda ejecutando el extracto del `run:` con las
flags reales de Actions (`bash --noprofile --norc -eo pipefail`) en las 5 combinaciones de
evento: `push` y `workflow_dispatch` -> `true`; `conclusion=failure` y `head_branch!=main`
-> `false`; apply exitoso en `main` -> continua a resolver el PR. Las tres ramas del CA-3 se
comportan como especifica el issue.

## Correcciones aplicadas

### 1. Inyeccion de comandos via `head_branch` (seguridad) -- corregido en los dos archivos

El `run:` de `determinar-alcance` interpolaba los datos del evento como `${{ ... }}` **dentro
del cuerpo del script**, incluido `github.event.workflow_run.head_branch`. Un `${{ }}` ahi se
sustituye como **texto** antes de que bash parsee, asi que un nombre de rama se vuelve codigo.
Esto viene tal cual de la plantilla del harness, pero es un defecto igual.

No lo reporto como teorico: lo verifique empiricamente.

- `git check-ref-format` **acepta** `"`, `'`, `` ` ``, `$`, `;`, `&`, `|`, `<`, `>`, `(`, `)`,
  `#`, `%`, `{`, `}` en un nombre de rama (solo rechaza espacio, `~`, `^`, `:`, `?`, `*`, `[`, `\`).
- La rama `main"$IFS]&&whoami&&test$IFS"x` es un **ref valido** (`check-ref-format` -> 0). El
  `$IFS` sortea la prohibicion de espacios.
- Ejecutada con las flags de Actions, esa rama produce el peor resultado posible: **ejecuto
  `whoami`** (imprimio el usuario) **y ademas dejo la guarda en verdadero** ("guarda superada",
  exit 0). Es decir, no solo RCE: tambien bypass del filtro, con el token de escritura y los
  secrets que -- como advierte la nota de seguridad del propio issue -- este disparador expone.

Correccion: los cinco valores del evento pasan por `env:` y el script los lee como variables
de shell (`$RUN_RAMA`, etc.). Es la mitigacion que prescribe el hardening de GitHub Actions.
El mismo payload ahora se trata como valor, falla la comparacion y devuelve `false`.

**Por que lo arregle aqui y no lo deje como hallazgo**: el issue manda transcribir el molde
literal, pero (a) ya admite mejoras estrictas sobre la plantilla -- el `grep -qE` con puntos
escapados es exactamente ese precedente, y el writer lo tomo; (b) no cambia ninguna de las 3
ramas de decision del CA-3, solo como llegan los valores al shell; (c) el vector se vuelve
alcanzable justo en el escenario para el que la guarda existe (que `infra-cd.yml` gane un
trigger de `pull_request`), asi que blindarlo junto con ella es lo coherente. Hoy es
**latente, no explotable**: `Infra CD - Terraform Apply` solo corre en push a `main`, asi que
`head_branch` siempre vale `main`. Queda documentado en el archivo con el payload concreto.

### 2. Imprecision en el comentario de `global.json` -- corregido en los dos archivos

Decia "el job de abajo le pasa 'dotnet-version'" (singular). Son **dos** jobs los que corren
`setup-dotnet` con `dotnet-version` explicito (`build-and-test` y `deploy`) -- verificado por
grep. La plantilla del harness usa el plural correcto; se restauro. En un comentario cuyo
proposito es la precision tecnica, el numero importa.

## Observaciones que NO toque (para issues aparte)

- **`smoke-tests-dominio.yml` hace `checkout` sin `ref:`**. En una corrida disparada por
  `workflow_run`, `GITHUB_SHA` es el ultimo commit de la rama por defecto, asi que el
  reutilizable saca el codigo de test de `main` HEAD mientras el `expected_sha` que recibe es
  el `head_sha` del run. Coinciden casi siempre; divergen si `main` avanza entre el merge y el
  disparo del `workflow_run`. Impacto bajo y **fuera de alcance**: el issue lista ese archivo
  como solo-lectura ("contrato de inputs"), y arreglarlo bien exige un input nuevo en el
  reutilizable, que afectaria tambien a `deploy-projections.yml` y `smoke-tests.yml`.
- **`deploy-projections.yml` no tiene el encadenamiento `workflow_run`**. El PR #259 le
  arreglo el filtro de `paths` pero no el orden frente al apply de infra. Es read-side, fuera
  del eje de este issue (write-side); candidato a issue propio.
- **El fix de inyeccion pertenece tambien al harness.** La plantilla del Paso 5 de
  `domain-scaffolder.md` tiene el mismo patron, asi que cada dominio nuevo lo hereda. Conviene
  un issue en `eda-evsourcing-azure-harness` que aplique el `env:` en la plantilla.
- `actionlint` reporta 2 hallazgos de estilo preexistentes en `ci.yml` (SC2129) y
  `smoke-tests.yml` (SC2086). Confirme con `git stash` que son baseline, no introducidos aqui;
  ambos archivos estan fuera del alcance del issue.

## Consecuencias aceptadas: respetadas, no "corregidas"

El issue pide declararlas y no arreglarlas. Lo verifique y las deje intactas:

1. **Doble deploy en el caso mixto** -- no agregue `concurrency`, aunque seria el reflejo
   natural. El issue lo declara seguro por idempotencia y con el encadenado corriendo ultimo.
2. **Un PR de infra que no toca `src/{Dominio}/` ya no redespliega** -- es el ahorro buscado.
3. **El `workflow_run` no se valida desde la rama del PR** -- la verificacion end-to-end es
   post-merge; aqui solo `actionlint` + lectura, como fija el issue.

## Alcance

Solo `.github/workflows/deploy-programacion.yml` y `.github/workflows/deploy-control-horas.yml`
(mas este resumen). **Ninguna ruta prohibida tocada** -- confirmado con `git diff --name-only`.
Los dos archivos son 100% ASCII. Sin codigo C#: no hay build ni tests que correr.

</details>

## Commits

09004b4 fix(issue-262): blindar determinar-alcance contra inyeccion via head_branch
f2c7439 feat(issue-262): alinear disparo de deploys del write-side con la plantilla del harness

Closes #262