### PR TITLE
infra(dev): #276 Retirar el topic marcacion-registrada que queda sin productor ni consumidor

### DIFF
--- a/infra/environments/dev/main.tf
+++ b/infra/environments/dev/main.tf
@@ -77,26 +77,11 @@ module "service_bus" {
         }
       ]
     }
-    # ADR del marco (decision #3): todo evento privado cruza fisicamente el
-    # ASB interno, aun cuando productor (RegistrarMarcacion) y consumidor
-    # (AdicionarMarcacion) viven en el mismo Function App (ControlHoras).
-    "marcacion-registrada" = {
-      subscriptions = [
-        {
-          name               = "control-horas-escucha-marcacion"
-          correlation_filter = null
-        },
-        {
-          name                = "smoke-tests"
-          correlation_filter  = null
-          default_message_ttl = "PT5M"
-        }
-      ]
-    }
     # Issue #274: contrato de bus propio nacido de separar el doble rol de
-    # MarcacionRegistrada (issue #270). Convive temporalmente con
-    # "marcacion-registrada" hasta que #270 migre productor y consumidor;
-    # el retiro de ese topic es un issue posterior y dependiente de #270.
+    # MarcacionRegistrada (issue #270). El topic "marcacion-registrada" que
+    # este reemplazo dejaba huerfano (sin productor ni consumidor) se retiro
+    # en el issue #276 (MEF-ADR-0001: un topic sin evento no tiene razon de
+    # existir).
     "registro-de-marcacion-creado" = {
       subscriptions = [
         {


### PR DESCRIPTION
## Infraestructura

Implementa los cambios de infraestructura del issue #276.

- **Ambiente**: dev
- **Estado**: HCL escrito y revisado localmente (sin plan ni apply local); pendiente de aplicar por CI
- **Pipeline**: iac-pipeline.sh

## Decisiones del pipeline

<details>
<summary>infra-writer -- 0m 58s</summary>

_(El agente no genero resumen)_

</details>

<details>
<summary>infra-reviewer -- 2m 9s</summary>

_(El agente no genero resumen)_

</details>

## Cambios Terraform

 infra/environments/dev/main.tf | 23 ++++-------------------
 1 file changed, 4 insertions(+), 19 deletions(-)

## Commits

929b5bc infra(dev): retirar el topic marcacion-registrada huerfano

> **Apply pendiente en CI**: este PR no cierra el issue #276. El `terraform apply` lo ejecuta el workflow **Infra CD** al mergear este PR a `main` (MEF-ADR-0022); el issue se cierra automaticamente cuando ese apply termine exitosamente.