### PR TITLE
Proteger el evento de dominio MarcacionRegistrada con factory y ctor privado

### DIFF
--- a/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/Bitakora.ControlAsistencia.ControlHoras.DomainEvents.csproj
+++ b/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/Bitakora.ControlAsistencia.ControlHoras.DomainEvents.csproj
@@ -6,8 +6,9 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <!-- MarcacionRegistrada implementa IPrivateEvent (ver #270: su aplanamiento
-       y traslado a PrivateEvents queda pendiente). -->
+  <!-- Issue #270: MarcacionRegistrada ya no implementa IPrivateEvent: es el evento de dominio
+       persistido en el stream, no cruza el bus. El contrato de bus es RegistroDeMarcacionCreado
+       en PrivateEvents.ControlHoras. -->
   <ItemGroup>
     <PackageReference Include="Cosmos.EventDriven.Abstractions" Version="2.3.1" />
   </ItemGroup>
@@ -15,6 +16,12 @@
   <ItemGroup>
     <ProjectReference Include="..\Bitakora.ControlAsistencia.PublicEvents\Bitakora.ControlAsistencia.PublicEvents.csproj" />
     <ProjectReference Include="..\Bitakora.ControlAsistencia.PrivateEvents\Bitakora.ControlAsistencia.PrivateEvents.csproj" />
+  </ItemGroup>
+
+  <!-- Issue #275: MarcacionRegistrada.Mensajes es internal y los tests lo usan en sus asserts
+       (MEF-ADR-0009, patron TurnoCreado.Mensajes). -->
+  <ItemGroup>
+    <InternalsVisibleTo Include="Bitakora.ControlAsistencia.ControlHoras.Tests" />
   </ItemGroup>
 
 </Project>

--- a/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/MarcacionRegistrada.Mensajes.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/MarcacionRegistrada.Mensajes.cs
@@ -1,0 +1,19 @@
+using System.Resources;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
+
+// Issue #275, MEF-ADR-0009: mensajes de error de MarcacionRegistrada en archivo .resx separado,
+// patron TurnoCreado.Mensajes (Programacion.DomainEvents).
+// internal: accesible desde tests via InternalsVisibleTo en el .csproj.
+public sealed partial class MarcacionRegistrada
+{
+    private static readonly ResourceManager ResourceManager = new(
+        "Bitakora.ControlAsistencia.ControlHoras.DomainEvents.MarcacionRegistradaMensajes",
+        typeof(MarcacionRegistrada).Assembly);
+
+    internal static class Mensajes
+    {
+        public static string EmpleadoIdVacio =>
+            ResourceManager.GetString(nameof(EmpleadoIdVacio))!;
+    }
+}

--- a/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/MarcacionRegistrada.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/MarcacionRegistrada.cs
@@ -65,11 +65,19 @@ public sealed partial class MarcacionRegistrada
 
     // CA-1, CA-2, CA-3: unica via de construccion. Trunca los segundos al minuto (floor) y rechaza
     // EmpleadoId nulo, vacio o solo espacios en blanco.
-    // Stub de compilacion -- implementacion real pendiente (fase verde, fase roja del TDD).
     public static MarcacionRegistrada Crear(
         string empleadoId,
         DateTime timestampCrudo,
         string? tipoMarcacion,
-        string? dispositivoId) =>
-        throw new NotImplementedException();
+        string? dispositivoId)
+    {
+        if (string.IsNullOrWhiteSpace(empleadoId))
+            throw new ArgumentException(Mensajes.EmpleadoIdVacio, nameof(empleadoId));
+
+        return new MarcacionRegistrada(empleadoId, TruncarAlMinuto(timestampCrudo), tipoMarcacion, dispositivoId);
+    }
+
+    // CA-2: trunca (floor) el timestamp al minuto, descartando segundos y fracciones
+    private static DateTime TruncarAlMinuto(DateTime timestamp) =>
+        timestamp.AddTicks(-(timestamp.Ticks % TimeSpan.TicksPerMinute));
 }

--- a/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/MarcacionRegistrada.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/MarcacionRegistrada.cs
@@ -3,25 +3,24 @@ using System.Text.Json.Serialization.Metadata;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 
-// HU-105: Evento de dominio que registra una marcacion normalizada
-// El timestamp se trunca al minuto (floor) antes de emitir
-// CA-2: TimestampNormalizado = Timestamp truncado al minuto
-// CA-3: TipoMarcacion y DispositivoId son opcionales (nullable)
-// Issue #270 CA-3: se persiste en el stream de RegistroDeMarcacionAggregateRoot; ya NO cruza el bus
-// (deja de implementar IPrivateEvent). El contrato de bus es RegistroDeMarcacionCreado
+// HU-105: Evento de dominio que registra una marcacion ya normalizada. TipoMarcacion y
+// DispositivoId son opcionales (los emite el dispositivo, no nuestro sistema).
+// Issue #270: se persiste en el stream de RegistroDeMarcacionAggregateRoot y ya NO cruza el bus
+// (dejo de implementar IPrivateEvent). El contrato de bus es RegistroDeMarcacionCreado
 // (PrivateEvents.ControlHoras), empaquetado por RegistroDeMarcacionAggregateRoot.CrearRegistroDeMarcacionCreado().
 // Issue #275: protegido con factory Crear() y ctores privados (patron TurnoCreado, MEF-ADR-0012).
 // El evento nunca tuvo ctor privado -- #105 cito mal su propio patron de referencia; #270 saco al
 // evento del bus y con eso desaparecio la razon (el ServiceBusDeserializador del consumidor) por la
-// que no podia protegerse antes.
+// que no podia protegerse antes. Cerrado el ctor, ConfigurarSerializacion pasa de redundante a
+// necesario: es la unica via de reconstruccion, y solo existe dentro del event store (CA-ADR-0025).
 public sealed partial class MarcacionRegistrada
 {
-    public string EmpleadoId { get; private set; } = null!;
+    public string EmpleadoId { get; private set; }
     public DateTime TimestampNormalizado { get; private set; }
     public string? TipoMarcacion { get; private set; }
     public string? DispositivoId { get; private set; }
 
-    // CA-1: constructor real privado -- solo el factory Crear lo invoca
+    // Issue #275 CA-1: constructor real privado -- solo el factory Crear lo invoca
     private MarcacionRegistrada(
         string empleadoId,
         DateTime timestampNormalizado,
@@ -34,8 +33,9 @@ public sealed partial class MarcacionRegistrada
         DispositivoId = dispositivoId;
     }
 
-    // CA-1: constructor vacio privado, solo para Marten/serializacion (via ConfigurarSerializacion)
-    private MarcacionRegistrada() { }
+    // Issue #275 CA-1: constructor vacio privado, solo para Marten/STJ via ConfigurarSerializacion
+    // (que repuebla los backing fields por reflexion). El dominio nunca lo invoca.
+    private MarcacionRegistrada() => EmpleadoId = string.Empty;
 
     // Configuracion de serializacion STJ/Marten: permite deserializar con constructor privado
     // y propiedades con private set. Ver MEF-ADR-0012 y MarcacionRegistradaSerializacionTests.
@@ -63,8 +63,8 @@ public sealed partial class MarcacionRegistrada
         });
     }
 
-    // CA-1, CA-2, CA-3: unica via de construccion. Trunca los segundos al minuto (floor) y rechaza
-    // EmpleadoId nulo, vacio o solo espacios en blanco.
+    // Issue #275 CA-1/CA-2/CA-3: unica via de construccion. Trunca los segundos al minuto (floor) y
+    // rechaza EmpleadoId nulo, vacio o solo espacios en blanco.
     public static MarcacionRegistrada Crear(
         string empleadoId,
         DateTime timestampCrudo,
@@ -77,7 +77,7 @@ public sealed partial class MarcacionRegistrada
         return new MarcacionRegistrada(empleadoId, TruncarAlMinuto(timestampCrudo), tipoMarcacion, dispositivoId);
     }
 
-    // CA-2: trunca (floor) el timestamp al minuto, descartando segundos y fracciones
+    // Issue #275 CA-2: trunca (floor) el timestamp al minuto, descartando segundos y fracciones
     private static DateTime TruncarAlMinuto(DateTime timestamp) =>
         timestamp.AddTicks(-(timestamp.Ticks % TimeSpan.TicksPerMinute));
 }

--- a/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/MarcacionRegistrada.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/MarcacionRegistrada.cs
@@ -10,14 +10,19 @@ namespace Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 // Issue #270 CA-3: se persiste en el stream de RegistroDeMarcacionAggregateRoot; ya NO cruza el bus
 // (deja de implementar IPrivateEvent). El contrato de bus es RegistroDeMarcacionCreado
 // (PrivateEvents.ControlHoras), empaquetado por RegistroDeMarcacionAggregateRoot.CrearRegistroDeMarcacionCreado().
-public sealed class MarcacionRegistrada
+// Issue #275: protegido con factory Crear() y ctores privados (patron TurnoCreado, MEF-ADR-0012).
+// El evento nunca tuvo ctor privado -- #105 cito mal su propio patron de referencia; #270 saco al
+// evento del bus y con eso desaparecio la razon (el ServiceBusDeserializador del consumidor) por la
+// que no podia protegerse antes.
+public sealed partial class MarcacionRegistrada
 {
     public string EmpleadoId { get; private set; } = null!;
     public DateTime TimestampNormalizado { get; private set; }
     public string? TipoMarcacion { get; private set; }
     public string? DispositivoId { get; private set; }
 
-    public MarcacionRegistrada(
+    // CA-1: constructor real privado -- solo el factory Crear lo invoca
+    private MarcacionRegistrada(
         string empleadoId,
         DateTime timestampNormalizado,
         string? tipoMarcacion,
@@ -29,11 +34,11 @@ public sealed class MarcacionRegistrada
         DispositivoId = dispositivoId;
     }
 
-    // Constructor privado para Marten/serializacion
+    // CA-1: constructor vacio privado, solo para Marten/serializacion (via ConfigurarSerializacion)
     private MarcacionRegistrada() { }
 
     // Configuracion de serializacion STJ/Marten: permite deserializar con constructor privado
-    // y propiedades con private set. Ver ADR-0013 y MarcacionRegistradaSerializacionTests.
+    // y propiedades con private set. Ver MEF-ADR-0012 y MarcacionRegistradaSerializacionTests.
     public static void ConfigurarSerializacion(DefaultJsonTypeInfoResolver resolver)
     {
         var ctor = typeof(MarcacionRegistrada)
@@ -57,4 +62,14 @@ public sealed class MarcacionRegistrada
             }
         });
     }
+
+    // CA-1, CA-2, CA-3: unica via de construccion. Trunca los segundos al minuto (floor) y rechaza
+    // EmpleadoId nulo, vacio o solo espacios en blanco.
+    // Stub de compilacion -- implementacion real pendiente (fase verde, fase roja del TDD).
+    public static MarcacionRegistrada Crear(
+        string empleadoId,
+        DateTime timestampCrudo,
+        string? tipoMarcacion,
+        string? dispositivoId) =>
+        throw new NotImplementedException();
 }

--- a/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/MarcacionRegistradaMensajes.resx
+++ b/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/MarcacionRegistradaMensajes.resx
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" msdata:Ordinal="0" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter</value></resheader>
+  <data name="EmpleadoIdVacio" xml:space="preserve">
+    <value>El EmpleadoId de la marcacion no puede estar vacio</value>
+  </data>
+</root>

--- a/src/Bitakora.ControlAsistencia.ControlHoras/RegistrarMarcacionFunction/CommandHandler/RegistrarMarcacionCommandHandler.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/RegistrarMarcacionFunction/CommandHandler/RegistrarMarcacionCommandHandler.cs
@@ -6,11 +6,15 @@ using Cosmos.EventSourcing.Abstractions.Commands;
 namespace Bitakora.ControlAsistencia.ControlHoras.RegistrarMarcacionFunction.CommandHandler;
 
 // HU-105: Handler del comando RegistrarMarcacion
-// Flujo: verificar idempotencia via ExistsAsync -> normalizar timestamp -> persistir -> publicar
+// Flujo: verificar idempotencia via ExistsAsync -> construir evento via factory -> persistir -> publicar
 // CA-4: si el stream ya existe (duplicado exacto), retornar silenciosamente sin persistir ni publicar
 // Issue #270 CA-4: tras StartStream, publica el contrato de bus RegistroDeMarcacionCreado empaquetado
 // por el traductor del aggregate (Tell-don't-Ask) via IPrivateEventSender. MarcacionRegistrada (evento
 // de dominio persistido) ya no cruza el bus.
+// Issue #275 CA-4: la normalizacion (truncar segundos) y la validacion de EmpleadoId ya no viven aqui
+// -- son responsabilidad del factory MarcacionRegistrada.Crear (MEF-ADR-0012: el handler construye el
+// evento antes de pasarlo al aggregate; si la construccion falla, el throw ocurre aqui, no dentro del
+// aggregate -- MEF-ADR-0004 se mantiene). La firma de Iniciar(streamId, timestampCrudo, evento) no cambia.
 // ADR-0015: partial class para soportar clase Mensajes en archivo separado si se requiere
 public partial class RegistrarMarcacionCommandHandler : ICommandHandlerAsync<RegistrarMarcacion>
 {
@@ -33,12 +37,11 @@ public partial class RegistrarMarcacionCommandHandler : ICommandHandlerAsync<Reg
         if (existe)
             return;
 
-        // CA-2: truncar segundos al minuto (floor) antes de emitir el evento
-        var timestampNormalizado = TruncarAlMinuto(command.Timestamp);
-
-        var evento = new MarcacionRegistrada(
+        // Issue #275 CA-1/CA-2/CA-3: el factory trunca el timestamp al minuto y valida EmpleadoId.
+        // Si falla, el throw ocurre aqui (borde del handler), no dentro del aggregate.
+        var evento = MarcacionRegistrada.Crear(
             command.EmpleadoId,
-            timestampNormalizado,
+            command.Timestamp,
             command.TipoMarcacion,
             command.DispositivoId);
 
@@ -49,8 +52,4 @@ public partial class RegistrarMarcacionCommandHandler : ICommandHandlerAsync<Reg
         // handlers downstream reaccionen
         await _privateEventSender.PublishAsync(registro.CrearRegistroDeMarcacionCreado());
     }
-
-    private static DateTime TruncarAlMinuto(DateTime timestamp) =>
-        new(timestamp.Year, timestamp.Month, timestamp.Day,
-            timestamp.Hour, timestamp.Minute, 0, timestamp.Kind);
 }

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/RegistrarMarcacionFunction/RegistrarMarcacionSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/RegistrarMarcacionFunction/RegistrarMarcacionSmokeTests.cs
@@ -24,18 +24,12 @@ namespace Bitakora.ControlAsistencia.ControlHoras.SmokeTests.RegistrarMarcacionF
 // request contra el entorno desplegado (no repiten la matriz completa del unit test del validator).
 // Quedan rojos hasta que el deploy publique el validator en dev: el endpoint desplegado responde 202
 // mientras la version anterior siga corriendo. El CI de PR no los ejecuta (solo corre *.Tests).
-// Issue #275: protege el evento de dominio MarcacionRegistrada con factory Crear() y ctores privados
-// (cobertura en *.Tests: MarcacionRegistradaTests, MarcacionRegistradaSerializacionTests). Es un
-// refactor interno sin contrato HTTP nuevo observable: RegistrarMarcacionValidator (#279, arriba) ya
-// intercepta el EmpleadoId vacio con 400 en el borde ANTES de que el comando llegue al handler, asi
-// que el ArgumentException que ahora lanza el factory nunca se alcanza en el flujo HTTP real -- es una
-// segunda barrera de dominio, no un caso nuevo para este archivo. El truncamiento al minuto (CA-2 de
-// #275) tampoco cambia de comportamiento observable: se movio del handler al factory, y
-// DebeRetornar202YPersistirEvento_CuandoMarcacionEsValida (mas abajo) ya lo verifica comparando
-// TimestampNormalizado contra el timestamp crudo con segundos. CA-1 (ctores privados), CA-5
-// (guardrail de serializacion del canal de bus) y CA-6 (roundtrip con las opciones de Marten) son
-// invariantes internas del tipo -- no observables via HTTP/Service Bus/Postgres, por lo que no
-// aplican a smoke tests. No se agregan tests nuevos para este issue.
+// Issue #275: protege MarcacionRegistrada con factory y ctores privados, sin efectos nuevos
+// observables desde afuera. El truncamiento al minuto solo cambio de casa (handler -> factory) y
+// DebeRetornar202YPersistirEvento_CuandoMarcacionEsValida lo sigue verificando end-to-end; el
+// EmpleadoId vacio ya lo rechaza el validator con 400 (#279, arriba) antes de llegar al factory.
+// El resto de sus CAs son invariantes internas del tipo (ctores privados, serializacion), cubiertas
+// en *.Tests por MarcacionRegistradaTests y MarcacionRegistradaSerializacionTests.
 public class RegistrarMarcacionSmokeTests(
     ApiFixture api,
     PostgresFixture postgres,

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/RegistrarMarcacionFunction/RegistrarMarcacionSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/RegistrarMarcacionFunction/RegistrarMarcacionSmokeTests.cs
@@ -24,6 +24,18 @@ namespace Bitakora.ControlAsistencia.ControlHoras.SmokeTests.RegistrarMarcacionF
 // request contra el entorno desplegado (no repiten la matriz completa del unit test del validator).
 // Quedan rojos hasta que el deploy publique el validator en dev: el endpoint desplegado responde 202
 // mientras la version anterior siga corriendo. El CI de PR no los ejecuta (solo corre *.Tests).
+// Issue #275: protege el evento de dominio MarcacionRegistrada con factory Crear() y ctores privados
+// (cobertura en *.Tests: MarcacionRegistradaTests, MarcacionRegistradaSerializacionTests). Es un
+// refactor interno sin contrato HTTP nuevo observable: RegistrarMarcacionValidator (#279, arriba) ya
+// intercepta el EmpleadoId vacio con 400 en el borde ANTES de que el comando llegue al handler, asi
+// que el ArgumentException que ahora lanza el factory nunca se alcanza en el flujo HTTP real -- es una
+// segunda barrera de dominio, no un caso nuevo para este archivo. El truncamiento al minuto (CA-2 de
+// #275) tampoco cambia de comportamiento observable: se movio del handler al factory, y
+// DebeRetornar202YPersistirEvento_CuandoMarcacionEsValida (mas abajo) ya lo verifica comparando
+// TimestampNormalizado contra el timestamp crudo con segundos. CA-1 (ctores privados), CA-5
+// (guardrail de serializacion del canal de bus) y CA-6 (roundtrip con las opciones de Marten) son
+// invariantes internas del tipo -- no observables via HTTP/Service Bus/Postgres, por lo que no
+// aplican a smoke tests. No se agregan tests nuevos para este issue.
 public class RegistrarMarcacionSmokeTests(
     ApiFixture api,
     PostgresFixture postgres,

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/RegistrarMarcacionFunction/Eventos/MarcacionRegistradaSerializacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/RegistrarMarcacionFunction/Eventos/MarcacionRegistradaSerializacionTests.cs
@@ -1,5 +1,7 @@
-// HU-105: Test de serializacion roundtrip para MarcacionRegistrada
-// Requerido por regla 16: todo evento persistido en Marten debe sobrevivir Serialize -> Deserialize
+// HU-105 / Issue #275: Proteger MarcacionRegistrada con factory Crear() y ctores privados.
+// Requerido por regla 16: todo evento persistido en Marten debe sobrevivir Serialize -> Deserialize.
+// CA-6: el round-trip con las opciones de Marten y el resolver custom sigue verde, ahora como
+// UNICA via de reconstruccion -- ya no hay ctor publico que STJ pueda usar como fallback.
 
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
@@ -9,31 +11,26 @@ using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 namespace Bitakora.ControlAsistencia.ControlHoras.Tests.RegistrarMarcacionFunction.Eventos;
 
 /// <summary>
-/// Verifica que MarcacionRegistrada sobrevive un roundtrip de serializacion STJ.
-/// Requerido porque Marten usa STJ con PropertyNamingPolicy=null (PascalCase)
-/// y el evento tiene constructor privado y propiedades con private set.
-/// Ver ADR-0013 y feedback: ConfigurarSerializacion es obligatorio.
+/// Verifica que MarcacionRegistrada sobrevive un roundtrip de serializacion STJ dentro del event
+/// store (opciones reales de Marten, con el resolver custom registrado), y que NO sobrevive fuera
+/// de ese canal -- ni con las mismas opciones sin el registro, ni con las del canal de bus.
 /// </summary>
 public class MarcacionRegistradaSerializacionTests
 {
-    // Replica las opciones que Marten usa: PropertyNamingPolicy = null (PascalCase)
-    private static JsonSerializerOptions CrearOpcionesMarten()
-    {
-        var resolver = new DefaultJsonTypeInfoResolver();
-        MarcacionRegistrada.ConfigurarSerializacion(resolver);
-        return new JsonSerializerOptions
-        {
-            TypeInfoResolver = resolver,
-            PropertyNamingPolicy = null // Marten fuerza null
-        };
-    }
+    // Usa las opciones REALES de Marten del dominio (regla 6d) -- no un resolver armado inline que
+    // solo registre este tipo. Si alguien borra la linea de registro en
+    // ConfiguracionSerializacionControlHoras.ConfigurarResolver, el test
+    // "Deserializar_Falla_CuandoResolverNoTieneRegistroDeMarcacionRegistrada" de abajo lo detecta.
+    private static JsonSerializerOptions CrearOpcionesMarten() =>
+        ConfiguracionSerializacionControlHoras.CrearOpcionesMarten();
 
-    // Verifica todos los campos incluyendo los opcionales con valores reales
+    // Verifica todos los campos incluyendo los opcionales con valores reales.
+    // Issue #275: el evento se construye con el factory Crear -- unica via posible con ctor privado.
     [Fact]
-    public void Deserializar_ReconstruyeEvento_ConDatosCompletos()
+    public void RoundTrip_ReconstruyeEvento_ConDatosCompletos()
     {
-        var timestamp = new DateTime(2026, 3, 15, 8, 9, 0);
-        var evento = new MarcacionRegistrada("EMP-001", timestamp, "ENTRADA", "DEV-001");
+        var timestampCrudo = new DateTime(2026, 3, 15, 8, 9, 59);
+        var evento = MarcacionRegistrada.Crear("EMP-001", timestampCrudo, "ENTRADA", "DEV-001");
         var opciones = CrearOpcionesMarten();
 
         var json = JsonSerializer.Serialize(evento, opciones);
@@ -41,17 +38,17 @@ public class MarcacionRegistradaSerializacionTests
 
         deserializado.Should().NotBeNull();
         deserializado!.EmpleadoId.Should().Be("EMP-001");
-        deserializado.TimestampNormalizado.Should().Be(timestamp);
+        deserializado.TimestampNormalizado.Should().Be(new DateTime(2026, 3, 15, 8, 9, 0));
         deserializado.TipoMarcacion.Should().Be("ENTRADA");
         deserializado.DispositivoId.Should().Be("DEV-001");
     }
 
     // Verifica que los campos opcionales null se preservan correctamente en el roundtrip
     [Fact]
-    public void Deserializar_ReconstruyeEvento_CuandoCamposOpcionalesSonNulos()
+    public void RoundTrip_ReconstruyeEvento_CuandoCamposOpcionalesSonNulos()
     {
-        var timestamp = new DateTime(2026, 3, 15, 8, 9, 0);
-        var evento = new MarcacionRegistrada("EMP-002", timestamp, null, null);
+        var timestampCrudo = new DateTime(2026, 3, 15, 8, 9, 0);
+        var evento = MarcacionRegistrada.Crear("EMP-002", timestampCrudo, null, null);
         var opciones = CrearOpcionesMarten();
 
         var json = JsonSerializer.Serialize(evento, opciones);
@@ -59,8 +56,47 @@ public class MarcacionRegistradaSerializacionTests
 
         deserializado.Should().NotBeNull();
         deserializado!.EmpleadoId.Should().Be("EMP-002");
-        deserializado.TimestampNormalizado.Should().Be(timestamp);
+        deserializado.TimestampNormalizado.Should().Be(timestampCrudo);
         deserializado.TipoMarcacion.Should().BeNull();
         deserializado.DispositivoId.Should().BeNull();
+    }
+
+    // CA-regresion (regla 16): si alguien borra el registro de MarcacionRegistrada en
+    // ConfiguracionSerializacionControlHoras.ConfigurarResolver, este test lo detecta -- sin el
+    // registro, STJ no tiene forma de invocar el ctor vacio privado.
+    [Fact]
+    public void Deserializar_Falla_CuandoResolverNoTieneRegistroDeMarcacionRegistrada()
+    {
+        var evento = MarcacionRegistrada.Crear(
+            "EMP-001", new DateTime(2026, 3, 15, 8, 9, 0), "ENTRADA", "DEV-001");
+        var opcionesSinRegistro = new JsonSerializerOptions
+        {
+            TypeInfoResolver = new DefaultJsonTypeInfoResolver(),
+            PropertyNamingPolicy = null
+        };
+        var json = JsonSerializer.Serialize(evento, opcionesSinRegistro);
+
+        var act = () => JsonSerializer.Deserialize<MarcacionRegistrada>(json, opcionesSinRegistro);
+
+        act.Should().Throw<NotSupportedException>();
+    }
+
+    // CA-5: guardrail anti-regresion -- MarcacionRegistrada ya no cruza el bus (issue #270) y,
+    // cerrado el ctor (issue #275), tampoco es reconstruible con el serializador del canal (sin
+    // resolver custom): la operacion lanza NotSupportedException. Es la barrera que CA-ADR-0025
+    // describe para HorasDiscriminadas, en sentido inverso -- alli el payload plano DEBE sobrevivir
+    // sin resolver; aqui el evento de dominio rico NO debe hacerlo, porque solo vive en el event
+    // store (CA-ADR-0025 seccion 4).
+    [Fact]
+    public void Deserializar_LanzaNotSupportedException_ConSerializadorDelCanalDeBus()
+    {
+        var evento = MarcacionRegistrada.Crear(
+            "EMP-001", new DateTime(2026, 3, 15, 8, 9, 0), "ENTRADA", "DEV-001");
+        var opcionesDelBus = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+        var json = JsonSerializer.Serialize(evento, opcionesDelBus);
+
+        var act = () => JsonSerializer.Deserialize<MarcacionRegistrada>(json, opcionesDelBus);
+
+        act.Should().Throw<NotSupportedException>();
     }
 }

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/RegistrarMarcacionFunction/Eventos/MarcacionRegistradaSerializacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/RegistrarMarcacionFunction/Eventos/MarcacionRegistradaSerializacionTests.cs
@@ -17,28 +17,32 @@ namespace Bitakora.ControlAsistencia.ControlHoras.Tests.RegistrarMarcacionFuncti
 /// </summary>
 public class MarcacionRegistradaSerializacionTests
 {
+    private const string EmpleadoId = "EMP-001";
+    private static readonly DateTime TimestampConSegundos = new(2026, 3, 15, 8, 9, 59);
+    private static readonly DateTime TimestampNormalizadoEsperado = new(2026, 3, 15, 8, 9, 0);
+
     // Usa las opciones REALES de Marten del dominio (regla 6d) -- no un resolver armado inline que
-    // solo registre este tipo. Si alguien borra la linea de registro en
-    // ConfiguracionSerializacionControlHoras.ConfigurarResolver, el test
-    // "Deserializar_Falla_CuandoResolverNoTieneRegistroDeMarcacionRegistrada" de abajo lo detecta.
+    // solo registre este tipo. Esa eleccion es lo que convierte a los dos RoundTrip_* de abajo en la
+    // barrera contra el borrado de la linea de registro en
+    // ConfiguracionSerializacionControlHoras.ConfigurarResolver: sin ella, el ctor vacio privado es
+    // inalcanzable para STJ y ambos fallan con NotSupportedException.
     private static JsonSerializerOptions CrearOpcionesMarten() =>
         ConfiguracionSerializacionControlHoras.CrearOpcionesMarten();
 
     // Verifica todos los campos incluyendo los opcionales con valores reales.
     // Issue #275: el evento se construye con el factory Crear -- unica via posible con ctor privado.
     [Fact]
-    public void RoundTrip_ReconstruyeEvento_ConDatosCompletos()
+    public void RoundTrip_ReconstruyeEvento_CuandoDatosCompletos()
     {
-        var timestampCrudo = new DateTime(2026, 3, 15, 8, 9, 59);
-        var evento = MarcacionRegistrada.Crear("EMP-001", timestampCrudo, "ENTRADA", "DEV-001");
+        var evento = MarcacionRegistrada.Crear(EmpleadoId, TimestampConSegundos, "ENTRADA", "DEV-001");
         var opciones = CrearOpcionesMarten();
 
         var json = JsonSerializer.Serialize(evento, opciones);
         var deserializado = JsonSerializer.Deserialize<MarcacionRegistrada>(json, opciones);
 
         deserializado.Should().NotBeNull();
-        deserializado!.EmpleadoId.Should().Be("EMP-001");
-        deserializado.TimestampNormalizado.Should().Be(new DateTime(2026, 3, 15, 8, 9, 0));
+        deserializado!.EmpleadoId.Should().Be(EmpleadoId);
+        deserializado.TimestampNormalizado.Should().Be(TimestampNormalizadoEsperado);
         deserializado.TipoMarcacion.Should().Be("ENTRADA");
         deserializado.DispositivoId.Should().Be("DEV-001");
     }
@@ -47,8 +51,7 @@ public class MarcacionRegistradaSerializacionTests
     [Fact]
     public void RoundTrip_ReconstruyeEvento_CuandoCamposOpcionalesSonNulos()
     {
-        var timestampCrudo = new DateTime(2026, 3, 15, 8, 9, 0);
-        var evento = MarcacionRegistrada.Crear("EMP-002", timestampCrudo, null, null);
+        var evento = MarcacionRegistrada.Crear("EMP-002", TimestampNormalizadoEsperado, null, null);
         var opciones = CrearOpcionesMarten();
 
         var json = JsonSerializer.Serialize(evento, opciones);
@@ -56,19 +59,20 @@ public class MarcacionRegistradaSerializacionTests
 
         deserializado.Should().NotBeNull();
         deserializado!.EmpleadoId.Should().Be("EMP-002");
-        deserializado.TimestampNormalizado.Should().Be(timestampCrudo);
+        deserializado.TimestampNormalizado.Should().Be(TimestampNormalizadoEsperado);
         deserializado.TipoMarcacion.Should().BeNull();
         deserializado.DispositivoId.Should().BeNull();
     }
 
-    // CA-regresion (regla 16): si alguien borra el registro de MarcacionRegistrada en
-    // ConfiguracionSerializacionControlHoras.ConfigurarResolver, este test lo detecta -- sin el
-    // registro, STJ no tiene forma de invocar el ctor vacio privado.
+    // Documenta POR QUE el registro en ConfigurarResolver es obligatorio: con las mismas opciones de
+    // Marten pero un resolver vacio, STJ no tiene forma de invocar el ctor vacio privado. Quien
+    // detecta el borrado del registro son los RoundTrip_* de arriba (usan las opciones reales del
+    // dominio); este test fija el comportamiento del canal sin resolver.
     [Fact]
-    public void Deserializar_Falla_CuandoResolverNoTieneRegistroDeMarcacionRegistrada()
+    public void Deserializar_LanzaNotSupportedException_CuandoElResolverNoRegistraElTipo()
     {
         var evento = MarcacionRegistrada.Crear(
-            "EMP-001", new DateTime(2026, 3, 15, 8, 9, 0), "ENTRADA", "DEV-001");
+            EmpleadoId, TimestampNormalizadoEsperado, "ENTRADA", "DEV-001");
         var opcionesSinRegistro = new JsonSerializerOptions
         {
             TypeInfoResolver = new DefaultJsonTypeInfoResolver(),
@@ -88,10 +92,10 @@ public class MarcacionRegistradaSerializacionTests
     // sin resolver; aqui el evento de dominio rico NO debe hacerlo, porque solo vive en el event
     // store (CA-ADR-0025 seccion 4).
     [Fact]
-    public void Deserializar_LanzaNotSupportedException_ConSerializadorDelCanalDeBus()
+    public void Deserializar_LanzaNotSupportedException_CuandoUsaElSerializadorDelCanalDeBus()
     {
         var evento = MarcacionRegistrada.Crear(
-            "EMP-001", new DateTime(2026, 3, 15, 8, 9, 0), "ENTRADA", "DEV-001");
+            EmpleadoId, TimestampNormalizadoEsperado, "ENTRADA", "DEV-001");
         var opcionesDelBus = new JsonSerializerOptions(JsonSerializerDefaults.Web);
         var json = JsonSerializer.Serialize(evento, opcionesDelBus);
 

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/RegistrarMarcacionFunction/Eventos/MarcacionRegistradaTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/RegistrarMarcacionFunction/Eventos/MarcacionRegistradaTests.cs
@@ -1,0 +1,93 @@
+// Issue #275: Proteger el evento de dominio MarcacionRegistrada con factory y ctor privado.
+// Interfaz publica: Crear(...), EmpleadoId, TimestampNormalizado, TipoMarcacion, DispositivoId.
+// El evento nunca cruzo el bus como razon para tener ctor publico (#270 ya lo saco del canal);
+// este issue le da, por primera vez, la proteccion que ese rol impedia (ver contexto del issue).
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Tests.RegistrarMarcacionFunction.Eventos;
+
+public class MarcacionRegistradaTests
+{
+    private const string EmpleadoId = "EMP-001";
+    private static readonly DateTime TimestampConSegundos = new(2026, 3, 15, 8, 9, 59);
+    private static readonly DateTime TimestampNormalizadoEsperado = new(2026, 3, 15, 8, 9, 0);
+
+    // ---------- CA-1: unica via de construccion es Crear(...); ningun ctor publico ----------
+
+    [Fact]
+    public void MarcacionRegistrada_NoExponeConstructorPublico()
+    {
+        typeof(MarcacionRegistrada).GetConstructors().Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Crear_RetornaMarcacionRegistrada_ConDatosValidos()
+    {
+        var evento = MarcacionRegistrada.Crear(EmpleadoId, TimestampConSegundos, "ENTRADA", "DEV-001");
+
+        evento.EmpleadoId.Should().Be(EmpleadoId);
+        evento.TipoMarcacion.Should().Be("ENTRADA");
+        evento.DispositivoId.Should().Be("DEV-001");
+    }
+
+    // ---------- CA-2: Crear trunca los segundos del timestamp recibido (floor al minuto) ----------
+
+    [Fact]
+    public void Crear_TruncaSegundosAlMinuto_CuandoTimestampTraeSegundos()
+    {
+        var evento = MarcacionRegistrada.Crear(EmpleadoId, TimestampConSegundos, "ENTRADA", "DEV-001");
+
+        evento.TimestampNormalizado.Should().Be(TimestampNormalizadoEsperado);
+    }
+
+    [Fact]
+    public void Crear_ConservaTimestamp_CuandoYaVieneSinSegundos()
+    {
+        var evento = MarcacionRegistrada.Crear(
+            EmpleadoId, TimestampNormalizadoEsperado, "ENTRADA", "DEV-001");
+
+        evento.TimestampNormalizado.Should().Be(TimestampNormalizadoEsperado);
+    }
+
+    // ---------- CA-3: EmpleadoId nulo, vacio o solo espacios es rechazado ----------
+
+    [Fact]
+    public void Crear_LanzaArgumentException_CuandoEmpleadoIdEsNulo()
+    {
+        var act = () => MarcacionRegistrada.Crear(null!, TimestampConSegundos, "ENTRADA", "DEV-001");
+
+        act.Should().ThrowExactly<ArgumentException>()
+            .WithMessage($"*{MarcacionRegistrada.Mensajes.EmpleadoIdVacio}*");
+    }
+
+    [Fact]
+    public void Crear_LanzaArgumentException_CuandoEmpleadoIdEsVacio()
+    {
+        var act = () => MarcacionRegistrada.Crear(string.Empty, TimestampConSegundos, "ENTRADA", "DEV-001");
+
+        act.Should().ThrowExactly<ArgumentException>()
+            .WithMessage($"*{MarcacionRegistrada.Mensajes.EmpleadoIdVacio}*");
+    }
+
+    [Fact]
+    public void Crear_LanzaArgumentException_CuandoEmpleadoIdEsSoloEspacios()
+    {
+        var act = () => MarcacionRegistrada.Crear("   ", TimestampConSegundos, "ENTRADA", "DEV-001");
+
+        act.Should().ThrowExactly<ArgumentException>()
+            .WithMessage($"*{MarcacionRegistrada.Mensajes.EmpleadoIdVacio}*");
+    }
+
+    // ---------- TipoMarcacion y DispositivoId son opcionales (nullable) ----------
+
+    [Fact]
+    public void Crear_AceptaCamposOpcionalesNulos()
+    {
+        var evento = MarcacionRegistrada.Crear(EmpleadoId, TimestampConSegundos, null, null);
+
+        evento.TipoMarcacion.Should().BeNull();
+        evento.DispositivoId.Should().BeNull();
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/RegistrarMarcacionFunction/Eventos/MarcacionRegistradaTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/RegistrarMarcacionFunction/Eventos/MarcacionRegistradaTests.cs
@@ -23,7 +23,7 @@ public class MarcacionRegistradaTests
     }
 
     [Fact]
-    public void Crear_RetornaMarcacionRegistrada_ConDatosValidos()
+    public void Crear_RetornaMarcacionRegistrada_CuandoDatosSonValidos()
     {
         var evento = MarcacionRegistrada.Crear(EmpleadoId, TimestampConSegundos, "ENTRADA", "DEV-001");
 
@@ -49,6 +49,32 @@ public class MarcacionRegistradaTests
             EmpleadoId, TimestampNormalizadoEsperado, "ENTRADA", "DEV-001");
 
         evento.TimestampNormalizado.Should().Be(TimestampNormalizadoEsperado);
+    }
+
+    // Un dispositivo puede reportar sub-segundos: el floor tambien los descarta, no solo los
+    // segundos enteros. Sin esto, dos marcaciones del mismo minuto podrian diferir en ticks.
+    [Fact]
+    public void Crear_TruncaFraccionesDeSegundo_CuandoTimestampTraeTicks()
+    {
+        var conTicks = TimestampConSegundos.AddTicks(1234567);
+
+        var evento = MarcacionRegistrada.Crear(EmpleadoId, conTicks, "ENTRADA", "DEV-001");
+
+        evento.TimestampNormalizado.Should().Be(TimestampNormalizadoEsperado);
+    }
+
+    // El truncamiento no puede reinterpretar la zona horaria: el evento persiste el mismo Kind que
+    // recibio (el endpoint entrega Utc). Fijarlo protege el cambio de implementacion del floor.
+    [Fact]
+    public void Crear_PreservaElKindDelTimestamp_CuandoTimestampEsUtc()
+    {
+        var utcConSegundos = new DateTime(2026, 3, 15, 8, 9, 59, DateTimeKind.Utc);
+
+        var evento = MarcacionRegistrada.Crear(EmpleadoId, utcConSegundos, "ENTRADA", "DEV-001");
+
+        evento.TimestampNormalizado.Kind.Should().Be(DateTimeKind.Utc);
+        evento.TimestampNormalizado.Should().Be(
+            new DateTime(2026, 3, 15, 8, 9, 0, DateTimeKind.Utc));
     }
 
     // ---------- CA-3: EmpleadoId nulo, vacio o solo espacios es rechazado ----------

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/RegistrarMarcacionFunction/RegistrarMarcacionCommandHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/RegistrarMarcacionFunction/RegistrarMarcacionCommandHandlerTests.cs
@@ -33,6 +33,10 @@ public class RegistrarMarcacionCommandHandlerTests : CommandHandlerAsyncTest<Reg
     // CA-5: stream ID determinista {EmpleadoId}:{Timestamp:yyyy-MM-ddTHH:mm:ss}
     private static readonly string StreamId = $"{EmpleadoId}:{Timestamp:yyyy-MM-ddTHH:mm:ss}";
 
+    // Issue #275: el stream que el handler habria abierto si el factory no hubiera rechazado el
+    // EmpleadoId vacio -- se afirma vacio para probar que el throw precede a cualquier escritura.
+    private static readonly string StreamIdSinEmpleado = $":{Timestamp:yyyy-MM-ddTHH:mm:ss}";
+
     protected override ICommandHandlerAsync<RegistrarMarcacion> Handler =>
         new RegistrarMarcacionCommandHandler(EventStore, PrivateEventSender);
 
@@ -98,13 +102,17 @@ public class RegistrarMarcacionCommandHandlerTests : CommandHandlerAsyncTest<Reg
     // Issue #275 CA-3/CA-4: el factory MarcacionRegistrada.Crear valida el EmpleadoId; el throw
     // ocurre en el borde del handler (MEF-ADR-0004), nunca dentro del aggregate. No es un evento de
     // fallo del aggregate -- es un dato invalido que nunca deberia haber llegado hasta aqui.
+    // El throw ocurre ANTES de tocar el event store: ni se abre el stream ni se publica el contrato
+    // de bus, de modo que un dato invalido no deja rastro parcial.
     [Fact]
-    public async Task RegistrarMarcacion_PropagaArgumentException_CuandoEmpleadoIdEsVacio()
+    public async Task RegistrarMarcacion_PropagaArgumentExceptionSinPersistirNiPublicar_CuandoEmpleadoIdEsVacio()
     {
         var act = async () => await WhenAsync(
             new RegistrarMarcacion(string.Empty, Timestamp, "ENTRADA", "DEV-001"));
 
         await act.Should().ThrowExactlyAsync<ArgumentException>()
             .WithMessage($"*{MarcacionRegistrada.Mensajes.EmpleadoIdVacio}*");
+        Then(StreamIdSinEmpleado);
+        ThenIsPublishedPrivately();
     }
 }

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/RegistrarMarcacionFunction/RegistrarMarcacionCommandHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/RegistrarMarcacionFunction/RegistrarMarcacionCommandHandlerTests.cs
@@ -2,7 +2,13 @@
 // CA-4: el handler publica RegistroDeMarcacionCreado (contrato de bus, PrivateEvents.ControlHoras)
 // empaquetado por el traductor del aggregate, tras StartStream. MarcacionRegistrada (evento de
 // dominio persistido en el stream) ya NO cruza el bus -- deja de implementar IPrivateEvent (CA-3).
+// Issue #275 CA-4: el handler ya no trunca segundos ni invoca "new MarcacionRegistrada(...)" --
+// llama al factory MarcacionRegistrada.Crear(...), que trunca y valida (patron TurnoCreado,
+// CrearTurnoCommandHandlerTests). El evento esperado en los tests tambien se construye con el
+// factory, con el mismo timestamp crudo que recibe el comando -- unica via posible ahora que el
+// ctor es privado.
 
+using AwesomeAssertions;
 using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 using Bitakora.ControlAsistencia.ControlHoras.Entities;
 using Bitakora.ControlAsistencia.ControlHoras.RegistrarMarcacionFunction;
@@ -30,10 +36,14 @@ public class RegistrarMarcacionCommandHandlerTests : CommandHandlerAsyncTest<Reg
     protected override ICommandHandlerAsync<RegistrarMarcacion> Handler =>
         new RegistrarMarcacionCommandHandler(EventStore, PrivateEventSender);
 
+    // Issue #275: el ctor de MarcacionRegistrada es privado -- la unica via de construccion, tanto
+    // para el handler como para el oraculo del test, es Crear(...). Se le pasa el mismo timestamp
+    // CRUDO (con segundos) que recibe el comando: si el handler dejara de delegar la normalizacion
+    // al factory, este test lo detectaria porque el oraculo tambien pasa por el mismo truncamiento.
     private static MarcacionRegistrada CrearMarcacionRegistrada(
         string? tipoMarcacion = "ENTRADA",
         string? dispositivoId = "DEV-001") =>
-        new(EmpleadoId, TimestampNormalizado, tipoMarcacion, dispositivoId);
+        MarcacionRegistrada.Crear(EmpleadoId, Timestamp, tipoMarcacion, dispositivoId);
 
     // Issue #270 CA-4: el contrato de bus que se espera publicado -- construido a mano como oraculo
     // independiente (regla 20), con la misma paridad de campos que MarcacionRegistrada, sin invocar
@@ -83,5 +93,18 @@ public class RegistrarMarcacionCommandHandlerTests : CommandHandlerAsyncTest<Reg
         Then(StreamId);
         ThenIsPublishedPrivately();
         And<RegistroDeMarcacionAggregateRoot, string>(StreamId, r => r.EmpleadoId, EmpleadoId);
+    }
+
+    // Issue #275 CA-3/CA-4: el factory MarcacionRegistrada.Crear valida el EmpleadoId; el throw
+    // ocurre en el borde del handler (MEF-ADR-0004), nunca dentro del aggregate. No es un evento de
+    // fallo del aggregate -- es un dato invalido que nunca deberia haber llegado hasta aqui.
+    [Fact]
+    public async Task RegistrarMarcacion_PropagaArgumentException_CuandoEmpleadoIdEsVacio()
+    {
+        var act = async () => await WhenAsync(
+            new RegistrarMarcacion(string.Empty, Timestamp, "ENTRADA", "DEV-001"));
+
+        await act.Should().ThrowExactlyAsync<ArgumentException>()
+            .WithMessage($"*{MarcacionRegistrada.Mensajes.EmpleadoIdVacio}*");
     }
 }


### PR DESCRIPTION
## Resumen

Pipeline TDD completado:
- Fase roja: tests escritos con stubs
- Fase verde: implementación completa
- Smoke tests: escritos para endpoints detectados
- Fase refactor: revisión de calidad

## Decisiones del pipeline

<details>
<summary>Test Writer (fase roja) — 10m 13s</summary>

## ES Test Writer - Decisiones

### Tests creados

- `MarcacionRegistradaTests.cs` (nuevo, 8 tests): tests directos del factory `Crear` como value
  object (sin harness Given/When/Then -- no es aggregate ni command handler).
  - `MarcacionRegistrada_NoExponeConstructorPublico` - CA-1 (reflexion: `GetConstructors()` vacio)
  - `Crear_RetornaMarcacionRegistrada_ConDatosValidos` - CA-1 camino feliz
  - `Crear_TruncaSegundosAlMinuto_CuandoTimestampTraeSegundos` - CA-2
  - `Crear_ConservaTimestamp_CuandoYaVieneSinSegundos` - CA-2 caso borde (ya normalizado)
  - `Crear_LanzaArgumentException_CuandoEmpleadoIdEsNulo` - CA-3
  - `Crear_LanzaArgumentException_CuandoEmpleadoIdEsVacio` - CA-3
  - `Crear_LanzaArgumentException_CuandoEmpleadoIdEsSoloEspacios` - CA-3
  - `Crear_AceptaCamposOpcionalesNulos` - TipoMarcacion/DispositivoId nullable (sin cambios)

- `MarcacionRegistradaSerializacionTests.cs` (modificado, 4 tests): round-trip Marten + guardrails.
  - `RoundTrip_ReconstruyeEvento_ConDatosCompletos` - CA-6, ahora via `MarcacionRegistrada.Crear(...)`
  - `RoundTrip_ReconstruyeEvento_CuandoCamposOpcionalesSonNulos` - CA-6
  - `Deserializar_Falla_CuandoResolverNoTieneRegistroDeMarcacionRegistrada` (nuevo) - regla 16,
    barrera anti-regresion si se borra el registro en `ConfiguracionSerializacionControlHoras`
  - `Deserializar_LanzaNotSupportedException_ConSerializadorDelCanalDeBus` (nuevo) - CA-5

- `RegistrarMarcacionCommandHandlerTests.cs` (modificado, 4 tests): orquestacion del handler.
  - `RegistrarMarcacion_EmiteMarcacionRegistradaYPublicaRegistroDeMarcacionCreado_CuandoMarcacionEsNueva` - CA-4 camino feliz
  - `RegistrarMarcacion_PropagaCamposOpcionalesNulos_CuandoElComandoNoLosTrae` - CA-4
  - `RegistrarMarcacion_NoPersisteNiPublica_CuandoStreamYaExiste` - CA-4 idempotencia (sin cambios de fondo)
  - `RegistrarMarcacion_PropagaArgumentException_CuandoEmpleadoIdEsVacio` (nuevo) - CA-3/CA-4,
    verifica que el throw del factory se propaga en el borde del handler (MEF-ADR-0004)

### Estructura elegida

- `MarcacionRegistradaTests.cs` como clase plana (no hereda `CommandHandlerAsyncTest<>`): el sujeto
  bajo prueba es un value object/evento de dominio con factory estatico, no un command handler ni
  un aggregate. Sigue el patron de `TurnoCreadoTests.cs` / `FranjaOrdinariaTests.cs` (Facts directos
  + AwesomeAssertions, sin Given/When/Then/And).
- `RegistrarMarcacionCommandHandlerTests.cs` mantiene su estructura previa (una clase, sin nested
  classes) porque solo hay un command handler en este feature folder.

### Stubs creados

- `MarcacionRegistrada.Crear(string, DateTime, string?, string?) => throw new NotImplementedException()`
  - Ctores parametrizado y vacio pasan de publico/privado(vacio) a **ambos privados**.
  - Clase pasa de `sealed class` a `sealed partial class` para soportar `Mensajes` en archivo separado.
- `MarcacionRegistrada.Mensajes.cs` (nuevo): `internal static class Mensajes { EmpleadoIdVacio }`
  leyendo de `MarcacionRegistradaMensajes.resx`, patron `TurnoCreado.Mensajes.cs`.
- `RegistrarMarcacionCommandHandler.HandleAsync`: se removio `TruncarAlMinuto` y la construccion
  manual `new MarcacionRegistrada(...)`; ahora llama a `MarcacionRegistrada.Crear(...)` (sigue con
  logica real de orquestacion -- idempotencia, StartStream, publicacion -- que ya existia y no es
  parte de lo que este issue cambia; el unico cambio de comportamiento nuevo vive en el factory
  stubeado, que lanza `NotImplementedException`).
- `.csproj` de `ControlHoras.DomainEvents`: agregado `InternalsVisibleTo` hacia
  `Bitakora.ControlAsistencia.ControlHoras.Tests` para que los tests accedan a `Mensajes` (internal).

### Decisiones de diseno

- **Oraculo del factory reusado en el test del handler** (`RegistrarMarcacionCommandHandlerTests`):
  el evento esperado se construye con `MarcacionRegistrada.Crear(EmpleadoId, Timestamp, ...)` -- el
  mismo timestamp CRUDO (con segundos) que recibe el comando, no el ya truncado. Esto sigue el
  precedente exacto de `CrearTurnoCommandHandlerTests` (`TurnoCreado.Crear(comando.TurnoId, ...)`
  como oraculo). No es tautologico (regla 20): la logica bajo prueba en *este* test es la
  orquestacion del handler (idempotencia, StartStream, publicacion), no el truncamiento/validacion
  interno de `Crear`, que tiene su propia suite independiente (`MarcacionRegistradaTests`) con
  valores hardcodeados como oraculo. Con el ctor privado, `Crear` es ademas la UNICA via posible de
  construir el evento desde fuera de la clase -- no hay alternativa "a mano".
- **Dos tests de guardrail de serializacion, no uno**: la regla 16 (barrera anti-regresion "sin
  registro falla" con opciones estilo Marten) y el CA-5 explicito (canal de bus) verifican fallos
  con distintas opciones de serializacion. Se mantienen como tests separados porque cubren dos
  canales distintos (event store sin registro vs. canal de bus) aunque el resultado esperado
  (`NotSupportedException`) coincida.
- **`CrearOpcionesMarten()` del test de round-trip ahora delega a
  `ConfiguracionSerializacionControlHoras.CrearOpcionesMarten()`** en vez de armar un resolver
  inline que solo registrara `MarcacionRegistrada` (regla 6d): asi el test de round-trip verifica
  el registro REAL usado en produccion, y el test "sin registro" es el que efectivamente prueba la
  ausencia de ese registro.
- **Test adicional no listado explicitamente en los CAs**:
  `RegistrarMarcacion_PropagaArgumentException_CuandoEmpleadoIdEsVacio` en el handler. Ninguna CA lo
  exige literalmente, pero cierra el circuito end-to-end del principio central del issue ("el throw
  significa que nuestro borde fallo, 500") a nivel de integracion del handler, complementando los
  tests unitarios del factory.
- **Comentario desactualizado corregido en el .csproj**: el comentario original decia "MarcacionRegistrada
  implementa IPrivateEvent (ver #270... pendiente)", pero #270 ya elimino esa implementacion. Se
  corrigio la redaccion sin tocar el `PackageReference` (fuera de alcance de este issue).

### Cobertura de criterios

| Criterio de aceptacion | Test(s) |
|---|---|
| CA-1: sin ctor publico, unica via es Crear | `MarcacionRegistrada_NoExponeConstructorPublico`, `Crear_RetornaMarcacionRegistrada_ConDatosValidos` |
| CA-2: trunca segundos al minuto | `Crear_TruncaSegundosAlMinuto_CuandoTimestampTraeSegundos`, `Crear_ConservaTimestamp_CuandoYaVieneSinSegundos` |
| CA-3: ArgumentException si EmpleadoId invalido | `Crear_LanzaArgumentException_CuandoEmpleadoIdEsNulo/Vacio/EsSoloEspacios`, `RegistrarMarcacion_PropagaArgumentException_CuandoEmpleadoIdEsVacio` |
| CA-4: handler usa el factory, sin TruncarAlMinuto, idempotencia se preserva | `RegistrarMarcacion_EmiteMarcacionRegistradaYPublicaRegistroDeMarcacionCreado_CuandoMarcacionEsNueva`, `RegistrarMarcacion_PropagaCamposOpcionalesNulos_CuandoElComandoNoLosTrae`, `RegistrarMarcacion_NoPersisteNiPublica_CuandoStreamYaExiste` |
| CA-5: no deserializable con serializador del canal de bus | `Deserializar_LanzaNotSupportedException_ConSerializadorDelCanalDeBus` |
| CA-6: round-trip Marten sigue verde, unica via de reconstruccion | `RoundTrip_ReconstruyeEvento_ConDatosCompletos`, `RoundTrip_ReconstruyeEvento_CuandoCamposOpcionalesSonNulos`, `Deserializar_Falla_CuandoResolverNoTieneRegistroDeMarcacionRegistrada` |

### Desviaciones del plan del planner

Ninguna estructural. El planner no incluyo seccion "Interfaz publica propuesta" con una lista
formal de miembros no publicos exhaustiva mas alla del texto narrativo del issue; se siguio al pie
de la letra: `Crear` y `ConfigurarSerializacion` publicos; ambos ctores y `Mensajes` no publicos.

Un ajuste menor no listado en "Impacto / Modifica": se corrigio el comentario desactualizado sobre
`IPrivateEvent` en `Bitakora.ControlAsistencia.ControlHoras.DomainEvents.csproj` (archivo que de
todas formas habia que tocar para agregar `InternalsVisibleTo`). Razon: el comentario original era
factualmente incorrecto tras el cierre de #270 y podia confundir a un lector futuro. Consecuencia:
ningun test ni CA depende de esto; es limpieza de documentacion inline sin efecto en compilacion.

</details>

<details>
<summary>Implementer (fase verde) — 1m 58s</summary>

## ES Implementer - Decisiones

### Enfoque de implementacion

El test-writer ya habia dejado entregada casi toda la estructura del cambio en el commit rojo:
`MarcacionRegistrada` ya era `sealed partial class` con ambos constructores privados,
`ConfigurarSerializacion` con el resolver custom, y la clase `Mensajes` (+ `.resx`) con la
entrada `EmpleadoIdVacio`. El `RegistrarMarcacionCommandHandler` tambien ya invocaba
`MarcacionRegistrada.Crear(...)` en vez de `new MarcacionRegistrada(...)`. El unico stub
pendiente (`throw new NotImplementedException()`) era el cuerpo del factory `Crear`.

Implementacion minima del factory:
1. Guard clause: si `EmpleadoId` es nulo, vacio o solo espacios en blanco, lanza
   `ArgumentException` con el mensaje resuelto desde `.resx` (`Mensajes.EmpleadoIdVacio`).
2. Trunca (floor) el timestamp crudo al minuto con un metodo privado `TruncarAlMinuto`,
   descontando el resto de ticks modulo `TimeSpan.TicksPerMinute` (evita magic numbers de
   60/1000/etc. y es exacto para cualquier resolucion de `DateTime`).
3. Invoca el constructor privado parametrizado con el `EmpleadoId` recibido y el timestamp
   ya truncado.

No se toco el CommandHandler, los ctores, `ConfigurarSerializacion`, `Mensajes.cs` ni el `.resx`
-- ya estaban correctos y alineados al patron `TurnoCreado` citado en el issue.

### Decisiones de diseno

- `TruncarAlMinuto` como metodo privado del evento (no expuesto), coherente con "Validaciones de
  consistencia interna -> invariantes del constructor/factory" y con la decision del planner de no
  anticipar la configurabilidad de politicas de truncamiento por empresa (MEF-ADR-0018): se
  implementa la version simple hoy, sin parametrizar.
- Un unico error (`ArgumentException` directa, no `AggregateException`) porque solo hay una regla
  de validacion -- exactamente la diferencia deliberada que el issue documenta respecto al
  precedente `TurnoCreado.Crear` (que acumula tres reglas).
- El mensaje de la excepcion usa `nameof(empleadoId)` como `paramName` de `ArgumentException`
  ademas del mensaje de `.resx`, siguiendo la convencion estandar de .NET para `ArgumentException`
  sin apartarse del patron de mensajes en `.resx` (MEF-ADR-0009).

### ADRs consultados

- MEF-ADR-0012 (via lectura del issue y el precedente `TurnoCreado.cs`): factory + ctores privados,
  proscripcion de `[JsonConstructor]`, quien construye el evento (el handler, no el aggregate).
- MEF-ADR-0004: el throw ocurre en el borde del handler, no en el aggregate -- ya resuelto en la
  implementacion entregada por el test-writer; verificado que se mantiene.
- MEF-ADR-0009: mensaje en `.resx`, patron `Mensajes` -- ya entregado por el test-writer, solo se
  consumio.
- CA-ADR-0025 seccion 4: el resolver custom aplica solo al event store -- verificado por los tests
  de `MarcacionRegistradaSerializacionTests` (CA-5, CA-6), ya en verde sin cambios adicionales.
- CA-ADR-0029 seccion 5: el factory no recibe el comando -- `Crear` recibe primitivos
  (`empleadoId`, `timestampCrudo`, `tipoMarcacion`, `dispositivoId`), no el comando
  `RegistrarMarcacion`.
- MEF-ADR-0018: no se anticipa configurabilidad del truncamiento por empresa; se implementa la
  regla fija de hoy (floor al minuto).

### Desviaciones de ADRs

Ninguna desviacion -- todos los ADRs aplicados al pie de la letra.

### Desviaciones del plan del planner

Ninguna desviacion -- la interfaz publica propuesta (`Crear`, `ConfigurarSerializacion`,
propiedades con `private set`) coincide exactamente con lo que el test-writer ya habia dejado
scaffoldeado y con lo que se implemento.

### Precedentes consultados

- `TurnoCreado.cs` (`Programacion.DomainEvents`): precedente estructural completo citado por el
  issue -- alineado con MEF-ADR-0012 (ctor privado real + ctor vacio privado, `ConfigurarSerializacion`,
  factory `Crear` publico). Se siguio el mismo patron de resolver custom (ya presente antes de esta
  tarea) y se diferencio deliberadamente en no acumular errores en `AggregateException` (una sola
  regla vs. tres en `TurnoCreado`), tal como el issue lo justifica.

### Infraestructura modificada

Ninguna. El evento `MarcacionRegistrada` no cruza el bus (ya salio del canal en #270); no hay
topics ni subscriptions que agregar.

### Complejidad encontrada

Ninguna: el commit rojo del test-writer ya dejaba resuelta toda la estructura (ctores privados,
serializacion, mensajes, handler). El unico trabajo de la fase verde fue implementar el cuerpo del
factory `Crear` con sus dos garantias (validacion + truncamiento).

### Resultado

- Tests pasando: 337/337 (proyecto `ControlHoras.Tests`), 530/538 en la solucion completa (8
  omitidos por falta de configuracion local de ServiceBus/Postgres para smoke tests, sin relacion
  con este cambio).

</details>
<details>
<summary>Smoke Test Writer — 3m 4s</summary>

_(El agente no generó resumen)_

</details>
<details>
<summary>Reviewer (fase refactor) — 14m 11s</summary>

## ES Reviewer - Revision

### Evaluacion general
- Calidad: **buena**
- Cambios realizados: **si** (commit `5179006`, refactor sin cambios de comportamiento)
- Suite: 540 tests, 532 correctos, 8 omitidos (smoke sin `ServiceBus__ConnectionString` /
  `Postgres__ConnectionString` local), 0 errores. Baseline al inicio de la revision tambien verde
  (538/530) -- no hubo tests rojos heredados ni `blockage-report.md`.

### Cumplimiento de ADRs aplicables

| ADR | Cumplimiento | Observacion |
|---|---|---|
| MEF-ADR-0012: modelado de objetos de dominio | ok | Evento con precondiciones -> `sealed partial class`, ctor parametrizado privado + ctor vacio privado, factory `Crear` que lanza, `ConfigurarSerializacion` via `typeInfo.CreateObject` + reflexion de backing fields. Sin `[JsonConstructor]`. El handler construye el evento y lo pasa a `Iniciar(...)`; el aggregate no construye ni valida. Corregido en refactor: el ctor vacio ahora inicializa `EmpleadoId` (el ADR y `TurnoCreado` lo hacen asi) en vez de suprimir la nulabilidad con `= null!`. |
| MEF-ADR-0004: manejo de errores | ok | El `throw` del factory ocurre en el borde del handler, nunca dentro del aggregate ni en un `Apply()`. Un `EmpleadoId` vacio es dato malo del cliente (ya interceptado con 400 por el validator de #279), no una regla de negocio, asi que no se modela como evento de fallo. Reforzado: el test del throw ahora afirma que no se persiste ni se publica nada. |
| MEF-ADR-0009: mensajes en `.resx` | ok | `MarcacionRegistradaMensajes.resx` + `MarcacionRegistrada.Mensajes.cs` (`partial class` con `ResourceManager` y clase `Mensajes` anidada) en el mismo ensamblado del evento, espejo exacto de `TurnoCreadoMensajes.resx` / `TurnoCreado.Mensajes.cs`. Nombre logico del recurso correcto. Tests afirman contra la constante, nunca contra el literal. |
| CA-ADR-0025 (seccion 4): el modelo rico no cruza el bus | ok | El resolver custom queda como mecanismo exclusivo del event store, y ahora es **verificable**: cerrado el ctor, el evento deja de ser reconstruible con el serializador del canal (`Deserializar_LanzaNotSupportedException_CuandoUsaElSerializadorDelCanalDeBus`). Lo que cruza el bus sigue siendo `RegistroDeMarcacionCreado`, plano, sin cambios. |
| CA-ADR-0029 (seccion 5): los eventos no conocen los comandos | ok | `Crear(string, DateTime, string?, string?)` recibe primitivos; no referencia `RegistrarMarcacion` (que vive en la Function App). Sin ciclo de referencias. |
| CA-ADR-0029 (seccion 6): el alias es la identidad | ok | El tipo conserva nombre y ensamblado -> alias `marcacion_registrada` intacto; sigue en `IdentidadEventosControlHoras.TiposPersistidos`. Sin `MapEventType` ni cambios de `EventNamingStyle`. |
| MEF-ADR-0018: extraccion vs duplicacion | ok | `TruncarAlMinuto` se mueve al factory como metodo privado, sin anticipar la configurabilidad por empresa que anuncia el glosario. Regla unica -> `ArgumentException` directa, sin la ceremonia del `AggregateException` de `TurnoCreado`. |
| MEF-ADR-0016: naming de tests (transversal) | desviacion NO declarada, corregida | Ver abajo. |

### Desviaciones de ADRs

**Desviaciones declaradas por el implementer**: ninguna. El resumen de fase verde declara
"Ninguna desviacion -- todos los ADRs aplicados al pie de la letra", y la verificacion sobre el
diff lo confirma para los seis ADRs listados en el issue.

**Desviaciones detectadas por el reviewer (NO declaradas por el implementer)**:

#### Desviacion: MEF-ADR-0016 (convencion de naming de tests)
- **Regla del ADR**: `<Sujeto>_<LoQuePasa>[_Cuando<Condicion>]` -- el tercer segmento, cuando existe,
  empieza por `Cuando`. `<LoQuePasa>` es el efecto observable (ej. `LanzaArgumentException`).
- **Desviacion encontrada en el diff**: cuatro metodos usaban `_Con<...>` como tercer segmento o un
  `<LoQuePasa>` inespecifico -- `RoundTrip_ReconstruyeEvento_ConDatosCompletos`,
  `Deserializar_LanzaNotSupportedException_ConSerializadorDelCanalDeBus`,
  `Deserializar_Falla_CuandoResolverNoTieneRegistroDeMarcacionRegistrada` (`Falla` no nombra el
  efecto), `Crear_RetornaMarcacionRegistrada_ConDatosValidos`.
- **Accion tomada**: corregida en refactor (renombres). Suite verde despues.
- **Status**: resuelta, no requiere evaluacion del usuario.

### Precedentes consultados por el implementer

| Precedente | ADR aplicable | Veredicto |
|---|---|---|
| `TurnoCreado.cs` (`Programacion.DomainEvents`) | MEF-ADR-0012 | **alineado**. Verificado archivo por archivo: `sealed partial class`, ctor real privado, ctor vacio privado que inicializa sus campos, `ConfigurarSerializacion` con `CreateObject` + backing fields, factory `Crear` publico. La diferencia deliberada (una regla -> `ArgumentException` directa vs. tres reglas -> `AggregateException`) esta justificada en el issue y es correcta. |
| `TurnoCreado.Mensajes.cs` + `InternalsVisibleTo` en `Programacion.DomainEvents.csproj` | MEF-ADR-0009, MEF-ADR-0012 | **alineado**. El `InternalsVisibleTo` que agrega el diff apunta de `ControlHoras.DomainEvents` al **proyecto de tests**, no a otro proyecto de produccion: no es el caso proscrito por MEF-ADR-0012 (abrir internals para que codigo de produccion ajeno haga conversiones). Es el patron ya vigente en el dominio gemelo. |

### Convenciones del pipeline (no ADRs)

| Convencion | Estado | Observacion |
|---|---|---|
| Cada test con `Then()` + `And<>()` | ok | Los tres tests de flujo del handler traen `Then(streamId, ...)` + `ThenIsPublishedPrivately(...)` + uno o dos `And<RegistroDeMarcacionAggregateRoot, T>(...)`. El test del `throw` no lleva `And<>` (el aggregate nunca llega a existir), igual que su precedente `CrearTurnoCommandHandlerTests.DebeLanzarExcepcion_CuandoTurnoYaExiste`; se reforzo con `Then(StreamIdSinEmpleado)` + `ThenIsPublishedPrivately()` para que afirme algo, y se **verifico por mutacion** que ambas aserciones muerden (mutar el camino feliz a esas mismas llamadas pone el test en rojo). |
| Overloads correctos para stream IDs compuestos | ok | `RegistroDeMarcacionAggregateRoot` tiene `ComputarStreamId(...)`; todos los tests usan `Given(StreamId, ...)`, `Then(StreamId, ...)` y `And<T,P>(StreamId, ...)`. Ningun overload sin `aggregateId`. |
| Fakes manuales (no NSubstitute) | n/a | El handler solo depende de `IEventStore` e `IPrivateEventSender`, provistos por el harness. Cero NSubstitute en el diff. |
| Feature folders (produccion y tests) | ok | Evento y `.resx` en `ControlHoras.DomainEvents` (raiz, junto a sus hermanos); tests en `RegistrarMarcacionFunction/Eventos/` (espejo del precedente `CrearTurnoFunction/Eventos/`), un archivo por responsabilidad: `MarcacionRegistradaTests` (factory) y `MarcacionRegistradaSerializacionTests` (contrato de serializacion). |
| Smoke tests: SkipWhen, secrets, cobertura | ok | No se agregan escenarios y la justificacion es correcta: #275 no introduce ningun efecto secundario nuevo (el handler sigue con `StartStream` + un `PublishAsync`), solo mueve la normalizacion de casa. La cobertura existente ya verifica los dos efectos (persistencia `marcacion_registrada` en Postgres y publicacion transitiva del contrato de bus via `DebePublicarDiaCalculadoYPersistirMarcacionAdicionada...`). Todos los tests con fixture usan `Assert.SkipWhen`; el filtrado es por `EmpleadoId`/`SolicitudId` unicos, nunca posicional. Se condenso la nota de 12 lineas a 6. |
| Proyecciones read-side | n/a | Diff puramente write-side. Ver hallazgo #3 sobre el worker. |
| Tests via ToString/comportamiento | ok | Las propiedades leidas por los tests (`EmpleadoId`, `TimestampNormalizado`, ...) son la interfaz publica que consume el `Apply` del aggregate -- no getters abiertos para el test. La ausencia de ctor publico se verifica por reflexion (`GetConstructors().Should().BeEmpty()`), no exponiendo nada nuevo. |
| Sin numeros magicos | ok | `TimeSpan.TicksPerMinute` en vez de 60/1000; constantes con nombre en los tests (`TimestampConSegundos`, `TimestampNormalizadoEsperado`), literales repetidos eliminados en el refactor. |
| Condiciones en positivo | ok | `if (string.IsNullOrWhiteSpace(empleadoId)) throw ...` es guard clause con early-exit (la excepcion documentada), no una bifurcacion `if`/`else` en negativo. `if (existe) return;` del handler ya esta en positivo. |

### Elegancia del codigo

- **Compacto**: el factory son 6 lineas y el truncamiento una expresion (`AddTicks(-(ticks % TicksPerMinute))`),
  mas exacto que el `new DateTime(y, m, d, h, min, 0, kind)` anterior porque tambien descarta
  fracciones de segundo. El handler perdio 5 lineas y una responsabilidad.
- **Legible**: `timestampCrudo` como nombre del parametro de entrada frente a `TimestampNormalizado`
  como propiedad de salida nombra la transformacion sin comentario adicional.
- **Idiomatico**: `sealed partial class` + factory + `partial class Mensajes` es el patron canonico del
  repo; expression-bodied donde corresponde.
- **Robusto**: la invariante es la ultima barrera antes de escribir la verdad del sistema (el endpoint
  es anonimo); no traga excepciones.
- **Limpio**: sin `Console.WriteLine`, sin codigo comentado, sin caracteres U+2500, sin usings
  innecesarios en los archivos del diff (los 9 `IDE0005` que reporta `dotnet format` son
  preexistentes en otros archivos -- verificado con `git stash`: identicos antes y despues).
- Lo que **no** era elegante y se corrigio: `= null!` como supresor de nulabilidad donde el patron pide
  inicializar en el ctor vacio; un encabezado de archivo con tres numeraciones de CA contradictorias
  entre HU-105, #270 y #275; literales de fecha/empleado repetidos seis veces en los tests.

### Criticas y hallazgos

1. **[mayor -- corregido] Comentario que afirmaba una garantia falsa.**
   `MarcacionRegistradaSerializacionTests` documentaba (dos veces) que el test
   `Deserializar_Falla_CuandoResolverNoTieneRegistroDeMarcacionRegistrada` detecta el borrado de la
   linea de registro en `ConfiguracionSerializacionControlHoras.ConfigurarResolver`. Es falso: ese
   test arma un `DefaultJsonTypeInfoResolver()` vacio inline, asi que pasa siempre, con registro o
   sin el. **Verificado empiricamente**: al borrar la linea de registro fallan exactamente los dos
   `RoundTrip_*` (que usan las opciones reales del dominio) y el test "sin registro" sigue verde.
   Corregido: los comentarios ahora atribuyen la barrera a quien realmente la sostiene.
   Es justo el modo de fallo que el issue documenta para #105 ("cito mal su propio patron de
   referencia") -- un comentario que describe una proteccion inexistente es peor que ninguno.

2. **[menor -- no corregido, fuera de alcance] `PackageReference` muerto en
   `ControlHoras.DomainEvents.csproj`.** Desde #270 ningun tipo del ensamblado implementa
   `IPrivateEvent`/`IPublicEvent`; **verificado** que el proyecto compila sin
   `<PackageReference Include="Cosmos.EventDriven.Abstractions" />` (llega transitivo desde
   `PrivateEvents`). El comentario que el diff actualiza ("ya no implementa IPrivateEvent") queda
   justo encima de la referencia que existia por ese motivo, lo que deja al lector preguntandose por
   que sigue ahi. No se toca: es deuda de #270, no de #275, y el issue no lo tiene en alcance.
   **Sugerencia**: recogerlo en un issue de higiene junto con la revision del mismo `PackageReference`
   en `Programacion.DomainEvents`.

3. **[mayor -- no corregido, riesgo latente, requiere issue propio] El worker de proyecciones registra
   los tipos persistidos pero no el resolver de serializacion.**
   `ConfiguracionMartenProjectionsControlHoras` hace `opts.Events.AddEventTypes(IdentidadEventosControlHoras.TiposPersistidos)`
   -- que incluye `MarcacionRegistrada` -- pero **no** invoca
   `ConfiguracionSerializacionControlHoras.ConfigurarResolver` sobre el serializador del named store
   (el write-side si lo hace, en `ComposicionServicios`). Hoy no rompe nada porque el worker no tiene
   proyecciones concretas y su daemon no lee eventos; el gap ademas **preexiste** a este issue
   (`TurnoCreado` tiene ctor privado desde #3, y los tipos ricos de `TurnoCreado` dependen del
   resolver). Lo que cambia con #275 es que `MarcacionRegistrada` se suma a la lista de tipos que el
   dia que exista la primera proyeccion de ControlHoras fallaran con `NotSupportedException` en vez de
   reconstruirse por su ctor publico. No se corrige aqui porque toca otro proceso, no tiene CA en este
   issue y su guardrail natural es una prueba nueva en el config-test (MEF-ADR-0034 seccion 6).
   **Sugerencia**: issue "replicar el resolver de serializacion de cada dominio en el named store del
   worker de proyecciones", hermano de #277 (que hizo lo mismo con `AddEventTypes`).

4. **[cosmetico -- corregido] Duplicacion aparente entre los dos tests de `NotSupportedException`.**
   Son legitimamente distintos (uno fija el comportamiento con las opciones de Marten sin registro,
   el otro con el serializador del canal de bus, CA-5) pero sus nombres y comentarios no lo dejaban
   ver. Renombrados y re-documentados para que cada uno declare que canal representa.

5. **Sin hallazgos** en: antipatrones de MEF-ADR-0012 (no hay propiedad nueva consumida solo por un
   externo, ni clase estatica operando sobre datos crudos del evento, ni getter para test, ni
   `InternalsVisibleTo` hacia produccion, ni `[JsonConstructor]`, ni `record` con coleccion, ni
   payload rico con marker de bus -- `MarcacionRegistrada` **no** implementa ningun marker desde #270,
   y el que si cruza el bus, `RegistroDeMarcacionCreado`, es un `record` 100% plano sin cambios en
   este diff); comando espejo evitable; `switch`/`if` convertible a lookup map; eficiencia algoritmica.

### Refactorings aplicados

Todos con `dotnet test` verde despues de cada paso (commit `5179006`):

1. `MarcacionRegistrada`: ctor vacio inicializa `EmpleadoId = string.Empty` y se elimina `= null!`
   (alineacion con MEF-ADR-0012 y `TurnoCreado`).
2. `MarcacionRegistrada`: encabezado consolidado; los comentarios de CA quedan prefijados por issue
   (`Issue #275 CA-1`, ...) para que no colisionen las numeraciones de HU-105, #270 y #275.
3. `MarcacionRegistradaSerializacionTests`: comentarios corregidos (hallazgo 1), constantes
   compartidas, orden campos-antes-de-helpers, cuatro renombres por MEF-ADR-0016.
4. `MarcacionRegistradaTests`: renombre por MEF-ADR-0016 + dos casos borde nuevos.
5. `RegistrarMarcacionCommandHandlerTests`: el test del `throw` afirma ahora ausencia de escritura y
   de publicacion; renombre acorde al efecto verificado.
6. `RegistrarMarcacionSmokeTests`: nota de 12 lineas condensada a 6, sin perder la justificacion.

### Cobertura de criterios de aceptacion

| Criterio | Estado | Test(s) |
|---|---|---|
| CA-1: sin constructor publico; unica via es `Crear(...)` | cubierto | `MarcacionRegistrada_NoExponeConstructorPublico` (reflexion sobre `GetConstructors()`), `Crear_RetornaMarcacionRegistrada_CuandoDatosSonValidos`. Refuerzo estructural: todos los demas tests y el handler solo pueden construir via `Crear` -- si el ctor volviera, nada lo delataria salvo el primero. |
| CA-2: `Crear` trunca los segundos (08:09:59 -> 08:09:00) | cubierto | `Crear_TruncaSegundosAlMinuto_CuandoTimestampTraeSegundos`, `Crear_ConservaTimestamp_CuandoYaVieneSinSegundos`, + agregados en revision: `Crear_TruncaFraccionesDeSegundo_CuandoTimestampTraeTicks`, `Crear_PreservaElKindDelTimestamp_CuandoTimestampEsUtc`. |
| CA-3: `ArgumentException` con mensaje de `.resx` si `EmpleadoId` es nulo/vacio/espacios | cubierto | `Crear_LanzaArgumentException_CuandoEmpleadoIdEsNulo` / `...EsVacio` / `...EsSoloEspacios`, los tres afirmando contra `MarcacionRegistrada.Mensajes.EmpleadoIdVacio`. |
| CA-4: el handler ya no trunca ni hace `new`; firma de `Iniciar` intacta; idempotencia preservada | cubierto | `RegistrarMarcacion_EmiteMarcacionRegistradaYPublicaRegistroDeMarcacionCreado_CuandoMarcacionEsNueva`, `RegistrarMarcacion_PropagaCamposOpcionalesNulos_CuandoElComandoNoLosTrae`, `RegistrarMarcacion_NoPersisteNiPublica_CuandoStreamYaExiste`, `RegistrarMarcacion_PropagaArgumentExceptionSinPersistirNiPublicar_CuandoEmpleadoIdEsVacio`. Verificado en el codigo: `TruncarAlMinuto` ya no existe en el handler y `Iniciar(streamId, timestampCrudo, evento)` conserva su firma. |
| CA-5: guardrail -- no deserializable con el serializador del canal de bus | cubierto | `Deserializar_LanzaNotSupportedException_CuandoUsaElSerializadorDelCanalDeBus` (`JsonSerializerDefaults.Web`, sin resolver). Complementado por `Deserializar_LanzaNotSupportedException_CuandoElResolverNoRegistraElTipo`. |
| CA-6: el round-trip con opciones de Marten sigue verde como unica via | cubierto | `RoundTrip_ReconstruyeEvento_CuandoDatosCompletos`, `RoundTrip_ReconstruyeEvento_CuandoCamposOpcionalesSonNulos`, ambos sobre `ConfiguracionSerializacionControlHoras.CrearOpcionesMarten()`. Verificado por mutacion que detectan el borrado del registro. |

### Tests agregados

- `Crear_TruncaFraccionesDeSegundo_CuandoTimestampTraeTicks` -- caso borde de CA-2: el comentario del
  factory promete descartar "segundos y fracciones" y ningun test cubria las fracciones.
- `Crear_PreservaElKindDelTimestamp_CuandoTimestampEsUtc` -- caso borde de CA-2: la implementacion del
  floor cambio de `new DateTime(...)` a aritmetica de ticks; el `Kind` (Utc en el flujo real del
  endpoint) queda fijado contra futuras reimplementaciones.
- Aserciones agregadas (no test nuevo) al test del `throw` del handler: ausencia de escritura en el
  stream y de publicacion al bus.
- Tests de contrato: **no aplica** `IgualdadTestBase<T>` -- MEF-ADR-0012 es explicito en que los
  eventos no implementan `IEquatable<T>` (se identifican por posicion en el stream), y
  `MarcacionRegistrada` no lo implementa. El contrato de serializacion (`ConfigurarSerializacion`) ya
  tiene sus round-trip. El guardrail de portabilidad por bus **no aplica**: el tipo no lleva marker de
  bus desde #270 -- y su version invertida (debe fallar, no sobrevivir) es justamente el CA-5.

</details>

## Cobertura

| Archivo | Cobertura | Umbral | Estado |
|---|---|---|---|
| RegistrarMarcacionCommandHandler.cs | 100.0% | 95% | ok |
| MarcacionRegistrada.Mensajes.cs | - | excluido | - |
| MarcacionRegistrada.cs | - | no evaluado | - |
## Commits

5179006 refactor(hu-275): comentarios verificados, naming MEF-ADR-0016 y casos borde del factory
d3b8327 docs(hu-275): documenta por que no se agregan smoke tests nuevos
a7e90b5 feat(issue-275): implementar factory Crear de MarcacionRegistrada (fase verde)
c26b962 test(hu-275): tests para proteger MarcacionRegistrada con factory y ctor privado (fase roja)

Closes #275