### PR TITLE
Actualizar los paquetes Cosmos a 2.3.1 y retirar la configuracion de metadata redundante

### DIFF
--- a/src/Bitakora.ControlAsistencia.Contracts/Bitakora.ControlAsistencia.Contracts.csproj
+++ b/src/Bitakora.ControlAsistencia.Contracts/Bitakora.ControlAsistencia.Contracts.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cosmos.EventDriven.Abstractions" Version="2.1.0" />
+    <PackageReference Include="Cosmos.EventDriven.Abstractions" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Bitakora.ControlAsistencia.ControlHoras/Bitakora.ControlAsistencia.ControlHoras.csproj
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Bitakora.ControlAsistencia.ControlHoras.csproj
@@ -17,11 +17,11 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.OpenTelemetry" Version="1.2.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.*" />
-    <PackageReference Include="Cosmos.EventDriven.Abstractions" Version="2.1.0" />
-    <PackageReference Include="Cosmos.EventDriven.CritterStack" Version="2.1.0" />
-    <PackageReference Include="Cosmos.EventDriven.CritterStack.AzureServiceBus" Version="2.1.0" />
-    <PackageReference Include="Cosmos.EventSourcing.Abstractions" Version="2.1.0" />
-    <PackageReference Include="Cosmos.EventSourcing.CritterStack" Version="2.1.0" />
+    <PackageReference Include="Cosmos.EventDriven.Abstractions" Version="2.3.1" />
+    <PackageReference Include="Cosmos.EventDriven.CritterStack" Version="2.3.1" />
+    <PackageReference Include="Cosmos.EventDriven.CritterStack.AzureServiceBus" Version="2.3.1" />
+    <PackageReference Include="Cosmos.EventSourcing.Abstractions" Version="2.3.1" />
+    <PackageReference Include="Cosmos.EventSourcing.CritterStack" Version="2.3.1" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.*" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
   </ItemGroup>

--- a/src/Bitakora.ControlAsistencia.ControlHoras/Infraestructura/ComposicionServicios.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Infraestructura/ComposicionServicios.cs
@@ -59,7 +59,11 @@ public static class ComposicionServicios
         services.AgregarWolverinePrivateEventRouter();
         services.AgregarWolverineEventSender();
 
-        // Registrar serializacion custom para tipos con constructores privados
+        // Registrar serializacion custom para tipos con constructores privados.
+        // Issue #267: las tres columnas de metadata de evento que exige MEF-ADR-0034 seccion 7
+        // (CorrelationId/CausationId/Headers) ya no se habilitan aqui -- las fija
+        // AgregarConfiguracionMartenComandos desde Cosmos.EventSourcing.CritterStack v2.3.1, y
+        // ComposicionServiciosTests lo verifica sobre el store real del contenedor.
         services.ConfigureMarten(options =>
         {
             if (options.Serializer() is Marten.Services.SystemTextJsonSerializer stj)
@@ -71,15 +75,6 @@ public static class ComposicionServicios
                     jsonOptions.TypeInfoResolver = resolver;
                 });
             }
-
-            // Issue #232 (MEF-ADR-0034 seccion 7): Marten deja estas tres columnas de metadata de
-            // evento deshabilitadas por defecto -- sin este opt-in explicito, la columna ni
-            // siquiera se crea en la tabla de eventos, y ninguna proyeccion futura (Inline/Async)
-            // puede leer un CorrelationId/CausationId/header que nunca se persistio. Requisito del
-            // writer, independiente de que este dominio tenga o no un middleware de trazas activo.
-            options.Events.MetadataConfig.CorrelationIdEnabled = true;
-            options.Events.MetadataConfig.CausationIdEnabled = true;
-            options.Events.MetadataConfig.HeadersEnabled = true;
         });
 
         // Observabilidad: exporta las trazas del worker (Npgsql, Marten, Wolverine, handlers) a

--- a/src/Bitakora.ControlAsistencia.Programacion/Bitakora.ControlAsistencia.Programacion.csproj
+++ b/src/Bitakora.ControlAsistencia.Programacion/Bitakora.ControlAsistencia.Programacion.csproj
@@ -15,11 +15,11 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.*" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
-    <PackageReference Include="Cosmos.EventDriven.Abstractions" Version="2.1.0" />
-    <PackageReference Include="Cosmos.EventDriven.CritterStack" Version="2.1.0" />
-    <PackageReference Include="Cosmos.EventDriven.CritterStack.AzureServiceBus" Version="2.1.0" />
-    <PackageReference Include="Cosmos.EventSourcing.Abstractions" Version="2.1.0" />
-    <PackageReference Include="Cosmos.EventSourcing.CritterStack" Version="2.1.0" />
+    <PackageReference Include="Cosmos.EventDriven.Abstractions" Version="2.3.1" />
+    <PackageReference Include="Cosmos.EventDriven.CritterStack" Version="2.3.1" />
+    <PackageReference Include="Cosmos.EventDriven.CritterStack.AzureServiceBus" Version="2.3.1" />
+    <PackageReference Include="Cosmos.EventSourcing.Abstractions" Version="2.3.1" />
+    <PackageReference Include="Cosmos.EventSourcing.CritterStack" Version="2.3.1" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.4.0" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.*" />
   </ItemGroup>

--- a/src/Bitakora.ControlAsistencia.Programacion/Infraestructura/ComposicionServicios.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/Infraestructura/ComposicionServicios.cs
@@ -51,7 +51,11 @@ public static class ComposicionServicios
         services.AgregarWolverineCommandRouter();
         services.AgregarWolverineEventSender();
 
-        // Registrar serializacion custom para tipos con constructores privados
+        // Registrar serializacion custom para tipos con constructores privados.
+        // Issue #267: las tres columnas de metadata de evento que exige MEF-ADR-0034 seccion 7
+        // (CorrelationId/CausationId/Headers) ya no se habilitan aqui -- las fija
+        // AgregarConfiguracionMartenComandos desde Cosmos.EventSourcing.CritterStack v2.3.1, y
+        // ComposicionServiciosTests lo verifica sobre el store real del contenedor.
         services.ConfigureMarten(options =>
         {
             if (options.Serializer() is Marten.Services.SystemTextJsonSerializer stj)
@@ -65,15 +69,6 @@ public static class ComposicionServicios
                     jsonOptions.TypeInfoResolver = resolver;
                 });
             }
-
-            // Issue #232 (MEF-ADR-0034 seccion 7): Marten deja estas tres columnas de metadata de
-            // evento deshabilitadas por defecto -- sin este opt-in explicito, la columna ni
-            // siquiera se crea en la tabla de eventos, y ninguna proyeccion futura (Inline/Async)
-            // puede leer un CorrelationId/CausationId/header que nunca se persistio. Requisito del
-            // writer, independiente de que este dominio tenga o no un middleware de trazas activo.
-            options.Events.MetadataConfig.CorrelationIdEnabled = true;
-            options.Events.MetadataConfig.CausationIdEnabled = true;
-            options.Events.MetadataConfig.HeadersEnabled = true;
         });
 
         services.AddOpenTelemetry()

--- a/tests/Bitakora.ControlAsistencia.Contracts.Tests/Bitakora.ControlAsistencia.Contracts.Tests.csproj
+++ b/tests/Bitakora.ControlAsistencia.Contracts.Tests/Bitakora.ControlAsistencia.Contracts.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cosmos.EventSourcing.Testing.Utilities" Version="2.1.0" />
+    <PackageReference Include="Cosmos.EventSourcing.Testing.Utilities" Version="2.3.1" />
     <PackageReference Include="xunit.v3.mtp-v2" Version="3.*" />
   </ItemGroup>
 

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Bitakora.ControlAsistencia.ControlHoras.Tests.csproj
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Bitakora.ControlAsistencia.ControlHoras.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cosmos.EventSourcing.Testing.Utilities" Version="2.1.0" />
+    <PackageReference Include="Cosmos.EventSourcing.Testing.Utilities" Version="2.3.1" />
     <PackageReference Include="xunit.v3.mtp-v2" Version="3.*" />
   </ItemGroup>
 

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/Bitakora.ControlAsistencia.Programacion.Tests.csproj
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/Bitakora.ControlAsistencia.Programacion.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cosmos.EventSourcing.Testing.Utilities" Version="2.1.0" />
+    <PackageReference Include="Cosmos.EventSourcing.Testing.Utilities" Version="2.3.1" />
     <PackageReference Include="xunit.v3.mtp-v2" Version="3.*" />
   </ItemGroup>
 


### PR DESCRIPTION
## Resumen

Pipeline TDD completado (refactoring puro):
- Análisis: no se requieren tests nuevos
- Justificación: Issue #267 es actualizacion de dependencias (Cosmos.* 2.1.0 -> 2.3.1 en los 6 .csproj) mas retiro de codigo local que la nueva version del building block vuelve redundante. No define comportamiento nuevo: los 5 criterios de aceptacion son (CA-1) version de paquete, (CA-2) build/test verdes, (CA-3) retiro de 3 lineas de `options.Events.MetadataConfig.*` + comentario del issue #232 en `ComposicionServicios.cs` de ControlHoras y Programacion, (CA-4) las mismas lineas en el worker de proyecciones permanecen intactas (asimetria deliberada, MEF-ADR-0034 seccion 6-7), (CA-5) `ComposicionServiciosTests` (ambos dominios) y `AssertsProyecciones` (worker) NO se modifican y deben seguir verdes.
- Baseline: 473 tests pasando
- Refactoring ejecutado manteniendo todos los tests verdes

## Decisiones del pipeline

<details>
<summary>Test Writer (fase roja) — 1m 48s</summary>

_(El agente no generó resumen)_

</details>

<details>
<summary>Reviewer (fase refactor) — 10m 52s</summary>

## ES Reviewer - Revision

Carril de **refactor puro** (`pipeline-state/refactor-signal.md`, `REFACTOR_ONLY=true`,
`REMOVED_TESTS=0`): no hubo fase roja ni verde, asi que este agente ejecuto el refactoring completo
y se revisa a si mismo. No existe `stage-2-implementer.md` ni `stage-2-projection-implementer.md`
que auditar, y no habia `blockage-report.md`.

### Evaluacion general
- Calidad: **buena**
- Cambios realizados: **si** (commit `66c2209`)
- Baseline verde confirmado antes de empezar: 496 tests / 488 correctos / 8 omitidos / 0 errores
- Suite final: **identica al baseline** (496 / 488 / 8 / 0)

### Cumplimiento de ADRs aplicables

| ADR | Cumplimiento | Observacion |
|---|---|---|
| MEF-ADR-0029: test de composicion del contenedor DI | **ok** | Los `ComposicionServiciosTests` de ambos dominios quedaron como red de seguridad **sin ser modificados** y siguen verdes sobre el store real. Se cumple la propiedad "auto-mantenido" que el ADR declara en Consecuencias: si un upgrade futuro del building block dejara de fijar la metadata, el test se pone rojo solo. La fuente unica de verdad del wiring (`ComposicionServicios.{Dominio}`) se conserva: `Program.cs` y el test siguen invocando el mismo metodo. |
| MEF-ADR-0034 seccion 6 (config-test del worker) | **ok** | `AssertsProyecciones.AssertOpcionesDeEvento` intacto; ningun archivo de `Projections`/`Projections.Tests` aparece en el diff. |
| MEF-ADR-0034 seccion 7 (metadata como requisito del writer) | **ok** | La obligacion estructural sigue satisfecha en ambos write-sides; cambia **quien** la cumple (building block en vez de codigo local), no **si** se cumple. Verificado empiricamente, no por lectura del ADR: ver "Verificacion del supuesto central". |

El issue **si** traia seccion `## ADRs aplicables` correctamente poblada — no hay nada que escalar al
planner por ese lado.

### Verificacion del supuesto central (no me apoye en el precedente ni en el texto del issue)

El issue afirmaba, citando el repo del building block, que 2.3.1 fija las tres `MetadataConfig`.
Retirar codigo de produccion sobre una afirmacion de segunda mano seria precisamente el patron que
la memoria de gaps de este agente marca como riesgoso ("precedente != autoridad"). Lo verifique
contra el **binario que el proyecto realmente consume**, decompilando con `ilspycmd`
`Cosmos.EventSourcing.CritterStack.dll` en ambas versiones desde `~/.nuget/packages`:

| Version | `AgregarConfiguracionMartenComandos` fija... |
|---|---|
| 2.1.0 | `UseSystemTextJsonForSerialization`, `Events.StreamIdentity` — **ninguna** `MetadataConfig` |
| 2.3.1 | lo anterior **mas** `HeadersEnabled`, `CorrelationIdEnabled`, `CausationIdEnabled` |

Queda probado que (a) el issue #232 fue necesario en su momento y (b) su opt-in local es
exactamente lo que 2.3.1 vuelve redundante — "ni mas ni menos", como pedia el issue.

**Prueba de mutacion sobre la red de seguridad.** Un verde tras retirar codigo puede ser un falso
verde si el test no observa el valor efectivo. Introduje temporalmente
`options.Events.MetadataConfig.CorrelationIdEnabled = false` en `ComposicionServicios` de
ControlHoras: el test fallo con *"Expected metadataConfig.CorrelationIdEnabled to be True, but found
False"*. Mutacion revertida y verificada por `grep` (sin residuos). Conclusion: el callback local
corre **despues** del building block y el test lee el valor efectivo, asi que su verde sin codigo
local es evidencia real, no tautologia.

*Nota metodologica*: el primer intento de esta prueba dio un falso negativo porque pase dos
directorios a `dotnet build` (el comando fallo y el runner ejecuto el binario anterior). Lo detecte
por el conteo de errores y repeti la prueba con build explicito del `.csproj`.

### Desviaciones de ADRs

**Ninguna desviacion — todos los ADRs aplicables se cumplen.** No hubo implementer que declarara
desviaciones, y no detecte ninguna en el diff.

### Precedentes consultados

| Precedente | ADR aplicable | Veredicto |
|---|---|---|
| Issue #232 (opt-in local de metadata) | MEF-ADR-0034 secc. 7 | **alineado**, y correctamente jubilado: era necesario contra 2.1.0 y dejo de serlo contra 2.3.1. No se replico ni se elimino la *obligacion*, solo su implementacion local. |
| Worker de proyecciones (`ConfiguracionMartenProjections*`) | MEF-ADR-0034 secc. 6-7 | **alineado**, y su asimetria es legitima: verifique que `Bitakora.ControlAsistencia.Projections.csproj` **no referencia ningun paquete `Cosmos.*`** (solo Marten) y registra su store con `AddMartenStore`. No pasa por `AgregarConfiguracionMartenComandos`, asi que sus tres lineas **no** son redundantes. CA-4 confirmado con base tecnica, no por obediencia al issue. |

### Convenciones del pipeline (no ADRs)

| Convencion | Estado | Observacion |
|---|---|---|
| Cada test con `Then()` + `And<>()` | n/a | No se agrego ni modifico ningun test (CA-5 lo prohibe explicitamente). |
| Overloads correctos para stream IDs compuestos | n/a | Sin cambios en tests de aggregates. |
| Fakes manuales (no NSubstitute) | n/a | Sin cambios en dependencias de handlers. |
| Feature folders (produccion y tests) | ok | Sin movimientos de archivos; ambos `ComposicionServicios.cs` siguen en `Infraestructura/` a nivel raiz del dominio. |
| Smoke tests: SkipWhen, secrets, cobertura | n/a | Sin cambios en smoke tests; los 8 omitidos son los de siempre (sin Postgres/ASB local). |
| Proyecciones read-side | n/a | Diff puramente write-side + `.csproj`. El Skill `projections` no produce hallazgos aqui. |
| Tests via ToString/comportamiento | ok | Sin getters nuevos. |
| Sin numeros magicos | ok | Las versiones de paquete viven en `.csproj` (el repo no usa Central Package Management: no hay `Directory.Packages.props`). |
| Condiciones en positivo | ok | El unico `if` tocado indirectamente (`options.Serializer() is SystemTextJsonSerializer stj`) esta en positivo y no se modifico. |
| Sin caracter U+2500 en `.cs` | ok | Verificado por `grep` sobre `src/` y `tests/`. |

### Elegancia del codigo

- **Compacidad**: el retiro deja el callback `ConfigureMarten` con una sola responsabilidad (registrar
  el resolver de serializacion), que es mas legible que el bloque anterior de dos temas no
  relacionados. Neto: **-34 / +30 lineas**.
- **Autocritica aplicada**: mi primera version del comentario de reemplazo ocupaba 7 lineas. CA-3
  pide un comentario *breve*, asi que lo compacte a 4 antes de commitear, conservando los cuatro
  datos que dan trazabilidad (issue, ADR, quien aporta la config ahora, donde se verifica).
- **Simetria entre dominios**: el cambio quedo identico en ControlHoras y Programacion, lo que
  facilita leer los dos archivos como variantes del mismo patron.
- El resto del codigo tocado ya era elegante y no requirio intervencion.

### Criticas y hallazgos

1. **[cosmetico, NO corregido a proposito]** Los comentarios de cabecera de `ComposicionServiciosTests`
   (ambos dominios) siguen atribuyendo el opt-in de metadata al issue #232 y afirman que *"las tres
   banderas comparten el mismo callback `ConfigureMarten` que registra el resolver"* — premisa que
   este cambio vuelve obsoleta. **No lo toque: CA-5 prohibe modificar esos archivos.** El cuerpo de
   los tests sigue siendo correcto y hoy vale mas que antes (paso de verificar codigo propio a
   verificar un contrato del building block). Candidato natural al paso 2 de la secuencia.
2. **[menor, fuera de alcance por decision del issue]** En ControlHoras el bloque de serializacion usa
   nombres completamente cualificados inline (`Marten.Services.SystemTextJsonSerializer`,
   `System.Text.Json.Serialization.Metadata.DefaultJsonTypeInfoResolver`) mientras Programacion usa
   `using`. Inconsistencia de estilo real, pero el issue reserva **explicitamente** ese bloque para el
   paso 2 ("no se toca en este issue"). Ampliar el diff hacia el codigo que el siguiente issue va a
   reescribir seria peor que dejarlo; lo reporto en vez de corregirlo.
3. **[informativo, insumo para el paso 2]** 2.3.1 expone tambien
   `AgregarConfiguracionMartenConsultas`, que fija las **mismas** tres columnas mas
   `StreamIdentity` (es el "iguala comandos y consultas" del release). El worker **no la usa hoy**,
   pero es el candidato obvio para el paso 2 de la secuencia acordada: adoptarla eliminaria la
   replica manual del worker igual que este issue elimino la del write-side.
4. **[preexistente, no introducido aqui]** `dotnet format --verify-no-changes` reporta `IDE0005`
   (usings innecesarios) en 6 archivos. Verifique que **ninguno** esta en mi diff. Deuda de formato
   previa, fuera del alcance de #267.
5. **Sin hallazgos bloqueantes.**

### Refactorings aplicados

Los del propio issue (este es el carril de refactor puro):

1. Version `2.1.0` -> `2.3.1` en las **14 referencias** `Cosmos.*` de los 6 `.csproj`. Cuide
   deliberadamente **no** tocar `Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore`, que
   tambien esta en `2.1.0` y es una coincidencia de version, no un paquete del building block.
2. Retiro de las 3 asignaciones `options.Events.MetadataConfig.*` + el comentario de #232 en
   `ComposicionServicios` de ControlHoras y Programacion (6 lineas de codigo, 10 de comentario).
3. Comentario de reemplazo breve en ambos dominios, apuntando a `AgregarConfiguracionMartenComandos`
   v2.3.1, a MEF-ADR-0034 secc. 7 y al test que lo verifica.

No aplique ningun refactor adicional de oportunidad: el diff se mantiene exactamente en los 8
archivos que el issue declara en "Impacto en archivos".

### Riesgo declarado por el issue: el fix del DSL de testing de v2.2.0

El issue marcaba como riesgo principal que v2.2.0 cambia cuando el DSL espera al handler antes de
`SaveChanges`, con potencial de mover resultados de tests existentes. **No movio ninguno**: la suite
quedo en 496/488/8/0, cifra por cifra identica al baseline. No hubo que decidir entre "defecto real
de produccion" y "supuesto incorrecto del test" porque ningun test cayo, y por lo tanto **no se
ajusto ningun test** para volver al verde.

### Nota tecnica del issue: ambiguedad de sobrecargas

El issue pedia revisar si la sobrecarga nueva de `AgregarWolverineParaComandosServerless` (v2.2.0,
con `Action<MartenRegistry>`) genera ambiguedad. **No la genera**: el build compila con 0 errores.
Confirme por decompilacion que 2.3.1 expone dos sobrecargas y que la llamada actual (5 argumentos,
lambda de un parametro) resuelve a la original sin ambiguedad — la nueva exigiria omitir su
parametro opcional final, y la resolucion de sobrecarga de C# prefiere el candidato que no omite
opcionales. Como el issue indicaba, **no se ajusto nada**.

### Cobertura de criterios de aceptacion

| Criterio | Estado | Evidencia / Test(s) |
|---|---|---|
| CA-1: los 6 paquetes `Cosmos.*` en `2.3.1`, sin residuos en `2.1.0` | **cubierto** | Las 14 referencias listadas en `2.3.1`; `grep` de `Cosmos.*2\.1\.0` en `*.csproj` devuelve **NINGUNO**. `dotnet restore` resolvio los seis desde nuget.org. |
| CA-2: build sin errores ni warnings nuevos; suite verde | **cubierto** | `0 Errores`. Warnings comparados de forma determinista (`--no-incremental`, warnings unicos normalizados, baseline via `git stash` de los `.csproj`): `diff` = **SIN DIFERENCIAS**. Los dos existentes (`NU1902` de `OpenTelemetry.Api` 1.14.0, `CS0414` de `CatalogoTurnos._estaActivo`) son preexistentes. Suite 496/488/8/0. |
| CA-3: retiro de las 3 asignaciones + comentario de #232 en ambos dominios, con comentario breve de reemplazo | **cubierto** | Diff de los dos `ComposicionServicios.cs`. |
| CA-4: metadata del worker de proyecciones **intacta** | **cubierto** | Ningun archivo `Projections*` en `git diff --name-only`; las lineas 53-55 de ambos `ConfiguracionMartenProjections*` sin cambios. Base tecnica verificada (worker sin paquetes `Cosmos.*`). |
| CA-5: `ComposicionServiciosTests` (x2) y `AssertsProyecciones` verdes **sin ser modificados** | **cubierto** | Ningun archivo de `tests/` en el diff. Ejecucion dirigida: `ComposicionServiciosTests` de ControlHoras **5/5** y de Programacion **4/4**, `Failed: 0`, `Skipped: 0` — corrieron de verdad, no quedaron silenciosamente omitidos. `Projections.Tests` verde. Efectividad probada por mutacion (ver arriba). |

### Tests agregados

**Ninguno, deliberadamente.** CA-5 designa a los tests existentes como la red de seguridad del
cambio y prohibe modificarlos; el canal de prueba ya existe y cubre los cinco CAs. Tampoco aplica la
seccion de tests de contrato (igualdad / round-trip de serializacion): el diff no introduce ni
modifica ningun `IEquatable<T>`, `ConfigurarSerializacion` ni evento con marker de bus. Agregar
tests aqui seria ruido sin canal nuevo que cubrir.

</details>

## Commits

66c2209 refactor(hu-267): actualizar paquetes Cosmos a 2.3.1 y retirar metadata redundante

Closes #267