### PR TITLE
Exponer la representacion textual del turno en los DTOs planos

### DIFF
--- a/src/Bitakora.ControlAsistencia.PrivateEvents/Programacion/DetalleFranjaOrdinaria.cs
+++ b/src/Bitakora.ControlAsistencia.PrivateEvents/Programacion/DetalleFranjaOrdinaria.cs
@@ -8,13 +8,18 @@ namespace Bitakora.ControlAsistencia.PrivateEvents.Programacion;
 /// El record por defecto compara colecciones por referencia (ADR-0015 advierte sobre records con
 /// IReadOnlyList que prometen igualdad por valor que no cumplen). Esta intervencion preserva la
 /// forma de record (constructor primario publico, properties get-only) y corrige el bug.
+///
+/// Issue #288: Descripcion (representacion textual normalizada, formato del tipo rico
+/// FranjaOrdinaria.ToString()) se agrega como dato derivado persistido. NO se agrega a
+/// Equals/GetHashCode: es texto derivado de los demas campos, no identidad de la franja.
 /// </remarks>
 public record DetalleFranjaOrdinaria(
     TimeOnly HoraInicio,
     TimeOnly HoraFin,
     int DiaOffsetFin,
     IReadOnlyList<DetalleSubFranja> Descansos,
-    IReadOnlyList<DetalleSubFranja> Extras)
+    IReadOnlyList<DetalleSubFranja> Extras,
+    string Descripcion)
 {
     public virtual bool Equals(DetalleFranjaOrdinaria? other)
     {

--- a/src/Bitakora.ControlAsistencia.PrivateEvents/Programacion/DetalleFranjaOrdinaria.cs
+++ b/src/Bitakora.ControlAsistencia.PrivateEvents/Programacion/DetalleFranjaOrdinaria.cs
@@ -21,6 +21,13 @@ public record DetalleFranjaOrdinaria(
     IReadOnlyList<DetalleSubFranja> Extras,
     string Descripcion)
 {
+    /// <summary>
+    /// Los eventos anteriores al issue #288 no llevan el campo: STJ deja null en el parametro
+    /// posicional y la propiedad declarada como string no anulable mentiria. Se normaliza a
+    /// cadena vacia, que es la consecuencia que el issue asumio para los eventos ya persistidos.
+    /// </summary>
+    public string Descripcion { get; init; } = Descripcion ?? string.Empty;
+
     public virtual bool Equals(DetalleFranjaOrdinaria? other)
     {
         if (other is null) return false;

--- a/src/Bitakora.ControlAsistencia.PrivateEvents/Programacion/DetalleSubFranja.cs
+++ b/src/Bitakora.ControlAsistencia.PrivateEvents/Programacion/DetalleSubFranja.cs
@@ -3,8 +3,30 @@ namespace Bitakora.ControlAsistencia.PrivateEvents.Programacion;
 /// <summary>
 /// Representacion plana de una sub-franja (descanso o extra) que viaja en eventos entre dominios.
 /// </summary>
+/// <remarks>
+/// Issue #288: Descripcion es la representacion textual normalizada (formato tecnico del tipo rico
+/// SubFranja.ToString()), persistida en vez de calculada al leer -- decision consciente documentada
+/// en el issue (Rule of Three, MEF-ADR-0018; el read-side no puede rehidratar el tipo rico).
+/// Equals/GetHashCode propios EXCLUYEN Descripcion: es un dato derivado, no identidad de la
+/// sub-franja. Mismo patron que el override de DetalleFranjaOrdinaria (issue #129).
+/// </remarks>
 public record DetalleSubFranja(
     TimeOnly HoraInicio,
     TimeOnly HoraFin,
     int DiaOffsetInicio,
-    int DiaOffsetFin);
+    int DiaOffsetFin,
+    string Descripcion)
+{
+    public virtual bool Equals(DetalleSubFranja? other)
+    {
+        if (other is null) return false;
+        if (ReferenceEquals(this, other)) return true;
+        return HoraInicio == other.HoraInicio
+            && HoraFin == other.HoraFin
+            && DiaOffsetInicio == other.DiaOffsetInicio
+            && DiaOffsetFin == other.DiaOffsetFin;
+    }
+
+    public override int GetHashCode() =>
+        HashCode.Combine(HoraInicio, HoraFin, DiaOffsetInicio, DiaOffsetFin);
+}

--- a/src/Bitakora.ControlAsistencia.PrivateEvents/Programacion/DetalleSubFranja.cs
+++ b/src/Bitakora.ControlAsistencia.PrivateEvents/Programacion/DetalleSubFranja.cs
@@ -17,6 +17,13 @@ public record DetalleSubFranja(
     int DiaOffsetFin,
     string Descripcion)
 {
+    /// <summary>
+    /// Los eventos anteriores al issue #288 no llevan el campo: STJ deja null en el parametro
+    /// posicional y la propiedad declarada como string no anulable mentiria. Se normaliza a
+    /// cadena vacia, que es la consecuencia que el issue asumio para los eventos ya persistidos.
+    /// </summary>
+    public string Descripcion { get; init; } = Descripcion ?? string.Empty;
+
     public virtual bool Equals(DetalleSubFranja? other)
     {
         if (other is null) return false;

--- a/src/Bitakora.ControlAsistencia.PrivateEvents/Programacion/DetalleTurno.cs
+++ b/src/Bitakora.ControlAsistencia.PrivateEvents/Programacion/DetalleTurno.cs
@@ -18,6 +18,13 @@ public record DetalleTurno(
     IReadOnlyList<DetalleFranjaOrdinaria> FranjasOrdinarias,
     string Descripcion)
 {
+    /// <summary>
+    /// Los eventos anteriores al issue #288 no llevan el campo: STJ deja null en el parametro
+    /// posicional y la propiedad declarada como string no anulable mentiria. Se normaliza a
+    /// cadena vacia, que es la consecuencia que el issue asumio para los eventos ya persistidos.
+    /// </summary>
+    public string Descripcion { get; init; } = Descripcion ?? string.Empty;
+
     public virtual bool Equals(DetalleTurno? other)
     {
         if (other is null) return false;

--- a/src/Bitakora.ControlAsistencia.PrivateEvents/Programacion/DetalleTurno.cs
+++ b/src/Bitakora.ControlAsistencia.PrivateEvents/Programacion/DetalleTurno.cs
@@ -4,6 +4,33 @@ namespace Bitakora.ControlAsistencia.PrivateEvents.Programacion;
 /// Representacion plana del turno que viaja en eventos entre dominios.
 /// No tiene comportamiento de dominio, solo datos.
 /// </summary>
+/// <remarks>
+/// Issue #288: dos intervenciones sobre el record por defecto.
+/// 1) Descripcion: representacion textual normalizada (formato del tipo rico
+///    CatalogoTurnos.ToString()), dato derivado persistido -- ver decision del issue.
+/// 2) Bug latente corregido: FranjasOrdinarias es IReadOnlyList y el record por defecto la compara
+///    por referencia (ADR-0015; mismo bug que #129 ya corrigio en DetalleFranjaOrdinaria).
+///    Equals/GetHashCode propios comparan Nombre y FranjasOrdinarias POR VALOR (SequenceEqual) y
+///    EXCLUYEN Descripcion (dato derivado, no identidad del turno).
+/// </remarks>
 public record DetalleTurno(
     string Nombre,
-    IReadOnlyList<DetalleFranjaOrdinaria> FranjasOrdinarias);
+    IReadOnlyList<DetalleFranjaOrdinaria> FranjasOrdinarias,
+    string Descripcion)
+{
+    public virtual bool Equals(DetalleTurno? other)
+    {
+        if (other is null) return false;
+        if (ReferenceEquals(this, other)) return true;
+        return Nombre == other.Nombre
+            && FranjasOrdinarias.SequenceEqual(other.FranjasOrdinarias);
+    }
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(Nombre);
+        foreach (var franja in FranjasOrdinarias) hash.Add(franja);
+        return hash.ToHashCode();
+    }
+}

--- a/src/Bitakora.ControlAsistencia.Programacion.DomainEvents/FranjaOrdinaria.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion.DomainEvents/FranjaOrdinaria.cs
@@ -68,12 +68,12 @@ public sealed class FranjaOrdinaria : FranjaTemporal, IEquatable<FranjaOrdinaria
     }
 
     // Conversion a DTO plano para eventos entre dominios
-    // Issue #288 CA-2: Descripcion pendiente de asignar con ToString() (fase verde del implementer).
+    // Issue #288 CA-2: Descripcion se asigna con el ToString() de este mismo tipo rico.
     public DetalleFranjaOrdinaria ToDetalle() => new(
         _horaInicio, _horaFin, _diaOffsetFin,
         _descansos.Select(d => d.ToDetalle()).ToList().AsReadOnly(),
         _extras.Select(e => e.ToDetalle()).ToList().AsReadOnly(),
-        string.Empty);
+        ToString());
 
     // CA-20, CA-21: formato "(06:00-12:00)" o "(22:00-06:00+1)"
     public override string ToString()

--- a/src/Bitakora.ControlAsistencia.Programacion.DomainEvents/FranjaOrdinaria.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion.DomainEvents/FranjaOrdinaria.cs
@@ -68,10 +68,12 @@ public sealed class FranjaOrdinaria : FranjaTemporal, IEquatable<FranjaOrdinaria
     }
 
     // Conversion a DTO plano para eventos entre dominios
+    // Issue #288 CA-2: Descripcion pendiente de asignar con ToString() (fase verde del implementer).
     public DetalleFranjaOrdinaria ToDetalle() => new(
         _horaInicio, _horaFin, _diaOffsetFin,
         _descansos.Select(d => d.ToDetalle()).ToList().AsReadOnly(),
-        _extras.Select(e => e.ToDetalle()).ToList().AsReadOnly());
+        _extras.Select(e => e.ToDetalle()).ToList().AsReadOnly(),
+        string.Empty);
 
     // CA-20, CA-21: formato "(06:00-12:00)" o "(22:00-06:00+1)"
     public override string ToString()

--- a/src/Bitakora.ControlAsistencia.Programacion.DomainEvents/SubFranja.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion.DomainEvents/SubFranja.cs
@@ -30,8 +30,9 @@ public sealed class SubFranja : FranjaTemporal, IEquatable<SubFranja>
     }
 
     // Conversion a DTO plano para eventos entre dominios
+    // Issue #288 CA-2: Descripcion pendiente de asignar con ToString() (fase verde del implementer).
     public DetalleSubFranja ToDetalle() =>
-        new(_horaInicio, _horaFin, _diaOffsetInicio, _diaOffsetFin);
+        new(_horaInicio, _horaFin, _diaOffsetInicio, _diaOffsetFin, string.Empty);
 
     // CA-20, CA-21: formato legible con offsets
     public override string ToString() =>

--- a/src/Bitakora.ControlAsistencia.Programacion.DomainEvents/SubFranja.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion.DomainEvents/SubFranja.cs
@@ -30,9 +30,9 @@ public sealed class SubFranja : FranjaTemporal, IEquatable<SubFranja>
     }
 
     // Conversion a DTO plano para eventos entre dominios
-    // Issue #288 CA-2: Descripcion pendiente de asignar con ToString() (fase verde del implementer).
+    // Issue #288 CA-2: Descripcion se asigna con el ToString() de este mismo tipo rico.
     public DetalleSubFranja ToDetalle() =>
-        new(_horaInicio, _horaFin, _diaOffsetInicio, _diaOffsetFin, string.Empty);
+        new(_horaInicio, _horaFin, _diaOffsetInicio, _diaOffsetFin, ToString());
 
     // CA-20, CA-21: formato legible con offsets
     public override string ToString() =>

--- a/src/Bitakora.ControlAsistencia.Programacion/Entities/CatalogoTurnos.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/Entities/CatalogoTurnos.cs
@@ -30,11 +30,11 @@ public partial class CatalogoTurnos : AggregateRoot
         $"{_nombre} {string.Join("", _franjasOrdinarias)}";
 
     // Devuelve una representacion plana del turno para usar en eventos entre dominios
-    // Issue #288 CA-2: Descripcion pendiente de asignar con ToString() (fase verde del implementer).
+    // Issue #288 CA-2: Descripcion se asigna con el ToString() de este mismo aggregate.
     internal DetalleTurno ObtenerDetalle() => new(
         _nombre,
         _franjasOrdinarias.Select(f => f.ToDetalle()).ToList().AsReadOnly(),
-        string.Empty);
+        ToString());
 
     // Factory interno: crea el aggregate con el evento en _uncommittedEvents
     // Usado por el handler para StartStream -- no es parte de la interfaz publica del dominio

--- a/src/Bitakora.ControlAsistencia.Programacion/Entities/CatalogoTurnos.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/Entities/CatalogoTurnos.cs
@@ -30,9 +30,11 @@ public partial class CatalogoTurnos : AggregateRoot
         $"{_nombre} {string.Join("", _franjasOrdinarias)}";
 
     // Devuelve una representacion plana del turno para usar en eventos entre dominios
+    // Issue #288 CA-2: Descripcion pendiente de asignar con ToString() (fase verde del implementer).
     internal DetalleTurno ObtenerDetalle() => new(
         _nombre,
-        _franjasOrdinarias.Select(f => f.ToDetalle()).ToList().AsReadOnly());
+        _franjasOrdinarias.Select(f => f.ToDetalle()).ToList().AsReadOnly(),
+        string.Empty);
 
     // Factory interno: crea el aggregate con el evento en _uncommittedEvents
     // Usado por el handler para StartStream -- no es parte de la interfaz publica del dominio

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/AsignarTurnoViaSbSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/AsignarTurnoViaSbSmokeTests.cs
@@ -89,10 +89,11 @@ public class AsignarTurnoViaSbSmokeTests(ServiceBusFixture serviceBus, PostgresF
             .GetProperty("InformacionEmpleado").Deserialize<InformacionEmpleado>();
         infoEmpleadoPersistida.Should().Be(infoEmpleadoEsperada);
 
-        // Issue #288: el evento crudo publicado arriba (objeto anonimo) no lleva "Descripcion" -- el
-        // dato derivado lo asigna Programacion en produccion (CatalogoTurnos/FranjaOrdinaria/SubFranja),
-        // no este payload de smoke test. Se excluye de la comparacion estructural porque no es
-        // relevante para lo que este smoke test verifica (que el mensaje crudo se persiste).
+        // Issue #288: el mensaje crudo publicado arriba (objeto anonimo) no lleva "Descripcion" -- el
+        // dato derivado solo lo asigna Programacion en produccion (CatalogoTurnos/FranjaOrdinaria/
+        // SubFranja), no este payload sintetico. Los DTOs lo normalizan a cadena vacia; el campo se
+        // excluye de la comparacion estructural porque aqui no hay texto real que verificar (esa
+        // normalizacion la cubre ProgramacionTurnoDiarioSolicitadaPortabilidadTests).
         var detalleTurnoEsperado = new DetalleTurno("[TEST] Turno Smoke SB", [
             new DetalleFranjaOrdinaria(
                 new TimeOnly(8, 0), new TimeOnly(16, 0), 0,
@@ -223,7 +224,7 @@ public class AsignarTurnoViaSbSmokeTests(ServiceBusFixture serviceBus, PostgresF
             .GetProperty("InformacionEmpleado").Deserialize<InformacionEmpleado>();
         infoEmpleadoPersistida.Should().Be(infoEmpleadoEsperada);
 
-        // Issue #288: mismo motivo que el test anterior - el mensaje crudo en camelCase no lleva
+        // Issue #288: mismo motivo que el test anterior -- el mensaje crudo en camelCase no lleva
         // "descripcion", asi que se excluye de la comparacion estructural.
         var detalleTurnoEsperado = new DetalleTurno("[TEST] Turno Wolverine CamelCase", [
             new DetalleFranjaOrdinaria(

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/AsignarTurnoViaSbSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/AsignarTurnoViaSbSmokeTests.cs
@@ -89,14 +89,19 @@ public class AsignarTurnoViaSbSmokeTests(ServiceBusFixture serviceBus, PostgresF
             .GetProperty("InformacionEmpleado").Deserialize<InformacionEmpleado>();
         infoEmpleadoPersistida.Should().Be(infoEmpleadoEsperada);
 
+        // Issue #288: el evento crudo publicado arriba (objeto anonimo) no lleva "Descripcion" -- el
+        // dato derivado lo asigna Programacion en produccion (CatalogoTurnos/FranjaOrdinaria/SubFranja),
+        // no este payload de smoke test. Se excluye de la comparacion estructural porque no es
+        // relevante para lo que este smoke test verifica (que el mensaje crudo se persiste).
         var detalleTurnoEsperado = new DetalleTurno("[TEST] Turno Smoke SB", [
             new DetalleFranjaOrdinaria(
                 new TimeOnly(8, 0), new TimeOnly(16, 0), 0,
-                Array.Empty<DetalleSubFranja>(), Array.Empty<DetalleSubFranja>())
-        ]);
+                Array.Empty<DetalleSubFranja>(), Array.Empty<DetalleSubFranja>(), "")
+        ], "");
         var detalleTurnoPersistido = eventoPersistido
             .GetProperty("DetalleTurno").Deserialize<DetalleTurno>();
-        detalleTurnoPersistido.Should().BeEquivalentTo(detalleTurnoEsperado);
+        detalleTurnoPersistido.Should().BeEquivalentTo(detalleTurnoEsperado,
+            opciones => opciones.ExcludingMembersNamed("Descripcion"));
 
         // Assert HU-131 CA-1/CA-2: DiaCalculado publicado al topic dia-calculado.
         // Se emite siempre, incluso si ControlesDeFranja queda vacio tras la depuracion reactiva.
@@ -218,14 +223,17 @@ public class AsignarTurnoViaSbSmokeTests(ServiceBusFixture serviceBus, PostgresF
             .GetProperty("InformacionEmpleado").Deserialize<InformacionEmpleado>();
         infoEmpleadoPersistida.Should().Be(infoEmpleadoEsperada);
 
+        // Issue #288: mismo motivo que el test anterior - el mensaje crudo en camelCase no lleva
+        // "descripcion", asi que se excluye de la comparacion estructural.
         var detalleTurnoEsperado = new DetalleTurno("[TEST] Turno Wolverine CamelCase", [
             new DetalleFranjaOrdinaria(
                 new TimeOnly(7, 0), new TimeOnly(15, 0), 0,
-                Array.Empty<DetalleSubFranja>(), Array.Empty<DetalleSubFranja>())
-        ]);
+                Array.Empty<DetalleSubFranja>(), Array.Empty<DetalleSubFranja>(), "")
+        ], "");
         var detalleTurnoPersistido = eventoPersistido
             .GetProperty("DetalleTurno").Deserialize<DetalleTurno>();
-        detalleTurnoPersistido.Should().BeEquivalentTo(detalleTurnoEsperado);
+        detalleTurnoPersistido.Should().BeEquivalentTo(detalleTurnoEsperado,
+            opciones => opciones.ExcludingMembersNamed("Descripcion"));
 
         // Assert HU-131: DiaCalculado publicado incluso cuando el mensaje llega en camelCase.
         // Valida que la cadena completa (deserializacion case-insensitive -> handler -> publicacion) funciona.

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoRegistroDeMarcacionCreado/DepurarAlAdicionarMarcacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoRegistroDeMarcacionCreado/DepurarAlAdicionarMarcacionTests.cs
@@ -32,14 +32,15 @@ public class DepurarAlAdicionarMarcacionTests : PrivateEventHandlerAsyncTest<Reg
     private static readonly Guid SolicitudId = Guid.Parse("019600c0-0000-7000-8000-000000000001");
 
     // CA-1: franja unica 06:00-14:00
+    // Issue #288: Descripcion (dato derivado) es irrelevante para estos tests -> placeholder "".
     private static readonly DetalleFranjaOrdinaria Franja06_14 =
-        new(new TimeOnly(6, 0), new TimeOnly(14, 0), 0, [], []);
+        new(new TimeOnly(6, 0), new TimeOnly(14, 0), 0, [], [], "");
 
     // CA-3: turno partido con dos franjas
     private static readonly DetalleFranjaOrdinaria Franja06_12 =
-        new(new TimeOnly(6, 0), new TimeOnly(12, 0), 0, [], []);
+        new(new TimeOnly(6, 0), new TimeOnly(12, 0), 0, [], [], "");
     private static readonly DetalleFranjaOrdinaria Franja14_18 =
-        new(new TimeOnly(14, 0), new TimeOnly(18, 0), 0, [], []);
+        new(new TimeOnly(14, 0), new TimeOnly(18, 0), 0, [], [], "");
 
     // Timestamps de marcaciones (fuera de ventana nocturna: >= 04:00)
     private static readonly DateTime Timestamp07_00 = new(2026, 3, 15, 7, 0, 0);
@@ -74,7 +75,7 @@ public class DepurarAlAdicionarMarcacionTests : PrivateEventHandlerAsyncTest<Reg
     [Fact]
     public async Task RegistroDeMarcacionCreado_CalculaControlFranja_CuandoHayTurnoYLlegaMarcacion()
     {
-        var turnoUnico = new DetalleTurno("Turno Manana", [Franja06_14]);
+        var turnoUnico = new DetalleTurno("Turno Manana", [Franja06_14], "");
         Given(StreamId, CrearTurnoDiarioAsignado(turnoUnico));
 
         await WhenAsync(CrearRegistroDeMarcacionCreado(Timestamp07_00));
@@ -128,7 +129,7 @@ public class DepurarAlAdicionarMarcacionTests : PrivateEventHandlerAsyncTest<Reg
     [Fact]
     public async Task RegistroDeMarcacionCreado_RecalculaControlesDeFranjaCompletos_CuandoHayTurnoPartidoYMarcacionesAcumuladas()
     {
-        var turnoPartido = new DetalleTurno("Turno Partido", [Franja06_12, Franja14_18]);
+        var turnoPartido = new DetalleTurno("Turno Partido", [Franja06_12, Franja14_18], "");
         Given(StreamId,
             CrearTurnoDiarioAsignado(turnoPartido),
             CrearMarcacionAdicionada(Timestamp05_50),

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoRegistroDeMarcacionCreado/DesgloseHorasTrasAdicionarMarcacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoRegistroDeMarcacionCreado/DesgloseHorasTrasAdicionarMarcacionTests.cs
@@ -36,10 +36,11 @@ public class DesgloseHorasTrasAdicionarMarcacionTests : PrivateEventHandlerAsync
     private static readonly Guid SolicitudId = Guid.Parse("019600c0-0000-7000-8000-000000000003");
 
     // CA-1: turno partido con dos franjas ordinarias 08:00-12:00 y 14:00-18:00
+    // Issue #288: Descripcion (dato derivado) es irrelevante para estos tests -> placeholder "".
     private static readonly DetalleFranjaOrdinaria Franja08_12 =
-        new(new TimeOnly(8, 0), new TimeOnly(12, 0), 0, [], []);
+        new(new TimeOnly(8, 0), new TimeOnly(12, 0), 0, [], [], "");
     private static readonly DetalleFranjaOrdinaria Franja14_18 =
-        new(new TimeOnly(14, 0), new TimeOnly(18, 0), 0, [], []);
+        new(new TimeOnly(14, 0), new TimeOnly(18, 0), 0, [], [], "");
 
     // Timestamps de marcaciones (fuera de ventana nocturna: >= 04:00)
     private static readonly DateTime Timestamp07_00 = new(2026, 3, 15, 7, 0, 0);
@@ -67,7 +68,7 @@ public class DesgloseHorasTrasAdicionarMarcacionTests : PrivateEventHandlerAsync
     [Fact]
     public async Task RegistroDeMarcacionCreado_RecalculaDesgloseHoras_CuandoMarcacionCompletaUltimaFranja()
     {
-        var turnoPartido = new DetalleTurno("Turno Partido", [Franja08_12, Franja14_18]);
+        var turnoPartido = new DetalleTurno("Turno Partido", [Franja08_12, Franja14_18], "");
         Given(StreamId,
             CrearTurnoDiarioAsignado(turnoPartido),
             CrearMarcacionAdicionada(Timestamp08_00),

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/DepurarAlAsignarTurnoTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/DepurarAlAsignarTurnoTests.cs
@@ -29,8 +29,9 @@ public class DepurarAlAsignarTurnoTests
     private static readonly string StreamId = $"{Empleado.EmpleadoId}:{Fecha:yyyy-MM-dd}";
 
     // CA-4: franja unica 06:00-14:00 para el turno asignado
+    // Issue #288: Descripcion (dato derivado) es irrelevante para estos tests -> placeholder "".
     private static readonly DetalleFranjaOrdinaria Franja06_14 =
-        new(new TimeOnly(6, 0), new TimeOnly(14, 0), 0, [], []);
+        new(new TimeOnly(6, 0), new TimeOnly(14, 0), 0, [], [], "");
 
     // Timestamps de las marcaciones que llegan antes que el turno
     private static readonly DateTime Timestamp07_00 = new(2026, 3, 15, 7, 0, 0);
@@ -66,7 +67,7 @@ public class DepurarAlAsignarTurnoTests
     [Fact]
     public async Task ProgramacionTurnoDiarioSolicitada_CalculaControlFranja_CuandoMarcacionesLlegaronAntesQueTurno()
     {
-        var turnoConFranjaUnica = new DetalleTurno("Turno Manana", [Franja06_14]);
+        var turnoConFranjaUnica = new DetalleTurno("Turno Manana", [Franja06_14], "");
         Given(StreamId,
             CrearMarcacionAdicionada(Timestamp07_00),
             CrearMarcacionAdicionada(Timestamp15_00));
@@ -105,7 +106,7 @@ public class DepurarAlAsignarTurnoTests
     public async Task ProgramacionTurnoDiarioSolicitada_PublicaDiaCalculado_CuandoNoHayMarcacionesPrevias()
     {
         // Sin Given - stream nuevo, sin marcaciones previas
-        var turnoConFranjaUnica = new DetalleTurno("Turno Manana", [Franja06_14]);
+        var turnoConFranjaUnica = new DetalleTurno("Turno Manana", [Franja06_14], "");
 
         await WhenAsync(CrearEvento(turnoConFranjaUnica));
 
@@ -130,7 +131,7 @@ public class DepurarAlAsignarTurnoTests
     public async Task ProgramacionTurnoDiarioSolicitada_PublicaDiaCalculado_CuandoTurnoNoTieneFranjas()
     {
         // Sin Given - stream nuevo, turno sin franjas ordinarias
-        var turnoSinFranjas = new DetalleTurno("Turno Sin Franjas", []);
+        var turnoSinFranjas = new DetalleTurno("Turno Sin Franjas", [], "");
 
         await WhenAsync(CrearEvento(turnoSinFranjas));
 

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/DesgloseHorasTrasAsignarTurnoTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/DesgloseHorasTrasAsignarTurnoTests.cs
@@ -33,14 +33,15 @@ public class DesgloseHorasTrasAsignarTurnoTests
     private static readonly string StreamId = $"{Empleado.EmpleadoId}:{Fecha:yyyy-MM-dd}";
 
     // CA-3: franja unica 06:00-14:00 para el turno asignado
+    // Issue #288: Descripcion (dato derivado) es irrelevante para estos tests -> placeholder "".
     private static readonly DetalleFranjaOrdinaria Franja06_14 =
-        new(new TimeOnly(6, 0), new TimeOnly(14, 0), 0, [], []);
+        new(new TimeOnly(6, 0), new TimeOnly(14, 0), 0, [], [], "");
 
     // CA-4: turno partido con dos franjas ordinarias (ambas quedaran anomalas sin marcaciones)
     private static readonly DetalleFranjaOrdinaria Franja06_12 =
-        new(new TimeOnly(6, 0), new TimeOnly(12, 0), 0, [], []);
+        new(new TimeOnly(6, 0), new TimeOnly(12, 0), 0, [], [], "");
     private static readonly DetalleFranjaOrdinaria Franja14_18 =
-        new(new TimeOnly(14, 0), new TimeOnly(18, 0), 0, [], []);
+        new(new TimeOnly(14, 0), new TimeOnly(18, 0), 0, [], [], "");
 
     // Timestamps de las marcaciones que llegan antes que el turno (CA-3)
     private static readonly DateTime Timestamp07_00 = new(2026, 3, 15, 7, 0, 0);
@@ -69,7 +70,7 @@ public class DesgloseHorasTrasAsignarTurnoTests
             CrearMarcacionAdicionada(Timestamp07_00),
             CrearMarcacionAdicionada(Timestamp15_00));
 
-        var turnoFranjaUnica = new DetalleTurno("Turno Manana", [Franja06_14]);
+        var turnoFranjaUnica = new DetalleTurno("Turno Manana", [Franja06_14], "");
         await WhenAsync(CrearEvento(turnoFranjaUnica));
 
         Then(StreamId, CrearTurnoDiarioAsignado(turnoFranjaUnica));
@@ -114,7 +115,7 @@ public class DesgloseHorasTrasAsignarTurnoTests
     public async Task ProgramacionTurnoDiarioSolicitada_DejaDesgloseHorasConFranjasAnomalas_CuandoTurnoSinMarcaciones()
     {
         // Sin Given - stream nuevo, turno partido sin marcaciones previas
-        var turnoPartido = new DetalleTurno("Turno Partido", [Franja06_12, Franja14_18]);
+        var turnoPartido = new DetalleTurno("Turno Partido", [Franja06_12, Franja14_18], "");
 
         await WhenAsync(CrearEvento(turnoPartido));
 

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/ProgramacionTurnoDiarioSolicitadaPortabilidadTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/ProgramacionTurnoDiarioSolicitadaPortabilidadTests.cs
@@ -30,15 +30,20 @@ public class ProgramacionTurnoDiarioSolicitadaPortabilidadTests
     private static JsonSerializerOptions CrearOpcionesProductor() =>
         new(JsonSerializerDefaults.Web);
 
+    // Turno con descanso: cubre los tres niveles de Descripcion (turno, franja y sub-franja).
+    private static DetalleTurno CrearDetalleTurno() => new(
+        "Turno Manana",
+        [new DetalleFranjaOrdinaria(
+            new TimeOnly(8, 0), new TimeOnly(16, 0), 0,
+            [new DetalleSubFranja(new TimeOnly(12, 0), new TimeOnly(13, 0), 0, 0, "(12:00-13:00)")],
+            [],
+            "(08:00-16:00)[Descansos:(12:00-13:00)]")],
+        "Turno Manana (08:00-16:00)[Descansos:(12:00-13:00)]");
+
     [Fact]
     public void RoundTrip_PreservaDescripcion_ConSerializadorPorDefectoDelBus()
     {
-        var detalleTurno = new DetalleTurno(
-            "Turno Manana",
-            [new DetalleFranjaOrdinaria(
-                new TimeOnly(8, 0), new TimeOnly(16, 0), 0, [], [],
-                "(08:00-16:00)")],
-            "Turno Manana (08:00-16:00)");
+        var detalleTurno = CrearDetalleTurno();
         var evento = new ProgramacionTurnoDiarioSolicitada(SolicitudId, Empleado, Fecha, detalleTurno);
 
         // El productor publica con sus propias opciones (sin resolver custom, DTO plano)...
@@ -50,8 +55,49 @@ public class ProgramacionTurnoDiarioSolicitadaPortabilidadTests
         var restaurado = ServiceBusDeserializador.Deserializar<ProgramacionTurnoDiarioSolicitada>(body);
 
         restaurado.Should().NotBeNull();
+        var franjaRestaurada = restaurado.DetalleTurno.FranjasOrdinarias[0];
         restaurado.DetalleTurno.Descripcion.Should().Be(detalleTurno.Descripcion);
-        restaurado.DetalleTurno.FranjasOrdinarias[0].Descripcion
-            .Should().Be(detalleTurno.FranjasOrdinarias[0].Descripcion);
+        franjaRestaurada.Descripcion.Should().Be(detalleTurno.FranjasOrdinarias[0].Descripcion);
+        franjaRestaurada.Descansos[0].Descripcion
+            .Should().Be(detalleTurno.FranjasOrdinarias[0].Descansos[0].Descripcion);
+    }
+
+    // Retro-compatibilidad: los eventos publicados antes de #288 no llevan el campo. STJ dejaria
+    // null en un parametro posicional declarado como string no anulable, lo que seria una mina
+    // para cualquier consumidor. Los DTOs lo normalizan a cadena vacia -- la consecuencia que el
+    // issue asumio explicitamente ("habra mezcla entre solicitudes viejas sin texto y nuevas").
+    [Fact]
+    public void Deserializar_DejaDescripcionEnCadenaVacia_CuandoEventoNoLlevaElCampo()
+    {
+        const string jsonPrevioAlCampo = """
+            {
+              "solicitudId": "019600b0-0000-7000-8000-000000000009",
+              "informacionEmpleado": {
+                "empleadoId": "EMP-001", "tipoDocumento": "CC", "numeroDocumento": "1234567890",
+                "nombres": "Luis Augusto", "apellidos": "Barreto"
+              },
+              "fecha": "2026-03-15",
+              "detalleTurno": {
+                "nombre": "Turno Manana",
+                "franjasOrdinarias": [{
+                  "horaInicio": "08:00:00", "horaFin": "16:00:00", "diaOffsetFin": 0,
+                  "descansos": [{
+                    "horaInicio": "12:00:00", "horaFin": "13:00:00",
+                    "diaOffsetInicio": 0, "diaOffsetFin": 0
+                  }],
+                  "extras": []
+                }]
+              }
+            }
+            """;
+
+        var restaurado = ServiceBusDeserializador.Deserializar<ProgramacionTurnoDiarioSolicitada>(
+            BinaryData.FromString(jsonPrevioAlCampo));
+
+        restaurado.Should().NotBeNull();
+        var franja = restaurado.DetalleTurno.FranjasOrdinarias[0];
+        restaurado.DetalleTurno.Descripcion.Should().BeEmpty();
+        franja.Descripcion.Should().BeEmpty();
+        franja.Descansos[0].Descripcion.Should().BeEmpty();
     }
 }

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/ProgramacionTurnoDiarioSolicitadaPortabilidadTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/ProgramacionTurnoDiarioSolicitadaPortabilidadTests.cs
@@ -1,0 +1,57 @@
+// Issue #288 CA-7: ProgramacionTurnoDiarioSolicitada es IPrivateEvent (cruza el ASB interno del BC,
+// ADR-0024 decision #3). Descripcion (agregada a DetalleTurno/DetalleFranjaOrdinaria/DetalleSubFranja)
+// es un string plano: sigue cumpliendo CA-ADR-0025 ("lo que cruza un bus es plano"). Este test
+// verifica portabilidad con el serializador POR DEFECTO (sin el resolver custom de Programacion,
+// que es quien produce el evento) -- exactamente lo que ve ControlHoras al consumirlo del bus.
+// Distinto del round-trip de Marten (6d): aqui la expectativa es que Descripcion SOBREVIVA sin
+// resolver, porque el DTO plano no necesita uno (a diferencia de los tipos ricos con campos
+// privados como SubFranja/FranjaOrdinaria).
+
+using System.Text.Json;
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.ControlHoras.Infraestructura;
+using Bitakora.ControlAsistencia.PrivateEvents.Programacion;
+using Bitakora.ControlAsistencia.PublicEvents.Empleados;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Tests.AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction.Eventos;
+
+public class ProgramacionTurnoDiarioSolicitadaPortabilidadTests
+{
+    private static readonly Guid SolicitudId =
+        Guid.Parse("019600b0-0000-7000-8000-000000000009");
+
+    private static readonly InformacionEmpleado Empleado = new(
+        "EMP-001", "CC", "1234567890", "Luis Augusto", "Barreto");
+
+    private static readonly DateOnly Fecha = new(2026, 3, 15);
+
+    // Serializador del productor (Programacion): sin resolver custom, DetalleTurno es un DTO plano
+    // (solo tipos primitivos y listas), no necesita uno.
+    private static JsonSerializerOptions CrearOpcionesProductor() =>
+        new(JsonSerializerDefaults.Web);
+
+    [Fact]
+    public void RoundTrip_PreservaDescripcion_ConSerializadorPorDefectoDelBus()
+    {
+        var detalleTurno = new DetalleTurno(
+            "Turno Manana",
+            [new DetalleFranjaOrdinaria(
+                new TimeOnly(8, 0), new TimeOnly(16, 0), 0, [], [],
+                "(08:00-16:00)")],
+            "Turno Manana (08:00-16:00)");
+        var evento = new ProgramacionTurnoDiarioSolicitada(SolicitudId, Empleado, Fecha, detalleTurno);
+
+        // El productor publica con sus propias opciones (sin resolver custom, DTO plano)...
+        var json = JsonSerializer.Serialize(evento, CrearOpcionesProductor());
+
+        // ...y el consumidor (ControlHoras) deserializa con SUS opciones (case-insensitive,
+        // tampoco con resolver custom) -- el mismo camino que ServiceBusDeserializador usa en produccion.
+        var body = BinaryData.FromString(json);
+        var restaurado = ServiceBusDeserializador.Deserializar<ProgramacionTurnoDiarioSolicitada>(body);
+
+        restaurado.Should().NotBeNull();
+        restaurado.DetalleTurno.Descripcion.Should().Be(detalleTurno.Descripcion);
+        restaurado.DetalleTurno.FranjasOrdinarias[0].Descripcion
+            .Should().Be(detalleTurno.FranjasOrdinarias[0].Descripcion);
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/TurnoDiarioAsignadoSerializacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/TurnoDiarioAsignadoSerializacionTests.cs
@@ -25,9 +25,12 @@ public class TurnoDiarioAsignadoSerializacionTests
 
     private static readonly DateOnly Fecha = new DateOnly(2026, 3, 15);
 
+    // Issue #288: Descripcion (dato derivado, texto del formato tecnico) es irrelevante para este
+    // round-trip -> placeholder no vacio para verificar tambien que sobrevive la serializacion.
     private static readonly DetalleTurno DetalleTurnoTest = new(
         "Turno Manana",
-        [new DetalleFranjaOrdinaria(new TimeOnly(8, 0), new TimeOnly(16, 0), 0, [], [])]);
+        [new DetalleFranjaOrdinaria(new TimeOnly(8, 0), new TimeOnly(16, 0), 0, [], [], "(08:00-16:00)")],
+        "Turno Manana (08:00-16:00)");
 
     private static readonly string StreamId = $"{Empleado.EmpleadoId}:{Fecha:yyyy-MM-dd}";
 
@@ -52,5 +55,11 @@ public class TurnoDiarioAsignadoSerializacionTests
         deserializado.DetalleTurno.FranjasOrdinarias.Should().HaveCount(1);
         deserializado.DetalleTurno.FranjasOrdinarias[0].HoraInicio
             .Should().Be(new TimeOnly(8, 0));
+
+        // Issue #288 CA-7: Descripcion (dato derivado persistido) sobrevive el round-trip,
+        // tanto a nivel turno como a nivel de cada franja ordinaria.
+        deserializado.DetalleTurno.Descripcion.Should().Be(DetalleTurnoTest.Descripcion);
+        deserializado.DetalleTurno.FranjasOrdinarias[0].Descripcion
+            .Should().Be(DetalleTurnoTest.FranjasOrdinarias[0].Descripcion);
     }
 }

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/ProgramacionTurnoDiarioSolicitadaEventHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/ProgramacionTurnoDiarioSolicitadaEventHandlerTests.cs
@@ -26,9 +26,11 @@ public class ProgramacionTurnoDiarioSolicitadaEventHandlerTests
     // CA-7: stream ID determinista que el handler debe computar internamente
     private static readonly string StreamId = $"{Empleado.EmpleadoId}:{Fecha:yyyy-MM-dd}";
 
+    // Issue #288: Descripcion (dato derivado) es irrelevante para este test -> placeholder "".
     private static readonly DetalleTurno DetalleTurnoTest = new(
         "Turno Manana",
-        [new DetalleFranjaOrdinaria(new TimeOnly(8, 0), new TimeOnly(16, 0), 0, [], [])]);
+        [new DetalleFranjaOrdinaria(new TimeOnly(8, 0), new TimeOnly(16, 0), 0, [], [], "")],
+        "");
 
     protected override IPrivateEventHandlerAsync<ProgramacionTurnoDiarioSolicitada> Handler =>
         new ProgramacionTurnoDiarioSolicitadaEventHandler(EventStore, PublicEventSender);

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/CalcularDesgloseFranjaTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/CalcularDesgloseFranjaTests.cs
@@ -49,8 +49,9 @@ public class CalcularDesgloseFranjaTests
     private static IntervaloClasificado Clasif(MomentoDelDia inicio, MomentoDelDia fin, Concepto concepto) =>
         new(IntervaloTemporal.Crear(inicio, fin), concepto);
 
+    // Issue #288: Descripcion (dato derivado) es irrelevante para estos tests -> placeholder "".
     private static DetalleSubFranja Sub(int horaInicio, int horaFin, int diaOffsetInicio = 0, int diaOffsetFin = 0) =>
-        new(new TimeOnly(horaInicio, 0), new TimeOnly(horaFin, 0), diaOffsetInicio, diaOffsetFin);
+        new(new TimeOnly(horaInicio, 0), new TimeOnly(horaFin, 0), diaOffsetInicio, diaOffsetFin, "");
 
     private static DetalleFranjaOrdinaria Franja(
         int horaInicio,
@@ -59,7 +60,7 @@ public class CalcularDesgloseFranjaTests
         IReadOnlyList<DetalleSubFranja>? descansos = null,
         IReadOnlyList<DetalleSubFranja>? extras = null) =>
         new(new TimeOnly(horaInicio, 0), new TimeOnly(horaFin, 0), diaOffsetFin,
-            descansos ?? [], extras ?? []);
+            descansos ?? [], extras ?? [], "");
 
     // ----- CA-1: compuerta de anomala -----
 

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/ClasificadorTrabajoTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/ClasificadorTrabajoTests.cs
@@ -40,8 +40,9 @@ public class ClasificadorTrabajoTests
     private static IntervaloClasificado Clasif(MomentoDelDia inicio, MomentoDelDia fin, Concepto concepto) =>
         new(IntervaloTemporal.Crear(inicio, fin), concepto);
 
+    // Issue #288: Descripcion (dato derivado) es irrelevante para estos tests -> placeholder "".
     private static DetalleSubFranja Sub(int horaInicio, int horaFin, int diaOffsetInicio = 0, int diaOffsetFin = 0) =>
-        new(new TimeOnly(horaInicio, 0), new TimeOnly(horaFin, 0), diaOffsetInicio, diaOffsetFin);
+        new(new TimeOnly(horaInicio, 0), new TimeOnly(horaFin, 0), diaOffsetInicio, diaOffsetFin, "");
 
     private static DetalleFranjaOrdinaria Franja(
         int horaInicio,
@@ -50,7 +51,7 @@ public class ClasificadorTrabajoTests
         IReadOnlyList<DetalleSubFranja>? descansos = null,
         IReadOnlyList<DetalleSubFranja>? extras = null) =>
         new(new TimeOnly(horaInicio, 0), new TimeOnly(horaFin, 0), diaOffsetFin,
-            descansos ?? [], extras ?? []);
+            descansos ?? [], extras ?? [], "");
 
     [Fact]
     public void Clasificar_DesglosaOrdinariaConDescanso_CuandoFranjaDiurnaSeTrabajaCompleta()

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/ConsolidadorDesgloseHorasTestData.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/ConsolidadorDesgloseHorasTestData.cs
@@ -36,8 +36,9 @@ internal static class ConsolidadorDesgloseHorasTestData
     // Franja programada plana (sin descansos ni extras programadas declarados): solo
     // viaja en el DesgloseFranja para que el consolidador la preserve en DesglosePorFranja.
     // El detalle real de lo trabajado vive en los IntervaloClasificado de cada franja.
+    // Issue #288: Descripcion (dato derivado) es irrelevante para estos tests -> placeholder "".
     public static DetalleFranjaOrdinaria Programada(int horaInicio, int horaFin, int diaOffsetFin = 0) =>
-        new(new TimeOnly(horaInicio, 0), new TimeOnly(horaFin, 0), diaOffsetFin, [], []);
+        new(new TimeOnly(horaInicio, 0), new TimeOnly(horaFin, 0), diaOffsetFin, [], [], "");
 
     // Retardo de una franja, a partir de sus intervalos retardados y compensados.
     public static Retardo CrearRetardo(

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/ControlFranjaTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/ControlFranjaTests.cs
@@ -12,8 +12,9 @@ namespace Bitakora.ControlAsistencia.ControlHoras.Tests.Entities;
 /// </summary>
 public class ControlFranjaTests
 {
+    // Issue #288: Descripcion (dato derivado) es irrelevante para estos tests -> placeholder "".
     private static readonly DetalleFranjaOrdinaria Franja06_14 = new(
-        new TimeOnly(6, 0), new TimeOnly(14, 0), 0, [], []);
+        new TimeOnly(6, 0), new TimeOnly(14, 0), 0, [], [], "");
 
     private static readonly DateTime T07 = new(2026, 3, 15, 7, 0, 0);
     private static readonly DateTime T15 = new(2026, 3, 15, 15, 0, 0);

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/CrearDiaCalculadoConHorasDiscriminadasTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/CrearDiaCalculadoConHorasDiscriminadasTests.cs
@@ -45,8 +45,9 @@ public class CrearDiaCalculadoConHorasDiscriminadasTests
     private static readonly Guid SolicitudId = Guid.Parse("019600d0-0000-7000-8000-000000000001");
 
     // Franja unica 06:00-14:00 usada por los escenarios de turno.
+    // Issue #288: Descripcion (dato derivado) es irrelevante para estos tests -> placeholder "".
     private static readonly DetalleFranjaOrdinaria Franja06_14 =
-        new(new TimeOnly(6, 0), new TimeOnly(14, 0), 0, [], []);
+        new(new TimeOnly(6, 0), new TimeOnly(14, 0), 0, [], [], "");
 
     // Marcaciones que completan la franja (entrada+salida) -> franja NO anomala (CA-4).
     private static readonly DateTime Timestamp07_00 = new(2026, 3, 15, 7, 0, 0);
@@ -90,7 +91,7 @@ public class CrearDiaCalculadoConHorasDiscriminadasTests
                 CrearMarcacionAdicionada(Timestamp07_00),
                 CrearMarcacionAdicionada(Timestamp15_00));
 
-            var turnoFranjaUnica = new DetalleTurno("Turno Manana", [Franja06_14]);
+            var turnoFranjaUnica = new DetalleTurno("Turno Manana", [Franja06_14], "");
             await WhenAsync(CrearEvento(turnoFranjaUnica));
 
             Then(StreamId, CrearTurnoDiarioAsignado(turnoFranjaUnica));
@@ -114,7 +115,7 @@ public class CrearDiaCalculadoConHorasDiscriminadasTests
         public async Task CrearDiaCalculado_LlevaMinutosPorConceptoVacio_CuandoTurnoSinMarcaciones()
         {
             // Sin Given - stream nuevo, turno sin marcaciones previas.
-            var turnoFranjaUnica = new DetalleTurno("Turno Manana", [Franja06_14]);
+            var turnoFranjaUnica = new DetalleTurno("Turno Manana", [Franja06_14], "");
             await WhenAsync(CrearEvento(turnoFranjaUnica));
 
             Then(StreamId, CrearTurnoDiarioAsignado(turnoFranjaUnica));

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/DepuradorDeMarcacionesTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/DepuradorDeMarcacionesTests.cs
@@ -13,18 +13,19 @@ namespace Bitakora.ControlAsistencia.ControlHoras.Tests.Entities;
 public class DepuradorDeMarcacionesTests
 {
     // Franjas nombradas semanticamente
+    // Issue #288: Descripcion (dato derivado) es irrelevante para estos tests -> placeholder "".
     private static readonly DetalleFranjaOrdinaria Franja06_14 = new(
-        new TimeOnly(6, 0), new TimeOnly(14, 0), 0, [], []);
+        new TimeOnly(6, 0), new TimeOnly(14, 0), 0, [], [], "");
 
     private static readonly DetalleFranjaOrdinaria Franja06_12 = new(
-        new TimeOnly(6, 0), new TimeOnly(12, 0), 0, [], []);
+        new TimeOnly(6, 0), new TimeOnly(12, 0), 0, [], [], "");
 
     private static readonly DetalleFranjaOrdinaria Franja14_18 = new(
-        new TimeOnly(14, 0), new TimeOnly(18, 0), 0, [], []);
+        new TimeOnly(14, 0), new TimeOnly(18, 0), 0, [], [], "");
 
     // DiaOffsetFin=1 porque 22:00 > 06:00 (fin al dia siguiente)
     private static readonly DetalleFranjaOrdinaria Franja22_06_Nocturna = new(
-        new TimeOnly(22, 0), new TimeOnly(6, 0), 1, [], []);
+        new TimeOnly(22, 0), new TimeOnly(6, 0), 1, [], [], "");
 
     // Fecha de referencia para todos los tests
     private static readonly DateOnly FechaBase = new(2026, 3, 15);
@@ -48,7 +49,7 @@ public class DepuradorDeMarcacionesTests
     {
         // CA-1: Una franja (06:00-14:00) con dos marcaciones (07:00, 15:00)
         // Con franja unica el rango es (-inf, +inf) -> primera=Entrada, ultima=Salida
-        var turno = new DetalleTurno("Diurno", [Franja06_14]);
+        var turno = new DetalleTurno("Diurno", [Franja06_14], "");
 
         var resultado = DepuradorDeMarcaciones.Depurar(turno, FechaBase, [M(7, 0), M(15, 0)]);
 
@@ -64,7 +65,7 @@ public class DepuradorDeMarcacionesTests
         // Gap 12:00-14:00 -> punto de corte = 13:00 (punto medio del gap)
         // F1 captura marcaciones antes de 13:00: 05:50 y 12:05
         // F2 captura marcaciones desde 13:00: 14:10 y 18:15
-        var turno = new DetalleTurno("Partido", [Franja06_12, Franja14_18]);
+        var turno = new DetalleTurno("Partido", [Franja06_12, Franja14_18], "");
 
         var resultado = DepuradorDeMarcaciones.Depurar(turno, FechaBase,
             [Marcacion05_50, Marcacion12_05, M(14, 10), M(18, 15)]);
@@ -80,7 +81,7 @@ public class DepuradorDeMarcacionesTests
     public void Depurar_ProduceEntradaConSalidaNull_CuandoFranjaTieneUnaSolaMarcacion()
     {
         // CA-3: Franja con una sola marcacion -> Entrada poblada, Salida null, EsAnomala true
-        var turno = new DetalleTurno("Diurno", [Franja06_14]);
+        var turno = new DetalleTurno("Diurno", [Franja06_14], "");
 
         var resultado = DepuradorDeMarcaciones.Depurar(turno, FechaBase, [M(7, 0)]);
 
@@ -94,7 +95,7 @@ public class DepuradorDeMarcacionesTests
     public void Depurar_ProduceEntradaYSalidaNull_CuandoFranjaSinMarcaciones()
     {
         // CA-4: Franja sin marcaciones -> Entrada null, Salida null, EsAnomala true
-        var turno = new DetalleTurno("Diurno", [Franja06_14]);
+        var turno = new DetalleTurno("Diurno", [Franja06_14], "");
 
         var resultado = DepuradorDeMarcaciones.Depurar(turno, FechaBase, []);
 
@@ -109,7 +110,7 @@ public class DepuradorDeMarcacionesTests
     {
         // CA-5: Franja unica con marcaciones 07:00, 10:00, 12:00, 15:00
         // -> Entrada=07:00, Salida=15:00; las de 10:00 y 12:00 se descartan
-        var turno = new DetalleTurno("Diurno", [Franja06_14]);
+        var turno = new DetalleTurno("Diurno", [Franja06_14], "");
 
         var resultado = DepuradorDeMarcaciones.Depurar(turno, FechaBase,
             [M(7, 0), M(10, 0), M(12, 0), M(15, 0)]);
@@ -134,7 +135,7 @@ public class DepuradorDeMarcacionesTests
         // CA-7: Franja nocturna 22:00-06:00 con DiaOffsetFin=1, fecha ancla 2026-03-15
         // Rango resuelto: 2026-03-15 22:00 -> 2026-03-16 06:00
         // Marcacion 22:30 del 15 y 05:30 del 16 quedan en la misma franja
-        var turno = new DetalleTurno("Nocturno", [Franja22_06_Nocturna]);
+        var turno = new DetalleTurno("Nocturno", [Franja22_06_Nocturna], "");
 
         var resultado = DepuradorDeMarcaciones.Depurar(turno, FechaBase, [M(22, 30), MSig(5, 30)]);
 
@@ -148,7 +149,7 @@ public class DepuradorDeMarcacionesTests
     {
         // CA-8: Con una sola franja, el rango es (-inf, +inf) -> todas las marcaciones le pertenecen.
         // Timestamps fuera del horario nominal de la franja para verificar que no se filtra por hora.
-        var turno = new DetalleTurno("Diurno", [Franja06_14]);
+        var turno = new DetalleTurno("Diurno", [Franja06_14], "");
 
         var resultado = DepuradorDeMarcaciones.Depurar(turno, FechaBase, [M(3, 0), M(20, 0)]);
 
@@ -163,7 +164,7 @@ public class DepuradorDeMarcacionesTests
         // CA-10: Turno partido donde solo la primera franja tiene marcaciones
         // F1 (06:00-12:00): Entrada=05:50, Salida=12:05 -> EsAnomala false
         // F2 (14:00-18:00): Entrada=null, Salida=null -> EsAnomala true
-        var turno = new DetalleTurno("Partido", [Franja06_12, Franja14_18]);
+        var turno = new DetalleTurno("Partido", [Franja06_12, Franja14_18], "");
 
         var resultado = DepuradorDeMarcaciones.Depurar(turno, FechaBase,
             [Marcacion05_50, Marcacion12_05]);

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/DesgloseFranjaSerializacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/DesgloseFranjaSerializacionTests.cs
@@ -20,14 +20,15 @@ public class DesgloseFranjaSerializacionTests
     private static IntervaloTemporal CrearIntervalo(TimeOnly inicio, TimeOnly fin) =>
         IntervaloTemporal.Crear(new MomentoDelDia(inicio), new MomentoDelDia(fin));
 
+    // Issue #288: Descripcion (dato derivado) es irrelevante para estos tests -> placeholder "".
     private static DetalleFranjaOrdinaria CrearFranjaProgramadaConDescanso() =>
         new DetalleFranjaOrdinaria(
             new TimeOnly(8, 0), new TimeOnly(17, 0), 0,
-            [new DetalleSubFranja(new TimeOnly(12, 0), new TimeOnly(13, 0), 0, 0)],
-            []);
+            [new DetalleSubFranja(new TimeOnly(12, 0), new TimeOnly(13, 0), 0, 0, "")],
+            [], "");
 
     private static DetalleFranjaOrdinaria CrearFranjaProgramadaSimple() =>
-        new DetalleFranjaOrdinaria(new TimeOnly(8, 0), new TimeOnly(17, 0), 0, [], []);
+        new DetalleFranjaOrdinaria(new TimeOnly(8, 0), new TimeOnly(17, 0), 0, [], [], "");
 
     [Fact]
     public void RoundTrip_PreservaProgramada_CuandoFranjaConDescanso()

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/DesgloseHorasSerializacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/DesgloseHorasSerializacionTests.cs
@@ -20,8 +20,9 @@ public class DesgloseHorasSerializacionTests
     private static IntervaloTemporal CrearIntervalo(TimeOnly inicio, TimeOnly fin) =>
         IntervaloTemporal.Crear(new MomentoDelDia(inicio), new MomentoDelDia(fin));
 
+    // Issue #288: Descripcion (dato derivado) es irrelevante para estos tests -> placeholder "".
     private static DetalleFranjaOrdinaria CrearFranjaProgramadaSimple() =>
-        new DetalleFranjaOrdinaria(new TimeOnly(8, 0), new TimeOnly(17, 0), 0, [], []);
+        new DetalleFranjaOrdinaria(new TimeOnly(8, 0), new TimeOnly(17, 0), 0, [], [], "");
 
     private static DesgloseFranja CrearFranjaDiurna() =>
         new DesgloseFranja(

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ValueObjects/DesgloseFranjaTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ValueObjects/DesgloseFranjaTests.cs
@@ -16,8 +16,9 @@ public class DesgloseFranjaTests
     private static IntervaloTemporal CrearIntervalo(TimeOnly inicio, TimeOnly fin) =>
         IntervaloTemporal.Crear(new MomentoDelDia(inicio), new MomentoDelDia(fin));
 
+    // Issue #288: Descripcion (dato derivado) es irrelevante para estos tests -> placeholder "".
     private static DetalleFranjaOrdinaria CrearFranjaProgramada() =>
-        new DetalleFranjaOrdinaria(new TimeOnly(8, 0), new TimeOnly(17, 0), 0, [], []);
+        new DetalleFranjaOrdinaria(new TimeOnly(8, 0), new TimeOnly(17, 0), 0, [], [], "");
 
     // ---------- CA-1: agrupa por concepto y suma duraciones ----------
 

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ValueObjects/DesgloseHorasDiscriminarTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ValueObjects/DesgloseHorasDiscriminarTests.cs
@@ -30,8 +30,9 @@ public class DesgloseHorasDiscriminarTests
     private static IntervaloTemporal CrearIntervalo(TimeOnly inicio, TimeOnly fin) =>
         IntervaloTemporal.Crear(new MomentoDelDia(inicio), new MomentoDelDia(fin));
 
+    // Issue #288: Descripcion (dato derivado) es irrelevante para estos tests -> placeholder "".
     private static DetalleFranjaOrdinaria FranjaProgramada() =>
-        new(new TimeOnly(8, 0), new TimeOnly(17, 0), 0, [], []);
+        new(new TimeOnly(8, 0), new TimeOnly(17, 0), 0, [], [], "");
 
     // El retardo de la franja no influye en Discriminar (solo lo hace DesgloseHoras.RetardoTotal):
     // las franjas se construyen con Retardo.Vacio y el retardo del dia se pasa aparte.

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ValueObjects/DesgloseHorasTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ValueObjects/DesgloseHorasTests.cs
@@ -18,8 +18,9 @@ public class DesgloseHorasTests
     private static IntervaloTemporal CrearIntervalo(TimeOnly inicio, TimeOnly fin) =>
         IntervaloTemporal.Crear(new MomentoDelDia(inicio), new MomentoDelDia(fin));
 
+    // Issue #288: Descripcion (dato derivado) es irrelevante para estos tests -> placeholder "".
     private static DetalleFranjaOrdinaria CrearFranjaProgramada() =>
-        new DetalleFranjaOrdinaria(new TimeOnly(8, 0), new TimeOnly(17, 0), 0, [], []);
+        new DetalleFranjaOrdinaria(new TimeOnly(8, 0), new TimeOnly(17, 0), 0, [], [], "");
 
     private static DesgloseFranja CrearFranjaConIntervalos(
         params (TimeOnly inicio, TimeOnly fin, Concepto concepto)[] datos)

--- a/tests/Bitakora.ControlAsistencia.PrivateEvents.Tests/Programacion/DetalleFranjaOrdinariaIgualdadTests.cs
+++ b/tests/Bitakora.ControlAsistencia.PrivateEvents.Tests/Programacion/DetalleFranjaOrdinariaIgualdadTests.cs
@@ -13,10 +13,10 @@ namespace Bitakora.ControlAsistencia.PrivateEvents.Tests.Programacion;
 public class DetalleFranjaOrdinariaIgualdadTests : IgualdadTestBase<DetalleFranjaOrdinaria>
 {
     private static DetalleSubFranja Descanso() =>
-        new(new TimeOnly(12, 0), new TimeOnly(13, 0), (int)0, (int)0, "");
+        new(new TimeOnly(12, 0), new TimeOnly(13, 0), 0, 0, "");
 
     private static DetalleSubFranja Extra() =>
-        new(new TimeOnly(17, 0), new TimeOnly(19, 0), (int)0, (int)0, "");
+        new(new TimeOnly(17, 0), new TimeOnly(19, 0), 0, 0, "");
 
     protected override DetalleFranjaOrdinaria CrearInstancia() =>
         new(new TimeOnly(8, 0), new TimeOnly(17, 0), 0, [Descanso()], [Extra()], "");

--- a/tests/Bitakora.ControlAsistencia.PrivateEvents.Tests/Programacion/DetalleFranjaOrdinariaIgualdadTests.cs
+++ b/tests/Bitakora.ControlAsistencia.PrivateEvents.Tests/Programacion/DetalleFranjaOrdinariaIgualdadTests.cs
@@ -2,6 +2,9 @@
 // DetalleFranjaOrdinaria es record con override manual de Equals/GetHashCode que compara
 // las colecciones Descansos y Extras con SequenceEqual (en lugar de la igualdad por
 // referencia que el record genera por defecto - ADR-0015).
+// Issue #288: se agrego Descripcion (dato derivado, texto del formato tecnico) al constructor
+// primario. NO participa en Equals/GetHashCode (ver DetalleFranjaOrdinaria.cs); los construction
+// sites de este archivo pasan "" porque el valor es irrelevante para estos tests de igualdad.
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.PrivateEvents.Programacion;
 
@@ -10,29 +13,29 @@ namespace Bitakora.ControlAsistencia.PrivateEvents.Tests.Programacion;
 public class DetalleFranjaOrdinariaIgualdadTests : IgualdadTestBase<DetalleFranjaOrdinaria>
 {
     private static DetalleSubFranja Descanso() =>
-        new(new TimeOnly(12, 0), new TimeOnly(13, 0), (int)0, (int)0);
+        new(new TimeOnly(12, 0), new TimeOnly(13, 0), (int)0, (int)0, "");
 
     private static DetalleSubFranja Extra() =>
-        new(new TimeOnly(17, 0), new TimeOnly(19, 0), (int)0, (int)0);
+        new(new TimeOnly(17, 0), new TimeOnly(19, 0), (int)0, (int)0, "");
 
     protected override DetalleFranjaOrdinaria CrearInstancia() =>
-        new(new TimeOnly(8, 0), new TimeOnly(17, 0), 0, [Descanso()], [Extra()]);
+        new(new TimeOnly(8, 0), new TimeOnly(17, 0), 0, [Descanso()], [Extra()], "");
 
     protected override DetalleFranjaOrdinaria CrearInstanciaCopia() =>
-        new(new TimeOnly(8, 0), new TimeOnly(17, 0), 0, [Descanso()], [Extra()]);
+        new(new TimeOnly(8, 0), new TimeOnly(17, 0), 0, [Descanso()], [Extra()], "");
 
     protected override IEnumerable<(string, DetalleFranjaOrdinaria)> CrearInstanciasDiferentes()
     {
         yield return ("HoraInicio",
-            new DetalleFranjaOrdinaria(new TimeOnly(7, 0), new TimeOnly(17, 0), 0, [Descanso()], [Extra()]));
+            new DetalleFranjaOrdinaria(new TimeOnly(7, 0), new TimeOnly(17, 0), 0, [Descanso()], [Extra()], ""));
         yield return ("HoraFin",
-            new DetalleFranjaOrdinaria(new TimeOnly(8, 0), new TimeOnly(18, 0), 0, [Descanso()], [Extra()]));
+            new DetalleFranjaOrdinaria(new TimeOnly(8, 0), new TimeOnly(18, 0), 0, [Descanso()], [Extra()], ""));
         yield return ("DiaOffsetFin",
-            new DetalleFranjaOrdinaria(new TimeOnly(8, 0), new TimeOnly(17, 0), 1, [Descanso()], [Extra()]));
+            new DetalleFranjaOrdinaria(new TimeOnly(8, 0), new TimeOnly(17, 0), 1, [Descanso()], [Extra()], ""));
         yield return ("Descansos",
-            new DetalleFranjaOrdinaria(new TimeOnly(8, 0), new TimeOnly(17, 0), 0, [], [Extra()]));
+            new DetalleFranjaOrdinaria(new TimeOnly(8, 0), new TimeOnly(17, 0), 0, [], [Extra()], ""));
         yield return ("Extras",
-            new DetalleFranjaOrdinaria(new TimeOnly(8, 0), new TimeOnly(17, 0), 0, [Descanso()], []));
+            new DetalleFranjaOrdinaria(new TimeOnly(8, 0), new TimeOnly(17, 0), 0, [Descanso()], [], ""));
     }
 
     // Cobertura especifica del override: las listas se comparan por valor, no por referencia.
@@ -41,11 +44,11 @@ public class DetalleFranjaOrdinariaIgualdadTests : IgualdadTestBase<DetalleFranj
     public void Equals_RetornaTrue_CuandoListasSonInstanciasDiferentesConMismoContenido()
     {
         var a = new DetalleFranjaOrdinaria(new TimeOnly(8, 0), new TimeOnly(17, 0), 0,
-            [new DetalleSubFranja(new TimeOnly(12, 0), new TimeOnly(13, 0), 0, 0)],
-            [new DetalleSubFranja(new TimeOnly(17, 0), new TimeOnly(19, 0), 0, 0)]);
+            [new DetalleSubFranja(new TimeOnly(12, 0), new TimeOnly(13, 0), 0, 0, "")],
+            [new DetalleSubFranja(new TimeOnly(17, 0), new TimeOnly(19, 0), 0, 0, "")], "");
         var b = new DetalleFranjaOrdinaria(new TimeOnly(8, 0), new TimeOnly(17, 0), 0,
-            [new DetalleSubFranja(new TimeOnly(12, 0), new TimeOnly(13, 0), 0, 0)],
-            [new DetalleSubFranja(new TimeOnly(17, 0), new TimeOnly(19, 0), 0, 0)]);
+            [new DetalleSubFranja(new TimeOnly(12, 0), new TimeOnly(13, 0), 0, 0, "")],
+            [new DetalleSubFranja(new TimeOnly(17, 0), new TimeOnly(19, 0), 0, 0, "")], "");
 
         a.Equals(b).Should().BeTrue();
     }
@@ -54,11 +57,11 @@ public class DetalleFranjaOrdinariaIgualdadTests : IgualdadTestBase<DetalleFranj
     public void GetHashCode_RetornaMismoHash_CuandoListasSonInstanciasDiferentesConMismoContenido()
     {
         var a = new DetalleFranjaOrdinaria(new TimeOnly(8, 0), new TimeOnly(17, 0), 0,
-            [new DetalleSubFranja(new TimeOnly(12, 0), new TimeOnly(13, 0), 0, 0)],
-            []);
+            [new DetalleSubFranja(new TimeOnly(12, 0), new TimeOnly(13, 0), 0, 0, "")],
+            [], "");
         var b = new DetalleFranjaOrdinaria(new TimeOnly(8, 0), new TimeOnly(17, 0), 0,
-            [new DetalleSubFranja(new TimeOnly(12, 0), new TimeOnly(13, 0), 0, 0)],
-            []);
+            [new DetalleSubFranja(new TimeOnly(12, 0), new TimeOnly(13, 0), 0, 0, "")],
+            [], "");
 
         a.GetHashCode().Should().Be(b.GetHashCode());
     }

--- a/tests/Bitakora.ControlAsistencia.PrivateEvents.Tests/Programacion/DetalleSubFranjaIgualdadTests.cs
+++ b/tests/Bitakora.ControlAsistencia.PrivateEvents.Tests/Programacion/DetalleSubFranjaIgualdadTests.cs
@@ -1,0 +1,50 @@
+// Issue #288: Tests de contrato IEquatable para DetalleSubFranja.
+// DetalleSubFranja suma Descripcion (dato derivado, texto del formato tecnico de SubFranja.ToString())
+// persistido en el DTO plano. Equals/GetHashCode propios EXCLUYEN Descripcion explicitamente: dos
+// instancias que solo difieren en el texto formateado siguen siendo la misma sub-franja (mismo patron
+// que el override de DetalleFranjaOrdinaria, issue #129).
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.PrivateEvents.Programacion;
+
+namespace Bitakora.ControlAsistencia.PrivateEvents.Tests.Programacion;
+
+public class DetalleSubFranjaIgualdadTests : IgualdadTestBase<DetalleSubFranja>
+{
+    protected override DetalleSubFranja CrearInstancia() =>
+        new(new TimeOnly(10, 0), new TimeOnly(10, 15), 0, 0, "(10:00-10:15)");
+
+    protected override DetalleSubFranja CrearInstanciaCopia() =>
+        new(new TimeOnly(10, 0), new TimeOnly(10, 15), 0, 0, "(10:00-10:15)");
+
+    protected override IEnumerable<(string, DetalleSubFranja)> CrearInstanciasDiferentes()
+    {
+        yield return ("HoraInicio",
+            new DetalleSubFranja(new TimeOnly(10, 5), new TimeOnly(10, 15), 0, 0, "(10:05-10:15)"));
+        yield return ("HoraFin",
+            new DetalleSubFranja(new TimeOnly(10, 0), new TimeOnly(10, 30), 0, 0, "(10:00-10:30)"));
+        yield return ("DiaOffsetInicio",
+            new DetalleSubFranja(new TimeOnly(1, 0), new TimeOnly(1, 15), 1, 0, "(01:00+1-01:15)"));
+        yield return ("DiaOffsetFin",
+            new DetalleSubFranja(new TimeOnly(23, 50), new TimeOnly(0, 10), 0, 1, "(23:50-00:10+1)"));
+    }
+
+    // CA-4: dos instancias que difieren SOLO en Descripcion son iguales (dato derivado, no identidad).
+
+    [Fact]
+    public void Equals_RetornaTrue_CuandoSoloDescripcionEsDiferente()
+    {
+        var a = new DetalleSubFranja(new TimeOnly(10, 0), new TimeOnly(10, 15), 0, 0, "(10:00-10:15)");
+        var b = new DetalleSubFranja(new TimeOnly(10, 0), new TimeOnly(10, 15), 0, 0, "otro texto distinto");
+
+        a.Equals(b).Should().BeTrue();
+    }
+
+    [Fact]
+    public void GetHashCode_RetornaMismoHash_CuandoSoloDescripcionEsDiferente()
+    {
+        var a = new DetalleSubFranja(new TimeOnly(10, 0), new TimeOnly(10, 15), 0, 0, "(10:00-10:15)");
+        var b = new DetalleSubFranja(new TimeOnly(10, 0), new TimeOnly(10, 15), 0, 0, "otro texto distinto");
+
+        a.GetHashCode().Should().Be(b.GetHashCode());
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.PrivateEvents.Tests/Programacion/DetalleTurnoIgualdadTests.cs
+++ b/tests/Bitakora.ControlAsistencia.PrivateEvents.Tests/Programacion/DetalleTurnoIgualdadTests.cs
@@ -1,0 +1,81 @@
+// Issue #288: Tests de contrato IEquatable para DetalleTurno.
+// Dos intervenciones sobre el record por defecto:
+// 1) Descripcion (dato derivado, texto de CatalogoTurnos.ToString()) EXCLUIDA de Equals/GetHashCode.
+// 2) Bug latente corregido: FranjasOrdinarias es IReadOnlyList y el record por defecto la compara
+//    por referencia (ADR-0015 advierte sobre esto; mismo bug que #129 ya corrigio en
+//    DetalleFranjaOrdinaria). Equals/GetHashCode propios comparan FranjasOrdinarias POR VALOR
+//    (SequenceEqual).
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.PrivateEvents.Programacion;
+
+namespace Bitakora.ControlAsistencia.PrivateEvents.Tests.Programacion;
+
+public class DetalleTurnoIgualdadTests : IgualdadTestBase<DetalleTurno>
+{
+    private static DetalleFranjaOrdinaria FranjaOrdinaria() =>
+        new(new TimeOnly(6, 0), new TimeOnly(14, 0), 0, [], [], "(06:00-14:00)");
+
+    protected override DetalleTurno CrearInstancia() =>
+        new("Turno Manana", [FranjaOrdinaria()], "Turno Manana (06:00-14:00)");
+
+    protected override DetalleTurno CrearInstanciaCopia() =>
+        new("Turno Manana", [FranjaOrdinaria()], "Turno Manana (06:00-14:00)");
+
+    protected override IEnumerable<(string, DetalleTurno)> CrearInstanciasDiferentes()
+    {
+        yield return ("Nombre",
+            new DetalleTurno("Turno Tarde", [FranjaOrdinaria()], "Turno Tarde (06:00-14:00)"));
+        yield return ("FranjasOrdinarias",
+            new DetalleTurno("Turno Manana", [], "Turno Manana"));
+    }
+
+    // CA-4: dos instancias que difieren SOLO en Descripcion son iguales (dato derivado, no identidad).
+
+    [Fact]
+    public void Equals_RetornaTrue_CuandoSoloDescripcionEsDiferente()
+    {
+        var a = new DetalleTurno("Turno Manana", [FranjaOrdinaria()], "Turno Manana (06:00-14:00)");
+        var b = new DetalleTurno("Turno Manana", [FranjaOrdinaria()], "otro texto distinto");
+
+        a.Equals(b).Should().BeTrue();
+    }
+
+    [Fact]
+    public void GetHashCode_RetornaMismoHash_CuandoSoloDescripcionEsDiferente()
+    {
+        var a = new DetalleTurno("Turno Manana", [FranjaOrdinaria()], "Turno Manana (06:00-14:00)");
+        var b = new DetalleTurno("Turno Manana", [FranjaOrdinaria()], "otro texto distinto");
+
+        a.GetHashCode().Should().Be(b.GetHashCode());
+    }
+
+    // CA-5: bug latente corregido - dos DetalleTurno con franjas EQUIVALENTES en listas DISTINTAS
+    // son iguales. Antes de esta correccion, el record por defecto comparaba FranjasOrdinarias por
+    // referencia y este caso fallaba (mismo bug que #129 corrigio en DetalleFranjaOrdinaria).
+
+    [Fact]
+    public void Equals_RetornaTrue_CuandoFranjasSonInstanciasDeListaDiferentesConMismoContenido()
+    {
+        var a = new DetalleTurno("Turno Manana",
+            new List<DetalleFranjaOrdinaria> { FranjaOrdinaria() }.AsReadOnly(),
+            "Turno Manana (06:00-14:00)");
+        var b = new DetalleTurno("Turno Manana",
+            new List<DetalleFranjaOrdinaria> { FranjaOrdinaria() }.AsReadOnly(),
+            "Turno Manana (06:00-14:00)");
+
+        a.Equals(b).Should().BeTrue();
+    }
+
+    [Fact]
+    public void GetHashCode_RetornaMismoHash_CuandoFranjasSonInstanciasDeListaDiferentesConMismoContenido()
+    {
+        var a = new DetalleTurno("Turno Manana",
+            new List<DetalleFranjaOrdinaria> { FranjaOrdinaria() }.AsReadOnly(),
+            "Turno Manana (06:00-14:00)");
+        var b = new DetalleTurno("Turno Manana",
+            new List<DetalleFranjaOrdinaria> { FranjaOrdinaria() }.AsReadOnly(),
+            "Turno Manana (06:00-14:00)");
+
+        a.GetHashCode().Should().Be(b.GetHashCode());
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/Entities/CatalogoTurnosTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/Entities/CatalogoTurnosTests.cs
@@ -3,8 +3,6 @@
 // aggregate, en el Function App de Programacion (el worker de proyecciones no puede referenciarlo,
 // MEF-ADR-0034 seccion 5). ObtenerDetalle() e Iniciar() son internal (ADR-0015); accesibles en este
 // proyecto de tests via InternalsVisibleTo (Bitakora.ControlAsistencia.Programacion.csproj).
-// Hoy ObtenerDetalle() todavia asigna un placeholder (fase roja); este test queda en rojo hasta que
-// el implementer asigne ToString() en el sitio de produccion (CA-2).
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.Programacion.DomainEvents;
 using Bitakora.ControlAsistencia.Programacion.Entities;
@@ -15,19 +13,37 @@ public class CatalogoTurnosTests
 {
     private static readonly Guid TurnoId = Guid.Parse("019600a0-0000-7000-8000-000000000099");
 
-    private static TurnoCreado CrearEventoTurno() =>
-        TurnoCreado.Crear(
-            TurnoId,
-            "Turno Manana",
-            [new DatosFranja(new TimeOnly(6, 0), new TimeOnly(14, 0), [], [])]);
+    private static CatalogoTurnos CrearCatalogo(params DatosFranja[] franjas) =>
+        CatalogoTurnos.Iniciar(TurnoCreado.Crear(TurnoId, "Turno Manana", franjas));
+
+    private static DatosFranja Ordinaria(
+        TimeOnly inicio, TimeOnly fin, List<(TimeOnly inicio, TimeOnly fin)>? descansos = null) =>
+        new(inicio, fin, descansos ?? [], []);
 
     [Fact]
     public void ObtenerDetalle_TieneDescripcionCoherenteConToString_CuandoTurnoConUnaOrdinaria()
     {
-        var catalogo = CatalogoTurnos.Iniciar(CrearEventoTurno());
+        var catalogo = CrearCatalogo(Ordinaria(new TimeOnly(6, 0), new TimeOnly(14, 0)));
 
         var detalle = catalogo.ObtenerDetalle();
 
         detalle.Descripcion.Should().Be(catalogo.ToString());
+    }
+
+    // El ToString() del turno concatena las ordinarias y arrastra los labels .resx de los
+    // descansos (MEF-ADR-0009): el caso compuesto es el que puede divergir, no el simple.
+    [Fact]
+    public void ObtenerDetalle_TieneDescripcionCoherenteConToString_CuandoTurnoPartidoConDescanso()
+    {
+        var catalogo = CrearCatalogo(
+            Ordinaria(new TimeOnly(6, 0), new TimeOnly(12, 0),
+                [(new TimeOnly(9, 0), new TimeOnly(9, 15))]),
+            Ordinaria(new TimeOnly(14, 0), new TimeOnly(18, 0)));
+
+        var detalle = catalogo.ObtenerDetalle();
+
+        detalle.Descripcion.Should().Be(catalogo.ToString());
+        detalle.FranjasOrdinarias.Should().HaveCount(2);
+        detalle.FranjasOrdinarias[0].Descansos[0].Descripcion.Should().Be("(09:00-09:15)");
     }
 }

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/Entities/CatalogoTurnosTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/Entities/CatalogoTurnosTests.cs
@@ -1,0 +1,33 @@
+// Issue #288 CA-3: coherencia entre CatalogoTurnos.ObtenerDetalle().Descripcion y
+// CatalogoTurnos.ToString(). El formato de nivel turno ("{nombre} {franjas}") vive en este
+// aggregate, en el Function App de Programacion (el worker de proyecciones no puede referenciarlo,
+// MEF-ADR-0034 seccion 5). ObtenerDetalle() e Iniciar() son internal (ADR-0015); accesibles en este
+// proyecto de tests via InternalsVisibleTo (Bitakora.ControlAsistencia.Programacion.csproj).
+// Hoy ObtenerDetalle() todavia asigna un placeholder (fase roja); este test queda en rojo hasta que
+// el implementer asigne ToString() en el sitio de produccion (CA-2).
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Programacion.DomainEvents;
+using Bitakora.ControlAsistencia.Programacion.Entities;
+
+namespace Bitakora.ControlAsistencia.Programacion.Tests.Entities;
+
+public class CatalogoTurnosTests
+{
+    private static readonly Guid TurnoId = Guid.Parse("019600a0-0000-7000-8000-000000000099");
+
+    private static TurnoCreado CrearEventoTurno() =>
+        TurnoCreado.Crear(
+            TurnoId,
+            "Turno Manana",
+            [new DatosFranja(new TimeOnly(6, 0), new TimeOnly(14, 0), [], [])]);
+
+    [Fact]
+    public void ObtenerDetalle_TieneDescripcionCoherenteConToString_CuandoTurnoConUnaOrdinaria()
+    {
+        var catalogo = CatalogoTurnos.Iniciar(CrearEventoTurno());
+
+        var detalle = catalogo.ObtenerDetalle();
+
+        detalle.Descripcion.Should().Be(catalogo.ToString());
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoCommandHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoCommandHandlerTests.cs
@@ -26,17 +26,17 @@ public class SolicitarProgramacionTurnoCommandHandlerTests
         new("E001", "CC", "12345678", "Juan", "Perez");
 
     // El DetalleTurno esperado corresponde al catalogo creado en CrearEventoTurno()
-    // Issue #288: Descripcion queda en "" porque CatalogoTurnos.ObtenerDetalle() y
-    // FranjaOrdinaria.ToDetalle() todavia no la asignan (placeholder de compilacion, fase verde
-    // pendiente en el implementer - ver CA-2). La coherencia con ToString() la prueba
-    // CatalogoTurnosTests (nuevo), no este archivo.
+    // Issue #288 CA-2: Descripcion lleva el texto real que produce el ToString() del tipo rico
+    // (CatalogoTurnos a nivel turno, FranjaOrdinaria a nivel franja). La coherencia entre ambos
+    // la prueban CatalogoTurnosTests y FranjaOrdinariaToDetalleTests; aqui el valor literal
+    // documenta que fluye intacto hasta el evento emitido y el publicado por el bus privado.
     private static readonly DetalleTurno DetalleEsperado = new(
         "Turno Manana",
         new List<DetalleFranjaOrdinaria>
         {
-            new(new TimeOnly(6, 0), new TimeOnly(14, 0), 0, [], [], "")
+            new(new TimeOnly(6, 0), new TimeOnly(14, 0), 0, [], [], "(06:00-14:00)")
         }.AsReadOnly(),
-        "");
+        "Turno Manana (06:00-14:00)");
 
     // --- Configuracion del handler ---
 

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoCommandHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoCommandHandlerTests.cs
@@ -26,12 +26,17 @@ public class SolicitarProgramacionTurnoCommandHandlerTests
         new("E001", "CC", "12345678", "Juan", "Perez");
 
     // El DetalleTurno esperado corresponde al catalogo creado en CrearEventoTurno()
+    // Issue #288: Descripcion queda en "" porque CatalogoTurnos.ObtenerDetalle() y
+    // FranjaOrdinaria.ToDetalle() todavia no la asignan (placeholder de compilacion, fase verde
+    // pendiente en el implementer - ver CA-2). La coherencia con ToString() la prueba
+    // CatalogoTurnosTests (nuevo), no este archivo.
     private static readonly DetalleTurno DetalleEsperado = new(
         "Turno Manana",
         new List<DetalleFranjaOrdinaria>
         {
-            new(new TimeOnly(6, 0), new TimeOnly(14, 0), 0, [], [])
-        }.AsReadOnly());
+            new(new TimeOnly(6, 0), new TimeOnly(14, 0), 0, [], [], "")
+        }.AsReadOnly(),
+        "");
 
     // --- Configuracion del handler ---
 

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/ValueObjects/FranjaOrdinariaToDetalleTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/ValueObjects/FranjaOrdinariaToDetalleTests.cs
@@ -1,8 +1,6 @@
 // Issue #288 CA-3: coherencia entre FranjaOrdinaria.ToDetalle().Descripcion y FranjaOrdinaria.ToString().
 // El formato tecnico ya existente (CA-20/CA-21 de FranjaOrdinariaTests, que NO se modifica -- CA-6
-// del issue) se persiste tal cual en el DTO plano. Hoy FranjaOrdinaria.ToDetalle() todavia asigna un
-// placeholder (fase roja); este test queda en rojo hasta que el implementer asigne ToString() en el
-// sitio de produccion.
+// del issue) se persiste tal cual en el DTO plano.
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.Programacion.DomainEvents;
 

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/ValueObjects/FranjaOrdinariaToDetalleTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/ValueObjects/FranjaOrdinariaToDetalleTests.cs
@@ -1,0 +1,51 @@
+// Issue #288 CA-3: coherencia entre FranjaOrdinaria.ToDetalle().Descripcion y FranjaOrdinaria.ToString().
+// El formato tecnico ya existente (CA-20/CA-21 de FranjaOrdinariaTests, que NO se modifica -- CA-6
+// del issue) se persiste tal cual en el DTO plano. Hoy FranjaOrdinaria.ToDetalle() todavia asigna un
+// placeholder (fase roja); este test queda en rojo hasta que el implementer asigne ToString() en el
+// sitio de produccion.
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Programacion.DomainEvents;
+
+namespace Bitakora.ControlAsistencia.Programacion.Tests.ValueObjects;
+
+public class FranjaOrdinariaToDetalleTests
+{
+    [Fact]
+    public void ToDetalle_TieneDescripcionCoherenteConToString_CuandoFranjaSinHijos()
+    {
+        var franja = FranjaOrdinaria.Crear(new TimeOnly(6, 0), new TimeOnly(12, 0));
+
+        var detalle = franja.ToDetalle();
+
+        detalle.Descripcion.Should().Be(franja.ToString());
+    }
+
+    [Fact]
+    public void ToDetalle_TieneDescripcionCoherenteConToString_CuandoFranjaConDescansosYExtras()
+    {
+        var descanso = SubFranja.Crear(new TimeOnly(10, 0), new TimeOnly(10, 15));
+        var extra = SubFranja.Crear(new TimeOnly(6, 0), new TimeOnly(8, 0));
+        var franja = FranjaOrdinaria.Crear(
+            new TimeOnly(6, 0), new TimeOnly(12, 0),
+            descansos: [descanso], extras: [extra]);
+
+        var detalle = franja.ToDetalle();
+
+        detalle.Descripcion.Should().Be(franja.ToString());
+    }
+
+    // CA-3: cada sub-franja hija tambien lleva su propia Descripcion coherente con su propio
+    // ToString(), no solo el nivel padre (el issue pide Descripcion en los tres niveles).
+    [Fact]
+    public void ToDetalle_PropagaDescripcionCoherenteEnHijos_CuandoFranjaConDescanso()
+    {
+        var descanso = SubFranja.Crear(new TimeOnly(10, 0), new TimeOnly(10, 15));
+        var franja = FranjaOrdinaria.Crear(
+            new TimeOnly(6, 0), new TimeOnly(12, 0),
+            descansos: [descanso]);
+
+        var detalle = franja.ToDetalle();
+
+        detalle.Descansos[0].Descripcion.Should().Be(descanso.ToString());
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/ValueObjects/SubFranjaToDetalleTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/ValueObjects/SubFranjaToDetalleTests.cs
@@ -1,0 +1,33 @@
+// Issue #288 CA-3: coherencia entre SubFranja.ToDetalle().Descripcion y SubFranja.ToString().
+// El formato tecnico ya existente (CA-20/CA-21 de SubFranjaTests, que NO se modifica -- CA-6 del
+// issue) se persiste tal cual en el DTO plano: una sola implementacion, sin inventar un formato
+// nuevo (decision del issue). Hoy SubFranja.ToDetalle() todavia asigna un placeholder (fase roja);
+// este test queda en rojo hasta que el implementer asigne ToString() en el sitio de produccion.
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Programacion.DomainEvents;
+
+namespace Bitakora.ControlAsistencia.Programacion.Tests.ValueObjects;
+
+public class SubFranjaToDetalleTests
+{
+    [Fact]
+    public void ToDetalle_TieneDescripcionCoherenteConToString_CuandoSubFranjaSinOffset()
+    {
+        var franja = SubFranja.Crear(new TimeOnly(10, 0), new TimeOnly(10, 15));
+
+        var detalle = franja.ToDetalle();
+
+        detalle.Descripcion.Should().Be(franja.ToString());
+    }
+
+    [Fact]
+    public void ToDetalle_TieneDescripcionCoherenteConToString_CuandoSubFranjaCruzaMedianoche()
+    {
+        var franja = SubFranja.Crear(new TimeOnly(23, 45), new TimeOnly(0, 15),
+            diaOffsetInicio: 0, diaOffsetFin: 1);
+
+        var detalle = franja.ToDetalle();
+
+        detalle.Descripcion.Should().Be(franja.ToString());
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/ValueObjects/SubFranjaToDetalleTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/ValueObjects/SubFranjaToDetalleTests.cs
@@ -1,8 +1,7 @@
 // Issue #288 CA-3: coherencia entre SubFranja.ToDetalle().Descripcion y SubFranja.ToString().
 // El formato tecnico ya existente (CA-20/CA-21 de SubFranjaTests, que NO se modifica -- CA-6 del
 // issue) se persiste tal cual en el DTO plano: una sola implementacion, sin inventar un formato
-// nuevo (decision del issue). Hoy SubFranja.ToDetalle() todavia asigna un placeholder (fase roja);
-// este test queda en rojo hasta que el implementer asigne ToString() en el sitio de produccion.
+// nuevo (decision del issue).
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.Programacion.DomainEvents;
 


### PR DESCRIPTION
## Resumen

Pipeline TDD completado:
- Fase roja: tests escritos con stubs
- Fase verde: implementación completa
- Fase refactor: revisión de calidad

## Decisiones del pipeline

<details>
<summary>Test Writer (fase roja) — 27m 26s</summary>

## ES Test Writer - Decisiones (Issue #288)

### Naturaleza de la tarea

Este issue no es un command handler tipico: modifica el **payload** de tres DTOs planos
(`DetalleTurno`, `DetalleFranjaOrdinaria`, `DetalleSubFranja`) agregando un campo derivado
(`Descripcion`) y corrigiendo un bug de igualdad latente en `DetalleTurno`. No hay
`Given/When/Then` de command handler involucrado en los tests nuevos -- son tests directos de
value objects/DTOs y de un aggregate (`CatalogoTurnos`), siguiendo el patron ya usado por
`SubFranjaTests`, `FranjaOrdinariaTests`, `TurnoCreadoTests` e `IgualdadTestBase<T>`.

### Tests creados

- `tests/Bitakora.ControlAsistencia.PrivateEvents.Tests/Programacion/DetalleSubFranjaIgualdadTests.cs` (8 heredados + 2 propios)
  - Hereda `IgualdadTestBase<DetalleSubFranja>`: cubre HoraInicio/HoraFin/DiaOffsetInicio/DiaOffsetFin
  - `Equals_RetornaTrue_CuandoSoloDescripcionEsDiferente` (CA-4)
  - `GetHashCode_RetornaMismoHash_CuandoSoloDescripcionEsDiferente` (CA-4)
- `tests/Bitakora.ControlAsistencia.PrivateEvents.Tests/Programacion/DetalleTurnoIgualdadTests.cs` (8 heredados + 4 propios)
  - Hereda `IgualdadTestBase<DetalleTurno>`: cubre Nombre/FranjasOrdinarias
  - `Equals_RetornaTrue_CuandoSoloDescripcionEsDiferente` / `GetHashCode_...` (CA-4)
  - `Equals_RetornaTrue_CuandoFranjasSonInstanciasDeListaDiferentesConMismoContenido` / `GetHashCode_...` (CA-5, bug latente corregido)
- `tests/Bitakora.ControlAsistencia.Programacion.Tests/ValueObjects/SubFranjaToDetalleTests.cs` (2 tests)
  - Coherencia `SubFranja.ToDetalle().Descripcion == SubFranja.ToString()` (CA-3)
- `tests/Bitakora.ControlAsistencia.Programacion.Tests/ValueObjects/FranjaOrdinariaToDetalleTests.cs` (3 tests)
  - Coherencia a nivel franja + propagacion de Descripcion coherente en las sub-franjas hijas (CA-3)
- `tests/Bitakora.ControlAsistencia.Programacion.Tests/Entities/CatalogoTurnosTests.cs` (1 test, archivo nuevo -- no existia)
  - Coherencia `CatalogoTurnos.ObtenerDetalle().Descripcion == CatalogoTurnos.ToString()` (CA-3)
- `tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/ProgramacionTurnoDiarioSolicitadaPortabilidadTests.cs` (1 test, regla 21 / seccion 6e)
  - `ProgramacionTurnoDiarioSolicitada` es `IPrivateEvent`: round-trip con `JsonSerializerOptions` por defecto (sin resolver custom del productor) verificando que Descripcion sobrevive el canal del bus interno.

### Tests existentes actualizados (45+ sitios de construccion, CA-1)

Se localizaron y actualizaron **exactamente** los sitios que el planner conto (20 `new
DetalleTurno(`, 18 `new DetalleFranjaOrdinaria(`, 7 `new DetalleSubFranja(`), mas varios sitios
adicionales con `new(...)` target-typed que el grep literal del planner no capturo (helpers
`Franja(...)`/`Sub(...)` en `CalcularDesgloseFranjaTests`, `ClasificadorTrabajoTests`,
`ConsolidadorDesgloseHorasTestData`, y el campo `DetalleEsperado` de
`SolicitarProgramacionTurnoCommandHandlerTests`). El build confirmo cobertura completa (0
errores tras el ultimo cambio).

En todos estos sitios el valor de `Descripcion` es un placeholder (`""`) porque a la prueba no
le importa (mismo dato reusado entre `Given`/`Then`/valor esperado en cada archivo, nunca
recalculado independientemente), excepto:

- `TurnoDiarioAsignadoSerializacionTests.cs`: placeholder no vacio (`"(08:00-16:00)"` /
  `"Turno Manana (08:00-16:00)"`) + aserciones nuevas de que Descripcion sobrevive el
  round-trip de Marten (CA-7).
- `AsignarTurnoViaSbSmokeTests.cs`: el payload JSON crudo publicado no incluye `Descripcion`
  (simula el evento tal como lo emite Programacion hoy, con el placeholder de produccion);
  la comparacion `BeEquivalentTo` se ajusto con `.ExcludingMembersNamed("Descripcion")` porque
  el smoke test verifica que el mensaje se persiste, no el contenido de un campo derivado que
  este issue deja pendiente de wiring.

### Estructura elegida

- Un archivo de test por responsabilidad, siguiendo la convencion de feature folders del
  proyecto (Igualdad en `PrivateEvents.Tests`, coherencia ToDetalle/ToString en
  `Programacion.Tests/ValueObjects` y `Entities`, portabilidad en `ControlHoras.Tests`).
- `DetalleTurnoIgualdadTests`/`DetalleSubFranjaIgualdadTests` heredan `IgualdadTestBase<T>`
  (patron ya establecido por `DetalleFranjaOrdinariaIgualdadTests`, issue #129) para maxima
  consistencia y minima duplicacion.

### Stubs creados (produccion)

Los tres tipos (`DetalleSubFranja`, `DetalleFranjaOrdinaria`, `DetalleTurno`) ganaron el
parametro obligatorio `Descripcion` al **final** del constructor primario (posicion elegida
porque casi todos los sitios de construccion existentes son posicionales; agregarlo al final
minimiza el diff de cada sitio).

- `DetalleSubFranja`: `Equals`/`GetHashCode` propios (antes usaba los de record por defecto,
  correctos para todos los campos primitivos) que EXCLUYEN Descripcion.
- `DetalleFranjaOrdinaria`: `Equals`/`GetHashCode` YA existian (issue #129) y NO se les agrego
  Descripcion -- quedan intactos.
- `DetalleTurno`: `Equals`/`GetHashCode` propios NUEVOS (antes heredaba el default de record,
  que comparaba `FranjasOrdinarias` por referencia -- bug latente que el issue senala). Ahora
  compara `Nombre` + `FranjasOrdinarias` con `SequenceEqual`, excluyendo Descripcion.

Los tres sitios de produccion que construyen estos DTOs (`CatalogoTurnos.ObtenerDetalle()`,
`FranjaOrdinaria.ToDetalle()`, `SubFranja.ToDetalle()`) se actualizaron con el placeholder
`string.Empty` para Descripcion, marcados con comentario `// Issue #288 CA-2: ... pendiente
... (fase verde del implementer)`. Es la implementacion real (`ToString()`) la que el
implementer debe wire-ear para poner en verde los tests de coherencia (CA-3).

### Decision de diseno: `string.Empty` en vez de `NotImplementedException` en los 3 sitios de produccion

Estos tres metodos **ya existian y funcionaban** antes de este issue (no son handlers nuevos).
Hacerlos lanzar `NotImplementedException` hubiera roto en tiempo de ejecucion muchos tests
PRE-EXISTENTES y no relacionados con este issue que ejercitan el camino real de produccion
(ej. `SolicitarProgramacionTurnoCommandHandlerTests`, que invoca el handler real que llama
`CatalogoTurnos.ObtenerDetalle()`). Usar `string.Empty` como placeholder de compilacion:

- Mantiene esos tests pre-existentes en su estado actual (verde), porque `DetalleEsperado` en
  ese archivo tambien se ajusto a `Descripcion = ""` (mismo placeholder en ambos lados de la
  comparacion estructural).
- Deja los tests NUEVOS de coherencia (CA-3: `SubFranjaToDetalleTests`,
  `FranjaOrdinariaToDetalleTests`, `CatalogoTurnosTests`) en **rojo legitimo**, porque
  `rico.ToString()` no es `""` -- exactamente la senal que el implementer necesita para el CA-2.

### Verificacion de `BeEquivalentTo` con records (investigacion en fuente)

Se decompilo `AwesomeAssertions.dll` (`EqualityStrategyProvider.GetEqualityStrategy`) para
confirmar que `BeEquivalentTo` compara records estructuralmente **por defecto** (compara TODOS
los miembros publicos, incluyendo `Descripcion`), **sin usar** el `Equals` custom del tipo,
salvo que se configure `ComparingByValue<T>()` explicitamente. Esto significa que el harness
(`Then`/`And<>`, que usa `BeEquivalentTo` -- confirmado en el cheatsheet linea 291) y el
`BeEquivalentTo` manual de varios tests SI ven el campo `Descripcion`. La mitigacion en todos
los sitios existentes fue reusar la MISMA instancia/valor de `Descripcion` en el lado
"entrada" y en el lado "esperado" de cada test (nunca recalcularla independientemente), de
forma que la comparacion trivialmente coincide sin importar el placeholder elegido. Donde eso
no era posible (el smoke test, que compara el DTO deserializado desde JSON crudo contra un DTO
construido a mano), se uso `.ExcludingMembersNamed("Descripcion")`.

### Cobertura de criterios

| Criterio de aceptacion | Test(s) |
|---|---|
| CA-1: Descripcion obligatorio en los 3 records + 45+ sitios actualizados | Los 3 records modificados; build verde confirma cobertura completa |
| CA-2: 3 sitios de produccion asignan el texto | Pendiente del implementer (placeholder `string.Empty` puesto por el test-writer) |
| CA-3: coherencia Descripcion == ToString() en los 3 niveles | `SubFranjaToDetalleTests`, `FranjaOrdinariaToDetalleTests`, `CatalogoTurnosTests` (rojo legitimo hoy) |
| CA-4: Equals/GetHashCode excluyen Descripcion | `DetalleSubFranjaIgualdadTests`, `DetalleTurnoIgualdadTests`, `DetalleFranjaOrdinariaIgualdadTests` (ya existente, conserva su Equals) |
| CA-5: DetalleTurno.Equals compara FranjasOrdinarias por valor | `DetalleTurnoIgualdadTests.Equals_RetornaTrue_CuandoFranjasSonInstanciasDeListaDiferentesConMismoContenido` |
| CA-6: ToString() de los tipos ricos sin cambios | No se modificaron `SubFranjaTests.cs`, `FranjaOrdinariaTests.cs` ni el round-trip de `ComposicionServiciosTests.cs` (Programacion.Tests) |
| CA-7: round-trip preserva Descripcion | `TurnoDiarioAsignadoSerializacionTests` (aserciones nuevas), `DesgloseFranjaSerializacionTests`, `DesgloseHorasSerializacionTests` (sin cambios de logica, solo firma) |
| CA-8: build sin errores/warnings nuevos | `dotnet build` verificado: 0 errores, mismas 4 warnings preexistentes (NU1902, no relacionadas) |

### Desviaciones del plan del planner

| Sugerencia del issue | Desviacion aplicada | Razon tecnica | Consecuencia |
|---|---|---|---|
| "Interfaz publica propuesta" no especifica la posicion de `Descripcion` en el constructor | Se agrego al **final** de cada constructor primario | Todos los sitios existentes usan argumentos posicionales; agregarlo al final minimiza el diff y evita reordenar argumentos en 45+ sitios | Ninguna -- resultado identico al pedido por el issue |
| El issue no menciona explicitamente un test de portabilidad por el bus para `ProgramacionTurnoDiarioSolicitada` | Se agrego `ProgramacionTurnoDiarioSolicitadaPortabilidadTests.cs` (1 test) | Regla propia del rol (seccion 6e): todo evento con marker de bus (`IPrivateEvent`) debe tener un test de portabilidad. `ProgramacionTurnoDiarioSolicitada` implementa `IPrivateEvent` y ahora transporta el campo nuevo | Cobertura adicional, sin tocar ningun archivo existente; no afecta ningun CA declarado |
| Ningun sitio del issue senala la necesidad de `ExcludingMembersNamed` en el smoke test | Se ajusto `AsignarTurnoViaSbSmokeTests.cs` con `.ExcludingMembersNamed("Descripcion")` en las dos comparaciones `BeEquivalentTo` | Se investigo (decompilando AwesomeAssertions) que `BeEquivalentTo` compara records estructuralmente por defecto, incluyendo campos nuevos. El JSON crudo publicado en el smoke test no lleva "Descripcion", asi que sin la exclusion la comparacion fallaria por un campo que el smoke test no esta verificando | El smoke test sigue verificando lo que le corresponde (persistencia del mensaje), sin acoplarse al valor de un campo derivado que este issue deja pendiente de wiring |

No hubo cuestionamientos al plan del planner (seccion "Auditoria activa de Tell-don't-Ask"): el
issue no propone una interfaz publica de VO con getters cuestionables, es una adicion de campo
de datos a DTOs planos ya existentes.

</details>

<details>
<summary>Implementer (fase verde) — 11m 43s</summary>

## ES Implementer - Decisiones (Issue #288)

### Enfoque de implementacion

El test-writer dejo los tres sitios de produccion con un placeholder de compilacion
(`string.Empty`) explicitamente marcado como pendiente de "wiring real" por el implementer. El
trabajo de esta fase fue minimo y mecanico: reemplazar ese placeholder por `ToString()` del
propio tipo rico en cada uno de los tres sitios, exactamente como especifica CA-2 y como
sugiere la "Interfaz publica propuesta" del issue:

- `SubFranja.ToDetalle()`: `Descripcion = ToString()` (del propio `SubFranja`).
- `FranjaOrdinaria.ToDetalle()`: `Descripcion = ToString()` (del propio `FranjaOrdinaria`; ya
  compone los `ToString()` de sus `SubFranja` hijas via `string.Join` dentro de su propio
  `ToString()`, asi que no hace falta concatenar los `Detalle` hijos por separado).
- `CatalogoTurnos.ObtenerDetalle()`: `Descripcion = ToString()` (del propio aggregate).

No hubo que tocar `Equals`/`GetHashCode` ni la forma de los records: el test-writer ya los dejo
completos y correctos (verificado leyendo los tres archivos de `PrivateEvents/Programacion/`
antes de tocar nada).

### Decisiones de diseno

- Ningun diseño nuevo: la unica decision fue confirmar que el orden de composicion (sub-franja
  -> franja -> turno, cada nivel usando su propio `ToString()`, sin concatenar los `Detalle` de
  los hijos) ya estaba resuelto por la estructura existente de cada `ToString()` -- no había que
  construir nada adicional.
- Se dejo el comentario `// Issue #288 CA-2: ...` en los tres sitios, actualizado de "pendiente"
  a "se asigna con el ToString() de este mismo tipo rico/aggregate", para que el historial de
  intencion quede legible sin tener que rastrear el commit del test-writer.

### ADRs consultados

- MEF-ADR-0012: modelado de objetos de dominio, Tell-don't-Ask, `ToString()` para exponer
  derivados. El issue mismo ya documenta la desviacion consciente de su espiritu (persistir el
  derivado en vez de recalcularlo) -- no se reevaluo esa decision, ya estaba tomada y justificada
  en el issue.
- MEF-ADR-0018: Rule of Three -- ya citado por el issue para descartar consolidar el formateo en
  los DTOs planos. No aplico ningun cambio adicional bajo este criterio.
- MEF-ADR-0009: mensajes en `.resx`. No se toco ningun mensaje; `FranjaOrdinaria.ToString()` ya
  usaba `Mensajes.LabelDescansos`/`LabelExtras` sin cambios.
- CA-ADR-0025 / MEF-ADR-0023 (equivalente en este repo): `Descripcion` es `string`, plano y
  portable -- no se agrego ningun tipo rico al payload que cruza el bus.

### Desviaciones de ADRs

Ninguna desviacion — todos los ADRs aplicados al pie de la letra. El issue ya declaraba y
justificaba su propia desviacion consciente de MEF-ADR-0012 (persistir el derivado); no se
tomo ninguna decision adicional de ese tipo en esta fase.

### Precedentes consultados

- `DetalleFranjaOrdinariaIgualdadTests.cs` / el override de `Equals`/`GetHashCode` de
  `DetalleFranjaOrdinaria` (issue #129): usado como referencia de forma por el test-writer, no
  por mi -- ya estaba completo antes de que yo tocara el codigo. Alineado con MEF-ADR-0012 (no se
  detecto ninguna violacion).

### Infraestructura modificada

Ninguna. Este issue no publica ningun evento nuevo ni cambia ningun topic/subscription: modifica
el payload (agrega un campo `string`) de eventos que ya existian y ya tenian su infraestructura
provisionada.

### Complejidad encontrada

El unico obstaculo no trivial fue detectar que 2 tests de
`SolicitarProgramacionTurnoCommandHandlerTests.cs` quedan en contradiccion irresoluble con la
implementacion de CA-2 -- ver `.claude/pipeline/blockage-report.md` para el detalle completo
(hipotesis, evidencia citada del propio commit/resumen del test-writer, y la resolucion sugerida
con los valores exactos que el fixture deberia tener). No se modifico ese test: siguiendo la
regla del rol, se reporta el bloqueo en vez de resolverlo unilateralmente.

### Resultado
- Tests pasando: 568/570 (8 adicionales `omitido` por falta de infraestructura local -- Postgres/
  ServiceBus -- no relacionados con este issue)
- Tests bloqueados: 2, reportados en `.claude/pipeline/blockage-report.md`

</details>
<details>
<summary>Reviewer (fase refactor) — 18m 25s</summary>

## ES Reviewer - Revision (Issue #288)

### Evaluacion general
- Calidad: **buena** (el nucleo del diff estaba bien resuelto; se corrigio un defecto de
  retro-compatibilidad no detectado y se cerro cobertura faltante)
- Cambios realizados: **si** (commit `760f477`)
- Suite final: **572 correctos / 0 errores / 8 omitidos** (los 8 omitidos son smoke tests sin
  Postgres/ServiceBus local, ajenos al issue). Baseline heredado: 568 correctos / 2 errores.

### Resolucion de bloqueo heredado

El implementer reporto 2 tests rojos. Se resolvieron en **1 intento**, aplicando la excepcion de
"contradiccion estructural no resuelta por el test-writer" (seccion 2b del rol).

| Test afectado | Naturaleza del problema | Accion tomada | Donde queda cubierto el CA |
|---|---|---|---|
| `SolicitarProgramacionTurnoCommandHandlerTests.DebeEmitirProgramacionSolicitadaYPublicarEvento_CuandoDatosValidos` | Fixture desactualizado: `DetalleEsperado` conservaba el placeholder `Descripcion = ""` que el **propio test-writer** documento en el codigo como "placeholder de compilacion, fase verde pendiente en el implementer - ver CA-2" | Se actualizo el valor del fixture al texto real (`"(06:00-14:00)"` / `"Turno Manana (06:00-14:00)"`). **El intent del test no cambia**: sigue afirmando que el handler emite `ProgramacionTurnoSolicitada` y publica `ProgramacionTurnoDiarioSolicitada` con el `DetalleTurno` del catalogo | CA-1/CA-2 en este mismo test (ahora con el literal, refuerza CA-6); coherencia en `CatalogoTurnosTests` y `FranjaOrdinariaToDetalleTests` |
| `SolicitarProgramacionTurnoCommandHandlerTests.DebePublicarUnEventoPorCadaFecha_CuandoHayMultiplesFechas` | Misma causa raiz (fixture compartido) | Misma correccion | Idem |

Se coincide con el diagnostico del implementer: no habia solucion por codigo de produccion. Revertir
CA-2 habria roto 6 tests en 3 archivos y violado CA-2/CA-3 explicitamente. **No se elimino ningun
test ni se relajo ninguna asercion**: el literal en el fixture es hoy *mas* estricto que el `""`
anterior, porque congela el formato exacto que fluye hasta el evento publicado.

### Cumplimiento de ADRs aplicables

| ADR | Cumplimiento | Observacion |
|---|---|---|
| MEF-ADR-0012: modelado, Tell-don't-Ask, `ToString()` para derivados | **desviacion declarada (en el issue, no por el implementer)** | El issue declara y justifica persistir el derivado en vez de recalcularlo (seccion "Decision consciente: el texto se persiste, no se calcula") e instruye al reviewer a no reportarlo como hallazgo. Se acata. El resto del ADR se cumple: el formateo **vive en el tipo rico** (`SubFranja`/`FranjaOrdinaria`/`CatalogoTurnos` exponen `ToString()`), y los sitios de asignacion **consumen esa superficie** en vez de reimplementar el formato -- justo la "contrapartida activa" del ADR (lineas 218-243). Ninguna clase estatica externa opera sobre datos crudos de un VO. |
| MEF-ADR-0012: frontera de serializacion event store vs bus | **ok** | `ProgramacionTurnoDiarioSolicitada : IPrivateEvent` (verificado en el fuente) cruza el ASB interno. Su payload `DetalleTurno` sigue siendo plano: `string`, `TimeOnly`, `int` y `record` DTO planos. `Descripcion` es `string` -- portable con el serializador por defecto. El guardrail de round-trip **sin resolver custom** existe (`ProgramacionTurnoDiarioSolicitadaPortabilidadTests`) y se **amplio** a los tres niveles (antes cubria turno y franja, no sub-franja). |
| MEF-ADR-0018: Rule of Three | **ok** | Se conserva la duplicacion del formateo entre tipos ricos y DTOs planos en vez de consolidarla, tal como el issue argumenta. El reviewer **no pide extraccion** (regla de "autoridad de extraccion": la iniciativa parte del implementer). |
| MEF-ADR-0009: mensajes en `.resx` | **ok** | No se movieron `Mensajes.LabelDescansos`/`LabelExtras` ni se agrego ningun literal de UI en codigo. El texto derivado los arrastra, que es la consecuencia asumida. |
| MEF-ADR-0016: naming de tests | **ok** | Todos los tests nuevos usan `<Sujeto>_<LoQuePasa>[_Cuando<Condicion>]`. Unica variante: `RoundTrip_PreservaDescripcion_ConSerializadorPorDefectoDelBus` usa `Con...` en vez de `Cuando...`; se **mantiene** porque replica el precedente dominante del repo para esta categoria (`RoundTrip_PreservaTodosLosCampos_ConSerializadorPorDefectoDelPublisher`, `RoundTrip_PreservaMinutosPorConceptoYTrazabilidad_ConSerializadorPorDefecto`) y el ADR declara el tercer segmento opcional. |
| CA-ADR-0025: el modelo rico no cruza el bus | **ok** | No se agrego ningun tipo rico al payload. Se agrego un `string`. |
| CA-ADR-0029: ensamblados de eventos por rol | **ok** | `PrivateEvents` no gana ninguna referencia de proyecto nueva (verificado: los tres DTOs siguen sin `using` de dominio). El grafo queda igual. |

### Desviaciones de ADRs

**Desviaciones declaradas por el implementer**: ninguna. Su resumen declara "Ninguna desviacion".
Se verifico el diff contra los 7 ADRs aplicables y **se confirma**: el implementer no introdujo
desviaciones propias. Su fase fue estrictamente mecanica (reemplazar tres placeholders).

**Desviaciones detectadas por el reviewer (NO declaradas)**: ninguna desviacion de ADR.

Se detecto en cambio un **defecto funcional** contra el propio texto del issue (ver "Criticas y
hallazgos", hallazgo mayor #1), que no es una desviacion de ADR sino un incumplimiento de la
"Consecuencia asumida" que el issue declara. Se corrigio en el refactor.

### Precedentes consultados por el implementer

| Precedente | ADR aplicable | Veredicto |
|---|---|---|
| Override de `Equals`/`GetHashCode` de `DetalleFranjaOrdinaria` (issue #129) | MEF-ADR-0012 | **alineado**. El ADR advierte que `record` con `IReadOnlyList<T>` promete igualdad por valor que no cumple. El precedente resuelve la promesa con `SequenceEqual` manual conservando la forma `record` (correcta para un DTO plano sin invariantes, segun la tabla de heuristicas). `DetalleTurno` y `DetalleSubFranja` replican el patron con estilo identico. Se verifico linea por linea, no se asumio por precedencia. |

### Convenciones del pipeline (no ADRs)

| Convencion | Estado | Observacion |
|---|---|---|
| Cada test con `Then()` + `And<>()` | ok | Los tests de handler tocados ya traian ambos (`Then(...)` + `And<SolicitudProgramacionAggregateRoot, int>(s => s.Fechas.Count, N)`). Los tests nuevos del issue son de contrato (igualdad, serializacion, coherencia `ToDetalle`/`ToString`), no de handler: no aplica el DSL. |
| Overloads correctos para stream IDs compuestos | ok | `DepurarAlAdicionarMarcacionTests`, `DesgloseHorasTras*` y `CrearDiaCalculado*` usan `Given(StreamId, ...)` / `Then(StreamId, ...)` con el stream compuesto `{EmpleadoId}:{Fecha}`. `SolicitarProgramacionTurnoCommandHandlerTests` usa `Given(TurnoId.ToString(), ...)` para el catalogo y los overloads sin id para el aggregate de solicitud (Guid) -- correcto. |
| Fakes manuales (no NSubstitute) | n/a | El diff no introduce dependencias nuevas en ningun handler. |
| Feature folders (produccion y tests) | ok | Los archivos nuevos caen en el espejo correcto: `Programacion.Tests/Entities/`, `Programacion.Tests/ValueObjects/`, `PrivateEvents.Tests/Programacion/`, y `ControlHoras.Tests/AsignarTurnoCuando.../Eventos/`. Un archivo por responsabilidad. |
| Smoke tests: SkipWhen, secrets, cobertura | ok | El issue no agrega endpoints ni publicaciones, asi que no exige smoke tests nuevos (lo dice explicitamente). Los dos smoke tests tocados conservan sus `Assert.SkipWhen`, filtran por `SolicitudId` (campo unico, no por posicion) y siguen cubriendo los tres efectos: persistencia en Postgres, publicacion a `dia-calculado` y status del trigger. Ningun `appsettings.json` con secretos. |
| Proyecciones read-side | n/a | Issue write-side puro; no toca `ReadModels`/`Projections` ni ninguna Function GET. |
| Tests via ToString/comportamiento | ok | Los tests de coherencia comparan `rico.ToDetalle().Descripcion` con `rico.ToString()` -- comportamiento publico, sin getters abiertos para test. No se agrego ningun miembro publico solo para observar estado. |
| Sin numeros magicos | ok | Los literales son horas del escenario y textos de formato esperados; ambos tienen significado directo en el nombre del test. |
| Condiciones en positivo (guardas if/else afirmativas) | ok | Los `if (other is null) return false;` de los `Equals` son guard clauses de early-return, expresamente exceptuadas. No hay bifurcacion `if`/`else` en negativo. |
| Sin caracter U+2500 en `.cs` | ok | Barrido sobre `src/` y `tests/`: cero ocurrencias. |

### Elegancia del codigo

Lo que ya estaba bien y se conserva:

- **Idiomatico**: los tres sitios de produccion delegan en `ToString()` del propio tipo en vez de
  concatenar los `Detalle` de los hijos -- la composicion sale gratis porque cada `ToString()` ya
  compone el de sus hijas. Es la lectura correcta y la mas corta posible.
- **Compacto**: la fase verde fue de tres lineas. No hay codigo muerto, ni helper innecesario, ni
  abstraccion prematura.
- **Consistente**: los overrides de `Equals`/`GetHashCode` de `DetalleTurno` y `DetalleSubFranja`
  calcan el estilo del de `DetalleFranjaOrdinaria` (mismo orden de guardas, mismo uso de
  `HashCode.Add` en bucle). Un lector que conoce uno conoce los tres.

Lo que se mejoro:

- **Robustez** (hallazgo mayor, ver abajo): la propiedad `Descripcion` declaraba `string` no
  anulable pero podia contener `null`.
- **Limpieza**: se eliminaron cinco comentarios que afirmaban "este test queda en rojo hasta que el
  implementer asigne `ToString()`" -- ya falsos y activamente engañosos para quien lea el codigo
  mergeado. Tambien cuatro casts `(int)0` redundantes.
- **Legibilidad**: `CatalogoTurnosTests` gano dos factory methods (`CrearCatalogo`, `Ordinaria`) que
  eliminan el ruido de construir `TurnoCreado` + `DatosFranja` en cada test.

### Criticas y hallazgos

**1. MAYOR (corregido) -- `Descripcion` llegaba `null`, no `""`, en los eventos ya persistidos.**

El issue declara en "Consecuencia asumida": *"los eventos que ya estan en dev no tienen el campo --
se deserializan con `Descripcion = ""`"*. **Eso es falso.** Se verifico empiricamente (test
temporal, luego eliminado) deserializando un JSON sin el campo:

```
DESCRIPCION_TURNO=[<NULL>] DESCRIPCION_FRANJA=[<NULL>]
```

STJ construye el `record` por su constructor posicional; un parametro ausente en el JSON toma
`default(string)`, que es `null`. El resultado es una propiedad **declarada `string` no anulable que
contiene `null`** en los tres DTOs -- una mina de `NullReferenceException` que estallaria
precisamente en el consumidor que este issue habilita (`TurnoDiarioView`, el issue del read-side que
depende de este) y en cualquier rehidratacion de stream anterior a #288.

Ni el test-writer ni el implementer lo detectaron: el unico round-trip existente serializaba un
objeto que **si** llevaba el campo, asi que nunca ejercitaba el camino de los eventos viejos.

Correccion aplicada en los tres DTOs, sin cambiar la superficie publica (la propiedad posicional
que el compilador genera ya es `{ get; init; }`, se declara explicita con el mismo modificador):

```csharp
public string Descripcion { get; init; } = Descripcion ?? string.Empty;
```

Cubierto por el test nuevo `Deserializar_DejaDescripcionEnCadenaVacia_CuandoEventoNoLlevaElCampo`,
que deserializa un JSON con la forma exacta previa al issue y verifica cadena vacia en los tres
niveles. Con esto el codigo cumple lo que el issue prometio.

**2. MENOR (corregido) -- el guardrail de portabilidad no cubria el nivel sub-franja.**

`ProgramacionTurnoDiarioSolicitadaPortabilidadTests` construia un turno **sin descansos**, asi que
verificaba `Descripcion` en turno y franja pero nunca en `DetalleSubFranja`. El issue pide el texto
en los tres niveles y CA-7 pide que el round-trip lo preserve. Se agrego un descanso al fixture y la
tercera asercion.

**3. MENOR (corregido) -- comentarios de fase roja obsoletos en cinco puntos.**

`CatalogoTurnosTests`, `FranjaOrdinariaToDetalleTests`, `SubFranjaToDetalleTests` y el fixture de
`SolicitarProgramacionTurnoCommandHandlerTests` afirmaban que los sitios de produccion "todavia
asignan un placeholder" y que los tests "quedan en rojo". Todos falsos tras la fase verde. Un
comentario que miente es peor que no tener comentario.

**4. MENOR (corregido) -- `CatalogoTurnosTests` cubria solo el caso trivial.**

El unico test era un turno con una ordinaria sin hijos: el caso donde el `ToString()` del turno casi
no hace nada. El formato de nivel turno hace `string.Join("", franjas)` y arrastra los labels `.resx`
de los descansos; ese es el caso que puede divergir. Se agrego
`ObtenerDetalle_TieneDescripcionCoherenteConToString_CuandoTurnoPartidoConDescanso`.

**5. COSMETICO (corregido) -- casts `(int)0` redundantes** en `DetalleFranjaOrdinariaIgualdadTests`
(4 ocurrencias, preexistentes pero en lineas que el diff ya tocaba).

**6. OBSERVACION (no corregido, fuera de alcance) -- deuda preexistente de `IDE0005`.**

`dotnet format --verify-no-changes` sale con codigo 2 por 9 avisos `IDE0005` (using innecesario) en
archivos de test. Se verifico que **ninguno fue introducido por este issue**: los `using` que el diff
agrega estan todos en archivos nuevos y todos se usan. Es deuda anterior y amplia; limpiar solo los
4 archivos que este diff toca dejaria la inconsistencia a medias sin arreglar el gate. Merece su
propio issue. **CA-8 se cumple**: `dotnet build` sin errores y sin warnings nuevos (los 4 `NU1902`
de `OpenTelemetry.Api` tambien son preexistentes).

**7. OBSERVACION (no corregido, deliberado) -- la exclusion de `Descripcion` en los smoke tests
podria retirarse.**

Los dos smoke tests de Service Bus excluyen `Descripcion` de la comparacion estructural porque su
payload sintetico no lo lleva. Tras la normalizacion del hallazgo #1, el valor persistido seria `""`
y coincidiria con el esperado, asi que la exclusion ya no es estrictamente necesaria y retirarla
convertiria el smoke test en verificacion end-to-end de la normalizacion. **No se retiro**: estos
tests estan `omitido` en local (sin Service Bus/Postgres) y no puedo verificar el verde, y la regla
"nunca dejes tests fallando" pesa mas que la ganancia. Se dejo el comentario actualizado explicando
la situacion real. Candidato a apretar en un issue posterior con acceso a dev.

**Ningun hallazgo bloqueante.**

### Refactorings aplicados

1. **Normalizacion de `Descripcion` a cadena vacia** en `DetalleTurno`, `DetalleFranjaOrdinaria` y
   `DetalleSubFranja`. Justificacion: hallazgo #1. Superficie publica intacta.
2. **Fixture `DetalleEsperado` actualizado al texto real** en
   `SolicitarProgramacionTurnoCommandHandlerTests`. Justificacion: resolucion del bloqueo heredado.
3. **Factory methods `CrearCatalogo` / `Ordinaria`** en `CatalogoTurnosTests`. Justificacion:
   convencion de factory methods para precondiciones repetidas; hacen legible el segundo test.
4. **Extraccion de `CrearDetalleTurno()`** en el test de portabilidad, compartido por los dos tests.
5. **Eliminacion de comentarios de fase roja obsoletos** (5 sitios) y de casts `(int)0` (4 sitios).

Cada paso se verifico con `dotnet test`. Ninguno requirio revert.

### Cobertura de criterios de aceptacion

| Criterio | Estado | Test(s) |
|---|---|---|
| CA-1: los tres DTOs declaran `Descripcion` como parametro obligatorio; los sitios de construccion en tests actualizados | cubierto | Compilacion de toda la suite (580 tests) + `DetalleTurnoIgualdadTests`, `DetalleSubFranjaIgualdadTests`, `DetalleFranjaOrdinariaIgualdadTests` |
| CA-2: los tres sitios de produccion asignan el texto del `ToString()` del tipo rico | cubierto | `ObtenerDetalle_TieneDescripcionCoherenteConToString_CuandoTurnoConUnaOrdinaria`, `ToDetalle_TieneDescripcionCoherenteConToString_CuandoFranjaSinHijos`, `ToDetalle_TieneDescripcionCoherenteConToString_CuandoSubFranjaSinOffset`; ademas el literal en `DebeEmitirProgramacionSolicitadaYPublicarEvento_CuandoDatosValidos` |
| CA-3: un test de coherencia por cada uno de los tres niveles | cubierto | Nivel turno: `CatalogoTurnosTests` (2 tests, uno **agregado** en revision). Nivel franja: `FranjaOrdinariaToDetalleTests` (3 tests, incluye propagacion a hijos). Nivel sub-franja: `SubFranjaToDetalleTests` (2 tests, incluye cruce de medianoche) |
| CA-4: `DetalleSubFranja` y `DetalleTurno` con `Equals`/`GetHashCode` propios que excluyen `Descripcion`; `DetalleFranjaOrdinaria` conserva los suyos | cubierto | `DetalleSubFranjaIgualdadTests.Equals_RetornaTrue_CuandoSoloDescripcionEsDiferente` + `GetHashCode_RetornaMismoHash_CuandoSoloDescripcionEsDiferente`; idem en `DetalleTurnoIgualdadTests`; `DetalleFranjaOrdinariaIgualdadTests` (8 heredados + 2 propios) |
| CA-5: `DetalleTurno.Equals` compara `FranjasOrdinarias` por valor (bug latente) | cubierto | `DetalleTurnoIgualdadTests.Equals_RetornaTrue_CuandoFranjasSonInstanciasDeListaDiferentesConMismoContenido` + `GetHashCode_RetornaMismoHash_...` (caso que fallaria sin la correccion) |
| CA-6: el `ToString()` de los tres tipos ricos produce el mismo string que antes | cubierto | Verificado con `git diff` contra el merge-base: los cuerpos de `SubFranja.ToString()`, `FranjaOrdinaria.ToString()` y `CatalogoTurnos.ToString()` **no cambiaron ni una linea**, y `SubFranjaTests`/`FranjaOrdinariaTests` no fueron modificados. Verdes. Reforzado por el literal `"Turno Manana (06:00-14:00)"` que la revision congelo en el fixture del handler |
| CA-7: el round-trip de serializacion preserva `Descripcion` | cubierto | `TurnoDiarioAsignadoSerializacionTests` (Marten, con resolver), `ProgramacionTurnoDiarioSolicitadaPortabilidadTests.RoundTrip_PreservaDescripcion_ConSerializadorPorDefectoDelBus` (bus, sin resolver, **ampliado** a los tres niveles), `DesgloseFranjaSerializacionTests`, `DesgloseHorasSerializacionTests`. Ademas el caso de retro-compatibilidad **agregado** en revision |
| CA-8: `dotnet build` sin errores ni warnings nuevos y `dotnet test` verde | cubierto | `dotnet build`: 0 errores, 4 warnings `NU1902` preexistentes. `dotnet test`: 572 correctos / 0 errores / 8 omitidos por infraestructura local |

### Tests agregados

1. `ProgramacionTurnoDiarioSolicitadaPortabilidadTests.Deserializar_DejaDescripcionEnCadenaVacia_CuandoEventoNoLlevaElCampo`
   -- guardrail de retro-compatibilidad. Deserializa la forma JSON exacta anterior a #288 y verifica
   cadena vacia en los tres niveles. Es el test que faltaba para que la "Consecuencia asumida" del
   issue sea verdad y no una suposicion.
2. `CatalogoTurnosTests.ObtenerDetalle_TieneDescripcionCoherenteConToString_CuandoTurnoPartidoConDescanso`
   -- caso compuesto del nivel turno (dos ordinarias + descanso), donde el formato concatena franjas
   y arrastra los labels `.resx`.
3. Ampliacion de `RoundTrip_PreservaDescripcion_ConSerializadorPorDefectoDelBus` con la asercion del
   nivel sub-franja (fixture con descanso).

Tests de contrato de igualdad y serializacion: **ya existian y son correctos**. El test-writer
genero `DetalleTurnoIgualdadTests` y `DetalleSubFranjaIgualdadTests` sobre `IgualdadTestBase<T>` con
los casos clave del issue (difieren solo en `Descripcion` -> iguales; listas distintas con mismo
contenido -> iguales). No hubo que agregar nada ahi.

</details>

## Cobertura

| Archivo | Cobertura | Umbral | Estado |
|---|---|---|---|
| DetalleFranjaOrdinaria.cs | - | no evaluado | - |
| DetalleSubFranja.cs | - | no evaluado | - |
| DetalleTurno.cs | - | no evaluado | - |
| FranjaOrdinaria.cs | - | no evaluado | - |
| SubFranja.cs | - | no evaluado | - |
| CatalogoTurnos.cs | - | no evaluado | - |
## Commits

760f477 refactor(issue-288): normalizar Descripcion nula y cerrar cobertura de los tres niveles
8942512 feat(issue-288): asignar Descripcion con ToString() en los tres sitios de produccion (fase verde)
8e41f29 test(issue-288): tests para Descripcion en DTOs planos de turno (fase roja)

Closes #288