### PR TITLE
Registrar los tipos de evento persistidos en el EventGraph de cada proceso

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,6 +153,7 @@ Si tu trabajo toca uno de estos temas, consulta el ADR correspondiente antes de 
 | Topics y subscriptions de Service Bus, un topic por evento | MEF-ADR-0001 |
 | Estrategia de testing con event sourcing, DSL de tests | MEF-ADR-0002 |
 | **Dónde va un evento nuevo: `PublicEvents` vs `PrivateEvents` vs `{Dominio}.DomainEvents`; qué referencia el worker de proyecciones; por qué un evento no conoce su comando** | CA-ADR-0029 |
+| **Identidad del evento en el event store: el alias manda, registro explícito con `AddEventTypes`, mover un evento de namespace sin migrar datos; proscripción de `MapEventType` y de alterar `EventNamingStyle`** | CA-ADR-0029 (decisión #6) |
 | Mensajes en `.resx` por aggregate/handler | MEF-ADR-0009 |
 | Definition of Ready | MEF-ADR-0011 |
 | Smoke tests contra entorno dev | MEF-ADR-0013 |

--- a/docs/adr/ca-adr-0029-ensamblados-de-eventos-por-rol.md
+++ b/docs/adr/ca-adr-0029-ensamblados-de-eventos-por-rol.md
@@ -94,6 +94,46 @@ La razón es estructural, no estética: `CrearTurno` vive en la Function App, qu
 `Programacion.DomainEvents`, así que un factory que reciba el comando cierra un ciclo de referencias
 y no compila.
 
+### 6. El alias es la identidad del evento persistido, y se registra explícitamente
+
+*Enmienda incorporada por el issue #277, que paga la deuda que la primera versión de este ADR había
+asumido (ver "Negativas y deuda asumida").*
+
+La identidad con la que Marten reconoce un evento al leer un stream es su **alias** --la columna
+`type` de `mt_events`--, no el nombre calificado del tipo. `EventDocumentStorage.Resolve` (Marten
+9.12) busca primero un mapping por alias y solo cae a `mt_dotnet_type` -> `Type.GetType(...)` cuando
+no lo encuentra; si el alias resuelve, un `mt_dotnet_type` desactualizado se ignora **por diseño**.
+De ahí que mover un evento de namespace o de ensamblado no obligue a migrar ningún dato: el alias
+lo deriva `EventTypeExtensions` del **nombre simple** de la clase (`eventType.Name.ToTableAlias()`),
+inmune al namespace.
+
+Lo que sí es obligatorio es que el mapping exista **antes de la primera lectura** del proceso, en vez
+de depender de que un append previo lo haya poblado. Por eso cada ensamblado de eventos aloja también
+la lista de sus tipos persistidos --`IdentidadEventos{Dominio}.TiposPersistidos`, hermana de la lista
+de serialización de la decisión #4--, y **todo** proceso que lea esos streams la registra en su propio
+`EventGraph` con `Events.AddEventTypes(...)`: el write-side en su `ComposicionServicios` y el worker
+de proyecciones en su `ConfiguracionMartenProjections{Dominio}`.
+
+Tres proscripciones delimitan el alcance de esta decisión:
+
+- **No se usa `MapEventType` ni se altera `EventNamingStyle`.** Registrar un tipo no redeclara su
+  alias: Marten lo sigue derivando del nombre de clase. Este ADR no cambia la estrategia de
+  identificación, solo garantiza que el mapping esté presente.
+- **No se registra ningún tipo con el nombre calificado antiguo** (ni clase shim, ni un
+  `MapEventType` al viejo). Eso invertiría la tolerancia descrita arriba: Marten encontraría un
+  mapping alternativo para el `mt_dotnet_type` obsoleto y deserializaría las filas viejas al tipo
+  viejo, que es exactamente lo que no se quiere.
+- **Un evento que solo cruza el bus no entra en la lista.** `PublicEvents` y `PrivateEvents` se
+  deserializan a un tipo fijo por endpoint y nunca pasan por el `EventGraph`. El criterio de
+  inclusión es el mismo del ensamblado (decisión #1): se persiste. `MarcacionRegistrada` entra por
+  ser persistida, no por ser `IPrivateEvent`.
+
+Dos guardrails sostienen la decisión, ambos sin Postgres (`AllKnownEventTypes()` es cálculo en
+memoria): uno verifica que los tipos estén registrados en el store real que compone cada lado, y otro
+**congela el alias contra literales** (`turno_creado`, `marcacion_registrada`, ...), de modo que el
+día en que un rename de clase cambie la identidad de un evento ya persistido se vea en la suite, no
+en producción.
+
 ## Alternativas consideradas
 
 **Mover el modelo de dominio completo (CA-ADR-0028 decisión #1).** Descartada por innecesaria:
@@ -135,14 +175,16 @@ de **salida** hacia ControlHoras, no de entrada.
 
 ### Negativas y deuda asumida
 
-- **Los streams de dev creados antes del refactor quedan ilegibles.** Este proyecto no registra
-  aliases (`Events.AddEventType`/`MapEventType` tienen cero ocurrencias en el repo y en el building
-  block), así que toda lectura depende del fallback por `mt_dotnet_type`, que apunta a un assembly
-  donde el tipo ya no existe: lanza `UnknownEventTypeException`, no degrada en silencio. Se asume la
-  pérdida y se purgan los schemas `programacion` y `control_horas` de dev al desplegar. El alias sí es
-  inmune al movimiento (`EventNamingStyle.SmarterTypeName` usa el nombre simple). Cuando dev tenga
-  datos que importen, o exista cualquier ambiente productivo, el registro explícito de aliases pasa a
-  ser precondición de todo movimiento futuro de namespace o assembly.
+- ~~**Los streams de dev creados antes del refactor quedan ilegibles.**~~ **Deuda pagada por el
+  issue #277 (decisión #6).** La primera versión de este ADR asumió la pérdida y mandaba purgar los
+  schemas `programacion` y `control_horas` de dev al desplegar, porque sin ningún tipo registrado toda
+  lectura dependía del fallback por `mt_dotnet_type` --que apunta a un assembly donde el tipo ya no
+  existe-- y lanzaba `UnknownEventTypeException`. Esa purga **nunca se ejecutó** y el código sí se
+  desplegó, así que el defecto quedó armado (lo dispara la primera rehidratación de un aggregate
+  preexistente). El registro explícito de la decisión #6 lo corrige **retroactivamente y sin tocar
+  datos**: como el alias resuelve, la columna obsoleta se ignora. La purga queda revertida como
+  estrategia -- no era necesaria, y de aquí en adelante el registro explícito es precondición de todo
+  movimiento futuro de namespace o assembly, no la purga.
 - **`MarcacionRegistrada` queda en `DomainEvents` siendo `IPrivateEvent`.** Se publica al topic
   `marcacion-registrada` y además se persiste, pero es un tipo rico y un tipo rico no puede vivir en
   un ensamblado cuyo contrato es que todo lo suyo cruza un bus siendo plano. Su aplanamiento y
@@ -185,3 +227,9 @@ de **salida** hacia ControlHoras, no de entrada.
   `PrivateEvents`, `{Dominio}.DomainEvents`), sus tres criterios de inclusión, el sentido de las
   dependencias permitidas y las reglas que el grafo de compilación garantiza. Supera a CA-ADR-0002 y
   CA-ADR-0028. Ejecutado en el issue #237.
+- 2026-07-31: enmienda (issue #277). Agrega la decisión #6: el alias --derivado del nombre simple de
+  la clase-- es la identidad del evento persistido, y cada ensamblado de eventos aloja la lista de sus
+  tipos persistidos (`IdentidadEventos{Dominio}.TiposPersistidos`) que write-side y read-side registran
+  con `Events.AddEventTypes(...)`. Proscribe `MapEventType`, alterar `EventNamingStyle` y registrar el
+  nombre calificado antiguo. Marca como pagada la primera deuda de "Negativas y deuda asumida" y
+  revierte la purga de streams como estrategia de mitigación.

--- a/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/IdentidadEventosControlHoras.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/IdentidadEventosControlHoras.cs
@@ -1,0 +1,28 @@
+namespace Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
+
+// Issue #277: gemela de IdentidadEventosProgramacion. Lista de los tipos de evento que SE
+// PERSISTEN en el event store de ControlHoras -- el mismo criterio de inclusion de este
+// ensamblado (CA-ADR-0029). MarcacionRegistrada implementa ademas IPrivateEvent (cruza el ASB
+// interno del BC), pero eso no la excluye: tambien se persiste en el stream de
+// ControlDiarioAggregateRoot, asi que entra en esta lista por ese motivo. Los eventos que SOLO
+// cruzan el bus (p.ej. DiaCalculado, ProgramacionTurnoDiarioSolicitada) no entran: nunca pasan
+// por el EventGraph de Marten.
+//
+// Registrar estos tipos via Events.AddEventTypes NO declara su alias -- Marten lo sigue
+// derivando del nombre de clase (JasperFx.Events.EventTypeExtensions.GetSmarterEventTypeName /
+// GetEventTypeName, Marten 9.12 + JasperFx.Events 2.18.1, ambos resuelven igual para tipos
+// top-level no genericos). Lo unico que AddEventTypes garantiza es que el mapping exista antes
+// de la primera lectura del proceso, en vez de depender de que un append lo haya poblado
+// (issue #237 seccion "Consecuencia asumida").
+//
+// No duplica ConfiguracionSerializacionControlHoras: esa cubre los tipos ricos que necesitan
+// ConfigurarSerializacion; esta cubre los tipos persistidos. Ninguna es subconjunto de la otra.
+//
+// STUB de fase roja (issue #277, test-writer): lista vacia a proposito. Sin los tres tipos aqui,
+// IdentidadEventosControlHorasTests (CA-1), AliasEventosControlHorasTests (CA-5) y las guardas de
+// ComposicionServiciosTests / ConfiguracionMartenProjectionsTests (CA-2/CA-3/CA-4) fallan. El
+// implementer completa esta lista con los tres tipos reales.
+public static class IdentidadEventosControlHoras
+{
+    public static IReadOnlyList<Type> TiposPersistidos { get; } = [];
+}

--- a/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/IdentidadEventosControlHoras.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/IdentidadEventosControlHoras.cs
@@ -17,12 +17,12 @@ namespace Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 //
 // No duplica ConfiguracionSerializacionControlHoras: esa cubre los tipos ricos que necesitan
 // ConfigurarSerializacion; esta cubre los tipos persistidos. Ninguna es subconjunto de la otra.
-//
-// STUB de fase roja (issue #277, test-writer): lista vacia a proposito. Sin los tres tipos aqui,
-// IdentidadEventosControlHorasTests (CA-1), AliasEventosControlHorasTests (CA-5) y las guardas de
-// ComposicionServiciosTests / ConfiguracionMartenProjectionsTests (CA-2/CA-3/CA-4) fallan. El
-// implementer completa esta lista con los tres tipos reales.
 public static class IdentidadEventosControlHoras
 {
-    public static IReadOnlyList<Type> TiposPersistidos { get; } = [];
+    public static IReadOnlyList<Type> TiposPersistidos { get; } =
+    [
+        typeof(MarcacionRegistrada),
+        typeof(MarcacionAdicionada),
+        typeof(TurnoDiarioAsignado)
+    ];
 }

--- a/src/Bitakora.ControlAsistencia.ControlHoras/Infraestructura/ComposicionServicios.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Infraestructura/ComposicionServicios.cs
@@ -66,6 +66,12 @@ public static class ComposicionServicios
         // ComposicionServiciosTests lo verifica sobre el store real del contenedor.
         services.ConfigureMarten(options =>
         {
+            // Issue #277: registra los tipos de evento persistidos en el EventGraph. No declara
+            // alias -- Marten lo sigue derivando del nombre de clase -- solo garantiza que el
+            // mapping exista antes de la primera lectura, en vez de depender de que un append lo
+            // haya poblado (issue #237 seccion "Consecuencia asumida").
+            options.Events.AddEventTypes(IdentidadEventosControlHoras.TiposPersistidos);
+
             if (options.Serializer() is Marten.Services.SystemTextJsonSerializer stj)
             {
                 stj.Configure(jsonOptions =>

--- a/src/Bitakora.ControlAsistencia.Programacion.DomainEvents/IdentidadEventosProgramacion.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion.DomainEvents/IdentidadEventosProgramacion.cs
@@ -16,12 +16,11 @@ namespace Bitakora.ControlAsistencia.Programacion.DomainEvents;
 // ConfigurarSerializacion (VOs con ctor privado); esta cubre los tipos persistidos (incluye
 // ProgramacionTurnoSolicitada, que STJ resuelve solo con su ctor publico). Ninguna es subconjunto
 // de la otra.
-//
-// STUB de fase roja (issue #277, test-writer): lista vacia a proposito. Sin los dos tipos aqui,
-// IdentidadEventosProgramacionTests (CA-1), AliasEventosProgramacionTests (CA-5) y las guardas de
-// ComposicionServiciosTests / ConfiguracionMartenProjectionsTests (CA-2/CA-3/CA-4) fallan. El
-// implementer completa esta lista con los dos tipos reales.
 public static class IdentidadEventosProgramacion
 {
-    public static IReadOnlyList<Type> TiposPersistidos { get; } = [];
+    public static IReadOnlyList<Type> TiposPersistidos { get; } =
+    [
+        typeof(TurnoCreado),
+        typeof(ProgramacionTurnoSolicitada)
+    ];
 }

--- a/src/Bitakora.ControlAsistencia.Programacion.DomainEvents/IdentidadEventosProgramacion.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion.DomainEvents/IdentidadEventosProgramacion.cs
@@ -1,0 +1,27 @@
+namespace Bitakora.ControlAsistencia.Programacion.DomainEvents;
+
+// Issue #277: lista de los tipos de evento que SE PERSISTEN en el event store de Programacion --
+// el mismo criterio de inclusion de este ensamblado (CA-ADR-0029). Los eventos de bus
+// (PrivateEvents/PublicEvents) no entran: se deserializan a un tipo fijo por endpoint y nunca
+// pasan por el EventGraph de Marten.
+//
+// Registrar estos tipos via Events.AddEventTypes NO declara su alias -- Marten lo sigue
+// derivando del nombre de clase (JasperFx.Events.EventTypeExtensions.GetSmarterEventTypeName /
+// GetEventTypeName, Marten 9.12 + JasperFx.Events 2.18.1, ambos resuelven igual para tipos
+// top-level no genericos). Lo unico que AddEventTypes garantiza es que el mapping exista antes
+// de la primera lectura del proceso, en vez de depender de que un append lo haya poblado
+// (issue #237 seccion "Consecuencia asumida").
+//
+// No duplica ConfiguracionSerializacionProgramacion: esa cubre los tipos ricos que necesitan
+// ConfigurarSerializacion (VOs con ctor privado); esta cubre los tipos persistidos (incluye
+// ProgramacionTurnoSolicitada, que STJ resuelve solo con su ctor publico). Ninguna es subconjunto
+// de la otra.
+//
+// STUB de fase roja (issue #277, test-writer): lista vacia a proposito. Sin los dos tipos aqui,
+// IdentidadEventosProgramacionTests (CA-1), AliasEventosProgramacionTests (CA-5) y las guardas de
+// ComposicionServiciosTests / ConfiguracionMartenProjectionsTests (CA-2/CA-3/CA-4) fallan. El
+// implementer completa esta lista con los dos tipos reales.
+public static class IdentidadEventosProgramacion
+{
+    public static IReadOnlyList<Type> TiposPersistidos { get; } = [];
+}

--- a/src/Bitakora.ControlAsistencia.Programacion/Infraestructura/ComposicionServicios.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/Infraestructura/ComposicionServicios.cs
@@ -57,6 +57,12 @@ public static class ComposicionServicios
         // ComposicionServiciosTests lo verifica sobre el store real del contenedor.
         services.ConfigureMarten(options =>
         {
+            // Issue #277: registra los tipos de evento persistidos en el EventGraph. No declara
+            // alias -- Marten lo sigue derivando del nombre de clase -- solo garantiza que el
+            // mapping exista antes de la primera lectura, en vez de depender de que un append lo
+            // haya poblado (issue #237 seccion "Consecuencia asumida").
+            options.Events.AddEventTypes(IdentidadEventosProgramacion.TiposPersistidos);
+
             if (options.Serializer() is Marten.Services.SystemTextJsonSerializer stj)
             {
                 stj.Configure(jsonOptions =>

--- a/src/Bitakora.ControlAsistencia.Projections/Infraestructura/ConfiguracionMartenProjectionsControlHoras.cs
+++ b/src/Bitakora.ControlAsistencia.Projections/Infraestructura/ConfiguracionMartenProjectionsControlHoras.cs
@@ -1,3 +1,4 @@
+using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 using JasperFx.Events; // StreamIdentity (NO Marten.Events, mismo gotcha que DaemonMode)
 using JasperFx.Events.Daemon; // DaemonMode (NO Marten.Events.Daemon: compila pero deja DaemonMode sin resolver)
 using Marten;
@@ -53,6 +54,12 @@ public static class ConfiguracionMartenProjectionsControlHoras
                 opts.Events.MetadataConfig.CorrelationIdEnabled = true;
                 opts.Events.MetadataConfig.CausationIdEnabled = true;
                 opts.Events.MetadataConfig.HeadersEnabled = true;
+
+                // Issue #277: defensa en profundidad read-side. Registra los tipos de evento
+                // persistidos de ControlHoras en el EventGraph de este named store, para que el
+                // daemon no dependa del fallback por mt_dotnet_type al leer streams preexistentes
+                // (issue #237 seccion "Consecuencia asumida").
+                opts.Events.AddEventTypes(IdentidadEventosControlHoras.TiposPersistidos);
             })
             // Registrar el store no basta: sin esta llamada el daemon queda apagado y ninguna
             // proyeccion se materializa. HotCold elige lider sobre advisory locks de PostgreSQL,

--- a/src/Bitakora.ControlAsistencia.Projections/Infraestructura/ConfiguracionMartenProjectionsProgramacion.cs
+++ b/src/Bitakora.ControlAsistencia.Projections/Infraestructura/ConfiguracionMartenProjectionsProgramacion.cs
@@ -1,3 +1,4 @@
+using Bitakora.ControlAsistencia.Programacion.DomainEvents;
 using JasperFx.Events; // StreamIdentity (NO Marten.Events, mismo gotcha que DaemonMode)
 using JasperFx.Events.Daemon; // DaemonMode (NO Marten.Events.Daemon: compila pero deja DaemonMode sin resolver)
 using Marten;
@@ -53,6 +54,12 @@ public static class ConfiguracionMartenProjectionsProgramacion
                 opts.Events.MetadataConfig.CorrelationIdEnabled = true;
                 opts.Events.MetadataConfig.CausationIdEnabled = true;
                 opts.Events.MetadataConfig.HeadersEnabled = true;
+
+                // Issue #277: defensa en profundidad read-side. Registra los tipos de evento
+                // persistidos de Programacion en el EventGraph de este named store, para que el
+                // daemon no dependa del fallback por mt_dotnet_type al leer streams preexistentes
+                // (issue #237 seccion "Consecuencia asumida").
+                opts.Events.AddEventTypes(IdentidadEventosProgramacion.TiposPersistidos);
             })
             // Registrar el store no basta: sin esta llamada el daemon queda apagado y ninguna
             // proyeccion se materializa. HotCold elige lider sobre advisory locks de PostgreSQL,

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/AliasEventosControlHorasTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/AliasEventosControlHorasTests.cs
@@ -1,0 +1,63 @@
+// Issue #277 CA-5: congela el alias que Marten deriva del nombre de clase de cada evento
+// persistido de ControlHoras (JasperFx.Events.EventTypeExtensions.GetSmarterEventTypeName /
+// GetEventTypeName -> eventType.Name.ToTableAlias(), verificado por decompilacion contra Marten
+// 9.12 + JasperFx.Events 2.18.1: ambos estilos de naming resuelven igual para tipos top-level no
+// genericos como los cinco eventos persistidos de este BC). Es la garantia central del fix: si
+// el alias resuelve, EventDocumentStorage.Resolve nunca cae al fallback por mt_dotnet_type que
+// rompio el issue #237. Este test hace visible el dia en que un rename de clase rompa la
+// convencion, ANTES de desplegarlo.
+//
+// No necesita Postgres: EventGraph.AllKnownEventTypes() es calculo puro en memoria sobre un
+// StoreOptions standalone (verificado por decompilacion: el constructor de StoreOptions no abre
+// conexion). Se alimenta de IdentidadEventosControlHoras.TiposPersistidos -- mismo stub que CA-1,
+// asi que en fase roja (lista vacia) este test tambien falla: AllKnownEventTypes() no encuentra
+// el tipo y el alias sale null.
+//
+// No se usan [Theory]/[InlineData] (MEF-ADR de convencion de tests de este agente: solo [Fact]):
+// un Fact por evento, en vez de la forma parametrizada que sugiere el issue.
+
+using System.Linq;
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
+using Marten;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Tests.Infraestructura;
+
+public class AliasEventosControlHorasTests
+{
+    private static StoreOptions CrearOpcionesConEventosDeControlHorasRegistrados()
+    {
+        var options = new StoreOptions();
+        options.Events.AddEventTypes(IdentidadEventosControlHoras.TiposPersistidos);
+        return options;
+    }
+
+    private static string? AliasDe<TEvento>(StoreOptions options) =>
+        ((IReadOnlyStoreOptions)options).Events.AllKnownEventTypes()
+            .SingleOrDefault(evento => evento.EventType == typeof(TEvento))
+            ?.Alias;
+
+    [Fact]
+    public void MarcacionRegistrada_TieneAliasMarcacionRegistrada()
+    {
+        var options = CrearOpcionesConEventosDeControlHorasRegistrados();
+
+        AliasDe<MarcacionRegistrada>(options).Should().Be("marcacion_registrada");
+    }
+
+    [Fact]
+    public void MarcacionAdicionada_TieneAliasMarcacionAdicionada()
+    {
+        var options = CrearOpcionesConEventosDeControlHorasRegistrados();
+
+        AliasDe<MarcacionAdicionada>(options).Should().Be("marcacion_adicionada");
+    }
+
+    [Fact]
+    public void TurnoDiarioAsignado_TieneAliasTurnoDiarioAsignado()
+    {
+        var options = CrearOpcionesConEventosDeControlHorasRegistrados();
+
+        AliasDe<TurnoDiarioAsignado>(options).Should().Be("turno_diario_asignado");
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/AliasEventosControlHorasTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/AliasEventosControlHorasTests.cs
@@ -9,14 +9,8 @@
 //
 // No necesita Postgres: EventGraph.AllKnownEventTypes() es calculo puro en memoria sobre un
 // StoreOptions standalone (verificado por decompilacion: el constructor de StoreOptions no abre
-// conexion). Se alimenta de IdentidadEventosControlHoras.TiposPersistidos -- mismo stub que CA-1,
-// asi que en fase roja (lista vacia) este test tambien falla: AllKnownEventTypes() no encuentra
-// el tipo y el alias sale null.
-//
-// No se usan [Theory]/[InlineData] (MEF-ADR de convencion de tests de este agente: solo [Fact]):
-// un Fact por evento, en vez de la forma parametrizada que sugiere el issue.
+// conexion), asi que el alias se interroga sin contenedor DI ni base de datos.
 
-using System.Linq;
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 using Marten;

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/AssertsIdentidadEventos.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/AssertsIdentidadEventos.cs
@@ -1,0 +1,23 @@
+using System.Linq;
+using AwesomeAssertions;
+using Marten;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Tests.Infraestructura;
+
+/// <summary>
+/// Issue #277 CA-4: detecta un evento persistido que quedo fuera del registro explicito de
+/// IdentidadEventos{Dominio}.TiposPersistidos. Sin AddEventTypes, la primera rehidratacion de un
+/// stream con datos preexistentes cae al fallback por mt_dotnet_type y revienta con
+/// UnknownEventTypeException (issue #237 seccion "Consecuencia asumida"). Se invoca sobre el
+/// IDocumentStore resuelto del contenedor real de este dominio (ComposicionServiciosTests) --
+/// sin Postgres: AllKnownEventTypes() es calculo en memoria (Marten 7+ no abre conexion en el
+/// bootstrap del IHost).
+/// </summary>
+public static class AssertsIdentidadEventos
+{
+    public static void AssertEventosPersistidosRegistrados(
+        this IDocumentStore store, IReadOnlyList<Type> tiposEsperados) =>
+        store.Options.Events.AllKnownEventTypes()
+            .Select(evento => evento.EventType)
+            .Should().Contain(tiposEsperados);
+}

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/AssertsIdentidadEventos.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/AssertsIdentidadEventos.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using AwesomeAssertions;
 using Marten;
 
@@ -20,4 +19,19 @@ public static class AssertsIdentidadEventos
         store.Options.Events.AllKnownEventTypes()
             .Select(evento => evento.EventType)
             .Should().Contain(tiposEsperados);
+
+    /// <summary>
+    /// Issue #277 CA-5/CA-7/CA-8: congela el alias -- la columna "type" de mt_events, la unica
+    /// identidad que Marten consulta antes del fallback -- sobre el store que realmente compuso el
+    /// contenedor. AliasEventos{Dominio}Tests ya lo congela sobre un StoreOptions standalone, pero
+    /// ahi no vive el wiring: un MapEventType o un EventNamingStyle introducidos en
+    /// ComposicionServicios cambiarian la identidad de eventos ya persistidos sin poner rojo ningun
+    /// otro test.
+    /// </summary>
+    public static void AssertAliasDeEventosPersistidos(
+        this IDocumentStore store, IReadOnlyDictionary<Type, string> aliasEsperados) =>
+        store.Options.Events.AllKnownEventTypes()
+            .Where(evento => aliasEsperados.ContainsKey(evento.EventType))
+            .ToDictionary(evento => evento.EventType, evento => evento.Alias)
+            .Should().Equal(aliasEsperados);
 }

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/ComposicionServiciosTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/ComposicionServiciosTests.cs
@@ -130,11 +130,10 @@ public class ComposicionServiciosTests
     // (columna "type" de mt_events). Este guardrail detecta el olvido sobre el store real que
     // compone el contenedor (mismo store que ya usan las guardas de arriba), sin Postgres.
     //
-    // Los tipos esperados se listan literalmente (oraculo independiente, MEF-ADR-0002): si se
-    // leyeran de IdentidadEventosControlHoras.TiposPersistidos, el guardrail quedaria acoplado al
-    // mismo artefacto que CA-1 ya verifica, y ademas AwesomeAssertions.Contain() lanza
-    // ArgumentException con una coleccion "esperada" vacia en vez de fallar semanticamente --
-    // el stub de fase roja (issue #277) deja esa lista vacia a proposito.
+    // Los tipos esperados se listan literalmente (oraculo independiente, MEF-ADR-0002): leerlos de
+    // IdentidadEventosControlHoras.TiposPersistidos acoplaria el guardrail al mismo artefacto que
+    // IdentidadEventosControlHorasTests ya verifica, y la asercion pasaria en verde aunque la lista
+    // quedara vacia.
     [Fact]
     public async Task AgregarServiciosControlHoras_RegistraLosTiposDeEventoPersistidos_CuandoElContenedorEstaCompuesto()
     {
@@ -145,5 +144,25 @@ public class ComposicionServiciosTests
 
         store.AssertEventosPersistidosRegistrados(
             [typeof(MarcacionRegistrada), typeof(MarcacionAdicionada), typeof(TurnoDiarioAsignado)]);
+    }
+
+    // Issue #277 CA-5/CA-7/CA-8: registrar el tipo solo sirve si el alias sigue siendo el que las
+    // filas ya escritas llevan en su columna "type". AliasEventosControlHorasTests lo congela sobre
+    // un StoreOptions standalone; esta guarda lo congela sobre el store del contenedor, el unico
+    // lugar donde un MapEventType o un EventNamingStyle agregados al wiring podrian cambiarlo.
+    [Fact]
+    public async Task AgregarServiciosControlHoras_DerivaElAliasDeEventoDelNombreDeClase_CuandoElContenedorEstaCompuesto()
+    {
+        await using var provider = ComponerServiceProvider();
+        await using var scope = provider.CreateAsyncScope();
+
+        var store = scope.ServiceProvider.GetRequiredService<IDocumentStore>();
+
+        store.AssertAliasDeEventosPersistidos(new Dictionary<Type, string>
+        {
+            [typeof(MarcacionRegistrada)] = "marcacion_registrada",
+            [typeof(MarcacionAdicionada)] = "marcacion_adicionada",
+            [typeof(TurnoDiarioAsignado)] = "turno_diario_asignado"
+        });
     }
 }

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/ComposicionServiciosTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/ComposicionServiciosTests.cs
@@ -21,6 +21,7 @@
 
 using System.Text;
 using AwesomeAssertions;
+using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 using Bitakora.ControlAsistencia.ControlHoras.Infraestructura;
 using Bitakora.ControlAsistencia.ControlHoras.ValueObjects;
 using Cosmos.EventDriven.Abstractions;
@@ -121,5 +122,28 @@ public class ComposicionServiciosTests
 
         restaurado.Should().Be(original);
         restaurado.ToString().Should().Be(original.ToString());
+    }
+
+    // Issue #277 CA-2/CA-4: el #237 movio los eventos persistidos a este ensamblado (namespace y
+    // assembly nuevos) sin registrar su tipo en el EventGraph. Toda lectura quedo dependiendo del
+    // fallback por mt_dotnet_type -- roto para el nuevo namespace -- en vez de resolver por alias
+    // (columna "type" de mt_events). Este guardrail detecta el olvido sobre el store real que
+    // compone el contenedor (mismo store que ya usan las guardas de arriba), sin Postgres.
+    //
+    // Los tipos esperados se listan literalmente (oraculo independiente, MEF-ADR-0002): si se
+    // leyeran de IdentidadEventosControlHoras.TiposPersistidos, el guardrail quedaria acoplado al
+    // mismo artefacto que CA-1 ya verifica, y ademas AwesomeAssertions.Contain() lanza
+    // ArgumentException con una coleccion "esperada" vacia en vez de fallar semanticamente --
+    // el stub de fase roja (issue #277) deja esa lista vacia a proposito.
+    [Fact]
+    public async Task AgregarServiciosControlHoras_RegistraLosTiposDeEventoPersistidos_CuandoElContenedorEstaCompuesto()
+    {
+        await using var provider = ComponerServiceProvider();
+        await using var scope = provider.CreateAsyncScope();
+
+        var store = scope.ServiceProvider.GetRequiredService<IDocumentStore>();
+
+        store.AssertEventosPersistidosRegistrados(
+            [typeof(MarcacionRegistrada), typeof(MarcacionAdicionada), typeof(TurnoDiarioAsignado)]);
     }
 }

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/IdentidadEventosControlHorasTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/IdentidadEventosControlHorasTests.cs
@@ -1,0 +1,25 @@
+// Issue #277 CA-1: IdentidadEventosControlHoras.TiposPersistidos debe listar exactamente los
+// tipos que se persisten en el event store de ControlHoras -- ni de mas (ningun evento que solo
+// cruce el bus, p.ej. DiaCalculado o ProgramacionTurnoDiarioSolicitada), ni de menos (el olvido
+// que este issue corrige). MarcacionRegistrada SI entra: ademas de IPrivateEvent, se persiste en
+// el stream de ControlDiarioAggregateRoot. No usa el harness Given/When/Then: es un dato
+// estatico, no hay aggregate ni command handler involucrado.
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Tests.Infraestructura;
+
+public class IdentidadEventosControlHorasTests
+{
+    [Fact]
+    public void TiposPersistidos_ContieneExactamenteLosTresEventosPersistidosDeControlHoras()
+    {
+        IdentidadEventosControlHoras.TiposPersistidos.Should().BeEquivalentTo(
+        [
+            typeof(MarcacionRegistrada),
+            typeof(MarcacionAdicionada),
+            typeof(TurnoDiarioAsignado)
+        ]);
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/IdentidadEventosControlHorasTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/IdentidadEventosControlHorasTests.cs
@@ -2,11 +2,13 @@
 // tipos que se persisten en el event store de ControlHoras -- ni de mas (ningun evento que solo
 // cruce el bus, p.ej. DiaCalculado o ProgramacionTurnoDiarioSolicitada), ni de menos (el olvido
 // que este issue corrige). MarcacionRegistrada SI entra: ademas de IPrivateEvent, se persiste en
-// el stream de ControlDiarioAggregateRoot. No usa el harness Given/When/Then: es un dato
-// estatico, no hay aggregate ni command handler involucrado.
+// el stream de RegistroDeMarcacionAggregateRoot, que la aplica. No usa el harness Given/When/Then:
+// se verifica un dato estatico de configuracion, no el comportamiento de un command handler.
 
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
+using Bitakora.ControlAsistencia.ControlHoras.Entities;
+using Cosmos.EventSourcing.Abstractions;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.Tests.Infraestructura;
 
@@ -22,4 +24,33 @@ public class IdentidadEventosControlHorasTests
             typeof(TurnoDiarioAsignado)
         ]);
     }
+
+    // Oraculo derivado del write-side, complementario del literal de arriba: la asercion literal
+    // congela la lista de hoy, pero un evento persistido que se agregue manana solo la pone roja si
+    // alguien recuerda editar el test -- justo el olvido que el #237 dejo armado. Esta guarda no
+    // necesita ese recuerdo: enumera por reflexion los eventos que los aggregate roots del dominio
+    // aplican al rehidratar y exige que todos esten registrados.
+    [Fact]
+    public void TiposPersistidos_IncluyeTodoEventoQueAplicaUnAggregateRootDelDominio()
+    {
+        var eventosAplicados = EventosAplicadosPorLosAggregateRoots();
+
+        eventosAplicados.Should().NotBeEmpty();
+        IdentidadEventosControlHoras.TiposPersistidos.Should().Contain(eventosAplicados);
+    }
+
+    // Un aggregate root aplica un evento persistido con la firma convencional de Marten
+    // "public void Apply(TEvento)", y ese evento vive en el ensamblado DomainEvents del dominio
+    // (CA-ADR-0029). Los eventos que solo cruzan el bus llegan por un endpoint, no por un Apply,
+    // asi que quedan fuera por construccion.
+    private static IReadOnlyList<Type> EventosAplicadosPorLosAggregateRoots() =>
+        typeof(ControlDiarioAggregateRoot).Assembly.GetTypes()
+            .Where(tipo => typeof(AggregateRoot).IsAssignableFrom(tipo))
+            .SelectMany(tipo => tipo.GetMethods())
+            .Where(metodo => metodo.Name == nameof(RegistroDeMarcacionAggregateRoot.Apply)
+                             && metodo.GetParameters().Length == 1)
+            .Select(metodo => metodo.GetParameters()[0].ParameterType)
+            .Where(evento => evento.Assembly == typeof(MarcacionRegistrada).Assembly)
+            .Distinct()
+            .ToList();
 }

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/Infraestructura/AliasEventosProgramacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/Infraestructura/AliasEventosProgramacionTests.cs
@@ -1,0 +1,55 @@
+// Issue #277 CA-5: congela el alias que Marten deriva del nombre de clase de cada evento
+// persistido de Programacion (JasperFx.Events.EventTypeExtensions.GetSmarterEventTypeName /
+// GetEventTypeName -> eventType.Name.ToTableAlias(), verificado por decompilacion contra Marten
+// 9.12 + JasperFx.Events 2.18.1: ambos estilos de naming resuelven igual para tipos top-level no
+// genericos como los cinco eventos persistidos de este BC). Es la garantia central del fix: si
+// el alias resuelve, EventDocumentStorage.Resolve nunca cae al fallback por mt_dotnet_type que
+// rompio el issue #237. Este test hace visible el dia en que un rename de clase rompa la
+// convencion, ANTES de desplegarlo.
+//
+// No necesita Postgres: EventGraph.AllKnownEventTypes() es calculo puro en memoria sobre un
+// StoreOptions standalone (verificado por decompilacion: el constructor de StoreOptions no abre
+// conexion). Se alimenta de IdentidadEventosProgramacion.TiposPersistidos -- mismo stub que CA-1,
+// asi que en fase roja (lista vacia) este test tambien falla: AllKnownEventTypes() no encuentra
+// el tipo y el alias sale null.
+//
+// No se usan [Theory]/[InlineData] (MEF-ADR de convencion de tests de este agente: solo [Fact]):
+// un Fact por evento, en vez de la forma parametrizada que sugiere el issue.
+
+using System.Linq;
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Programacion.DomainEvents;
+using Marten;
+
+namespace Bitakora.ControlAsistencia.Programacion.Tests.Infraestructura;
+
+public class AliasEventosProgramacionTests
+{
+    private static StoreOptions CrearOpcionesConEventosDeProgramacionRegistrados()
+    {
+        var options = new StoreOptions();
+        options.Events.AddEventTypes(IdentidadEventosProgramacion.TiposPersistidos);
+        return options;
+    }
+
+    private static string? AliasDe<TEvento>(StoreOptions options) =>
+        ((IReadOnlyStoreOptions)options).Events.AllKnownEventTypes()
+            .SingleOrDefault(evento => evento.EventType == typeof(TEvento))
+            ?.Alias;
+
+    [Fact]
+    public void TurnoCreado_TieneAliasTurnoCreado()
+    {
+        var options = CrearOpcionesConEventosDeProgramacionRegistrados();
+
+        AliasDe<TurnoCreado>(options).Should().Be("turno_creado");
+    }
+
+    [Fact]
+    public void ProgramacionTurnoSolicitada_TieneAliasProgramacionTurnoSolicitada()
+    {
+        var options = CrearOpcionesConEventosDeProgramacionRegistrados();
+
+        AliasDe<ProgramacionTurnoSolicitada>(options).Should().Be("programacion_turno_solicitada");
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/Infraestructura/AliasEventosProgramacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/Infraestructura/AliasEventosProgramacionTests.cs
@@ -9,14 +9,8 @@
 //
 // No necesita Postgres: EventGraph.AllKnownEventTypes() es calculo puro en memoria sobre un
 // StoreOptions standalone (verificado por decompilacion: el constructor de StoreOptions no abre
-// conexion). Se alimenta de IdentidadEventosProgramacion.TiposPersistidos -- mismo stub que CA-1,
-// asi que en fase roja (lista vacia) este test tambien falla: AllKnownEventTypes() no encuentra
-// el tipo y el alias sale null.
-//
-// No se usan [Theory]/[InlineData] (MEF-ADR de convencion de tests de este agente: solo [Fact]):
-// un Fact por evento, en vez de la forma parametrizada que sugiere el issue.
+// conexion), asi que el alias se interroga sin contenedor DI ni base de datos.
 
-using System.Linq;
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.Programacion.DomainEvents;
 using Marten;

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/Infraestructura/AssertsIdentidadEventos.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/Infraestructura/AssertsIdentidadEventos.cs
@@ -1,0 +1,23 @@
+using System.Linq;
+using AwesomeAssertions;
+using Marten;
+
+namespace Bitakora.ControlAsistencia.Programacion.Tests.Infraestructura;
+
+/// <summary>
+/// Issue #277 CA-4: detecta un evento persistido que quedo fuera del registro explicito de
+/// IdentidadEventos{Dominio}.TiposPersistidos. Sin AddEventTypes, la primera rehidratacion de un
+/// stream con datos preexistentes cae al fallback por mt_dotnet_type y revienta con
+/// UnknownEventTypeException (issue #237 seccion "Consecuencia asumida"). Se invoca sobre el
+/// IDocumentStore resuelto del contenedor real de este dominio (ComposicionServiciosTests) --
+/// sin Postgres: AllKnownEventTypes() es calculo en memoria (Marten 7+ no abre conexion en el
+/// bootstrap del IHost).
+/// </summary>
+public static class AssertsIdentidadEventos
+{
+    public static void AssertEventosPersistidosRegistrados(
+        this IDocumentStore store, IReadOnlyList<Type> tiposEsperados) =>
+        store.Options.Events.AllKnownEventTypes()
+            .Select(evento => evento.EventType)
+            .Should().Contain(tiposEsperados);
+}

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/Infraestructura/AssertsIdentidadEventos.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/Infraestructura/AssertsIdentidadEventos.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using AwesomeAssertions;
 using Marten;
 
@@ -20,4 +19,19 @@ public static class AssertsIdentidadEventos
         store.Options.Events.AllKnownEventTypes()
             .Select(evento => evento.EventType)
             .Should().Contain(tiposEsperados);
+
+    /// <summary>
+    /// Issue #277 CA-5/CA-7/CA-8: congela el alias -- la columna "type" de mt_events, la unica
+    /// identidad que Marten consulta antes del fallback -- sobre el store que realmente compuso el
+    /// contenedor. AliasEventos{Dominio}Tests ya lo congela sobre un StoreOptions standalone, pero
+    /// ahi no vive el wiring: un MapEventType o un EventNamingStyle introducidos en
+    /// ComposicionServicios cambiarian la identidad de eventos ya persistidos sin poner rojo ningun
+    /// otro test.
+    /// </summary>
+    public static void AssertAliasDeEventosPersistidos(
+        this IDocumentStore store, IReadOnlyDictionary<Type, string> aliasEsperados) =>
+        store.Options.Events.AllKnownEventTypes()
+            .Where(evento => aliasEsperados.ContainsKey(evento.EventType))
+            .ToDictionary(evento => evento.EventType, evento => evento.Alias)
+            .Should().Equal(aliasEsperados);
 }

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/Infraestructura/ComposicionServiciosTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/Infraestructura/ComposicionServiciosTests.cs
@@ -114,11 +114,10 @@ public class ComposicionServiciosTests
     // (columna "type" de mt_events). Este guardrail detecta el olvido sobre el store real que
     // compone el contenedor (mismo store que ya usan las guardas de arriba), sin Postgres.
     //
-    // Los tipos esperados se listan literalmente (oraculo independiente, MEF-ADR-0002): si se
-    // leyeran de IdentidadEventosProgramacion.TiposPersistidos, el guardrail quedaria acoplado al
-    // mismo artefacto que CA-1 ya verifica, y ademas AwesomeAssertions.Contain() lanza
-    // ArgumentException con una coleccion "esperada" vacia en vez de fallar semanticamente --
-    // el stub de fase roja (issue #277) deja esa lista vacia a proposito.
+    // Los tipos esperados se listan literalmente (oraculo independiente, MEF-ADR-0002): leerlos de
+    // IdentidadEventosProgramacion.TiposPersistidos acoplaria el guardrail al mismo artefacto que
+    // IdentidadEventosProgramacionTests ya verifica, y la asercion pasaria en verde aunque la lista
+    // quedara vacia.
     [Fact]
     public async Task AgregarServiciosProgramacion_RegistraLosTiposDeEventoPersistidos_CuandoElContenedorEstaCompuesto()
     {
@@ -128,5 +127,24 @@ public class ComposicionServiciosTests
         var store = scope.ServiceProvider.GetRequiredService<IDocumentStore>();
 
         store.AssertEventosPersistidosRegistrados([typeof(TurnoCreado), typeof(ProgramacionTurnoSolicitada)]);
+    }
+
+    // Issue #277 CA-5/CA-7/CA-8: registrar el tipo solo sirve si el alias sigue siendo el que las
+    // filas ya escritas llevan en su columna "type". AliasEventosProgramacionTests lo congela sobre
+    // un StoreOptions standalone; esta guarda lo congela sobre el store del contenedor, el unico
+    // lugar donde un MapEventType o un EventNamingStyle agregados al wiring podrian cambiarlo.
+    [Fact]
+    public async Task AgregarServiciosProgramacion_DerivaElAliasDeEventoDelNombreDeClase_CuandoElContenedorEstaCompuesto()
+    {
+        await using var provider = ComponerServiceProvider();
+        await using var scope = provider.CreateAsyncScope();
+
+        var store = scope.ServiceProvider.GetRequiredService<IDocumentStore>();
+
+        store.AssertAliasDeEventosPersistidos(new Dictionary<Type, string>
+        {
+            [typeof(TurnoCreado)] = "turno_creado",
+            [typeof(ProgramacionTurnoSolicitada)] = "programacion_turno_solicitada"
+        });
     }
 }

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/Infraestructura/ComposicionServiciosTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/Infraestructura/ComposicionServiciosTests.cs
@@ -107,4 +107,26 @@ public class ComposicionServiciosTests
         restaurado.Should().Be(original);
         restaurado.ToString().Should().Be(original.ToString());
     }
+
+    // Issue #277 CA-2/CA-4: el #237 movio los eventos persistidos a este ensamblado (namespace y
+    // assembly nuevos) sin registrar su tipo en el EventGraph. Toda lectura quedo dependiendo del
+    // fallback por mt_dotnet_type -- roto para el nuevo namespace -- en vez de resolver por alias
+    // (columna "type" de mt_events). Este guardrail detecta el olvido sobre el store real que
+    // compone el contenedor (mismo store que ya usan las guardas de arriba), sin Postgres.
+    //
+    // Los tipos esperados se listan literalmente (oraculo independiente, MEF-ADR-0002): si se
+    // leyeran de IdentidadEventosProgramacion.TiposPersistidos, el guardrail quedaria acoplado al
+    // mismo artefacto que CA-1 ya verifica, y ademas AwesomeAssertions.Contain() lanza
+    // ArgumentException con una coleccion "esperada" vacia en vez de fallar semanticamente --
+    // el stub de fase roja (issue #277) deja esa lista vacia a proposito.
+    [Fact]
+    public async Task AgregarServiciosProgramacion_RegistraLosTiposDeEventoPersistidos_CuandoElContenedorEstaCompuesto()
+    {
+        await using var provider = ComponerServiceProvider();
+        await using var scope = provider.CreateAsyncScope();
+
+        var store = scope.ServiceProvider.GetRequiredService<IDocumentStore>();
+
+        store.AssertEventosPersistidosRegistrados([typeof(TurnoCreado), typeof(ProgramacionTurnoSolicitada)]);
+    }
 }

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/Infraestructura/IdentidadEventosProgramacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/Infraestructura/IdentidadEventosProgramacionTests.cs
@@ -1,0 +1,23 @@
+// Issue #277 CA-1: IdentidadEventosProgramacion.TiposPersistidos debe listar exactamente los
+// tipos que se persisten en el event store de Programacion -- ni de mas (ningun evento de bus),
+// ni de menos (el olvido que este issue corrige). No usa el harness Given/When/Then: no hay
+// aggregate ni command handler involucrado, es un dato estatico que consume ComposicionServicios
+// (write-side) y ConfiguracionMartenProjectionsProgramacion (read-side).
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Programacion.DomainEvents;
+
+namespace Bitakora.ControlAsistencia.Programacion.Tests.Infraestructura;
+
+public class IdentidadEventosProgramacionTests
+{
+    [Fact]
+    public void TiposPersistidos_ContieneExactamenteLosDosEventosPersistidosDeProgramacion()
+    {
+        IdentidadEventosProgramacion.TiposPersistidos.Should().BeEquivalentTo(
+        [
+            typeof(TurnoCreado),
+            typeof(ProgramacionTurnoSolicitada)
+        ]);
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/Infraestructura/IdentidadEventosProgramacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/Infraestructura/IdentidadEventosProgramacionTests.cs
@@ -1,11 +1,13 @@
 // Issue #277 CA-1: IdentidadEventosProgramacion.TiposPersistidos debe listar exactamente los
 // tipos que se persisten en el event store de Programacion -- ni de mas (ningun evento de bus),
-// ni de menos (el olvido que este issue corrige). No usa el harness Given/When/Then: no hay
-// aggregate ni command handler involucrado, es un dato estatico que consume ComposicionServicios
-// (write-side) y ConfiguracionMartenProjectionsProgramacion (read-side).
+// ni de menos (el olvido que este issue corrige). No usa el harness Given/When/Then: se verifica un
+// dato estatico de configuracion -- el que consumen ComposicionServicios (write-side) y
+// ConfiguracionMartenProjectionsProgramacion (read-side) --, no el comportamiento de un handler.
 
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.Programacion.DomainEvents;
+using Bitakora.ControlAsistencia.Programacion.Entities;
+using Cosmos.EventSourcing.Abstractions;
 
 namespace Bitakora.ControlAsistencia.Programacion.Tests.Infraestructura;
 
@@ -20,4 +22,33 @@ public class IdentidadEventosProgramacionTests
             typeof(ProgramacionTurnoSolicitada)
         ]);
     }
+
+    // Oraculo derivado del write-side, complementario del literal de arriba: la asercion literal
+    // congela la lista de hoy, pero un evento persistido que se agregue manana solo la pone roja si
+    // alguien recuerda editar el test -- justo el olvido que el #237 dejo armado. Esta guarda no
+    // necesita ese recuerdo: enumera por reflexion los eventos que los aggregate roots del dominio
+    // aplican al rehidratar y exige que todos esten registrados.
+    [Fact]
+    public void TiposPersistidos_IncluyeTodoEventoQueAplicaUnAggregateRootDelDominio()
+    {
+        var eventosAplicados = EventosAplicadosPorLosAggregateRoots();
+
+        eventosAplicados.Should().NotBeEmpty();
+        IdentidadEventosProgramacion.TiposPersistidos.Should().Contain(eventosAplicados);
+    }
+
+    // Un aggregate root aplica un evento persistido con la firma convencional de Marten
+    // "public void Apply(TEvento)", y ese evento vive en el ensamblado DomainEvents del dominio
+    // (CA-ADR-0029). Los eventos que solo cruzan el bus llegan por un endpoint, no por un Apply,
+    // asi que quedan fuera por construccion.
+    private static IReadOnlyList<Type> EventosAplicadosPorLosAggregateRoots() =>
+        typeof(CatalogoTurnos).Assembly.GetTypes()
+            .Where(tipo => typeof(AggregateRoot).IsAssignableFrom(tipo))
+            .SelectMany(tipo => tipo.GetMethods())
+            .Where(metodo => metodo.Name == nameof(CatalogoTurnos.Apply)
+                             && metodo.GetParameters().Length == 1)
+            .Select(metodo => metodo.GetParameters()[0].ParameterType)
+            .Where(evento => evento.Assembly == typeof(TurnoCreado).Assembly)
+            .Distinct()
+            .ToList();
 }

--- a/tests/Bitakora.ControlAsistencia.Projections.Tests/ConfiguracionMartenProjectionsTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Projections.Tests/ConfiguracionMartenProjectionsTests.cs
@@ -1,4 +1,6 @@
 using AwesomeAssertions;
+using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
+using Bitakora.ControlAsistencia.Programacion.DomainEvents;
 using Bitakora.ControlAsistencia.Projections.Infraestructura;
 using Bitakora.ControlAsistencia.Projections.Tests.Infraestructura;
 using Microsoft.Extensions.DependencyInjection;
@@ -85,6 +87,23 @@ public class ConfiguracionMartenProjectionsTests
         provider.GetRequiredService<IProgramacionProjectionStore>().AssertStreamIdentityAsString();
     }
 
+    // Issue #277 CA-3/CA-4: defensa en profundidad read-side. El worker no esta expuesto hoy (sin
+    // proyecciones concretas), pero lo estara en cuanto las tenga -- este guardrail evita que ese
+    // dia el daemon lea streams preexistentes sin el tipo registrado en su propio EventGraph.
+    //
+    // Tipos esperados listados literalmente (oraculo independiente, MEF-ADR-0002): leerlos de
+    // IdentidadEventosProgramacion.TiposPersistidos acoplaria este guardrail al mismo artefacto
+    // que CA-1 ya verifica, y con la lista vacia del stub de fase roja (issue #277)
+    // AwesomeAssertions.Contain() lanza ArgumentException en vez de fallar semanticamente.
+    [Fact]
+    public void ConfigurarProgramacion_RegistraLosTiposDeEventoPersistidos()
+    {
+        using var provider = ProviderDeProgramacion();
+
+        provider.GetRequiredService<IProgramacionProjectionStore>()
+            .AssertEventosPersistidosRegistrados([typeof(TurnoCreado), typeof(ProgramacionTurnoSolicitada)]);
+    }
+
     // --- ControlHoras (CA-2, CA-3, CA-6, CA-7) ---
 
     [Fact]
@@ -135,6 +154,24 @@ public class ConfiguracionMartenProjectionsTests
         using var provider = ProviderDeControlHoras();
 
         provider.GetRequiredService<IControlHorasProjectionStore>().AssertStreamIdentityAsString();
+    }
+
+    // Issue #277 CA-3/CA-4: defensa en profundidad read-side. El worker no esta expuesto hoy (sin
+    // proyecciones concretas), pero lo estara en cuanto las tenga -- este guardrail evita que ese
+    // dia el daemon lea streams preexistentes sin el tipo registrado en su propio EventGraph.
+    //
+    // Tipos esperados listados literalmente (oraculo independiente, MEF-ADR-0002): leerlos de
+    // IdentidadEventosControlHoras.TiposPersistidos acoplaria este guardrail al mismo artefacto
+    // que CA-1 ya verifica, y con la lista vacia del stub de fase roja (issue #277)
+    // AwesomeAssertions.Contain() lanza ArgumentException en vez de fallar semanticamente.
+    [Fact]
+    public void ConfigurarControlHoras_RegistraLosTiposDeEventoPersistidos()
+    {
+        using var provider = ProviderDeControlHoras();
+
+        provider.GetRequiredService<IControlHorasProjectionStore>()
+            .AssertEventosPersistidosRegistrados(
+                [typeof(MarcacionRegistrada), typeof(MarcacionAdicionada), typeof(TurnoDiarioAsignado)]);
     }
 
     // --- Seam de nivel BC (CA-4) ---

--- a/tests/Bitakora.ControlAsistencia.Projections.Tests/ConfiguracionMartenProjectionsTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Projections.Tests/ConfiguracionMartenProjectionsTests.cs
@@ -92,9 +92,8 @@ public class ConfiguracionMartenProjectionsTests
     // dia el daemon lea streams preexistentes sin el tipo registrado en su propio EventGraph.
     //
     // Tipos esperados listados literalmente (oraculo independiente, MEF-ADR-0002): leerlos de
-    // IdentidadEventosProgramacion.TiposPersistidos acoplaria este guardrail al mismo artefacto
-    // que CA-1 ya verifica, y con la lista vacia del stub de fase roja (issue #277)
-    // AwesomeAssertions.Contain() lanza ArgumentException en vez de fallar semanticamente.
+    // IdentidadEventosProgramacion.TiposPersistidos acoplaria este guardrail al mismo artefacto que
+    // IdentidadEventosProgramacionTests ya verifica en el write-side.
     [Fact]
     public void ConfigurarProgramacion_RegistraLosTiposDeEventoPersistidos()
     {
@@ -161,9 +160,8 @@ public class ConfiguracionMartenProjectionsTests
     // dia el daemon lea streams preexistentes sin el tipo registrado en su propio EventGraph.
     //
     // Tipos esperados listados literalmente (oraculo independiente, MEF-ADR-0002): leerlos de
-    // IdentidadEventosControlHoras.TiposPersistidos acoplaria este guardrail al mismo artefacto
-    // que CA-1 ya verifica, y con la lista vacia del stub de fase roja (issue #277)
-    // AwesomeAssertions.Contain() lanza ArgumentException en vez de fallar semanticamente.
+    // IdentidadEventosControlHoras.TiposPersistidos acoplaria este guardrail al mismo artefacto que
+    // IdentidadEventosControlHorasTests ya verifica en el write-side.
     [Fact]
     public void ConfigurarControlHoras_RegistraLosTiposDeEventoPersistidos()
     {

--- a/tests/Bitakora.ControlAsistencia.Projections.Tests/Infraestructura/AssertsIdentidadEventos.cs
+++ b/tests/Bitakora.ControlAsistencia.Projections.Tests/Infraestructura/AssertsIdentidadEventos.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using AwesomeAssertions;
 using Marten;
 

--- a/tests/Bitakora.ControlAsistencia.Projections.Tests/Infraestructura/AssertsIdentidadEventos.cs
+++ b/tests/Bitakora.ControlAsistencia.Projections.Tests/Infraestructura/AssertsIdentidadEventos.cs
@@ -1,0 +1,23 @@
+using System.Linq;
+using AwesomeAssertions;
+using Marten;
+
+namespace Bitakora.ControlAsistencia.Projections.Tests.Infraestructura;
+
+/// <summary>
+/// Issue #277 CA-4: hermano read-side del helper del mismo nombre en Programacion.Tests /
+/// ControlHoras.Tests. Detecta un evento persistido que quedo fuera del registro explicito de
+/// IdentidadEventos{Dominio}.TiposPersistidos en el named store del worker de proyecciones. Sin
+/// AddEventTypes, la primera lectura de un stream con datos preexistentes cae al fallback por
+/// mt_dotnet_type y revienta con UnknownEventTypeException (issue #237 seccion "Consecuencia
+/// asumida"). No necesita Postgres: AllKnownEventTypes() es calculo en memoria, igual que el
+/// resto de guardas de AssertsProyecciones.
+/// </summary>
+public static class AssertsIdentidadEventos
+{
+    public static void AssertEventosPersistidosRegistrados(
+        this IDocumentStore store, IReadOnlyList<Type> tiposEsperados) =>
+        store.Options.Events.AllKnownEventTypes()
+            .Select(evento => evento.EventType)
+            .Should().Contain(tiposEsperados);
+}


### PR DESCRIPTION
## Resumen

Pipeline TDD completado:
- Fase roja: tests escritos con stubs
- Fase verde: implementación completa
- Fase refactor: revisión de calidad

## Decisiones del pipeline

<details>
<summary>Test Writer (fase roja) — 17m 18s</summary>

## ES Test Writer - Decisiones

### Naturaleza del issue

No hay ningun command handler ni aggregate nuevo. El issue #277 es configuracion del EventGraph
de Marten (registro explicito de tipos de evento persistidos) mas los guardrails de config-test
que ya usa este BC (mismo patron que `ComposicionServiciosTests` / `ConfiguracionMartenProjectionsTests`
de issues #221/#232/#268). Por eso ningun test usa el harness `CommandHandlerAsyncTest<T>`
(Given/When/Then): son tests de infraestructura con xUnit + AwesomeAssertions puro, igual que sus
precedentes en el repo.

### Tests creados

- `Programacion.Tests/Infraestructura/IdentidadEventosProgramacionTests.cs` (CA-1): 1 test
  - `TiposPersistidos_ContieneExactamenteLosDosEventosPersistidosDeProgramacion` - verifica que
    `IdentidadEventosProgramacion.TiposPersistidos` contiene exactamente `TurnoCreado` y
    `ProgramacionTurnoSolicitada` (ni de mas, ni de menos).
- `Programacion.Tests/Infraestructura/AliasEventosProgramacionTests.cs` (CA-5): 2 tests
  - `TurnoCreado_TieneAliasTurnoCreado`
  - `ProgramacionTurnoSolicitada_TieneAliasProgramacionTurnoSolicitada`
  - Ambos alimentan un `StoreOptions` standalone (sin Postgres, sin contenedor DI) con
    `IdentidadEventosProgramacion.TiposPersistidos` y leen el alias via
    `EventGraph.AllKnownEventTypes()` (publico en Marten 9.12, no `EventMappingFor`/`AllEvents`
    que son `internal`).
- `Programacion.Tests/Infraestructura/AssertsIdentidadEventos.cs`: helper
  `AssertEventosPersistidosRegistrados(this IDocumentStore, IReadOnlyList<Type>)` (CA-4, write-side).
- `Programacion.Tests/Infraestructura/ComposicionServiciosTests.cs`: +1 test
  - `AgregarServiciosProgramacion_RegistraLosTiposDeEventoPersistidos_CuandoElContenedorEstaCompuesto`
    (CA-2/CA-4) sobre el store real del contenedor.
- Gemelos exactos en `ControlHoras.Tests/Infraestructura/` (3 tipos: `MarcacionRegistrada`,
  `MarcacionAdicionada`, `TurnoDiarioAsignado`; aliases `marcacion_registrada`,
  `marcacion_adicionada`, `turno_diario_asignado`).
- `Projections.Tests/Infraestructura/AssertsIdentidadEventos.cs`: mismo helper, read-side.
- `Projections.Tests/ConfiguracionMartenProjectionsTests.cs`: +2 tests (CA-3/CA-4)
  - `ConfigurarProgramacion_RegistraLosTiposDeEventoPersistidos`
  - `ConfigurarControlHoras_RegistraLosTiposDeEventoPersistidos`

Total: 14 tests nuevos (2 CA-1, 5 CA-5, 4 CA-2/CA-3/CA-4 sobre store real, mas 3 archivos helper
sin `[Fact]` propios).

### Estructura elegida

- Una clase de test por responsabilidad (`IdentidadEventos*Tests` para CA-1, `AliasEventos*Tests`
  para CA-5), en vez de mezclar ambos CAs en un archivo. `AssertsIdentidadEventos` vive aparte,
  igual que `AssertsProyecciones` ya vive aparte de `ConfiguracionMartenProjectionsTests`.
- El guardrail CA-4 se duplica literalmente (mismo nombre, mismo cuerpo) en los tres proyectos de
  test (`Programacion.Tests`, `ControlHoras.Tests`, `Projections.Tests`) porque esos proyectos no
  se referencian entre si -- mismo patron que ya usa el repo para `ComposicionServiciosTests`
  (duplicado con variaciones entre Programacion y ControlHoras).

### Investigacion tecnica (Marten 9.12 / JasperFx.Events 2.18.1, via decompilacion)

- `EventGraph.AllEvents()` es **internal** (no compila desde el ensamblado de test); el issue lo
  sugeria pero no es alcanzable. Se uso `IReadOnlyEventStoreOptions.AllKnownEventTypes()` (publico,
  parte de `IDocumentStore.Options.Events`), que retorna `IReadOnlyList<IEventType>`.
- `IEventType` expone `EventType` (Type) y `Alias` (string) -- no `DocumentType` como sugeria el
  issue (ese miembro no existe en la superficie publica de Marten 9.12).
- `EventGraph.AllKnownEventTypes()` es calculo puro en memoria (`_events.OfType<IEventType>()`),
  confirmado por decompilacion: ningun test de este issue necesita Postgres, ni siquiera los de
  alias (que ni siquiera pasan por un contenedor DI, solo `new StoreOptions()`).
- Confirmado el alias que deriva Marten para los 5 eventos (`ToTableAlias()` = SplitPascalCase +
  lower + "_"): `turno_creado`, `programacion_turno_solicitada`, `marcacion_registrada`,
  `marcacion_adicionada`, `turno_diario_asignado`. `ClassicTypeName` (default) y `SmarterTypeName`
  resuelven identico para tipos top-level no genericos como estos 5 -- coincide con la nota del
  issue sobre #268.

### Stubs creados

- `Programacion.DomainEvents/IdentidadEventosProgramacion.cs`: `TiposPersistidos` con lista
  **vacia a proposito** (fase roja). Sin datos reales para no adelantar la implementacion.
- `ControlHoras.DomainEvents/IdentidadEventosControlHoras.cs`: idem, 3 tipos pendientes.
- No se toco `ComposicionServicios.cs` ni `ConfiguracionMartenProjections{Dominio}.cs`: la linea
  `Events.AddEventTypes(...)` es la implementacion real que corresponde al implementer.

### Decisiones de diseno

1. **Oraculo independiente en los guardrails CA-2/CA-3/CA-4 (regla absoluta 20 / MEF-ADR-0002).**
   Los tests sobre el store real (`ComposicionServiciosTests`, `ConfiguracionMartenProjectionsTests`)
   usan `[typeof(TurnoCreado), typeof(ProgramacionTurnoSolicitada)]` **literal**, no
   `IdentidadEventosProgramacion.TiposPersistidos`. Motivo doble:
   - Evita acoplar el guardrail al mismo artefacto que CA-1 ya verifica por separado.
   - `AwesomeAssertions.Collections.GenericCollectionAssertions.Contain(IEnumerable<T> expected)`
     lanza `ArgumentException("Cannot verify containment against an empty collection")` cuando
     `expected` esta vacio (verificado por decompilacion) -- si hubiera alimentado el helper con
     el stub vacio de `TiposPersistidos`, el test habria fallado por una razon accidental
     (coleccion esperada vacia) en vez de la razon real (tipos no registrados en el EventGraph).
   Los tests de alias (CA-5) SI usan `IdentidadEventosProgramacion.TiposPersistidos` para alimentar
   `AddEventTypes`, porque ahi la asercion es `Should().Be(alias)` (no `Contain`): con la lista
   vacia, `AllKnownEventTypes()` no encuentra el tipo, el alias sale `null`, y `null.Should().Be("turno_creado")`
   falla limpiamente -- sin el problema de coleccion vacia de `Contain`.

2. **[Fact] en vez de [Theory]/[InlineData] para CA-5 (regla absoluta de este agente).** El issue
   proponia un `[Theory]` parametrizado con `[InlineData(typeof(...), "alias")]`. Se desviò a un
   `[Fact]` por evento (2 en Programacion, 3 en ControlHoras). Documentado como desviacion abajo.

3. **No se creo un archivo de test para el ensamblado `DomainEvents`** (no existe un proyecto
   `Programacion.DomainEvents.Tests`). Los tests de `IdentidadEventos{Dominio}` viven en
   `{Dominio}.Tests/Infraestructura/`, agrupados junto a `ComposicionServiciosTests` que es su
   consumidor real -- mismo criterio que ya aplica el repo para `ConfiguracionSerializacion{Dominio}`
   (tampoco tiene test propio; se verifica indirectamente via `ComposicionServiciosTests`).

4. **No se escribio ningun test para CA-7/CA-8/CA-9** (no usar `MapEventType`, no alterar
   `EventNamingStyle`, no purgar streams, no registrar el nombre calificado antiguo). Son
   restricciones negativas sobre decisiones de implementacion que no producen una superficie
   observable estable para un test unitario (verificar "no se llamo a X" requiere instrumentar el
   propio `ComposicionServicios.cs`, que no existe hoy). Quedan para verificacion por inspeccion
   de codigo (reviewer), consistente con como el propio issue las redacta (como restricciones de
   diseno, no como criterios con guardrail propio como CA-4/CA-5).

### Cobertura de criterios

| Criterio de aceptacion | Test(s) |
|---|---|
| CA-1 | `IdentidadEventosProgramacionTests.TiposPersistidos_...`, `IdentidadEventosControlHorasTests.TiposPersistidos_...` |
| CA-2 | `ComposicionServiciosTests.AgregarServiciosProgramacion_RegistraLosTiposDeEventoPersistidos_...` (Programacion.Tests), `AgregarServiciosControlHoras_RegistraLosTiposDeEventoPersistidos_...` (ControlHoras.Tests) |
| CA-3 | `ConfiguracionMartenProjectionsTests.ConfigurarProgramacion_RegistraLosTiposDeEventoPersistidos`, `ConfigurarControlHoras_RegistraLosTiposDeEventoPersistidos` |
| CA-4 (guardrail existe y corre en ambos lados) | Los 4 tests de CA-2/CA-3 arriba, mas el helper `AssertEventosPersistidosRegistrados` duplicado en los 3 proyectos |
| CA-5 | `AliasEventosProgramacionTests` (2 Facts), `AliasEventosControlHorasTests` (3 Facts) |
| CA-6 (build sin warnings nuevos) | Verificado con `dotnet build` -- 0 errores, warnings preexistentes (NU1902, CS0414) sin cambios |
| CA-7, CA-8, CA-9 | Sin test dedicado -- restricciones de diseno verificables por inspeccion (ver Decisiones de diseno #4) |
| CA-10, CA-11, CA-12 | Fuera de alcance de test-writer (deploy, dead letters, ADR) |

### Desviaciones del plan del planner

| Sugerencia del issue | Desviacion aplicada | Razon tecnica | Consecuencia |
|---|---|---|---|
| CA-5: `[Theory]`/`[InlineData(typeof(...), "alias")]` | `[Fact]` por evento (5 en total) | Regla absoluta de este agente: solo `[Fact]`, nunca `[Theory]`/`[InlineData]` | Mismo criterio cubierto, 5 metodos de test en vez de 1 parametrizado |
| Guardrail CA-4: `store.Options.Events.AllEvents().Select(e => e.DocumentType)` | `store.Options.Events.AllKnownEventTypes().Select(e => e.EventType)` | `AllEvents()` es `internal` en `EventGraph` (Marten 9.12) y no compila desde el ensamblado de test; `IEventType` no tiene `DocumentType`, tiene `EventType`. Verificado por decompilacion (ilspycmd) contra Marten 9.12.0 + JasperFx.Events 2.18.1 | Mismo comportamiento observable (lista de tipos conocidos por el EventGraph), API realmente publica y compilable |
| Guardrail CA-4 alimentado con `IdentidadEventos{Dominio}.TiposPersistidos` | Alimentado con tipos literales (`typeof(...)`) | Oraculo independiente (regla absoluta 20): evita acoplar el guardrail al mismo stub que CA-1 verifica, y evita el `ArgumentException` que `AwesomeAssertions.Contain()` lanza con una coleccion "esperada" vacia (el stub de fase roja) | El guardrail falla por la razon correcta (tipos ausentes del EventGraph), no por un efecto colateral de la lista vacia |

</details>

<details>
<summary>Implementer (fase verde) — 4m 52s</summary>

## ES Implementer - Decisiones

### Enfoque de implementacion

El issue #277 llegaba con los tres stubs y los cinco archivos de test ya escritos por el
test-writer, con lista vacia en `IdentidadEventos{Dominio}.TiposPersistidos`. El trabajo se redujo
a:

1. Completar `IdentidadEventosProgramacion.TiposPersistidos` con `TurnoCreado` y
   `ProgramacionTurnoSolicitada` (CA-1).
2. Completar `IdentidadEventosControlHoras.TiposPersistidos` con `MarcacionRegistrada`,
   `MarcacionAdicionada` y `TurnoDiarioAsignado` (CA-1).
3. Encadenar `options.Events.AddEventTypes(Identidad{Dominio}.TiposPersistidos)` dentro del bloque
   `services.ConfigureMarten(options => { ... })` que ya existia en el `ComposicionServicios` de
   cada Function App -- write-side (CA-2).
4. Encadenar la misma llamada dentro del `opts =>` de `AddMartenStore<I{Dominio}ProjectionStore>`
   en `ConfiguracionMartenProjections{Dominio}.cs` del worker -- read-side, defensa en profundidad
   (CA-3).

No se toco ningun archivo de test. No se agrego infraestructura Terraform: este issue no publica
ningun evento nuevo, solo registra tipos ya existentes en el EventGraph de Marten -- no aplica la
seccion "Infraestructura (topics y subscriptions)".

### Decisiones de diseno

- Se elimino de los dos archivos `IdentidadEventos*.cs` el parrafo de comentario "STUB de fase
  roja" que el test-writer dejo documentando la lista vacia transitoria: ya no aplicaba una vez
  completada la lista y hubiera quedado como ruido/desinformacion en el codigo de produccion final.
  El resto de los comentarios explicativos (criterio de inclusion, por que no declara alias, por
  que no duplica `ConfiguracionSerializacion{Dominio}`) se conservo intacto, es informacion de
  produccion valida.
- La llamada a `AddEventTypes` se coloco como primera linea dentro de cada `ConfigureMarten`/`opts`,
  antes del bloque de configuracion del resolver de serializacion custom -- mismo orden que muestra
  el issue en su seccion "Write-side". No cambia el comportamiento (son configuraciones
  independientes), solo sigue la sugerencia literal del planner/issue.
- No se creo ninguna abstraccion nueva: la tarea es enteramente aditiva sobre archivos ya existentes
  (dos stubs + cuatro archivos de composicion de servicios/proyecciones).

### ADRs consultados

- CA-ADR-0029 (ensamblados de eventos por rol): confirma que `{Dominio}.DomainEvents` es el lugar
  correcto para `IdentidadEventos{Dominio}` (decision #4, mismo patron que
  `ConfiguracionSerializacion{Dominio}`) y que el criterio de inclusion ("se persiste") es
  exactamente el que aplica la lista de identidad.
- MEF-ADR-0012 (encapsulamiento y frontera de serializacion): no aplico cambios de modelado; se
  verifico que la lista de identidad no duplica ni reemplaza `ConfigurarSerializacion`, son
  preocupaciones distintas tal como exige el issue.
- MEF-ADR-0034 seccion 6 (config-test del worker, guardrail hermano de MEF-ADR-0029): los tests
  de `ConfiguracionMartenProjectionsTests`/`AssertsIdentidadEventos` ya seguian ese patron; no se
  requirio tocar el config-test, solo la produccion que esos tests ejercitan.
- MEF-ADR-0029 (test de composicion del contenedor): `ComposicionServiciosTests` de ambos dominios
  ya invocaba `AgregarServicios{Dominio}` real; la nueva linea de `AddEventTypes` quedo cubierta sin
  cambios en el test.
- MEF-ADR-0005 (naming/versionado de eventos): confirmado que no cubre este caso (identidad en el
  event store), tal como aclara el issue; no se aplico ninguna regla de esa ADR aqui.

### Desviaciones de ADRs

Ninguna desviacion -- todos los ADRs aplicados al pie de la letra.

### Precedentes consultados

- `ComposicionServicios.cs` (write-side de ambos dominios, patron ya alineado con MEF-ADR-0029):
  se replico el mismo bloque `ConfigureMarten` existente, solo agregando la linea de
  `AddEventTypes`.
- `ConfiguracionMartenProjections{Dominio}.cs` (read-side, patron ya alineado con MEF-ADR-0034
  seccion 6): se replico el mismo `opts =>` existente, agregando la linea equivalente.
- Ambos precedentes ya cumplian los ADRs aplicables; no se detecto ninguna violacion que reportar.

### Infraestructura modificada

Ninguna. Este issue no publica eventos nuevos ni cambia topics/subscriptions: solo registra tipos
de evento ya publicados/persistidos en el `EventGraph` de Marten (write-side y read-side). No aplica
ningun cambio a `infra/environments/dev/main.tf`.

### Complejidad encontrada

Ninguna: los cuatro puntos de enganche (dos `ComposicionServicios.cs`, dos
`ConfiguracionMartenProjections{Dominio}.cs`) ya estaban identificados por el issue con su forma
exacta, y los tests del test-writer ya apuntaban precisamente a esos archivos. `dotnet build` y
`dotnet test` pasaron en el primer intento tras completar las cuatro ediciones.

Nota para seguimiento administrativo (no bloqueante, no tocado por este agente): **CA-12** del issue
pide que el ADR local quede alineado (enmendar CA-ADR-0029 o crear un ADR nuevo que fije la
identidad del evento en el event store). Esa decision no esta cubierta por ningun test unitario y
es una decision de arquitectura documental -- queda fuera del alcance de "escribir codigo de
produccion que haga pasar los tests existentes" de este agente. Se documenta aqui para que el
reviewer o el planner la resuelvan explicitamente antes de cerrar el issue.

Tambien quedan fuera de alcance de este agente (requieren entorno desplegado, no verificables con
`dotnet test`): **CA-10** (ejercitar el write-side en dev tras el despliegue y confirmar ausencia de
`UnknownEventTypeException` en App Insights) y **CA-11** (reprocesar dead letters si las hubiera).
Ambos son criterios de aceptacion legitimos del issue, pero pertenecen a la fase de
despliegue/operacion, no a la fase verde del pipeline TDD.

### Resultado

- Tests pasando: 499/499 (8 omitidos por diseno -- smoke tests que requieren Postgres/ServiceBus
  reales, sin cambios respecto al estado previo a este issue).
- `dotnet build`: correcto, sin warnings nuevos (diff de warnings antes/despues del cambio: vacio).

</details>
<details>
<summary>Reviewer (fase refactor) — 16m 15s</summary>

## ES Reviewer - Revision

### Evaluacion general
- Calidad: **buena**. El diff de las fases roja y verde llegó correcto y alineado con los ADRs; los
  cambios que apliqué son de limpieza, de cobertura de dos CAs sin guardrail y de la enmienda
  documental que el implementer escaló explícitamente (CA-12).
- Cambios realizados: **si** (commit `bec1ca2`).
- Suite: **511 tests, 0 errores, 503 verdes, 8 omitidos** (los 8 son smoke tests que requieren
  Postgres/ServiceBus reales, sin cambio respecto al baseline). `dotnet build`: 0 errores, 4
  advertencias NU1902 preexistentes (OpenTelemetry.Api).

### Cumplimiento de ADRs aplicables

| ADR | Cumplimiento | Observacion |
|---|---|---|
| CA-ADR-0029: ensamblados de eventos por rol | **ok** (y enmendado por CA-12) | `IdentidadEventos{Dominio}` vive en el `DomainEvents` de su dominio, hermana de `ConfiguracionSerializacion{Dominio}` -- exactamente el patrón de la decisión #4 (una sola fuente de la lista, invocada por write-side y read-side). El criterio de inclusión "se persiste" se respeta: los 5 tipos son los que aplican los 4 aggregate roots; ningún evento de bus entró. `MarcacionRegistrada` entra por ser persistida, no por ser `IPrivateEvent`, consistente con la deuda que el propio ADR ya documenta (issue #270). |
| MEF-ADR-0012: encapsulamiento y frontera de serialización | **ok** | El diff no toca modelado de objetos ni serialización. Recorrí los 7 antipatrones del checklist: ninguna propiedad pública nueva en un VO, ninguna clase estática que opere sobre datos crudos de un VO (`IdentidadEventos{Dominio}` expone una lista de `Type` de configuración, no estado de dominio), ningún getter para test, ningún `InternalsVisibleTo`, ningún `[JsonConstructor]`, ningún `record` con colección de igualdad, ningún payload de evento con marker de bus modificado. La lista de identidad **no** duplica la de serialización: son conjuntos que se solapan sin contenerse, como exige el issue. |
| MEF-ADR-0034 sección 6: config-test del worker | **ok** | Las dos guardas read-side entran por la puerta del config-test existente (`ConfiguracionMartenProjectionsTests` + helpers de asserts en `Infraestructura/`), sin Postgres, sobre el named store resuelto del contenedor -- misma forma que `AssertsProyecciones`. La línea de producción quedó dentro del `opts =>` de `AddMartenStore<I{Dominio}ProjectionStore>`, junto a las réplicas de configuración del write-side que ya vivían ahí. |
| MEF-ADR-0029: test de composición del contenedor | **ok** | Las guardas write-side se apoyan en `ComposicionServiciosTests`, que compone el contenedor real con connection strings dummy y resuelve el `IDocumentStore` -- fuente única de wiring compartida con `Program.cs`, sin duplicar configuración en el test. |
| MEF-ADR-0002: estrategia de testing ES | **ok** | Oráculo independiente respetado en todos los guardrails (aserciones contra literales, no contra la lista bajo prueba). Verifiqué además por **mutación** que no son vacuos (ver "Tests agregados"). |
| MEF-ADR-0016: naming de tests | **ok** | Todos los tests nuevos siguen `<Sujeto>_<LoQuePasa>[_Cuando<Condicion>]`, en español y PascalCase. |
| MEF-ADR-0005: naming y versionado de eventos | **n/a, correctamente** | El issue ya establece que no cubre la identidad del tipo en el event store; ni el implementer ni yo aplicamos ninguna de sus reglas aquí. Ese vacío del marco lo atiende el issue hermano del harness (#474). |
| MEF-ADR-0018: evolución y reuso | **ok** | Ver "Críticas y hallazgos", hallazgo #4: su heurística de *autoridad de extracción* es la razón por la que **no** consolidé el helper triplicado. |

El issue traía la sección `## ADRs aplicables` completa y bien elegida. Nada que escalar al planner por
ese lado.

### Desviaciones de ADRs

**Desviaciones declaradas por el implementer**: ninguna. Su resumen registra "Ninguna desviación --
todos los ADRs aplicados al pie de la letra", y lo confirmé archivo por archivo contra el diff.

**Desviaciones detectadas por el reviewer (NO declaradas)**: ninguna.

**Ninguna desviación -- todos los ADRs aplicables se cumplen.**

Nota sobre las desviaciones que el *test-writer* declaró frente al **plan del planner** (no frente a
un ADR), las tres legítimas y confirmadas:

| Sugerencia del issue | Desviación | Evaluación del reviewer |
|---|---|---|
| `[Theory]`/`[InlineData]` para CA-5 | un `[Fact]` por evento | **aceptable**: es regla del pipeline. Retiré del código el comentario que la justificaba citando "un MEF-ADR de este agente" sin número -- el código no necesita justificar la ausencia de `[Theory]`. |
| `store.Options.Events.AllEvents()` / `.DocumentType` | `AllKnownEventTypes()` / `.EventType` | **aceptable y necesaria**: `AllEvents()` es `internal` en `EventGraph` y `IEventType` no expone `DocumentType` (Marten 9.12). Verifiqué que la firma usada compila y que `AllKnownEventTypes()` incluye tipos internos del propio Marten (`JasperFx.Events.Archived` aparece en el store), lo que confirma que `Contain` -- y no equivalencia estricta -- es la aserción correcta. |
| Guardrail alimentado desde `TiposPersistidos` | tipos literales | **aceptable**: es el oráculo independiente de MEF-ADR-0002. Corregí la justificación escrita, que se apoyaba en el `ArgumentException` de `Contain()` con colección vacía -- un argumento que caducó al llenarse la lista. |

### Precedentes consultados por el implementer

| Precedente | ADR aplicable | Veredicto |
|---|---|---|
| `ComposicionServicios.cs` (write-side, ambos dominios) | MEF-ADR-0029 | **alineado**. El bloque `ConfigureMarten` ya existía y la línea nueva se encadenó dentro; el test de composición lo ejercita sobre el store real. |
| `ConfiguracionMartenProjections{Dominio}.cs` (read-side) | MEF-ADR-0034 §6 | **alineado**. Mismo `opts =>`, misma cobertura por config-test. |
| `ConfiguracionSerializacion{Dominio}.cs` (hermana de la clase nueva) | CA-ADR-0029 §4 | **alineado**. La clase nueva copia su ubicación, su estilo de comentario y su rol de fuente única. |

Ningún precedente citado viola su ADR. No hay bug de precedente que reportar en este PR.

### Convenciones del pipeline (no ADRs)

| Convencion | Estado | Observacion |
|---|---|---|
| Cada test con `Then()` + `And<>()` | **n/a** | No hay ningún command handler ni aggregate nuevo: los 18 tests del issue son de configuración (categoría MEF-ADR-0029 / MEF-ADR-0034 §6), donde el DSL Given/When/Then no aplica. Los ADRs son explícitos en que son categorías complementarias, no sustitutas. |
| Overloads correctos para stream IDs compuestos | **n/a** | Ningún test usa el harness de aggregates. |
| Fakes manuales (no NSubstitute) | **n/a** | Cero dependencias fakeadas; los tests resuelven del contenedor real o construyen `StoreOptions` directo. |
| Feature folders (producción y tests) | **ok** | Producción: `IdentidadEventos{Dominio}.cs` en la raíz del ensamblado de eventos, junto a su hermana de serialización. Tests: `{Dominio}.Tests/Infraestructura/`, espejo de `src/.../Infraestructura/`, un archivo por responsabilidad (CA-1 y CA-5 separados, helper de asserts aparte). |
| Smoke tests: SkipWhen, secrets, cobertura | **n/a** | El diff no incluye smoke tests y no aporta efectos secundarios nuevos (ni topics, ni publicaciones, ni persistencia nueva): solo registra en el `EventGraph` tipos ya persistidos. Ninguna suscripción `smoke-tests` que dar de alta, ninguna infra que tocar. Ver "Fuera del alcance del pipeline" para CA-10/CA-11. |
| Proyecciones read-side: partial, inmutabilidad, read APIs, naming | **n/a** | El diff toca `ConfiguracionMartenProjections{Dominio}` (composición pura, excluida del coverage gate por MEF-ADR-0034 §9), sin read models, proyecciones ni Functions GET nuevas. No hay `partial`, `Create`/`Apply` ni `QuerySession` en el diff. |
| Tests via ToString/comportamiento | **n/a** | No hay estado de dominio que verificar; el sujeto es configuración de Marten leída por su superficie pública de solo lectura (`IDocumentStore.Options`, sin downcast). |
| Sin números mágicos | **ok** | Los literales de alias (`"turno_creado"`, ...) no son números mágicos: son el oráculo del test, y su presencia literal es justamente el valor de CA-5. |
| Condiciones en positivo (guardas if/else afirmativas) | **n/a** | El diff no introduce ningún condicional. |
| Sin `─` (U+2500) en `.cs` | **ok** | Verificado sobre todos los `.cs` del diff. |

### Elegancia del codigo

El código de producción ya era elegante y no lo toqué: cuatro líneas de enganche y dos clases de
ocho líneas, cada una con el comentario que explica *por qué* (que el registro no declara alias, y
por qué no duplica la lista de serialización) sin repetir *qué* hace el código. Consistente con el
estilo del repo, que prefija el comentario con el número de issue.

En los tests encontré y corregí cuatro cosas:

1. **Imports redundantes**: `using System.Linq;` en los 5 archivos nuevos, con `ImplicitUsings`
   habilitado en los 15 proyectos. Eran los únicos del repo (fuera de código generado). El baseline
   de la fase verde tenía 14 warnings IDE0005; ahora 9, todos preexistentes en archivos ajenos al
   issue.
2. **Comentarios que ya no describían el repo**: cuatro bloques justificaban decisiones apelando al
   "stub de fase roja (issue #277) deja esa lista vacía a propósito". Eso caducó cuando el
   implementer llenó la lista; leerlo hoy desinforma. Conservé la razón que perdura (oráculo
   independiente, MEF-ADR-0002) y quité el andamio del proceso -- misma limpieza que el implementer
   ya había hecho del lado de producción.
3. **Referencia a un ADR sin número** ("MEF-ADR de convención de tests de este agente"): un
   comentario no verificable. La regla es del pipeline, no de un ADR, así que eliminé el párrafo en
   vez de citar mal.
4. **Un error factual**: el encabezado de `IdentidadEventosControlHorasTests` afirmaba que
   `MarcacionRegistrada` se persiste "en el stream de `ControlDiarioAggregateRoot`". La aplica
   `RegistroDeMarcacionAggregateRoot` (`ControlDiario` aplica `MarcacionAdicionada` y
   `TurnoDiarioAsignado`). Corregido.

Sobre eficiencia y robustez: nada que señalar. Las consultas al `EventGraph` son LINQ de un paso
sobre listas de 2-3 elementos, la cadena de lectura es de solo lectura y sin downcast, y ningún test
abre conexión a Postgres.

### Criticas y hallazgos

1. **[mayor -- corregido] El guardrail de CA-4 no detectaba el olvido que el CA nombra.** El issue
   describe su guardrail como *"detecta el olvido: un evento persistido nuevo que nadie agregó a
   `TiposPersistidos`"*, pero tanto en el diseño del issue como en la implementación el oráculo es
   una **lista literal en el test**: un evento persistido nuevo que nadie agrega a la lista de
   producción **ni** al test deja los cuatro guardrails en verde. La detección dependía de que
   alguien recordara editar el test -- exactamente la clase de recordatorio que falló en el #237.
   Agregué una guarda derivada del write-side (ver "Tests agregados") que no necesita ese recuerdo.
2. **[mayor -- corregido] CA-5 congelaba el alias en el lugar equivocado; CA-7 y CA-8 no tenían
   guardrail.** Los tests de alias construyen un `new StoreOptions()` standalone, donde no vive el
   wiring: un `MapEventType` o un `EventNamingStyle` introducidos en `ComposicionServicios` -- las dos
   cosas que CA-7 y CA-8 proscriben -- cambiarían la identidad de eventos ya persistidos **sin poner
   rojo ningún test**. El test-writer dejó CA-7/CA-8 explícitamente "para verificación por inspección
   del reviewer"; en vez de solo inspeccionarlos (que también hice: cero ocurrencias de
   `MapEventType`/`EventNamingStyle` en `src/` y `tests/`), los convertí en guardrail permanente sobre
   el store del contenedor. Verificado por mutación: inyectar
   `MapEventType<TurnoCreado>("Bitakora.Contracts.TurnoCreado")` en el wiring pone rojo la guarda
   nueva y **deja verdes** los tests de alias standalone, que es la prueba del gap.
3. **[menor -- no corregido, deuda preexistente] 9 warnings IDE0005** en archivos de serialización
   anteriores al issue (`*SerializacionTests.cs`, `SolicitarProgramacionTurnoCommandHandlerTests.cs`).
   `dotnet format --verify-no-changes` sale con código 2 por ellos, tanto antes como después de este
   PR. No los toqué: quedan fuera del diff de la HU (regla de no refactorizar código no relacionado).
   Candidatos a un issue de limpieza propio.
4. **[cosmético -- no corregido a propósito] El helper `AssertsIdentidadEventos` está triplicado**
   (`Programacion.Tests`, `ControlHoras.Tests`, `Projections.Tests`), y en `Projections.Tests`
   convive con `AssertsProyecciones`, que MEF-ADR-0034 §6 designa como hogar de los helpers del
   config-test. Consolidar es tentador pero **no me corresponde originarlo**: MEF-ADR-0018 fija que
   *"el reviewer no debe pedir extracción si el implementer no la ofrece, salvo evidencia documentada
   de evolución conjunta"*, y aquí no hay tal evidencia -- además los tres proyectos de test no se
   referencian entre sí, así que la duplicación física es inevitable y ya está asumida en
   CA-ADR-0029 para `IgualdadTestBase` (4 copias). Lo dejo anotado para cuando exista un proyecto de
   utilidades de test compartido.
5. **[observación] Inconsistencia de orden entre lados**: en el write-side `AddEventTypes` va como
   primera línea del `ConfigureMarten`; en el read-side va como última del `opts =>`. Funcionalmente
   irrelevante (son configuraciones independientes) y cada lado sigue la forma que el issue mostró.
   No lo cambié.

### Refactorings aplicados

- **Limpieza de imports redundantes** en los 5 archivos nuevos (`using System.Linq`), alineando con
  `ImplicitUsings` del proyecto.
- **Condensación de 4 bloques de comentario** que apelaban al stub de fase roja, preservando la
  razón vigente (oráculo independiente) y eliminando el andamio de proceso; más el párrafo que citaba
  un ADR sin número.
- **Corrección factual** del aggregate que aplica `MarcacionRegistrada`.
- **Enmienda de CA-ADR-0029** (CA-12, ver abajo) e indexación del tema en `CLAUDE.md`.
- No renombré nada ni cambié ninguna API pública: la decisión del nombre `IdentidadEventos{Dominio}`
  / `TiposPersistidos` -- que el issue dejaba abierta -- me parece la correcta y ahora queda
  fundamentada en el ADR (el alias *es* la identidad; la clase es su registro).

### Cobertura de criterios de aceptacion

| Criterio | Estado | Test(s) |
|---|---|---|
| CA-1: existe `IdentidadEventos{Dominio}` con los 5 tipos repartidos y ningún evento de bus | **cubierto** | `IdentidadEventosProgramacionTests.TiposPersistidos_ContieneExactamenteLosDosEventosPersistidosDeProgramacion`, `IdentidadEventosControlHorasTests.TiposPersistidos_ContieneExactamenteLosTresEventosPersistidosDeControlHoras` |
| CA-2: `ComposicionServicios` de cada dominio invoca `AddEventTypes` | **cubierto** | `ComposicionServiciosTests.AgregarServicios{Programacion,ControlHoras}_RegistraLosTiposDeEventoPersistidos_CuandoElContenedorEstaCompuesto` (sobre el store real del contenedor) |
| CA-3: `ConfiguracionMartenProjections{Dominio}` invoca la misma lista | **cubierto** | `ConfiguracionMartenProjectionsTests.Configurar{Programacion,ControlHoras}_RegistraLosTiposDeEventoPersistidos` |
| CA-4: guardrail que detecta un evento persistido ausente de la lista, en ambos lados | **cubierto y reforzado** | Los 4 tests de CA-2/CA-3 (oráculo literal, ambos lados) **+ nuevos** `TiposPersistidos_IncluyeTodoEventoQueAplicaUnAggregateRootDelDominio` (x2), que derivan el oráculo de los `Apply(TEvento)` de los aggregate roots y por tanto se auto-mantienen |
| CA-5: guardrail que congela el alias de los 5 eventos contra literales, sin base de datos | **cubierto y reforzado** | `AliasEventosProgramacionTests` (2 `[Fact]`), `AliasEventosControlHorasTests` (3 `[Fact]`) sobre `StoreOptions` standalone **+ nuevos** `AgregarServicios{Dominio}_DerivaElAliasDeEventoDelNombreDeClase_CuandoElContenedorEstaCompuesto` (x2) sobre el store del contenedor |
| CA-6: `dotnet build` sin errores ni warnings nuevos; suite verde | **cubierto** | 511 tests / 0 errores / 503 verdes / 8 omitidos; build con 0 errores y solo las 4 NU1902 preexistentes; warnings IDE0005 **reducidos** de 14 a 9 |
| CA-7: no se introduce `MapEventType` ni se altera `EventNamingStyle` | **cubierto** | Inspección (cero ocurrencias en `src/` y `tests/`) **+ guardrail nuevo** de alias sobre el store real, validado por mutación |
| CA-8: no se registra ningún tipo con el nombre calificado antiguo | **cubierto** | Igual que CA-7: el guardrail de alias detecta el `MapEventType` al nombre viejo (verificado inyectándolo) |
| CA-9: no se purgan streams de ningún entorno | **cubierto** | Cero `DROP SCHEMA`/purga en `scripts/`, `.github/`, `infra/`; además la enmienda del ADR revierte la purga como estrategia |
| CA-10: tras el despliegue, ejercitar write-side en dev y confirmar ausencia de `UnknownEventTypeException` | **fuera del alcance del pipeline** | Requiere entorno desplegado + App Insights (`controlasistencias-dev-ai`, guardrails de CA-ADR-0019). El propio issue advierte que los smoke tests actuales crean streams nuevos, así que su verde no prueba la rehidratación de un stream preexistente: la verificación es manual/operativa |
| CA-11: reprocesar dead letters si quedaron | **fuera del alcance del pipeline** | Operación post-despliegue |
| CA-12: el ADR local queda alineado | **cubierto en esta fase** | El implementer lo escaló explícitamente. Enmendé **CA-ADR-0029** con la decisión #6 (ver abajo) en vez de crear un ADR nuevo |

**Sobre CA-12**: elegí enmendar CA-ADR-0029 y no abrir un ADR nuevo porque la deuda que este issue
paga está escrita literalmente en su sección "Negativas y deuda asumida", y porque la lista de
identidad replica el patrón de su decisión #4 -- un ADR aparte tendría que arrastrar todo ese
contexto para decir una sola cosa. La enmienda agrega:

- **Decisión #6**: el alias (derivado del nombre simple de la clase) es la identidad del evento
  persistido; el mapping debe existir antes de la primera lectura, así que cada `DomainEvents` aloja
  `IdentidadEventos{Dominio}.TiposPersistidos` y **todo** proceso que lea esos streams la registra con
  `Events.AddEventTypes(...)`. Con las tres proscripciones explícitas (nada de `MapEventType`, nada de
  alterar `EventNamingStyle`, nada de registrar el nombre calificado antiguo -- esta última con el
  motivo: invertiría la tolerancia de Marten al `mt_dotnet_type` obsoleto) y los dos guardrails que la
  sostienen.
- La primera viñeta de "Negativas y deuda asumida" queda **tachada y marcada como pagada**, con la
  historia real (la purga nunca se ejecutó, el código sí se desplegó, el defecto quedó armado) y la
  reversión de la purga como estrategia.
- Entrada nueva en "Control de cambios" y una fila nueva en el índice temático de `CLAUDE.md`, para
  que el tema "identidad del evento en el event store" tenga sede localizable -- hoy no la tenía, que
  es justo lo que CA-12 pedía resolver.

### Tests agregados

Cuatro tests nuevos, ambos pares verificados **por mutación** (no basta con que pasen: comprobé que
fallan por la razón correcta):

1. `TiposPersistidos_IncluyeTodoEventoQueAplicaUnAggregateRootDelDominio` en
   `IdentidadEventosProgramacionTests` e `IdentidadEventosControlHorasTests`. Enumera por reflexión
   los tipos que heredan de `AggregateRoot` en el ensamblado del dominio, toma el parámetro de sus
   métodos `public void Apply(TEvento)` -- la firma con la que Marten rehidrata -- filtra los que
   viven en el ensamblado `DomainEvents` y exige que todos estén en `TiposPersistidos`. Los eventos
   que solo cruzan el bus quedan fuera por construcción (llegan por un endpoint, no por un `Apply`).
   Incluye una aserción `NotBeEmpty()` que evita el falso verde si algún día se rompe la convención
   de nombre del método. **Mutación**: quitar `MarcacionAdicionada` de la lista de producción pone
   rojo esta guarda con el mensaje exacto (`could not find MarcacionAdicionada`), junto a los otros
   tres guardrails del dominio.
2. `AgregarServicios{Dominio}_DerivaElAliasDeEventoDelNombreDeClase_CuandoElContenedorEstaCompuesto`
   en los dos `ComposicionServiciosTests`, apoyados en un segundo método del helper
   (`AssertAliasDeEventosPersistidos`). Congelan el mapa tipo -> alias sobre el `IDocumentStore` que
   compone el contenedor real. **Mutación**: inyectar `MapEventType<TurnoCreado>("Bitakora.Contracts.TurnoCreado")`
   en `ComposicionServicios` pone rojo *solo* esta guarda (`differs at key ...TurnoCreado`), mientras
   `AliasEventosProgramacionTests` sigue verde -- la demostración de que el gap existía.

No agregué tests de contrato de igualdad ni de round-trip de serialización: el diff no introduce
`IEquatable<T>`, ni `ConfigurarSerializacion`, ni ningún evento con marker de bus (`IPrivateEvent` /
`IPublicEvent`), así que ninguna de esas tres puertas aplica en este issue.

</details>

## Cobertura

| Archivo | Cobertura | Umbral | Estado |
|---|---|---|---|
| IdentidadEventosControlHoras.cs | - | no evaluado | - |
| ComposicionServicios.cs | - | no evaluado | - |
| IdentidadEventosProgramacion.cs | - | no evaluado | - |
| ComposicionServicios.cs | - | no evaluado | - |
| ConfiguracionMartenProjectionsControlHoras.cs | - | no evaluado | - |
| ConfiguracionMartenProjectionsProgramacion.cs | - | no evaluado | - |
## Commits

bec1ca2 refactor(hu-277): guardrails auto-mantenidos de identidad de evento y enmienda de CA-ADR-0029
c5ae815 feat(hu-277): registrar tipos de evento persistidos en el EventGraph (fase verde)
8158230 test(hu-277): tests para registrar tipos de evento en el EventGraph (fase roja)

Closes #277