### PR TITLE
Alinear el named store de cada dominio con la configuracion de su write-side

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,7 +164,7 @@ Si tu trabajo toca uno de estos temas, consulta el ADR correspondiente antes de 
 | Extracción vs duplicación, Rule of Three, evolución del código | MEF-ADR-0018 |
 | El modelo de dominio rico vive en el dominio y no cruza el bus; lo que cruza es plano | CA-ADR-0025 |
 | Custodia de secretos: connection strings en Key Vault, referencias `@Microsoft.KeyVault(...)`, `AzureWebJobsStorage` por identidad administrada | CA-ADR-0026 |
-| Estrategia de tenancy mono-tenant, `ITenantResolver` de valores fijos | CA-ADR-0027 |
+| Tenancy conjoined operando con un unico tenant, `ITenantResolver` de valores fijos | CA-ADR-0027 |
 | ~~Biblioteca `{Dominio}.Dominio` como frontera write/read~~ — superado por CA-ADR-0029; se conserva su prohibición de que el worker referencie un Function App | CA-ADR-0028 |
 | ~~`Contracts` para eventos públicos y value objects compartidos~~ — superado por CA-ADR-0029; el proyecto fue eliminado | CA-ADR-0002 |
 

--- a/docs/adr/ca-adr-0027-tenancy-conjoined-con-tenant-unico.md
+++ b/docs/adr/ca-adr-0027-tenancy-conjoined-con-tenant-unico.md
@@ -1,4 +1,4 @@
-# CA-ADR-0027: Estrategia de tenancy mono-tenant
+# CA-ADR-0027: Tenancy conjoined operando con un unico tenant
 
 ## Estado
 
@@ -32,9 +32,13 @@ public interface ITenantResolver { string TenantId { get; } string UserId { get;
 - `AgregarTenantResolverHibrido()` / `ProxyTenantResolver`: resuelven `TenantId` y `UserId` a partir
   de headers HTTP (`TenantId`, `user_id`) y lanzan si faltan.
 
-Ninguno encaja con este producto: **Bitakora.ControlAsistencia es mono-tenant.** Los clientes HTTP
-(Postman, smoke tests, front futuro) no envian esos headers, y exigirlos romperia todos los requests
-existentes sin aportar nada -- no hay mas de un tenant que resolver.
+Ninguno encaja con este producto: **la infraestructura de Bitakora.ControlAsistencia es multi-tenant
+conjoined (`Events.TenancyStyle = Conjoined`, `Policies.AllDocumentsAreMultiTenanted()`,
+`AgregarConfiguracionMartenComandos`), pero opera con un unico tenant logico** -- el default de
+Marten, resuelto siempre por `TenantResolverFijo` (ver Decision). Los clientes HTTP (Postman, smoke
+tests, front futuro) no envian headers de tenant, y exigirlos romperia todos los requests existentes
+sin aportar nada -- no hay hoy mas de un tenant que resolver, aunque el modelo de datos ya sea
+conjoined.
 
 ## Decision
 
@@ -76,3 +80,17 @@ header-based de 2.x.**
   unitarios, falla solo en runtime desplegado). El guardrail de proceso para detectarlo antes de
   desplegar (test de composicion del `IHost`/`FunctionsApplication`, o smoke minimo obligatorio
   pre-merge) queda fuera de alcance de este ADR y se rastrea en un issue aparte.
+
+## Control de cambios
+
+- **2026-07-31 (issue #268)**: renombrado el archivo (de
+  `ca-adr-0027-estrategia-tenancy-mono-tenant.md` a
+  `ca-adr-0027-tenancy-conjoined-con-tenant-unico.md`) y corregidos titulo, contexto y decision.
+  El titulo y el contexto originales afirmaban que el producto es mono-tenant, pero la propia
+  decision #2 de este ADR ya describia el modelo real: Marten mapea el tenant fijo a
+  `Tenancy.Default` **aun con `AllDocumentsAreMultiTenanted()` activo** -- es decir, la
+  infraestructura ya es multi-tenant conjoined, y lo que es fijo es el numero de tenants logicos
+  operando sobre ella (uno). Era drift de nomenclatura, no drift de codigo: se detecto al alinear
+  el named store del worker de proyecciones con esta misma tenancy (issue #268), que exigio leer
+  este ADR para decidir si el worker debia declarar `TenancyStyle.Conjoined`. Las consecuencias no
+  cambiaron de fondo.

--- a/docs/adr/ca-adr-0027-tenancy-conjoined-con-tenant-unico.md
+++ b/docs/adr/ca-adr-0027-tenancy-conjoined-con-tenant-unico.md
@@ -42,8 +42,9 @@ conjoined.
 
 ## Decision
 
-**Se implementa un `ITenantResolver` propio, de valores fijos, en vez de adoptar los resolvers
-header-based de 2.x.**
+**Se conserva la infraestructura multi-tenant conjoined que fija `AgregarConfiguracionMartenComandos`
+y se opera sobre ella con un unico tenant logico: se implementa un `ITenantResolver` propio, de
+valores fijos, en vez de adoptar los resolvers header-based de 2.x.**
 
 1. Clase `TenantResolverFijo : ITenantResolver` en `Infraestructura/` de cada dominio
    (`ControlHoras` y `Programacion`). Con solo 2 usos se acepta duplicar la clase en lugar de
@@ -72,6 +73,11 @@ header-based de 2.x.**
   resolver que derive el tenant de una fuente real (header, claim de autenticacion, subdominio, etc.)
   y decidir entonces si adoptar `AgregarTenantResolverHibrido()`/`ProxyTenantResolver` de
   `Cosmos.MultiTenancy.CritterStack` en vez de la implementacion propia.
+- **Todo proceso que lea el event store debe declarar la misma tenancy conjoined que el write-side
+  escribio**, no solo el que escribe: el worker de proyecciones lo hace en el named store de cada
+  dominio (`ConfiguracionMartenProjections{Dominio}`, issue #268), con guardas de config-test que
+  fallan si esa linea desaparece. Un lector que quede con el default `Single` no rompe el build --
+  falla en runtime, leyendo un event store que no encuentra.
 - Este fix es puntual al registro del resolver: no se tocan los sitios de `Invoke`/publicacion de los
   comandos y eventos existentes, que ya construyen internamente `DeliveryOptions` con
   `TenantId`/`user_id` a partir del resolver inyectado.
@@ -93,4 +99,5 @@ header-based de 2.x.**
   operando sobre ella (uno). Era drift de nomenclatura, no drift de codigo: se detecto al alinear
   el named store del worker de proyecciones con esta misma tenancy (issue #268), que exigio leer
   este ADR para decidir si el worker debia declarar `TenancyStyle.Conjoined`. Las consecuencias no
-  cambiaron de fondo.
+  cambiaron de fondo; se sumo una que la version anterior no enunciaba: la obligacion se extiende a
+  **todo** proceso lector del event store, no solo al que escribe.

--- a/src/Bitakora.ControlAsistencia.ControlHoras/Infraestructura/ComposicionServicios.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Infraestructura/ComposicionServicios.cs
@@ -51,8 +51,9 @@ public static class ComposicionServicios
         services.AgregarMartenEventStore();
         // Issue #219: Cosmos.Event* 2.x dejo de auto-registrar un ITenantResolver por defecto (se movio a
         // Cosmos.MultiTenancy.CritterStack), pero los routers/senders de Wolverine lo siguen exigiendo por
-        // constructor. Este proyecto es mono-tenant: se registra un resolver de valores fijos en vez de los
-        // resolvers header-based de 2.x. Ver docs/adr/ca-adr-0027-estrategia-tenancy-mono-tenant.md.
+        // constructor. La infraestructura de este proyecto es multi-tenant conjoined (CA-ADR-0027) pero
+        // opera con un unico tenant logico: se registra un resolver de valores fijos en vez de los
+        // resolvers header-based de 2.x. Ver docs/adr/ca-adr-0027-tenancy-conjoined-con-tenant-unico.md.
         services.AddScoped<ITenantResolver, TenantResolverFijo>();
         // AgregarWolverineCommandRouter se conserva: RegistrarMarcacion (HTTP) lo sigue usando.
         services.AgregarWolverineCommandRouter();

--- a/src/Bitakora.ControlAsistencia.ControlHoras/Infraestructura/TenantResolverFijo.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Infraestructura/TenantResolverFijo.cs
@@ -3,14 +3,15 @@ using JasperFx;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.Infraestructura;
 
-// Issue #219: ITenantResolver mono-tenant. Cosmos.Event* 2.x dejo de auto-registrar un
+// Issue #219: ITenantResolver de tenant unico. Cosmos.Event* 2.x dejo de auto-registrar un
 // ITenantResolver por defecto en AgregarWolverineCommandRouter/AgregarWolverinePrivateEventRouter,
 // pero WolverineCommandRouter/WolverineQueryRouter/WolverinePrivateEventRouter/
 // WolverinePublicEventSender/WolverinePrivateEventSender lo siguen exigiendo por constructor.
-// Este proyecto es mono-tenant: se registra un ITenantResolver con valores fijos en vez de los
-// resolvers header-based de 2.x (AgregarTenantResolverHibrido/ProxyTenantResolver), que exigirian
-// headers TenantId/user_id inexistentes en este flujo HTTP.
-// Ver docs/adr/ca-adr-0027-estrategia-tenancy-mono-tenant.md y
+// La infraestructura de este proyecto es multi-tenant conjoined (CA-ADR-0027) pero opera con un
+// unico tenant logico: se registra un ITenantResolver con valores fijos en vez de los resolvers
+// header-based de 2.x (AgregarTenantResolverHibrido/ProxyTenantResolver), que exigirian headers
+// TenantId/user_id inexistentes en este flujo HTTP.
+// Ver docs/adr/ca-adr-0027-tenancy-conjoined-con-tenant-unico.md y
 // docs/bitacora/field-notes/2026-07-18-1905-bug-investigation.md.
 public sealed class TenantResolverFijo : ITenantResolver
 {

--- a/src/Bitakora.ControlAsistencia.Programacion/Infraestructura/ComposicionServicios.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/Infraestructura/ComposicionServicios.cs
@@ -44,8 +44,9 @@ public static class ComposicionServicios
         services.AgregarMartenEventStore();
         // Issue #219: Cosmos.Event* 2.x dejo de auto-registrar un ITenantResolver por defecto (se movio a
         // Cosmos.MultiTenancy.CritterStack), pero los routers/senders de Wolverine lo siguen exigiendo por
-        // constructor. Este proyecto es mono-tenant: se registra un resolver de valores fijos en vez de los
-        // resolvers header-based de 2.x. Ver docs/adr/ca-adr-0027-estrategia-tenancy-mono-tenant.md.
+        // constructor. La infraestructura de este proyecto es multi-tenant conjoined (CA-ADR-0027) pero
+        // opera con un unico tenant logico: se registra un resolver de valores fijos en vez de los
+        // resolvers header-based de 2.x. Ver docs/adr/ca-adr-0027-tenancy-conjoined-con-tenant-unico.md.
         services.AddScoped<ITenantResolver, TenantResolverFijo>();
         services.AgregarWolverineCommandRouter();
         services.AgregarWolverineEventSender();

--- a/src/Bitakora.ControlAsistencia.Programacion/Infraestructura/TenantResolverFijo.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/Infraestructura/TenantResolverFijo.cs
@@ -3,14 +3,15 @@ using JasperFx;
 
 namespace Bitakora.ControlAsistencia.Programacion.Infraestructura;
 
-// Issue #219: ITenantResolver mono-tenant. Cosmos.Event* 2.x dejo de auto-registrar un
+// Issue #219: ITenantResolver de tenant unico. Cosmos.Event* 2.x dejo de auto-registrar un
 // ITenantResolver por defecto en AgregarWolverineCommandRouter, pero WolverineCommandRouter/
 // WolverineQueryRouter/WolverinePublicEventSender/WolverinePrivateEventSender lo siguen
 // exigiendo por constructor.
-// Este proyecto es mono-tenant: se registra un ITenantResolver con valores fijos en vez de los
-// resolvers header-based de 2.x (AgregarTenantResolverHibrido/ProxyTenantResolver), que exigirian
-// headers TenantId/user_id inexistentes en este flujo HTTP.
-// Ver docs/adr/ca-adr-0027-estrategia-tenancy-mono-tenant.md y
+// La infraestructura de este proyecto es multi-tenant conjoined (CA-ADR-0027) pero opera con un
+// unico tenant logico: se registra un ITenantResolver con valores fijos en vez de los resolvers
+// header-based de 2.x (AgregarTenantResolverHibrido/ProxyTenantResolver), que exigirian headers
+// TenantId/user_id inexistentes en este flujo HTTP.
+// Ver docs/adr/ca-adr-0027-tenancy-conjoined-con-tenant-unico.md y
 // docs/bitacora/field-notes/2026-07-18-1905-bug-investigation.md.
 public sealed class TenantResolverFijo : ITenantResolver
 {

--- a/src/Bitakora.ControlAsistencia.Projections/Infraestructura/ConfiguracionMartenProjectionsControlHoras.cs
+++ b/src/Bitakora.ControlAsistencia.Projections/Infraestructura/ConfiguracionMartenProjectionsControlHoras.cs
@@ -1,7 +1,10 @@
+using System.Text.Json.Serialization.Metadata;
 using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
-using JasperFx.Events; // StreamIdentity (NO Marten.Events, mismo gotcha que DaemonMode)
+using JasperFx.Events; // StreamIdentity, EventNamingStyle (NO Marten.Events, mismo gotcha que DaemonMode)
 using JasperFx.Events.Daemon; // DaemonMode (NO Marten.Events.Daemon: compila pero deja DaemonMode sin resolver)
+using JasperFx.MultiTenancy; // TenancyStyle (NO Marten.*, mismo gotcha que StreamIdentity/DaemonMode)
 using Marten;
+using Weasel.Core; // EnumStorage, Casing (NO Marten.*: viven en Weasel.Core)
 
 namespace Bitakora.ControlAsistencia.Projections.Infraestructura;
 
@@ -47,6 +50,27 @@ public static class ConfiguracionMartenProjectionsControlHoras
                 // el event store (stream_id varchar) como uuid, sin encontrar ningun stream (#253).
                 opts.Events.StreamIdentity = StreamIdentity.AsString;
 
+                // Issue #268 CA-1 (MEF-ADR-0034 seccion 6 enmendada por #447 del marco, "par 1"):
+                // el event store se escribio con tenancy conjoined
+                // (AgregarConfiguracionMartenComandos, Cosmos.EventSourcing.CritterStack 2.3.1) y
+                // Marten documenta TenancyStyle.Conjoined como un modelo opt-in ("Event Store
+                // Multi-Tenancy": https://martendb.io/events/multitenancy.html) que el lado que lee
+                // debe declarar igual que el que escribio. Sin esta linea el daemon queda con el
+                // default Single, desalineado del write-side.
+                opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+
+                // Issue #268 CA-1: replica de Events.EventNamingStyle = SmarterTypeName. Hoy inocua
+                // (los eventos persistidos son tipos top-level; SmarterTypeName solo desambigua
+                // tipos anidados, doc XML de JasperFx.Events), pero sin esta linea un futuro evento
+                // anidado calcularia un alias distinto entre write-side y worker, sin ninguna senal
+                // en el build.
+                opts.Events.EventNamingStyle = EventNamingStyle.SmarterTypeName;
+
+                // Issue #268 CA-1 ("par 2"): Policies.AllDocumentsAreMultiTenanted() gobierna la
+                // forma de la tabla de cualquier read model que este worker llegue a materializar
+                // -- no el event store, sino el query-side del Function App (session.LoadAsync).
+                opts.Policies.AllDocumentsAreMultiTenanted();
+
                 // Replica de la configuracion de metadata del write-side (MEF-ADR-0034 seccion 6
                 // punto 3, seccion 7): el config-test verifica exactamente estas tres. La
                 // habilitacion real de las columnas es responsabilidad del write-side de este
@@ -60,6 +84,21 @@ public static class ConfiguracionMartenProjectionsControlHoras
                 // daemon no dependa del fallback por mt_dotnet_type al leer streams preexistentes
                 // (issue #237 seccion "Consecuencia asumida").
                 opts.Events.AddEventTypes(IdentidadEventosControlHoras.TiposPersistidos);
+
+                // Issue #268 CA-2: serializador y resolver en una sola llamada -- misma razon de
+                // forma que en Programacion (ver comentario en ConfiguracionMartenProjectionsProgramacion).
+                // Solo replica ConfiguracionSerializacionControlHoras (eventos persistidos en
+                // DomainEvents): ConfiguracionSerializacionCalculoHoras vive en el Function App de
+                // ControlHoras y cubre VOs de calculo que no se persisten -- este ensamblado no
+                // puede referenciarla (CA-ADR-0029) y no le hace falta (issue, notas de analisis).
+                // Fuente unica con el write-side (MEF-ADR-0029): se invoca la misma clase, nunca
+                // una copia.
+                opts.UseSystemTextJsonForSerialization(EnumStorage.AsInteger, Casing.Default, json =>
+                {
+                    var resolver = new DefaultJsonTypeInfoResolver();
+                    ConfiguracionSerializacionControlHoras.ConfigurarResolver(resolver);
+                    json.TypeInfoResolver = resolver;
+                });
             })
             // Registrar el store no basta: sin esta llamada el daemon queda apagado y ninguna
             // proyeccion se materializa. HotCold elige lider sobre advisory locks de PostgreSQL,

--- a/src/Bitakora.ControlAsistencia.Projections/Infraestructura/ConfiguracionMartenProjectionsControlHoras.cs
+++ b/src/Bitakora.ControlAsistencia.Projections/Infraestructura/ConfiguracionMartenProjectionsControlHoras.cs
@@ -93,11 +93,11 @@ public static class ConfiguracionMartenProjectionsControlHoras
                 // puede referenciarla (CA-ADR-0029) y no le hace falta (issue, notas de analisis).
                 // Fuente unica con el write-side (MEF-ADR-0029): se invoca la misma clase, nunca
                 // una copia.
-                opts.UseSystemTextJsonForSerialization(EnumStorage.AsInteger, Casing.Default, json =>
+                opts.UseSystemTextJsonForSerialization(EnumStorage.AsInteger, Casing.Default, jsonOptions =>
                 {
                     var resolver = new DefaultJsonTypeInfoResolver();
                     ConfiguracionSerializacionControlHoras.ConfigurarResolver(resolver);
-                    json.TypeInfoResolver = resolver;
+                    jsonOptions.TypeInfoResolver = resolver;
                 });
             })
             // Registrar el store no basta: sin esta llamada el daemon queda apagado y ninguna

--- a/src/Bitakora.ControlAsistencia.Projections/Infraestructura/ConfiguracionMartenProjectionsProgramacion.cs
+++ b/src/Bitakora.ControlAsistencia.Projections/Infraestructura/ConfiguracionMartenProjectionsProgramacion.cs
@@ -1,7 +1,10 @@
+using System.Text.Json.Serialization.Metadata;
 using Bitakora.ControlAsistencia.Programacion.DomainEvents;
-using JasperFx.Events; // StreamIdentity (NO Marten.Events, mismo gotcha que DaemonMode)
+using JasperFx.Events; // StreamIdentity, EventNamingStyle (NO Marten.Events, mismo gotcha que DaemonMode)
 using JasperFx.Events.Daemon; // DaemonMode (NO Marten.Events.Daemon: compila pero deja DaemonMode sin resolver)
+using JasperFx.MultiTenancy; // TenancyStyle (NO Marten.*, mismo gotcha que StreamIdentity/DaemonMode)
 using Marten;
+using Weasel.Core; // EnumStorage, Casing (NO Marten.*: viven en Weasel.Core)
 
 namespace Bitakora.ControlAsistencia.Projections.Infraestructura;
 
@@ -47,6 +50,27 @@ public static class ConfiguracionMartenProjectionsProgramacion
                 // el event store (stream_id varchar) como uuid, sin encontrar ningun stream (#253).
                 opts.Events.StreamIdentity = StreamIdentity.AsString;
 
+                // Issue #268 CA-1 (MEF-ADR-0034 seccion 6 enmendada por #447 del marco, "par 1"):
+                // el event store se escribio con tenancy conjoined
+                // (AgregarConfiguracionMartenComandos, Cosmos.EventSourcing.CritterStack 2.3.1) y
+                // Marten documenta TenancyStyle.Conjoined como un modelo opt-in ("Event Store
+                // Multi-Tenancy": https://martendb.io/events/multitenancy.html) que el lado que lee
+                // debe declarar igual que el que escribio. Sin esta linea el daemon queda con el
+                // default Single, desalineado del write-side.
+                opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+
+                // Issue #268 CA-1: replica de Events.EventNamingStyle = SmarterTypeName. Hoy inocua
+                // (los eventos persistidos son tipos top-level; SmarterTypeName solo desambigua
+                // tipos anidados, doc XML de JasperFx.Events), pero sin esta linea un futuro evento
+                // anidado calcularia un alias distinto entre write-side y worker, sin ninguna senal
+                // en el build.
+                opts.Events.EventNamingStyle = EventNamingStyle.SmarterTypeName;
+
+                // Issue #268 CA-1 ("par 2"): Policies.AllDocumentsAreMultiTenanted() gobierna la
+                // forma de la tabla de cualquier read model que este worker llegue a materializar
+                // -- no el event store, sino el query-side del Function App (session.LoadAsync).
+                opts.Policies.AllDocumentsAreMultiTenanted();
+
                 // Replica de la configuracion de metadata del write-side (MEF-ADR-0034 seccion 6
                 // punto 3, seccion 7): el config-test verifica exactamente estas tres. La
                 // habilitacion real de las columnas es responsabilidad del write-side de este
@@ -60,6 +84,26 @@ public static class ConfiguracionMartenProjectionsProgramacion
                 // daemon no dependa del fallback por mt_dotnet_type al leer streams preexistentes
                 // (issue #237 seccion "Consecuencia asumida").
                 opts.Events.AddEventTypes(IdentidadEventosProgramacion.TiposPersistidos);
+
+                // Issue #268 CA-2: serializador y resolver en una sola llamada. A diferencia del
+                // write-side (ComposicionServicios.cs), que engancha el resolver despues via
+                // `if (opts.Serializer() is SystemTextJsonSerializer stj) stj.Configure(...)`
+                // porque el paquete ya construyo el serializador, aqui se controla todo el lambda
+                // de una vez -- UseSystemTextJsonForSerialization construye un serializador NUEVO
+                // y lo reemplaza, asi que si se invocara despues de un stj.Configure(...) previo
+                // ("la trampa del orden") el TypeInfoResolver se perderia en runtime, sin error de
+                // compilacion. EnumStorage.AsInteger/Casing.Default son los defaults del propio
+                // metodo -- se declaran igual, no porque hoy diverjan (ningun enum persistido
+                // cruza este ensamblado, CA-ADR-0029), sino para no depender de un default de
+                // Marten que un upgrade futuro podria mover.
+                // Fuente unica con el write-side (MEF-ADR-0029): se invoca la misma clase
+                // ConfiguracionSerializacionProgramacion, nunca una copia.
+                opts.UseSystemTextJsonForSerialization(EnumStorage.AsInteger, Casing.Default, json =>
+                {
+                    var resolver = new DefaultJsonTypeInfoResolver();
+                    ConfiguracionSerializacionProgramacion.ConfigurarResolver(resolver);
+                    json.TypeInfoResolver = resolver;
+                });
             })
             // Registrar el store no basta: sin esta llamada el daemon queda apagado y ninguna
             // proyeccion se materializa. HotCold elige lider sobre advisory locks de PostgreSQL,

--- a/src/Bitakora.ControlAsistencia.Projections/Infraestructura/ConfiguracionMartenProjectionsProgramacion.cs
+++ b/src/Bitakora.ControlAsistencia.Projections/Infraestructura/ConfiguracionMartenProjectionsProgramacion.cs
@@ -98,11 +98,11 @@ public static class ConfiguracionMartenProjectionsProgramacion
                 // Marten que un upgrade futuro podria mover.
                 // Fuente unica con el write-side (MEF-ADR-0029): se invoca la misma clase
                 // ConfiguracionSerializacionProgramacion, nunca una copia.
-                opts.UseSystemTextJsonForSerialization(EnumStorage.AsInteger, Casing.Default, json =>
+                opts.UseSystemTextJsonForSerialization(EnumStorage.AsInteger, Casing.Default, jsonOptions =>
                 {
                     var resolver = new DefaultJsonTypeInfoResolver();
                     ConfiguracionSerializacionProgramacion.ConfigurarResolver(resolver);
-                    json.TypeInfoResolver = resolver;
+                    jsonOptions.TypeInfoResolver = resolver;
                 });
             })
             // Registrar el store no basta: sin esta llamada el daemon queda apagado y ninguna

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/TenantResolverFijoTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/TenantResolverFijoTests.cs
@@ -1,4 +1,5 @@
-// Issue #219: ITenantResolver mono-tenant para ControlHoras.
+// Issue #219: ITenantResolver de tenant unico para ControlHoras (CA-ADR-0027: infraestructura
+// multi-tenant conjoined operando con un unico tenant logico).
 // Sin este resolver registrado en el DI, WolverineCommandRouter y WolverinePrivateEventRouter no
 // pueden construirse (breaking change de Cosmos.Event* 2.x). Ver
 // docs/bitacora/field-notes/2026-07-18-1905-bug-investigation.md.

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/Infraestructura/TenantResolverFijoTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/Infraestructura/TenantResolverFijoTests.cs
@@ -1,4 +1,5 @@
-// Issue #219: ITenantResolver mono-tenant para Programacion.
+// Issue #219: ITenantResolver de tenant unico para Programacion (CA-ADR-0027: infraestructura
+// multi-tenant conjoined operando con un unico tenant logico).
 // Sin este resolver registrado en el DI, WolverineCommandRouter no puede construirse (breaking
 // change de Cosmos.Event* 2.x). Ver docs/bitacora/field-notes/2026-07-18-1905-bug-investigation.md.
 //

--- a/tests/Bitakora.ControlAsistencia.Projections.Tests/ConfiguracionMartenProjectionsTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Projections.Tests/ConfiguracionMartenProjectionsTests.cs
@@ -13,11 +13,18 @@ namespace Bitakora.ControlAsistencia.Projections.Tests;
 // cadena de conexion dummy, sin necesidad de Postgres real (Marten 7+ no abre la conexion durante
 // el bootstrapping del IHost). Cada dominio se cubre con las mismas guardas: el named store
 // resuelve del contenedor, apunta al schema del write-side, replica su metadata de evento y su
-// identidad de stream, no tiene ninguna proyeccion Inline y corre su daemon en HotCold. La
-// superficie de Marten que cada una interroga vive en AssertsProyecciones.
+// identidad de stream, no tiene ninguna proyeccion Inline y corre su daemon en HotCold. Issue #268
+// (CA-1/CA-2, MEF-ADR-0034 seccion 6 enmendada por #447 del marco): ademas replica la tenancy y el
+// naming de eventos del write-side, la politica de documentos multi-tenant (par 2 del issue) y el
+// resolver de serializacion custom (fuente unica con el write-side, MEF-ADR-0029). La superficie de
+// Marten que cada una interroga vive en AssertsProyecciones.
 public class ConfiguracionMartenProjectionsTests
 {
     private const string ConnectionStringDummy = "Host=localhost;Database=dummy";
+
+    // Issue #268 CA-2: identificadores fijos para los canarios de round-trip del resolver -- el
+    // valor en si es irrelevante, solo debe ser estable para que el test sea reproducible.
+    private static readonly Guid TurnoIdCanario = Guid.Parse("019600a0-0000-7000-8000-000000000099");
 
     private static ServiceProvider CrearProvider(Action<IServiceCollection> configurarDominio)
     {
@@ -87,6 +94,63 @@ public class ConfiguracionMartenProjectionsTests
         provider.GetRequiredService<IProgramacionProjectionStore>().AssertStreamIdentityAsString();
     }
 
+    // Issue #268 CA-1: tenancy de eventos conjoined, mismo modelo con el que el write-side escribio
+    // el event store.
+    [Fact]
+    public void ConfigurarProgramacion_DeclaraTenancyDeEventosConjoined()
+    {
+        using var provider = ProviderDeProgramacion();
+
+        provider.GetRequiredService<IProgramacionProjectionStore>().AssertTenancyDeEventosConjoined();
+    }
+
+    // Issue #268 CA-1: naming de eventos SmarterTypeName, replica del write-side.
+    [Fact]
+    public void ConfigurarProgramacion_DeclaraEventNamingStyleSmarterTypeName()
+    {
+        using var provider = ProviderDeProgramacion();
+
+        provider.GetRequiredService<IProgramacionProjectionStore>().AssertEventNamingStyleSmarterTypeName();
+    }
+
+    // Issue #268 CA-1: Policies.AllDocumentsAreMultiTenanted() -- gobierna el par 2 (worker ->
+    // query-side), la forma de la tabla de cualquier read model futuro de este dominio.
+    [Fact]
+    public void ConfigurarProgramacion_DeclaraLosDocumentosComoMultiTenant()
+    {
+        using var provider = ProviderDeProgramacion();
+
+        provider.GetRequiredService<IProgramacionProjectionStore>()
+            .AssertDocumentosMultiTenant<DocumentoCanarioTenancy>();
+    }
+
+    // Issue #268 CA-2: el resolver custom de Programacion (misma fuente que invoca el write-side,
+    // MEF-ADR-0029) sobrevive el round-trip contra el ISerializer real del named store.
+    // TurnoCreado.Crear tiene ambos constructores privados -- STJ no puede reconstruirlo sin el
+    // resolver, ni si UseSystemTextJsonForSerialization se invoca despues de engancharlo.
+    [Fact]
+    public void ConfigurarProgramacion_ConservaElResolverDeSerializacionCustom()
+    {
+        using var provider = ProviderDeProgramacion();
+        var evento = TurnoCreado.Crear(
+            TurnoIdCanario,
+            "Turno Canario",
+            [new DatosFranja(
+                new TimeOnly(6, 0), new TimeOnly(14, 0),
+                [(new TimeOnly(10, 0), new TimeOnly(10, 15))],
+                [(new TimeOnly(6, 0), new TimeOnly(6, 30))])]);
+
+        var restaurado = provider.GetRequiredService<IProgramacionProjectionStore>()
+            .DeserializarConResolverDeSerializacionCustom(evento);
+
+        restaurado.Should().NotBeNull();
+        restaurado.TurnoId.Should().Be(TurnoIdCanario);
+        restaurado.Nombre.Should().Be("Turno Canario");
+        restaurado.FranjasOrdinarias.Should().HaveCount(1);
+        restaurado.FranjasOrdinarias[0].ToString()
+            .Should().Be("(06:00-14:00)[Descansos:(10:00-10:15)][Extras:(06:00-06:30)]");
+    }
+
     // Issue #277 CA-3/CA-4: defensa en profundidad read-side. El worker no esta expuesto hoy (sin
     // proyecciones concretas), pero lo estara en cuanto las tenga -- este guardrail evita que ese
     // dia el daemon lea streams preexistentes sin el tipo registrado en su propio EventGraph.
@@ -153,6 +217,57 @@ public class ConfiguracionMartenProjectionsTests
         using var provider = ProviderDeControlHoras();
 
         provider.GetRequiredService<IControlHorasProjectionStore>().AssertStreamIdentityAsString();
+    }
+
+    // Issue #268 CA-1: tenancy de eventos conjoined, mismo modelo con el que el write-side escribio
+    // el event store.
+    [Fact]
+    public void ConfigurarControlHoras_DeclaraTenancyDeEventosConjoined()
+    {
+        using var provider = ProviderDeControlHoras();
+
+        provider.GetRequiredService<IControlHorasProjectionStore>().AssertTenancyDeEventosConjoined();
+    }
+
+    // Issue #268 CA-1: naming de eventos SmarterTypeName, replica del write-side.
+    [Fact]
+    public void ConfigurarControlHoras_DeclaraEventNamingStyleSmarterTypeName()
+    {
+        using var provider = ProviderDeControlHoras();
+
+        provider.GetRequiredService<IControlHorasProjectionStore>().AssertEventNamingStyleSmarterTypeName();
+    }
+
+    // Issue #268 CA-1: Policies.AllDocumentsAreMultiTenanted() -- gobierna el par 2 (worker ->
+    // query-side), la forma de la tabla de cualquier read model futuro de este dominio.
+    [Fact]
+    public void ConfigurarControlHoras_DeclaraLosDocumentosComoMultiTenant()
+    {
+        using var provider = ProviderDeControlHoras();
+
+        provider.GetRequiredService<IControlHorasProjectionStore>()
+            .AssertDocumentosMultiTenant<DocumentoCanarioTenancy>();
+    }
+
+    // Issue #268 CA-2: el resolver custom de ControlHoras (misma fuente que invoca el write-side,
+    // MEF-ADR-0029) sobrevive el round-trip contra el ISerializer real del named store.
+    // MarcacionRegistrada.Crear tiene ambos constructores privados -- STJ no puede reconstruirlo sin
+    // el resolver, ni si UseSystemTextJsonForSerialization se invoca despues de engancharlo.
+    [Fact]
+    public void ConfigurarControlHoras_ConservaElResolverDeSerializacionCustom()
+    {
+        using var provider = ProviderDeControlHoras();
+        var evento = MarcacionRegistrada.Crear(
+            "1098765432", new DateTime(2026, 7, 31, 8, 0, 0), "Entrada", "disp-01");
+
+        var restaurado = provider.GetRequiredService<IControlHorasProjectionStore>()
+            .DeserializarConResolverDeSerializacionCustom(evento);
+
+        restaurado.Should().NotBeNull();
+        restaurado.EmpleadoId.Should().Be("1098765432");
+        restaurado.TimestampNormalizado.Should().Be(new DateTime(2026, 7, 31, 8, 0, 0));
+        restaurado.TipoMarcacion.Should().Be("Entrada");
+        restaurado.DispositivoId.Should().Be("disp-01");
     }
 
     // Issue #277 CA-3/CA-4: defensa en profundidad read-side. El worker no esta expuesto hoy (sin

--- a/tests/Bitakora.ControlAsistencia.Projections.Tests/ConfiguracionMartenProjectionsTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Projections.Tests/ConfiguracionMartenProjectionsTests.cs
@@ -22,8 +22,9 @@ public class ConfiguracionMartenProjectionsTests
 {
     private const string ConnectionStringDummy = "Host=localhost;Database=dummy";
 
-    // Issue #268 CA-2: identificadores fijos para los canarios de round-trip del resolver -- el
-    // valor en si es irrelevante, solo debe ser estable para que el test sea reproducible.
+    // Issue #268 CA-2: identidad del canario de round-trip de Programacion (el de ControlHoras,
+    // MarcacionRegistrada, se identifica por EmpleadoId string y no necesita ninguna). El valor en
+    // si es irrelevante: solo debe ser estable para que el test sea reproducible.
     private static readonly Guid TurnoIdCanario = Guid.Parse("019600a0-0000-7000-8000-000000000099");
 
     private static ServiceProvider CrearProvider(Action<IServiceCollection> configurarDominio)

--- a/tests/Bitakora.ControlAsistencia.Projections.Tests/Infraestructura/AssertsProyecciones.cs
+++ b/tests/Bitakora.ControlAsistencia.Projections.Tests/Infraestructura/AssertsProyecciones.cs
@@ -154,7 +154,7 @@ public static class AssertsProyecciones
     {
         var serializador = store.Options.Serializer();
 
-        using var json = new MemoryStream(Encoding.UTF8.GetBytes(serializador.ToJson(original)));
-        return serializador.FromJson<TEvento>(json);
+        using var flujoJson = new MemoryStream(Encoding.UTF8.GetBytes(serializador.ToJson(original)));
+        return serializador.FromJson<TEvento>(flujoJson);
     }
 }

--- a/tests/Bitakora.ControlAsistencia.Projections.Tests/Infraestructura/AssertsProyecciones.cs
+++ b/tests/Bitakora.ControlAsistencia.Projections.Tests/Infraestructura/AssertsProyecciones.cs
@@ -1,7 +1,9 @@
+using System.Text;
 using AwesomeAssertions;
 using JasperFx.Events;
 using JasperFx.Events.Daemon;
 using JasperFx.Events.Projections;
+using JasperFx.MultiTenancy; // TenancyStyle (NO Marten.*, mismo gotcha que StreamIdentity/DaemonMode)
 using Marten;
 using Marten.Events.Daemon.Coordination;
 using Microsoft.Extensions.DependencyInjection;
@@ -91,4 +93,68 @@ public static class AssertsProyecciones
     /// </summary>
     public static void AssertStreamIdentityAsString(this IDocumentStore store) =>
         store.Options.Events.StreamIdentity.Should().Be(StreamIdentity.AsString);
+
+    /// <summary>
+    /// Issue #268 CA-1: el named store lee el event store con el mismo modelo de tenancy con el
+    /// que el write-side lo escribio (AgregarConfiguracionMartenComandos, Cosmos.EventSourcing.
+    /// CritterStack 2.3.1: Events.TenancyStyle = Conjoined). Marten documenta TenancyStyle.
+    /// Conjoined como un modelo opt-in que captura los eventos por tenant ("Event Store
+    /// Multi-Tenancy": https://martendb.io/events/multitenancy.html) -- el lado que lee tiene que
+    /// declarar el mismo modelo que el que escribio. Sin esta linea el named store queda con el
+    /// default Single, un par 1 (eventos, ver contexto del issue) desalineado con el write-side.
+    ///
+    /// Igual que StreamIdentity, TenancyStyle esta declarada en la superficie de solo lectura
+    /// (Marten.Events.IReadOnlyEventStoreOptions.TenancyStyle, get-only), asi que no hace falta
+    /// castear a StoreOptions.
+    /// </summary>
+    public static void AssertTenancyDeEventosConjoined(this IDocumentStore store) =>
+        store.Options.Events.TenancyStyle.Should().Be(TenancyStyle.Conjoined);
+
+    /// <summary>
+    /// Issue #268 CA-1: replica de Events.EventNamingStyle = SmarterTypeName (el write-side lo
+    /// declara via AgregarConfiguracionMartenComandos). Hoy es inocua -- los eventos persistidos de
+    /// este BC son tipos top-level, y SmarterTypeName solo desambigua tipos anidados prefijando
+    /// "[tipo externo].[tipo interno]" (doc XML de JasperFx.Events) -- pero sin esta linea el named
+    /// store calcularia el alias de un futuro evento anidado distinto de como lo calcula el
+    /// write-side, sin ninguna senal en el build.
+    /// </summary>
+    public static void AssertEventNamingStyleSmarterTypeName(this IDocumentStore store) =>
+        store.Options.Events.EventNamingStyle.Should().Be(EventNamingStyle.SmarterTypeName);
+
+    /// <summary>
+    /// Issue #268 CA-1: Policies.AllDocumentsAreMultiTenanted() gobierna el "par 2" (worker -> query-
+    /// side, ver contexto del issue): la forma de la tabla de cualquier read model que el worker
+    /// llegue a materializar. Es una politica que se aplica al registrar un documento, no una
+    /// propiedad expuesta directamente -- se observa por su efecto en el mapping que Marten resuelve
+    /// para un tipo cualquiera (FindOrResolveDocumentType), la unica superficie que la deja visible
+    /// sin Postgres y sin que el worker tenga todavia ningun read model real registrado. TCanario es
+    /// un tipo declarado en este proyecto de tests, sin relacion con ningun dominio.
+    /// </summary>
+    public static void AssertDocumentosMultiTenant<TCanario>(this IDocumentStore store) =>
+        store.Options.FindOrResolveDocumentType(typeof(TCanario)).TenancyStyle
+            .Should().Be(TenancyStyle.Conjoined);
+
+    /// <summary>
+    /// Issue #268 CA-2: deserializa <paramref name="original"/> contra el ISerializer real que este
+    /// named store compuso -- el mismo objeto que Marten usaria para leer un evento persistido.
+    /// Devuelve el objeto restaurado para que el llamador lo compare campo a campo contra un
+    /// oraculo construido a mano (MEF-ADR-0002, no-tautologia): este helper no decide que
+    /// verificar, solo ejecuta el round-trip.
+    ///
+    /// El eslabon que hace fallar esto si el seam esta mal armado: los eventos con AMBOS
+    /// constructores privados (TurnoCreado, MarcacionRegistrada) solo se reconstruyen via el
+    /// TypeInfoResolver custom que ConfiguracionSerializacion{Dominio}.ConfigurarResolver registra.
+    /// Sin ese resolver -- o si UseSystemTextJsonForSerialization se invoca DESPUES de engancharlo,
+    /// la "trampa del orden" que describe el issue -- STJ no tiene forma de instanciar el tipo y
+    /// esto lanza NotSupportedException en vez de fallar en silencio.
+    /// </summary>
+    public static TEvento DeserializarConResolverDeSerializacionCustom<TEvento>(
+        this IDocumentStore store, TEvento original)
+        where TEvento : notnull
+    {
+        var serializador = store.Options.Serializer();
+
+        using var json = new MemoryStream(Encoding.UTF8.GetBytes(serializador.ToJson(original)));
+        return serializador.FromJson<TEvento>(json);
+    }
 }

--- a/tests/Bitakora.ControlAsistencia.Projections.Tests/Infraestructura/DocumentoCanarioTenancy.cs
+++ b/tests/Bitakora.ControlAsistencia.Projections.Tests/Infraestructura/DocumentoCanarioTenancy.cs
@@ -1,0 +1,10 @@
+namespace Bitakora.ControlAsistencia.Projections.Tests.Infraestructura;
+
+/// <summary>
+/// Issue #268 CA-1/CA-3: documento canario para <see cref="AssertsProyecciones.AssertDocumentosMultiTenant{TCanario}"/>.
+/// Policies.AllDocumentsAreMultiTenanted() es una politica que se observa por su efecto en el
+/// mapping que Marten resuelve para cualquier tipo (FindOrResolveDocumentType) -- el worker
+/// todavia no registra ningun read model real, asi que un tipo sin relacion con ningun dominio
+/// alcanza para verificarla sin necesitar Postgres.
+/// </summary>
+public sealed record DocumentoCanarioTenancy(Guid Id);


### PR DESCRIPTION
## Resumen

Pipeline TDD completado:
- Fase roja: tests escritos con stubs
- Fase verde: implementación completa
- Fase refactor: revisión de calidad

## Decisiones del pipeline

<details>
<summary>Test Writer (fase roja) — 10m 38s</summary>

## ES Test Writer - Decisiones (issue #268)

### Naturaleza de la tarea

Este issue no introduce ningun command handler, aggregate ni evento de dominio nuevo: es
configuracion de Marten (named stores del worker de proyecciones) que hoy queda incompleta frente
al write-side (falta tenancy conjoined, naming SmarterTypeName, politica multi-tenant de
documentos y el resolver de serializacion custom). Se trato como TDD normal (no como refactor
puro, seccion 2 del rol) porque CA-1/CA-2/CA-3 definen comportamiento verificable que hoy no
existe y que el propio issue pide cubrir con guardas de config-test que deben fallar hasta que se
implemente -- exactamente el "carril rojo" del test-writer, aplicado a un config-test en vez de a
un command handler.

### Tests creados

Todos en `tests/Bitakora.ControlAsistencia.Projections.Tests/`:

- `ConfiguracionMartenProjectionsTests.cs`: 8 `[Fact]` nuevos (4 por dominio), todos en rojo hoy:
  - `ConfigurarProgramacion_DeclaraTenancyDeEventosConjoined` - CA-1 (Events.TenancyStyle)
  - `ConfigurarProgramacion_DeclaraEventNamingStyleSmarterTypeName` - CA-1 (Events.EventNamingStyle)
  - `ConfigurarProgramacion_DeclaraLosDocumentosComoMultiTenant` - CA-1 (Policies.AllDocumentsAreMultiTenanted, par 2)
  - `ConfigurarProgramacion_ConservaElResolverDeSerializacionCustom` - CA-2 (resolver, canario `TurnoCreado`)
  - `ConfigurarControlHoras_DeclaraTenancyDeEventosConjoined` - CA-1
  - `ConfigurarControlHoras_DeclaraEventNamingStyleSmarterTypeName` - CA-1
  - `ConfigurarControlHoras_DeclaraLosDocumentosComoMultiTenant` - CA-1 (par 2)
  - `ConfigurarControlHoras_ConservaElResolverDeSerializacionCustom` - CA-2 (resolver, canario `MarcacionRegistrada`)
- `Infraestructura/AssertsProyecciones.cs`: 4 guardas nuevas (metodos de extension, siguiendo el
  patron ya existente en el archivo), invocadas desde los 8 tests de arriba:
  - `AssertTenancyDeEventosConjoined(this IDocumentStore)`
  - `AssertEventNamingStyleSmarterTypeName(this IDocumentStore)`
  - `AssertDocumentosMultiTenant<TCanario>(this IDocumentStore)`
  - `DeserializarConResolverDeSerializacionCustom<TEvento>(this IDocumentStore, TEvento original)`
    -- devuelve el objeto restaurado; el llamador arma el oraculo a mano (regla 20/MEF-ADR-0002),
    nunca compara contra algo derivado del propio serializador.

### Stubs creados

- `Infraestructura/DocumentoCanarioTenancy.cs`: `public sealed record DocumentoCanarioTenancy(Guid Id)`.
  Tipo canario sin relacion con ningun dominio, exigido por la guarda de
  `Policies.AllDocumentsAreMultiTenanted()`: esa politica se observa por su efecto en el mapping
  que Marten resuelve para un tipo cualquiera (`FindOrResolveDocumentType`), no por una propiedad
  directa -- el worker todavia no registra ningun read model real.

No hizo falta ningun stub de produccion (comando/evento/aggregate/handler): todos los tipos que
los tests referencian (`IDocumentStore`, `TenancyStyle`, `EventNamingStyle`,
`FindOrResolveDocumentType`, `TurnoCreado.Crear`, `MarcacionRegistrada.Crear`) ya existen en el
codigo de produccion o en las librerias del paquete. La fase roja la produce la AUSENCIA de las
lineas de configuracion en `ConfiguracionMartenProjectionsProgramacion.cs` /
`ConfiguracionMartenProjectionsControlHoras.cs`, que no se tocaron (responsabilidad del
implementer).

### Verificacion de superficie Marten (por ejecucion, no solo lectura)

Antes de escribir las guardas se decompilo Marten 9.12.0 / JasperFx 2.18.1 / JasperFx.Events 2.18.1
(version resuelta real del proyecto, confirmada contra `project.assets.json`) para fijar la firma
exacta:

- `IReadOnlyEventStoreOptions.TenancyStyle` (get-only) y `.EventNamingStyle` (get/set) -- ambos en
  la superficie de solo lectura, sin necesidad de castear a `StoreOptions`.
- `TenancyStyle` vive en `JasperFx.MultiTenancy` (ensamblado `JasperFx`, NO `JasperFx.Events`) --
  gotcha adicional al que ya documentaba el archivo para `StreamIdentity`/`DaemonMode`.
- `IReadOnlyStoreOptions.FindOrResolveDocumentType(Type) : IDocumentType`, con
  `IDocumentType.TenancyStyle` (get-only) -- confirma que la politica es observable sin Postgres.
- `ISerializer.ToJson(object)`/`FromJson<T>(Stream)` -- mismo patron que ya usa
  `ComposicionServiciosTests` de ControlHoras.

Ademas se corrio el config-test nuevo contra el estado actual del repo (sin la implementacion) para
confirmar el rojo real, no solo argumentado:
- Las 6 guardas de CA-1 fallan por discrepancia de valor (`TenancyStyle.Single` en vez de
  `Conjoined`, `EventNamingStyle.ClassicTypeName` en vez de `SmarterTypeName`).
- Las 2 guardas de CA-2 fallan con `NotSupportedException` (STJ no puede instanciar un tipo con
  ambos constructores privados sin el resolver) -- exactamente el sintoma que describe el issue.
- Los 15 tests preexistentes del mismo archivo siguen en verde (sin regresion).
- Toda la suite de `ControlHoras.Tests` (339) y `Programacion.Tests` (120) sigue en verde.
- `dotnet build` de la solucion completa: sin errores (los unicos warnings, NU1902/CS0414, ya
  existian antes de este cambio).

### Estructura elegida

Se siguio el patron ya establecido en el archivo (un `[Fact]` por guarda por dominio, agrupados en
bloques `--- Programacion ---` / `--- ControlHoras ---`) en vez de introducir nested classes: es
consistente con el resto del archivo y cada test ya es autocontenible (una sola linea de Given
implicita via `ProviderDeProgramacion()`/`ProviderDeControlHoras()`).

El helper del resolver (`DeserializarConResolverDeSerializacionCustom<TEvento>`) se dejo generico y
retornando el objeto restaurado -- en vez de un helper especifico por tipo de evento con sus propias
aserciones -- para que cada test arme su propio oraculo independiente (campos de `TurnoCreado` /
`MarcacionRegistrada`), evitando acoplar el helper compartido a un tipo de evento concreto y
respetando la regla 20 (oraculo construido a mano, nunca via `BeEquivalentTo` derivando del mismo
objeto bajo prueba).

### Cobertura de criterios

| Criterio de aceptacion | Test(s) |
|---|---|
| CA-1 (tenancy conjoined) | `ConfigurarProgramacion_DeclaraTenancyDeEventosConjoined`, `ConfigurarControlHoras_DeclaraTenancyDeEventosConjoined` |
| CA-1 (naming SmarterTypeName) | `ConfigurarProgramacion_DeclaraEventNamingStyleSmarterTypeName`, `ConfigurarControlHoras_DeclaraEventNamingStyleSmarterTypeName` |
| CA-1 (documentos multi-tenant, par 2) | `ConfigurarProgramacion_DeclaraLosDocumentosComoMultiTenant`, `ConfigurarControlHoras_DeclaraLosDocumentosComoMultiTenant` |
| CA-2 (resolver, fuente unica) | `ConfigurarProgramacion_ConservaElResolverDeSerializacionCustom`, `ConfigurarControlHoras_ConservaElResolverDeSerializacionCustom` |
| CA-3 (guarda por item, sin Postgres) | Las 8 guardas de arriba; ninguna abre conexion real (mismo patron ya verificado por el resto del archivo) |
| CA-5 (build sin errores) | Verificado: `dotnet build` de la solucion completa en verde |

**CA-2 nota de alcance**: no se escribio ninguna asercion para `EnumStorage`/`Casing` -- el propio
issue lo excluye explicitamente ("no muerde": coincide con el default de Marten y ningun enum del
proyecto puede estar en un payload persistido, ver seccion "El caso del serializador"). Tampoco se
escribio un test que audite el texto fuente del seam para confirmar la ausencia del bloque
`if (opts.Serializer() is SystemTextJsonSerializer)`: esa restriccion de CA-2 es una guia de forma
para el implementer/reviewer (evitar la "trampa del orden"), no un comportamiento observable en
runtime distinto de lo que el round-trip del resolver ya cubre -- si el bloque quedara mal
ordenado, el mismo test de round-trip fallaria con `NotSupportedException`.

### CA-4 (correccion de CA-ADR-0027): fuera de alcance de este agente

CA-4 pide renombrar `docs/adr/ca-adr-0027-estrategia-tenancy-mono-tenant.md`, corregir su
contenido, agregar "Control de cambios" y actualizar referencias/comentarios en `CLAUDE.md`,
`TenantResolverFijo.cs` (x2) y `ComposicionServicios.cs` (x2, solo comentarios) y
`TenantResolverFijoTests.cs` (x2, solo comentarios). Es documentacion y nomenclatura pura: no hay
ningun comportamiento de codigo que un test pueda dejar en rojo (el `TenantResolverFijoTests.cs`
existente ya pasa hoy y seguira pasando sin cambios; su comentario superior menciona
"mono-tenant" pero eso no es una asercion ejecutable). Por el principio fundamental de este rol
("los tests que escribas DEBEN fallar"), no hay ningun test que escribir para CA-4 -- queda
integramente para la fase de implementacion (verde). No se toco ningun archivo de CA-4.

### Desviaciones del plan del planner

Ninguna significativa. El planner ya dejo resuelto por ejecucion (research del issue) el punto que
mas riesgo de rumiacion tenia -- si `Policies.AllDocumentsAreMultiTenanted()` es observable sin
Postgres via `FindOrResolveDocumentType` -- asi que no hizo falta explorar alternativas; solo se
verifico la firma exacta por decompilacion antes de escribir la guarda (`TenancyStyle` resulto
vivir en el ensamblado `JasperFx`, no en `JasperFx.Events` como el resto de los tipos de tenancy/
naming -- matiz que no cambia la guarda, solo el `using`).

Una precision menor: el issue sugiere "Canario propuesto: TurnoCreado.Crear(...) para Programacion
y MarcacionRegistrada.Crear(...) para ControlHoras" sin fijar la forma exacta del helper de
`AssertsProyecciones`. Se opto por un helper generico que retorna el objeto restaurado (en vez de
un helper con aserciones embebidas por tipo) para mantener el oraculo independiente en el propio
test -- ver "Estructura elegida".

</details>

<details>
<summary>Implementer (fase verde) — 7m 13s</summary>

## ES Implementer - Decisiones

### Enfoque de implementacion

El issue #268 ya traia la investigacion resuelta por ejecucion (tabla de los diez atributos, las
cuatro incertidumbres del planner ya cerradas, la forma exacta del seam en el alcance 2), asi que
la implementacion fue directa: reemplazar el bloque de configuracion de cada named store del
worker (`ConfiguracionMartenProjectionsProgramacion.cs`, `ConfiguracionMartenProjectionsControlHoras.cs`)
para sumar los tres atributos faltantes de CA-1 (`Events.TenancyStyle = Conjoined`,
`Events.EventNamingStyle = SmarterTypeName`, `Policies.AllDocumentsAreMultiTenanted()`) y el
serializador+resolver de CA-2 en una sola llamada a `UseSystemTextJsonForSerialization`, invocando
la misma clase `ConfiguracionSerializacion{Dominio}` que ya usa el write-side de cada dominio
(fuente unica, MEF-ADR-0029).

Los 8 tests que el test-writer dejo en rojo (`ConfiguracionMartenProjectionsTests.cs`) fueron los
que guiaron la implementacion: 2 de tenancy de eventos, 2 de naming, 2 de politica multi-tenant y 2
de round-trip del resolver (uno por dominio en cada caso). Los 30 tests restantes del proyecto ya
estaban verdes antes de tocar nada (guardas de #253/#232/#277 preexistentes) y siguieron verdes.

### Decisiones de diseno

- Los `using` de los enums nuevos (`TenancyStyle` en `JasperFx.MultiTenancy`, `EventNamingStyle` en
  `JasperFx.Events`, `EnumStorage`/`Casing` en `Weasel.Core`) se resolvieron verificando el
  namespace real, no por analogia -- el propio issue advierte del gotcha (`DaemonMode`,
  `StreamIdentity`) y `Weasel.Core` no estaba mencionado en el codigo existente todavia.
- Se replico literalmente la forma de una sola llamada (`UseSystemTextJsonForSerialization(...,
  configure)`) en vez de la forma de dos pasos del write-side (`if (opts.Serializer() is
  SystemTextJsonSerializer stj) stj.Configure(...)`), tal como especifica el alcance 2 del issue:
  el worker controla todo el lambda de configuracion del named store, asi que no hay riesgo de
  "trampa del orden" ni de que el `is` quede mudo si el serializador dejara de ser STJ.
- En ControlHoras, el resolver solo invoca `ConfiguracionSerializacionControlHoras.ConfigurarResolver`
  (eventos persistidos en `DomainEvents`), no `ConfiguracionSerializacionCalculoHoras` (VOs de
  calculo del Function App): ese segundo ensamblado no es alcanzable desde el worker por el grafo
  de CA-ADR-0029, y el propio issue documenta que no hace falta arrastrarla.
- No se pidio guarda de `EnumStorage`/`Casing`: el issue es explicito en que no muerde (coincide
  con el default del propio metodo), asi que no se agrego ninguna aserto nueva por esto -- las
  guardas ya estaban escritas por el test-writer y ninguna cubre ese atributo.

### ADRs consultados

- MEF-ADR-0034 (secciones 2, 3, 5, 6 -- enmendada por #447 del marco -- y 7): named store por
  dominio, ciclo `Async`, "los dos pares" de compatibilidad write-side/read-side, y el requisito de
  metadata del writer.
- MEF-ADR-0029: fuente unica de composicion entre write-side y test/worker -- el principio que
  exige invocar la misma clase `ConfiguracionSerializacion{Dominio}`, nunca una copia.
- MEF-ADR-0012: ctor privado + `ConfigurarSerializacion`, origen de la necesidad del resolver
  custom (los eventos con ambos constructores privados no son deserializables sin el).
- CA-ADR-0027: leido completo antes de corregirlo (CA-4) -- confirma que su propia decision #2 ya
  describia el modelo real (Marten mapea el tenant fijo a `Tenancy.Default` aun con
  `AllDocumentsAreMultiTenanted()` activo), lo que sirvio de base para la correccion de titulo y
  contexto sin tocar las consecuencias.
- CA-ADR-0029: confirma por que el ensamblado del worker no puede referenciar
  `ConfiguracionSerializacionCalculoHoras` (VOs de calculo viven en el Function App).

### Desviaciones de ADRs

Ninguna desviacion -- todos los ADRs aplicados al pie de la letra. La forma exacta del seam (una
sola llamada a `UseSystemTextJsonForSerialization`, atributos exactos de CA-1) ya venia fijada por
el issue con investigacion verificada por ejecucion, no hubo lugar a interpretacion.

### Precedentes consultados

- `ComposicionServicios.cs` de Programacion y ControlHoras (write-side, patron `if (opts.Serializer()
  is SystemTextJsonSerializer stj) stj.Configure(...)`): alineado con su propio ADR (MEF-ADR-0034
  seccion 6 explica por que esa forma es correcta para el write-side y no para el worker). No se
  replico esa forma en el worker -- el issue explica por que la forma correcta ahi es distinta
  (control total del lambda) y eso evita, no repite, el patron del write-side.
- `ConfiguracionMartenProjectionsProgramacion.cs`/`ConfiguracionMartenProjectionsControlHoras.cs`
  preexistentes (StreamIdentity, MetadataConfig, AddEventTypes de issues #253/#232/#277): alineados
  con MEF-ADR-0034, se conservaron intactos y solo se sumaron las lineas nuevas.

### Infraestructura modificada

Ninguna. Este issue no toca `infra/environments/dev/main.tf` -- es exclusivamente configuracion de
Marten en el worker de proyecciones y correccion de un ADR local.

### Complejidad encontrada

Ninguna significativa: el issue traia la investigacion resuelta por ejecucion (tabla de atributos,
namespaces de los enums, la forma exacta del seam, y los cuatro escenarios de la "trampa del
orden"), asi que la implementacion fue mecanica. La unica verificacion propia fue confirmar, antes
y despues del cambio, que los warnings de `dotnet build` no cambiaron (5 warnings preexistentes,
todos de `NU1902`/`CS0414` sin relacion con este issue).

### Resultado

- Tests del proyecto `Bitakora.ControlAsistencia.Projections.Tests`: 38/38 (los 8 que estaban en
  rojo ahora pasan; los 30 restantes ya estaban verdes y siguieron verdes).
- Suite completa (`dotnet test --solution ControlAsistencias.slnx`): 541 correctos, 0 errores, 8
  omitidos (smoke tests preexistentes que requieren Postgres/ServiceBus reales de dev -- sin
  relacion con este issue).
- `dotnet build`: 0 errores, mismos 5 warnings preexistentes (sin warnings nuevos) -- CA-5 cumplido.

</details>
<details>
<summary>Reviewer (fase refactor) — 12m 13s</summary>

## ES Reviewer - Revision

### Evaluacion general
- Calidad: **buena**
- Cambios realizados: si (menores -- vocabulario del seam y cierre literal de CA-4; ningun cambio de comportamiento)

Suite verde antes, durante y despues: **541 correctos / 0 errores / 8 omitidos** (los 8 omitidos son
smoke tests preexistentes que exigen Postgres/ServiceBus de dev). `dotnet build`: 0 errores, 4
advertencias `NU1902` preexistentes (OpenTelemetry.Api 1.14.0), ninguna nueva.

### Verificacion independiente (no por lectura del issue)

El issue declara su investigacion "verificada por ejecucion" y el implementer la tomo como dada. Como
el gate de compatibilidad write/read-side de #447 **no existe en el plugin instalado (v0.19.0)**, lo
corri a mano en vez de aceptar la declaracion:

1. **Inspeccion del ensamblado del paquete** (`Cosmos.EventSourcing.CritterStack 2.3.1`, dll real de
   `~/.nuget`): `AgregarConfiguracionMartenComandos` efectivamente referencia
   `AllDocumentsAreMultiTenanted`, `set_TenancyStyle`, `set_EventNamingStyle` y
   `UseSystemTextJsonForSerialization`. La tabla del issue no era una suposicion.
2. **Volcado comparativo por ejecucion** de los cuatro stores (write-side x2 componiendo el
   contenedor DI real de cada dominio, worker x2 componiendo `ConfigurarEventos`), con archivos de
   test temporales que se eliminaron despues (repo limpio, nada commiteado):

| Store | `Events.TenancyStyle` | `EventNamingStyle` | `StreamIdentity` | Doc `TenancyStyle` | Serializer | `EnumStorage` | `Casing` |
|---|---|---|---|---|---|---|---|
| WRITE-SIDE/Programacion | Conjoined | SmarterTypeName | AsString | Conjoined | SystemTextJsonSerializer | AsInteger | Default |
| WRITE-SIDE/ControlHoras | Conjoined | SmarterTypeName | AsString | Conjoined | SystemTextJsonSerializer | AsInteger | Default |
| WORKER/Programacion | Conjoined | SmarterTypeName | AsString | Conjoined | SystemTextJsonSerializer | AsInteger | Default |
| WORKER/ControlHoras | Conjoined | SmarterTypeName | AsString | Conjoined | SystemTextJsonSerializer | AsInteger | Default |

Los dos pares quedan efectivamente alineados, no solo declarados. Es la evidencia que el gate de
#447 habria producido.

3. **Verificacion por mutacion de las 8 guardas** (CA-3 exige que cada una falle si se retira su
   linea del seam). Comente cada linea por separado y corri el config-test: **cada mutacion hizo
   fallar exactamente 1 test, el suyo, y ningun otro** (37 correctos + 1 error en las 8 corridas).

| Linea retirada | Test que falla | Sintoma |
|---|---|---|
| `Programacion` / `Events.TenancyStyle` | `ConfigurarProgramacion_DeclaraTenancyDeEventosConjoined` | valor `Single` |
| `Programacion` / `EventNamingStyle` | `ConfigurarProgramacion_DeclaraEventNamingStyleSmarterTypeName` | valor `ClassicTypeName` |
| `Programacion` / `AllDocumentsAreMultiTenanted` | `ConfigurarProgramacion_DeclaraLosDocumentosComoMultiTenant` | mapping `Single` |
| `Programacion` / `ConfigurarResolver` | `ConfigurarProgramacion_ConservaElResolverDeSerializacionCustom` | `NotSupportedException` |
| `ControlHoras` / las mismas cuatro | los cuatro homologos | idem |

4. **La "trampa del orden" tambien muerde**: inyecte una segunda llamada a
   `UseSystemTextJsonForSerialization(EnumStorage.AsInteger, Casing.Default)` **despues** del bloque
   con el resolver -- exactamente el fallo silencioso que el comentario del seam afirma prevenir --
   y `ConfigurarProgramacion_ConservaElResolverDeSerializacionCustom` fallo con
   `NotSupportedException`. La afirmacion del comentario esta respaldada por la guarda, no solo por
   la prosa.

### Cumplimiento de ADRs aplicables

| ADR | Cumplimiento | Observacion |
|---|---|---|
| MEF-ADR-0034 secciones 2, 6 y 7 (named store por dominio + config-test que falla si el read-side diverge) | ok | Se mantiene un named store por dominio con `AddAsyncDaemon(HotCold)`; las guardas nuevas extienden el config-test sin tocar las tres de la seccion 6 ni la de metadata de la seccion 7. La seccion 6 del plugin instalado (v0.19.0) enumera 3 puntos; el issue sigue la version enmendada por #447 y enumera el criterio explicitamente -- verifique contra esa enumeracion mas el volcado comparativo de arriba |
| MEF-ADR-0029 (fuente unica compartida entre composicion y test) | ok | Ambos seams invocan `ConfiguracionSerializacion{Dominio}.ConfigurarResolver`, la **misma** clase de `{Dominio}.DomainEvents` que usa `ComposicionServicios` del write-side (verificado por grep: no hay copia de la lista de tipos en el worker). El config-test consume esos mismos seams, nunca una configuracion paralela |
| MEF-ADR-0012 (ctor privado + `ConfigurarSerializacion`, proscripcion de `[JsonConstructor]`) | ok | El diff no declara tipos de dominio nuevos. Los canarios elegidos (`TurnoCreado`, `MarcacionRegistrada`) son justamente los dos eventos con **ambos** ctores privados, que es lo que hace mordible la guarda. Sin `[JsonConstructor]` en ningun lado (verificado por grep en el diff) |
| CA-ADR-0027 (se corrige en este issue) | ok | Ver CA-4 abajo. Cerre la parte de "Decision" que quedaba pendiente |
| CA-ADR-0029 (grafo de ensamblados por rol) | ok | `ControlHoras` replica solo `ConfiguracionSerializacionControlHoras` (en `DomainEvents`) y **no** `ConfiguracionSerializacionCalculoHoras` (en el Function App) -- verificado: el `.csproj` del worker no referencia ningun Function App, asi que ni siquiera era alcanzable. El comentario del seam documenta la asimetria en vez de dejarla como omision tacita |
| MEF-ADR-0003 (Marten 9.12.0 pinneado, STJ en ambos lados) | ok | Ambos lados resuelven `SystemTextJsonSerializer` (verificado en el volcado); ninguna referencia a `Marten.Newtonsoft` |

### Desviaciones de ADRs

**Ninguna desviacion -- todos los ADRs aplicables se cumplen.**

- **Declaradas por el implementer**: ninguna (su resumen dice "todos los ADRs aplicados al pie de la
  letra"). Coincido: la forma del seam venia fijada por el issue con investigacion verificada y no
  hubo lugar a interpretacion.
- **Detectadas por el reviewer y no declaradas**: ninguna. Busque especificamente los antipatrones
  de MEF-ADR-0012 (propiedad publica de VO con unico consumidor externo, clase estatica sobre datos
  crudos, getter solo-para-test, `InternalsVisibleTo`, `[JsonConstructor]` en ctor privado, `record`
  con `IReadOnlyList` de igualdad, evento con marker de bus cargando modelo rico): **ninguno aplica**
  -- este diff no agrega ni modifica tipos de dominio, solo configuracion de Marten, un `record`
  canario de test sin comportamiento y comentarios/documentacion.

### Precedentes consultados por el implementer

| Precedente | ADR aplicable | Veredicto |
|---|---|---|
| `ComposicionServicios.cs` (write-side x2), patron `if (opts.Serializer() is SystemTextJsonSerializer stj) stj.Configure(...)` | MEF-ADR-0029 / MEF-ADR-0034 s.6 | **Alineado para su situacion, y correctamente NO replicado**. El write-side no controla la construccion del serializador (la hace el paquete), asi que la forma de dos pasos es la unica disponible ahi; el worker si controla el lambda y usa la forma de una llamada. El implementer no copio el precedente: lo evito con justificacion. Verifique por mutacion que la forma elegida es la que resiste la trampa del orden |
| `ConfiguracionMartenProjections{Dominio}.cs` preexistentes (`StreamIdentity`, `MetadataConfig`, `AddEventTypes` de #253/#232/#277) | MEF-ADR-0034 s.6/s.7 | Alineados. Se conservaron intactos; las lineas nuevas se sumaron sin reordenar ninguna existente |

Nota de vigilancia (memoria de PR 142/144/155): no acepte ningun patron "porque ya estaba en el
codigo". La afirmacion central del issue -- que el write-side es conjoined -- la verifique contra el
ensamblado del paquete y por ejecucion, no contra el codigo mergeado.

### Convenciones del pipeline (no ADRs)

| Convencion | Estado | Observacion |
|---|---|---|
| Cada test con `Then()` + `And<>()` | n/a | No hay command handlers ni aggregates en este diff: son config-tests de composicion (MEF-ADR-0034 s.6), no el DSL Given/When/Then de MEF-ADR-0002 |
| Overloads correctos para stream IDs compuestos | n/a | Sin tests de aggregate en el diff |
| Fakes manuales (no NSubstitute) | n/a | El config-test compone el `ServiceCollection` real; sin dobles de prueba |
| Feature folders (produccion y tests) | ok | El proyecto de tests espeja al worker: `Infraestructura/AssertsProyecciones.cs`, `Infraestructura/DocumentoCanarioTenancy.cs` junto al config-test de raiz |
| Smoke tests: SkipWhen, secrets, cobertura | n/a | El diff no toca smoke tests. El worker no tiene endpoint ni publica eventos; su verificacion contractual es el config-test |
| Proyecciones read-side: partial, inmutabilidad, read APIs, naming | n/a (parcial: **ok** en lo aplicable) | No hay ningun read model ni clase de proyeccion todavia -- por eso la guarda del par 2 necesita un canario. Naming del seam correcto: `I{Dominio}ProjectionStore`, `ConfiguracionMartenProjections{Dominio}.Configurar{Dominio}()` (MEF-ADR-0006 / MEF-ADR-0035) |
| Tests via ToString/comportamiento | ok | El oraculo de `TurnoCreado` se verifica via `FranjasOrdinarias[0].ToString()`, no exponiendo estado interno de la franja. `MarcacionRegistrada` compara sus 4 propiedades ya publicas |
| Sin numeros magicos | ok | `SchemaDelDominio`, `ConnectionStringDummy`, `TurnoIdCanario` son constantes con nombre; el Guid del canario esta nombrado y comentado |
| Condiciones en positivo (guardas if/else afirmativas) | n/a | El diff no introduce ninguna bifurcacion -- de hecho **elimina** la necesidad del `if (... is SystemTextJsonSerializer)` en el read-side (CA-2) |
| Naming de tests MEF-ADR-0016 | ok | `<Sujeto>_<LoQuePasa>`: `ConfigurarProgramacion_DeclaraTenancyDeEventosConjoined`, etc. Sujeto = metodo de composicion bajo prueba, consistente con los 15 tests preexistentes del archivo. Solo `[Fact]`, ningun `[Theory]` |
| Sin caracter U+2500 en `.cs` | ok | Verificado por busqueda en todo `src/` y `tests/` |
| `dotnet format --verify-no-changes` | ok en el diff | Las 9 advertencias `IDE0005` que reporta son **preexistentes** y con **cero interseccion** con los 13 archivos del pipeline (verificado comparando ambas listas). No las toco: regla de no refactorizar codigo ajeno a la HU |

### Elegancia del codigo

El codigo llego en muy buen estado. Los seis atributos:

- **Compacto**: el codigo ejecutable son 4 lineas por dominio; sin codigo muerto ni repeticion
  evitable. Los comentarios son extensos, pero es el estilo deliberado del proyecto (documentar la
  trampa verificada, no el "que" obvio) y aqui cargan informacion que no se deduce del codigo: por
  que `TenancyStyle` vive en `JasperFx.MultiTenancy`, por que la forma de una llamada difiere de la
  del write-side, por que `EventNamingStyle` es hoy inocuo. `ControlHoras` no duplica la explicacion
  larga: la referencia cruzada a `ConfiguracionMartenProjectionsProgramacion`. Correcto.
- **Legible**: los nombres de las guardas dicen que se verifica, no como. El helper de round-trip
  devuelve el objeto restaurado y deja el oraculo en el test, evitando el acoplamiento de un helper
  con aserciones embebidas.
- **Idiomatico**: metodos de extension para las guardas (patron ya establecido en el archivo),
  `record` posicional para el canario, collection expressions en el oraculo, expression-bodied
  members donde la guarda es una sola asercion.
- **Robusto**: sin boundaries nuevos; el round-trip deja propagar `NotSupportedException` en vez de
  tragarla -- que es precisamente lo que hace visible el fallo.
- **Eficiente**: n/a (composicion).
- **Limpio**: sin warnings nuevos, sin debug cruft, sin usings innecesarios en los archivos tocados.

**Duplicacion entre los dos seams (evaluada y no extraida)**: `ConfiguracionMartenProjectionsProgramacion`
y `...ControlHoras` son casi identicos salvo schema, lista de tipos y clase de serializacion. **No lo
refactorice, deliberadamente**: MEF-ADR-0034 seccion 6 exige que cada dominio contribuya su propio
seam como fuente unica, MEF-ADR-0018 (Rule of Three) acepta duplicar con 2 usos, y extraer una base
comun acoplaria los dos dominios en el punto donde justamente deben poder divergir (p. ej. si manana
un dominio necesita `Inline` o un resolver adicional). Lo dejo anotado por si aparece un tercer
dominio: ese es el momento de revisar la decision.

### Criticas y hallazgos

1. **[menor, corregido]** El parametro del lambda se llamaba `json` siendo un `JsonSerializerOptions`,
   mientras el write-side ya nombra `jsonOptions` en el codigo equivalente. Renombrado en ambos seams
   para que el vocabulario del par write/read sea el mismo.
2. **[cosmetico, corregido]** En `AssertsProyecciones`, la variable `json` era en realidad un
   `MemoryStream` -> `flujoJson`.
3. **[cosmetico, corregido]** El comentario de `TurnoIdCanario` hablaba de "los canarios" en plural
   cuando solo hay un Guid (el canario de ControlHoras se identifica por `EmpleadoId` string).
   Precisado.
4. **[menor, corregido]** **CA-4 estaba cubierto en 3 de sus 4 partes**: titulo, nombre de archivo y
   contexto quedaron corregidos, pero la **Decision** no se toco. Era defendible (su punto 2 ya
   describia el modelo real, y es lo que el propio issue cita), pero el CA pide explicitamente
   "titulo, nombre de archivo, contexto y decision" y un lector que entrara por la Decision seguia
   sin ver el modelo nombrado. Corregi el encabezado de la Decision para que enuncie el modelo
   (infra conjoined + tenant unico) y sume la consecuencia que este issue descubrio: la obligacion
   de declarar la tenancy alcanza a **todo proceso lector** del event store, no solo al escritor.
   Nota agregada al Control de cambios.
5. **[cosmetico, NO corregido -- fuera de alcance]** En `ConfiguracionMartenProjectionsProgramacion.cs`
   conviven dos versiones del paquete en comentarios: la linea de `StreamIdentity` (preexistente,
   #253) dice "Cosmos.EventSourcing.CritterStack 2.1.0" y la nueva dice "2.3.1". Ambas son ciertas
   como registro historico de cuando se introdujo cada linea, pero puede confundir. No lo toco:
   linea preexistente ajena a este issue.
6. **[cosmetico, NO corregido -- fuera de alcance]** El punto 1 de la Decision de CA-ADR-0027
   referencia `Contracts` y CA-ADR-0002, ambos superados por CA-ADR-0029 (el proyecto fue
   eliminado). Es drift de nomenclatura del mismo tipo que este issue corrige, pero en otra
   afirmacion y fuera de lo que pide CA-4. **Candidato a issue de seguimiento.**
7. **[observacion, sin accion]** La guarda del par 2 usa un canario porque el worker aun no registra
   ningun read model. Cuando #251 materialice `SolicitudProgramacionView`, vale la pena evaluar si
   la guarda debe apuntar al read model real en vez del canario -- seria una verificacion mas
   cercana a la realidad. No es un defecto de este diff: hoy no hay alternativa.

Ningun hallazgo bloqueante. Ningun test se modifico para hacerlo pasar; los unicos cambios en tests
son un nombre de variable local y un comentario.

### Refactorings aplicados

Commit `refactor(issue-268): precisar el vocabulario del seam y cerrar la correccion de CA-ADR-0027`:

1. `json` -> `jsonOptions` en el lambda de `UseSystemTextJsonForSerialization` de ambos named stores
   (consistencia de vocabulario con el write-side).
2. `json` -> `flujoJson` en el `MemoryStream` de `DeserializarConResolverDeSerializacionCustom`.
3. Comentario de `TurnoIdCanario` precisado a singular, explicando por que ControlHoras no necesita
   un Guid.
4. CA-ADR-0027: encabezado de la Decision enunciando el modelo real, consecuencia nueva sobre los
   procesos lectores, y nota en el Control de cambios.

`dotnet test` verde despues de cada cambio. Nada revertido.

### Cobertura de criterios de aceptacion

| Criterio | Estado | Test(s) / evidencia |
|---|---|---|
| CA-1: ambos named stores declaran `TenancyStyle.Conjoined`, `AllDocumentsAreMultiTenanted()` y `EventNamingStyle.SmarterTypeName` | cubierto | `ConfigurarProgramacion_DeclaraTenancyDeEventosConjoined`, `..._DeclaraEventNamingStyleSmarterTypeName`, `..._DeclaraLosDocumentosComoMultiTenant` y los tres homologos de `ConfigurarControlHoras_*`. Ademas verificado por volcado del store real |
| CA-2: serializador + resolver en **una sola llamada**, invocando la clase de `{Dominio}.DomainEvents`; sin bloque `if (opts.Serializer() is SystemTextJsonSerializer)` en el seam del worker | cubierto | `ConfigurarProgramacion_ConservaElResolverDeSerializacionCustom`, `ConfigurarControlHoras_ConservaElResolverDeSerializacionCustom`. La ausencia del bloque `is` la verifique por grep sobre `src/…Projections/`: aparece **solo dentro de un comentario explicativo**, nunca como codigo. La fuente unica la verifique por grep: no hay copia de la lista de tipos ricos en el worker |
| CA-3: una guarda por item, para cada named store, cada una falla si se retira su linea, ninguna necesita Postgres | cubierto | **Verificado por mutacion**, 8/8 (tabla arriba): cada mutacion falla exactamente su test. Ninguna guarda abre conexion (connection string dummy `Host=localhost;Database=dummy`; toda la suite del worker corre en ~0.6s). La de `EnumStorage`/`Casing` queda fuera, como el issue exige |
| CA-4: CA-ADR-0027 corregido (titulo, archivo, contexto, decision) + Control de cambios + referencias actualizadas; sin tocar `infra/` ni `docs/bitacora/**` | cubierto | Archivo renombrado (git lo registra como rename, 75% similarity). Titulo, contexto y -- tras mi correccion -- Decision. Control de cambios nuevo. Referencias: `CLAUDE.md:167`, `TenantResolverFijo.cs` x2, `ComposicionServicios.cs` x2, `TenantResolverFijoTests.cs` x2. Busqueda global de "mono-tenant" y del slug viejo: **solo quedan las 2 menciones dentro del Control de cambios**, que son historicas y correctas. `infra/modules/service-bus/main.tf` y `docs/bitacora/**` intactos (verificado en `git diff --name-only`) |
| CA-5: `dotnet build` sin errores ni warnings nuevos, `dotnet test` verde | cubierto | Build: 0 errores, 4 `NU1902` preexistentes. Test: 541 correctos / 0 errores / 8 omitidos |

### Tests agregados

Ninguno. Las 8 guardas del test-writer cubren los CA-1/CA-2/CA-3 y **verifique por mutacion que cada
una muerde**, que es la propiedad que el issue exige y la que un test de configuracion suele no
tener. No hay caso borde sin cubrir que corresponda a este issue:

- Tests de contrato de igualdad (`IgualdadTestBase<T>`) y de round-trip de serializacion: **no
  aplican** -- el diff no introduce ningun `IEquatable<T>` ni ningun `ConfigurarSerializacion` nuevo.
  Los tipos ricos involucrados (`TurnoCreado`, `MarcacionRegistrada`) ya tienen sus
  `*SerializacionTests` en el proyecto de tests de su dominio.
- Guardas de portabilidad por el bus (`IPrivateEvent`/`IPublicEvent` con round-trip sin resolver):
  **no aplican** -- este diff no toca ningun evento con marker de bus. La direccion es la opuesta:
  aqui el resolver **debe** estar presente porque es el event store de Marten, no el bus
  (MEF-ADR-0012, "Frontera de serializacion: event store vs bus").

</details>

## Cobertura

| Archivo | Cobertura | Umbral | Estado |
|---|---|---|---|
| ComposicionServicios.cs | - | no evaluado | - |
| TenantResolverFijo.cs | - | no evaluado | - |
| ComposicionServicios.cs | - | no evaluado | - |
| TenantResolverFijo.cs | - | no evaluado | - |
| ConfiguracionMartenProjectionsControlHoras.cs | - | no evaluado | - |
| ConfiguracionMartenProjectionsProgramacion.cs | - | no evaluado | - |
## Commits

994af35 refactor(issue-268): precisar el vocabulario del seam y cerrar la correccion de CA-ADR-0027
f9108a2 feat(issue-268): alinear tenancy/naming/resolver del worker con el write-side (fase verde)
ebedb9a test(issue-268): guardas rojas de tenancy/naming/resolver del worker de proyecciones

Closes #268