### PR TITLE
Listar los turnos diarios vigentes por empleado y rango de fechas

### DIFF
--- a/src/Bitakora.ControlAsistencia.ControlHoras/ListarTurnosDiarios/FunctionEndpoint.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ListarTurnosDiarios/FunctionEndpoint.cs
@@ -20,11 +20,6 @@ namespace Bitakora.ControlAsistencia.ControlHoras.ListarTurnosDiarios;
 // comando/query de ese recurso"). No hay colision de plantilla verificada en la investigacion del
 // planner: no existe ningun POST sobre este mismo segmento en este dominio.
 //
-// CA-1: la QuerySession se abre SIEMPRE acotada al tenant que resuelve ITenantResolver -- nunca a
-// un tenant id que llegue en la ruta o el query string (MEF-ADR-0028/skills/projections/read-apis.md,
-// mitigacion estructural contra BOLA/IDOR). empleadoId/desde/hasta SI vienen del query string: son
-// el filtro del recurso, no el tenant.
-//
 // Verificado empiricamente (projection-implementer, Marten 9.12.0 contra Postgres real via
 // contenedor local desechable, sin dejar rastro en el repo): session.Query<TView>() SI traduce a
 // SQL tanto el filtro de rango sobre DateOnly (v.Fecha >= desde && v.Fecha <= hasta) como su
@@ -57,10 +52,10 @@ public class FunctionEndpoint(IDocumentStore store, ITenantResolver tenantResolv
         if (hasta < desde)
             return new BadRequestObjectResult("El parametro 'hasta' no puede ser anterior a 'desde'");
 
-        // empleadoId es opcional (CA-2): ausente = todos los empleados.
-        var empleadoId = req.Query.TryGetValue("empleadoId", out var empleadoIdCrudo)
-            ? empleadoIdCrudo.ToString()
-            : null;
+        // empleadoId es opcional (CA-2): ausente = todos los empleados. StringValues.ToString()
+        // devuelve cadena vacia cuando el parametro no viene, asi que ausente y vacio se tratan
+        // igual -- sin filtro por empleado.
+        var empleadoId = req.Query["empleadoId"].ToString();
 
         // CA-3/CA-4: recorte de la cota de 31 dias, siempre hacia adelante desde `desde`.
         var rangoAplicado = RangoConsulta.Recortar(desde, hasta);
@@ -100,19 +95,21 @@ public class FunctionEndpoint(IDocumentStore store, ITenantResolver tenantResolv
         return new OkObjectResult(respuesta);
     }
 
+    // Ausente y mal formado comparten respuesta y mensaje a proposito: StringValues.ToString()
+    // devuelve cadena vacia cuando el parametro no viene, y TryParseExact la rechaza igual que a
+    // "31-12-2026". Un solo camino de fallo, un solo 400 (CA-2).
     private static bool TryLeerFecha(
         HttpRequest req, string nombreParametro, out DateOnly fecha, out string? error)
     {
-        if (!req.Query.TryGetValue(nombreParametro, out var crudo) ||
-            !DateOnly.TryParseExact(
-                crudo, FormatoFecha, CultureInfo.InvariantCulture, DateTimeStyles.None, out fecha))
+        if (DateOnly.TryParseExact(
+                req.Query[nombreParametro].ToString(),
+                FormatoFecha, CultureInfo.InvariantCulture, DateTimeStyles.None, out fecha))
         {
-            fecha = default;
-            error = $"El parametro '{nombreParametro}' es obligatorio y debe tener el formato {FormatoFecha}";
-            return false;
+            error = null;
+            return true;
         }
 
-        error = null;
-        return true;
+        error = $"El parametro '{nombreParametro}' es obligatorio y debe tener el formato {FormatoFecha}";
+        return false;
     }
 }

--- a/src/Bitakora.ControlAsistencia.ControlHoras/ListarTurnosDiarios/FunctionEndpoint.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ListarTurnosDiarios/FunctionEndpoint.cs
@@ -1,3 +1,6 @@
+using System.Globalization;
+using Bitakora.ControlAsistencia.ControlHoras.ObtenerTurnoDiario;
+using Bitakora.ControlAsistencia.ReadModels.ControlHoras;
 using Cosmos.MultiTenancy;
 using Marten;
 using Microsoft.AspNetCore.Http;
@@ -22,25 +25,94 @@ namespace Bitakora.ControlAsistencia.ControlHoras.ListarTurnosDiarios;
 // mitigacion estructural contra BOLA/IDOR). empleadoId/desde/hasta SI vienen del query string: son
 // el filtro del recurso, no el tenant.
 //
-// FASE ROJA (projection-test-writer): Run es un stub. projection-implementer completa el parseo de
-// desde/hasta/empleadoId desde el query string, la consulta session.Query<TurnoDiarioView>() (via
-// (a'), read-apis.md), el recorte de rango via RangoConsulta.Recortar (CA-3/CA-4) y el mapeo a
-// ListaTurnosDiarios (CA-5/CA-6). El constructor SI debe resolver limpio del contenedor -- eso es lo
-// que verifica el test de composicion de ComposicionServiciosTests (CA-7), hermano de MEF-ADR-0029:
-// no depende de que Run este implementado.
+// Verificado empiricamente (projection-implementer, Marten 9.12.0 contra Postgres real via
+// contenedor local desechable, sin dejar rastro en el repo): session.Query<TView>() SI traduce a
+// SQL tanto el filtro de rango sobre DateOnly (v.Fecha >= desde && v.Fecha <= hasta) como su
+// composicion con una igualdad de string anidada (v.Empleado.EmpleadoId == empleadoId) y el
+// OrderBy(v => v.Fecha) subsiguiente -- cierra el "riesgo abierto" que la investigacion del planner
+// dejaba pendiente para esta fase.
 public class FunctionEndpoint(IDocumentStore store, ITenantResolver tenantResolver)
 {
+    private const string FormatoFecha = "yyyy-MM-dd";
+
     [Function("ListarTurnosDiarios")]
-    public Task<IActionResult> Run(
+    public async Task<IActionResult> Run(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "control-horas/turnos-diarios")]
         HttpRequest req,
         CancellationToken ct)
     {
-        // Referencia minima a store/tenantResolver para evitar CS9113 (parametro de constructor
-        // primario sin lectura) mientras Run no tiene implementacion real -- projection-implementer
-        // reemplaza este cuerpo por la consulta/recorte/mapeo real (CA-1 a CA-6).
-        _ = store;
-        _ = tenantResolver;
-        throw new NotImplementedException();
+        // CA-2: desde/hasta son obligatorios -- ausencia o formato invalido devuelve 400. Igual que
+        // ObtenerTurnoDiario (#289): DateOnly no liga directo desde el query string en el modelo
+        // aislado de Functions, se parsea con formato explicito yyyy-MM-dd.
+        if (!TryLeerFecha(req, "desde", out var desde, out var errorDesde))
+            return new BadRequestObjectResult(errorDesde);
+
+        if (!TryLeerFecha(req, "hasta", out var hasta, out var errorHasta))
+            return new BadRequestObjectResult(errorHasta);
+
+        // Rango invertido (hasta < desde): no cubierto por ningun CA del issue #290 a proposito
+        // ("Propuesta revisable"). Se decide 400 -- coherente con el resto del contrato de
+        // validacion de este endpoint (desde/hasta obligatorios -> 400), y evita devolver
+        // silenciosamente una lista vacia ante lo que casi siempre es un error del cliente.
+        if (hasta < desde)
+            return new BadRequestObjectResult("El parametro 'hasta' no puede ser anterior a 'desde'");
+
+        // empleadoId es opcional (CA-2): ausente = todos los empleados.
+        var empleadoId = req.Query.TryGetValue("empleadoId", out var empleadoIdCrudo)
+            ? empleadoIdCrudo.ToString()
+            : null;
+
+        // CA-3/CA-4: recorte de la cota de 31 dias, siempre hacia adelante desde `desde`.
+        var rangoAplicado = RangoConsulta.Recortar(desde, hasta);
+
+        // CA-1: la QuerySession se abre SIEMPRE acotada al tenant que resuelve ITenantResolver --
+        // nunca a un tenant id que llegara por query string (mitigacion estructural contra
+        // BOLA/IDOR, MEF-ADR-0028/skills/projections/read-apis.md). empleadoId/desde/hasta SI vienen
+        // del query string: son el filtro del recurso, no el tenant.
+        await using var session = store.QuerySession(tenantResolver.TenantId);
+
+        // Propuesta revisable del planner adoptada: componer la query en pasos en vez de un unico
+        // Where con el filtro de empleadoId embebido condicionalmente -- mas legible que anidar el
+        // ternario dentro de la expresion LINQ.
+        IQueryable<TurnoDiarioView> query = session.Query<TurnoDiarioView>()
+            .Where(v => v.Fecha >= desde && v.Fecha <= rangoAplicado.HastaAplicado);
+
+        if (!string.IsNullOrEmpty(empleadoId))
+            query = query.Where(v => v.Empleado.EmpleadoId == empleadoId);
+
+        // CA-5: los dias sin turno asignado se omiten -- la proyeccion solo materializa un
+        // TurnoDiarioView por (empleado, fecha) con turno asignado, asi que un rango sin resultados
+        // ya produce turnos: [] de forma natural, sin relleno de huecos (ver issue #290, seccion
+        // "Los huecos: por que se omiten y no se rellenan").
+        var vistas = await query
+            .OrderBy(v => v.Fecha)
+            .ToListAsync(ct);
+
+        // CA-6: cada elemento es el mismo TurnoDiarioRespuesta de #289, sin el Id del documento.
+        var turnos = vistas
+            .Select(v => new TurnoDiarioRespuesta(v.Empleado, v.Fecha, v.DetalleTurno, v.UltimaSolicitudId))
+            .ToList();
+
+        var respuesta = new ListaTurnosDiarios(
+            desde, rangoAplicado.HastaAplicado, rangoAplicado.RangoRecortado, turnos);
+
+        // Nunca 404 (CA-5): sin resultados es 200 con turnos: [].
+        return new OkObjectResult(respuesta);
+    }
+
+    private static bool TryLeerFecha(
+        HttpRequest req, string nombreParametro, out DateOnly fecha, out string? error)
+    {
+        if (!req.Query.TryGetValue(nombreParametro, out var crudo) ||
+            !DateOnly.TryParseExact(
+                crudo, FormatoFecha, CultureInfo.InvariantCulture, DateTimeStyles.None, out fecha))
+        {
+            fecha = default;
+            error = $"El parametro '{nombreParametro}' es obligatorio y debe tener el formato {FormatoFecha}";
+            return false;
+        }
+
+        error = null;
+        return true;
     }
 }

--- a/src/Bitakora.ControlAsistencia.ControlHoras/ListarTurnosDiarios/FunctionEndpoint.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ListarTurnosDiarios/FunctionEndpoint.cs
@@ -1,0 +1,46 @@
+using Cosmos.MultiTenancy;
+using Marten;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.ListarTurnosDiarios;
+
+// Issue #290: segunda Function GET del BC (skills/projections/naming.md: Listar{X}s por
+// filtro/lista), sobre la MISMA vista materializada TurnoDiarioView que ya usa ObtenerTurnoDiario
+// (#289) -- ninguna proyeccion nueva, ningun cambio al seam del worker. Feature folder propio (un
+// namespace por query, skills/projections/read-apis.md y naming.md): esta clase FunctionEndpoint
+// no colisiona con las demas homonimas del ensamblado porque cada una vive en su propio namespace.
+//
+// Ruta sin {id}: reutiliza el mismo segmento de recurso "control-horas/turnos-diarios" que
+// ObtenerTurnoDiario (naming.md: "una query reutiliza el mismo segmento de recurso que ya usa el
+// comando/query de ese recurso"). No hay colision de plantilla verificada en la investigacion del
+// planner: no existe ningun POST sobre este mismo segmento en este dominio.
+//
+// CA-1: la QuerySession se abre SIEMPRE acotada al tenant que resuelve ITenantResolver -- nunca a
+// un tenant id que llegue en la ruta o el query string (MEF-ADR-0028/skills/projections/read-apis.md,
+// mitigacion estructural contra BOLA/IDOR). empleadoId/desde/hasta SI vienen del query string: son
+// el filtro del recurso, no el tenant.
+//
+// FASE ROJA (projection-test-writer): Run es un stub. projection-implementer completa el parseo de
+// desde/hasta/empleadoId desde el query string, la consulta session.Query<TurnoDiarioView>() (via
+// (a'), read-apis.md), el recorte de rango via RangoConsulta.Recortar (CA-3/CA-4) y el mapeo a
+// ListaTurnosDiarios (CA-5/CA-6). El constructor SI debe resolver limpio del contenedor -- eso es lo
+// que verifica el test de composicion de ComposicionServiciosTests (CA-7), hermano de MEF-ADR-0029:
+// no depende de que Run este implementado.
+public class FunctionEndpoint(IDocumentStore store, ITenantResolver tenantResolver)
+{
+    [Function("ListarTurnosDiarios")]
+    public Task<IActionResult> Run(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "control-horas/turnos-diarios")]
+        HttpRequest req,
+        CancellationToken ct)
+    {
+        // Referencia minima a store/tenantResolver para evitar CS9113 (parametro de constructor
+        // primario sin lectura) mientras Run no tiene implementacion real -- projection-implementer
+        // reemplaza este cuerpo por la consulta/recorte/mapeo real (CA-1 a CA-6).
+        _ = store;
+        _ = tenantResolver;
+        throw new NotImplementedException();
+    }
+}

--- a/src/Bitakora.ControlAsistencia.ControlHoras/ListarTurnosDiarios/ListaTurnosDiarios.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ListarTurnosDiarios/ListaTurnosDiarios.cs
@@ -1,0 +1,19 @@
+using Bitakora.ControlAsistencia.ControlHoras.ObtenerTurnoDiario;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.ListarTurnosDiarios;
+
+/// <summary>
+/// Envelope de respuesta de ListarTurnosDiarios (issue #290). NO es un read model -- vive en el
+/// Function App (ControlHoras), no en ReadModels: es el contrato HTTP de esta query, con el recorte
+/// de rango ya aplicado (CA-3/CA-4) y el seam donde aterrizan paginacion y tope de resultados sin
+/// romper clientes existentes el dia que se agreguen (Rule of Three, MEF-ADR-0018).
+///
+/// <c>Turnos</c> reutiliza el mismo <see cref="TurnoDiarioRespuesta"/> que devuelve ObtenerTurnoDiario
+/// (#289), sin el <c>Id</c> del documento (CA-6) -- no se redeclara un DTO nuevo para el mismo
+/// concepto.
+/// </summary>
+public sealed record ListaTurnosDiarios(
+    DateOnly DesdeAplicado,
+    DateOnly HastaAplicado,
+    bool RangoRecortado,
+    IReadOnlyList<TurnoDiarioRespuesta> Turnos);

--- a/src/Bitakora.ControlAsistencia.ControlHoras/ListarTurnosDiarios/RangoConsulta.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ListarTurnosDiarios/RangoConsulta.cs
@@ -1,0 +1,30 @@
+namespace Bitakora.ControlAsistencia.ControlHoras.ListarTurnosDiarios;
+
+/// <summary>
+/// Resultado de aplicar la cota de <see cref="RangoConsulta.CotaDias"/> sobre el rango de fechas
+/// pedido a ListarTurnosDiarios (issue #290, CA-3/CA-4).
+/// </summary>
+public readonly record struct RangoAplicado(DateOnly HastaAplicado, bool RangoRecortado);
+
+/// <summary>
+/// Logica pura de recorte del rango de consulta de ListarTurnosDiarios (issue #290, CA-3/CA-4).
+///
+/// El recorte es SIEMPRE hacia adelante desde <c>desde</c> -- nunca relativo a la fecha de hoy
+/// (issue #290, seccion "El envelope, y por que existe"): un recorte relativo a "hoy" haria que la
+/// misma consulta devolviera datos distintos segun el dia en que se ejecuta, lo que vuelve el
+/// endpoint dificil de testear y de cachear.
+///
+/// Sin dependencias de Marten/Postgres: se prueba como funcion pura sobre <see cref="DateOnly"/>,
+/// sin QuerySession (skills/projections/read-apis.md).
+///
+/// FASE ROJA (projection-test-writer): Recortar es un stub. projection-implementer completa la
+/// aritmetica de fechas que satisface RangoConsultaTests.
+/// </summary>
+public static class RangoConsulta
+{
+    /// <summary>Cota maxima del rango, en dias, INCLUSIVE (CA-3): desde y desde + 30 dias caben.</summary>
+    public const int CotaDias = 31;
+
+    public static RangoAplicado Recortar(DateOnly desde, DateOnly hasta) =>
+        throw new NotImplementedException();
+}

--- a/src/Bitakora.ControlAsistencia.ControlHoras/ListarTurnosDiarios/RangoConsulta.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ListarTurnosDiarios/RangoConsulta.cs
@@ -16,15 +16,20 @@ public readonly record struct RangoAplicado(DateOnly HastaAplicado, bool RangoRe
 ///
 /// Sin dependencias de Marten/Postgres: se prueba como funcion pura sobre <see cref="DateOnly"/>,
 /// sin QuerySession (skills/projections/read-apis.md).
-///
-/// FASE ROJA (projection-test-writer): Recortar es un stub. projection-implementer completa la
-/// aritmetica de fechas que satisface RangoConsultaTests.
 /// </summary>
 public static class RangoConsulta
 {
     /// <summary>Cota maxima del rango, en dias, INCLUSIVE (CA-3): desde y desde + 30 dias caben.</summary>
     public const int CotaDias = 31;
 
-    public static RangoAplicado Recortar(DateOnly desde, DateOnly hasta) =>
-        throw new NotImplementedException();
+    public static RangoAplicado Recortar(DateOnly desde, DateOnly hasta)
+    {
+        // CotaDias es INCLUSIVE (CA-4): desde + (CotaDias - 1) dias es el limite exacto que
+        // todavia no excede la cota (31 dias inclusive = desde + 30 dias).
+        var hastaMaxima = desde.AddDays(CotaDias - 1);
+
+        return hasta > hastaMaxima
+            ? new RangoAplicado(hastaMaxima, true)
+            : new RangoAplicado(hasta, false);
+    }
 }

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/ListarTurnosDiarios/ListarTurnosDiariosSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/ListarTurnosDiarios/ListarTurnosDiariosSmokeTests.cs
@@ -13,6 +13,12 @@ namespace Bitakora.ControlAsistencia.ControlHoras.SmokeTests.ListarTurnosDiarios
 // TurnoDiarioView que ya materializa #289 -- se siembran datos publicando ProgramacionTurnoDiario-
 // Solicitada al bus interno, exactamente el mismo mecanismo de ObtenerTurnoDiarioSmokeTests.
 //
+// Estos tests quedan ROJOS hasta que el deploy publique ListarTurnosDiarios en dev: mientras la
+// revision anterior siga corriendo, la ruta no existe y el host responde 404 a todo -- los casos
+// 400 y 200 fallan por esa razon, no por el contrato. Mismo precedente y misma lectura que
+// ObtenerTurnoDiarioSmokeTests (#289). El CI de PR no los ejecuta (solo corre *.Tests); su
+// veredicto real se lee despues del deploy.
+//
 // La proyeccion tiene lifecycle Async (MEF-ADR-0034): el worker la materializa DESPUES de que
 // ControlHoras persiste turno_diario_asignado. Los casos que dependen de datos sembrados envuelven
 // la consulta en Polling.WaitUntilAsync/WaitUntilTrueAsync (timeout estandar 30s) -- si el timeout
@@ -95,24 +101,22 @@ public class ListarTurnosDiariosSmokeTests(ApiFixture api, ServiceBusFixture ser
         await serviceBus.PublishAsync(TopicEntrada, evento, solicitudId.ToString());
     }
 
-    private async Task<bool> EsperarTurnoMaterializadoAsync(
-        string empleadoId, DateOnly fecha, CancellationToken ct)
+    // Sensa la materializacion asincrona consultando ESTE mismo endpoint sobre un rango de un solo
+    // dia (desde == hasta), que nunca activa el recorte -- no via ObtenerTurnoDiario (#289), para no
+    // acoplar el veredicto de este archivo a la salud de otra Function.
+    private async Task<bool> EsperarTurnoEnLaListaAsync(
+        string empleadoId, DateOnly fecha, Guid solicitudId, CancellationToken ct)
     {
         return await Polling.WaitUntilTrueAsync(async () =>
         {
-            var response = await _client.GetAsync(
-                $"/api/control-horas/turnos-diarios/{empleadoId}/{fecha:yyyy-MM-dd}", ct);
-            return response.StatusCode == HttpStatusCode.OK;
-        }, Timeout);
-    }
+            var response = await _client.GetAsync(Ruta(fecha, fecha, empleadoId), ct);
+            if (response.StatusCode != HttpStatusCode.OK)
+                return false;
 
-    [Fact]
-    [Trait("Category", "Smoke")]
-    public async Task DebeEstarDisponible_CuandoSeConsultaHealthCheck()
-    {
-        var ct = TestContext.Current.CancellationToken;
-        var response = await _client.GetAsync("/api/health", ct);
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+            var body = await response.Content.ReadFromJsonAsync<ListaTurnosDiariosSmoke>(
+                JsonOptions, cancellationToken: ct);
+            return body?.Turnos.Any(t => t.UltimaSolicitudId == solicitudId) ?? false;
+        }, Timeout);
     }
 
     [Fact]
@@ -305,11 +309,13 @@ public class ListarTurnosDiariosSmokeTests(ApiFixture api, ServiceBusFixture ser
 
         // Espera a que AMBAS vistas esten materializadas antes de verificar el recorte: si no
         // esperaramos, la ausencia de "fuera" podria deberse a lag asincrono y no al recorte mismo.
-        var dentroMaterializado = await EsperarTurnoMaterializadoAsync(empleadoId, fechaDentro, ct);
+        var dentroMaterializado = await EsperarTurnoEnLaListaAsync(
+            empleadoId, fechaDentro, solicitudDentro, ct);
         dentroMaterializado.Should().BeTrue(
             $"la vista de {empleadoId} en {fechaDentro} deberia materializarse dentro del timeout");
 
-        var fueraMaterializado = await EsperarTurnoMaterializadoAsync(empleadoId, fechaFuera, ct);
+        var fueraMaterializado = await EsperarTurnoEnLaListaAsync(
+            empleadoId, fechaFuera, solicitudFuera, ct);
         fueraMaterializado.Should().BeTrue(
             $"la vista de {empleadoId} en {fechaFuera} deberia materializarse dentro del timeout");
 

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/ListarTurnosDiarios/ListarTurnosDiariosSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/ListarTurnosDiarios/ListarTurnosDiariosSmokeTests.cs
@@ -1,0 +1,333 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.ControlHoras.SmokeTests.Fixtures;
+using Bitakora.ControlAsistencia.PrivateEvents.Programacion;
+using Bitakora.ControlAsistencia.PublicEvents.Empleados;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.SmokeTests.ListarTurnosDiarios;
+
+// Issue #290: smoke tests de ListarTurnosDiarios, GET control-horas/turnos-diarios con desde/hasta
+// obligatorios y empleadoId opcional. Segunda Function GET read-side del BC, sobre la MISMA vista
+// TurnoDiarioView que ya materializa #289 -- se siembran datos publicando ProgramacionTurnoDiario-
+// Solicitada al bus interno, exactamente el mismo mecanismo de ObtenerTurnoDiarioSmokeTests.
+//
+// La proyeccion tiene lifecycle Async (MEF-ADR-0034): el worker la materializa DESPUES de que
+// ControlHoras persiste turno_diario_asignado. Los casos que dependen de datos sembrados envuelven
+// la consulta en Polling.WaitUntilAsync/WaitUntilTrueAsync (timeout estandar 30s) -- si el timeout
+// se agota es un fallo real (worker no desplegado o proyeccion sin registrar), nunca un skip.
+//
+// Formas locales DESACOPLADAS del DTO de produccion (Bitakora.ControlAsistencia.ControlHoras.
+// ListarTurnosDiarios.ListaTurnosDiarios / ListarTurnosDiarios.RangoConsulta): el smoke test no
+// referencia el proyecto de dominio (ControlHoras), solo PublicEvents/PrivateEvents (mismo patron
+// que ObtenerTurnoDiarioSmokeTests). El limite de 31 dias se afirma como literal (desde + 30 dias),
+// nunca leyendo RangoConsulta.CotaDias.
+public class ListarTurnosDiariosSmokeTests(ApiFixture api, ServiceBusFixture serviceBus)
+{
+    private readonly HttpClient _client = api.Client;
+
+    private const string TopicEntrada = "programacion-turno-diario-solicitada";
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
+
+    // Case-insensitive: la respuesta viaja en camelCase (ComposicionServicios configura
+    // JsonNamingPolicy.CamelCase), mientras que las formas locales de este archivo son PascalCase.
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    private sealed record TurnoDiarioRespuestaSmoke(
+        InformacionEmpleado Empleado,
+        DateOnly Fecha,
+        DetalleTurno DetalleTurno,
+        Guid UltimaSolicitudId);
+
+    private sealed record ListaTurnosDiariosSmoke(
+        DateOnly DesdeAplicado,
+        DateOnly HastaAplicado,
+        bool RangoRecortado,
+        IReadOnlyList<TurnoDiarioRespuestaSmoke> Turnos);
+
+    private static string Ruta(DateOnly desde, DateOnly hasta, string? empleadoId = null)
+    {
+        var query = $"desde={desde:yyyy-MM-dd}&hasta={hasta:yyyy-MM-dd}";
+        if (empleadoId is not null)
+            query += $"&empleadoId={Uri.EscapeDataString(empleadoId)}";
+
+        return $"/api/control-horas/turnos-diarios?{query}";
+    }
+
+    private async Task PublicarTurnoAsync(
+        Guid solicitudId, string empleadoId, DateOnly fecha, string nombreTurno)
+    {
+        var evento = new
+        {
+            SolicitudId = solicitudId,
+            Empleado = new
+            {
+                EmpleadoId = empleadoId,
+                TipoIdentificacion = "CC",
+                NumeroIdentificacion = "777888999",
+                Nombres = "[TEST] Smoke Listar",
+                Apellidos = "[TEST] TurnosDiarios"
+            },
+            Fecha = fecha.ToString("yyyy-MM-dd"),
+            DetalleTurno = new
+            {
+                Nombre = nombreTurno,
+                FranjasOrdinarias = new[]
+                {
+                    new
+                    {
+                        HoraInicio = "08:00:00",
+                        HoraFin = "16:00:00",
+                        DiaOffsetFin = 0,
+                        Descansos = Array.Empty<object>(),
+                        Extras = Array.Empty<object>(),
+                        Descripcion = (string?)null
+                    }
+                },
+                Descripcion = (string?)null
+            }
+        };
+
+        await serviceBus.PublishAsync(TopicEntrada, evento, solicitudId.ToString());
+    }
+
+    private async Task<bool> EsperarTurnoMaterializadoAsync(
+        string empleadoId, DateOnly fecha, CancellationToken ct)
+    {
+        return await Polling.WaitUntilTrueAsync(async () =>
+        {
+            var response = await _client.GetAsync(
+                $"/api/control-horas/turnos-diarios/{empleadoId}/{fecha:yyyy-MM-dd}", ct);
+            return response.StatusCode == HttpStatusCode.OK;
+        }, Timeout);
+    }
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task DebeEstarDisponible_CuandoSeConsultaHealthCheck()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var response = await _client.GetAsync("/api/health", ct);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarTurnosDiarios_Retorna400_CuandoFaltaElParametroDesde()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        var response = await _client.GetAsync(
+            "/api/control-horas/turnos-diarios?hasta=2026-06-10", ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarTurnosDiarios_Retorna400_CuandoFaltaElParametroHasta()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        var response = await _client.GetAsync(
+            "/api/control-horas/turnos-diarios?desde=2026-06-01", ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarTurnosDiarios_Retorna400_CuandoDesdeTieneFormatoInvalido()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        // Formato DD-MM-YYYY en vez de yyyy-MM-dd, mismo precedente que ObtenerTurnoDiario (#289).
+        var response = await _client.GetAsync(
+            "/api/control-horas/turnos-diarios?desde=01-06-2026&hasta=2026-06-10", ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarTurnosDiarios_Retorna400_CuandoHastaEsAnteriorADesde()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        // Rango invertido: decision documentada en FunctionEndpoint.cs (400, no lista vacia).
+        var desde = new DateOnly(2026, 6, 10);
+        var hasta = new DateOnly(2026, 6, 5);
+
+        var response = await _client.GetAsync(Ruta(desde, hasta), ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarTurnosDiarios_Retorna200ConListaVacia_CuandoNoHayTurnoAsignadoParaEseEmpleado()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        // Arrange: empleadoId nuevo, nunca creado por ningun test -- no puede tener turno asignado.
+        var empleadoId = Guid.CreateVersion7().ToString();
+        var desde = new DateOnly(2026, 6, 1);
+        var hasta = new DateOnly(2026, 6, 5);
+
+        var response = await _client.GetAsync(Ruta(desde, hasta, empleadoId), ct);
+
+        // Assert: CA-5 -- 200 con turnos: [], nunca 404. CA-4 -- rango dentro de la cota, sin recorte.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var respuesta = await response.Content.ReadFromJsonAsync<ListaTurnosDiariosSmoke>(
+            JsonOptions, cancellationToken: ct);
+
+        respuesta.Should().NotBeNull();
+        respuesta!.Turnos.Should().BeEmpty();
+        respuesta.DesdeAplicado.Should().Be(desde);
+        respuesta.HastaAplicado.Should().Be(hasta);
+        respuesta.RangoRecortado.Should().BeFalse();
+    }
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarTurnosDiarios_Retorna200ConElTurnoDelEmpleado_CuandoSeConsultaPorRangoYEmpleado()
+    {
+        // Forma (b) del issue: "la programacion de Juan de esta semana" -- empleadoId + desde/hasta.
+        Assert.SkipWhen(!serviceBus.IsConfigured,
+            "ServiceBus no configurado. Usa appsettings.local.json o variable ServiceBus__ConnectionString.");
+
+        var ct = TestContext.Current.CancellationToken;
+
+        var solicitudId = Guid.CreateVersion7();
+        var empleadoId = Guid.CreateVersion7().ToString();
+        var fechaTurno = new DateOnly(2026, 6, 10);
+        var desde = new DateOnly(2026, 6, 1);
+        var hasta = new DateOnly(2026, 6, 15); // 15 dias, dentro de la cota de 31
+
+        await PublicarTurnoAsync(solicitudId, empleadoId, fechaTurno, "[TEST] Turno Listar Rango");
+
+        // Act + Assert: reintentar el GET hasta que la proyeccion asincrona materialice la vista.
+        var ruta = Ruta(desde, hasta, empleadoId);
+        var respuesta = await Polling.WaitUntilAsync(async () =>
+        {
+            var response = await _client.GetAsync(ruta, ct);
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+            var body = await response.Content.ReadFromJsonAsync<ListaTurnosDiariosSmoke>(
+                JsonOptions, cancellationToken: ct);
+            return body is { Turnos.Count: > 0 } ? body : null;
+        }, Timeout);
+
+        // Assert: CA-4 -- rango dentro de la cota, sin recorte. Filtrado por empleadoId (GUID unico
+        // de esta ejecucion), asi que la lista contiene exactamente el turno sembrado, nunca por
+        // posicion.
+        respuesta.DesdeAplicado.Should().Be(desde);
+        respuesta.HastaAplicado.Should().Be(hasta);
+        respuesta.RangoRecortado.Should().BeFalse();
+        respuesta.Turnos.Should().ContainSingle();
+
+        var turno = respuesta.Turnos[0];
+        turno.Fecha.Should().Be(fechaTurno);
+        turno.UltimaSolicitudId.Should().Be(solicitudId);
+        turno.Empleado.EmpleadoId.Should().Be(empleadoId);
+        turno.DetalleTurno.Nombre.Should().Be("[TEST] Turno Listar Rango");
+    }
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarTurnosDiarios_IncluyeElTurnoDelEmpleado_CuandoSeConsultaUnDiaConTodosLosEmpleados()
+    {
+        // Forma (c) del issue: "quien trabaja hoy y en que turno" -- desde == hasta, SIN empleadoId.
+        Assert.SkipWhen(!serviceBus.IsConfigured,
+            "ServiceBus no configurado. Usa appsettings.local.json o variable ServiceBus__ConnectionString.");
+
+        var ct = TestContext.Current.CancellationToken;
+
+        var solicitudId = Guid.CreateVersion7();
+        var empleadoId = Guid.CreateVersion7().ToString();
+        var fecha = new DateOnly(2026, 6, 20);
+
+        await PublicarTurnoAsync(solicitudId, empleadoId, fecha, "[TEST] Turno Listar Dia");
+
+        // Sin empleadoId: la lista puede incluir turnos de otras ejecuciones de esta misma suite
+        // (sin cleanup, GUIDs unicos por corrida) -- se filtra siempre por SolicitudId, nunca por
+        // posicion/indice.
+        var ruta = Ruta(fecha, fecha);
+        var respuesta = await Polling.WaitUntilAsync(async () =>
+        {
+            var response = await _client.GetAsync(ruta, ct);
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+            var body = await response.Content.ReadFromJsonAsync<ListaTurnosDiariosSmoke>(
+                JsonOptions, cancellationToken: ct);
+            var contieneElTurno = body?.Turnos.Any(t => t.UltimaSolicitudId == solicitudId) ?? false;
+            return contieneElTurno ? body : null;
+        }, Timeout);
+
+        // Assert: CA-4 -- un dia (desde == hasta) esta muy por debajo de la cota, sin recorte.
+        respuesta.DesdeAplicado.Should().Be(fecha);
+        respuesta.HastaAplicado.Should().Be(fecha);
+        respuesta.RangoRecortado.Should().BeFalse();
+
+        var turno = respuesta.Turnos.Single(t => t.UltimaSolicitudId == solicitudId);
+        turno.Empleado.EmpleadoId.Should().Be(empleadoId);
+        turno.DetalleTurno.Nombre.Should().Be("[TEST] Turno Listar Dia");
+    }
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarTurnosDiarios_RecortaHaciaAdelanteYExcluyeLoQueQuedaFuera_CuandoElRangoExcedeLaCotaDe31Dias()
+    {
+        // Forma (d) del issue: "la grilla del mes", pero pedida sobre un rango que excede la cota
+        // (CA-3) -- se verifica que el recorte SI restringe la consulta, no solo que se declara en
+        // el envelope.
+        Assert.SkipWhen(!serviceBus.IsConfigured,
+            "ServiceBus no configurado. Usa appsettings.local.json o variable ServiceBus__ConnectionString.");
+
+        var ct = TestContext.Current.CancellationToken;
+
+        var empleadoId = Guid.CreateVersion7().ToString();
+        var desde = new DateOnly(2026, 7, 1);
+        var hastaSolicitado = new DateOnly(2026, 9, 30); // ~91 dias, muy por encima de la cota
+        var hastaAplicadaEsperada = desde.AddDays(30); // CA-3: cota de 31 dias inclusive
+
+        var solicitudDentro = Guid.CreateVersion7();
+        var solicitudFuera = Guid.CreateVersion7();
+        var fechaDentro = desde; // dentro del rango recortado
+        var fechaFuera = hastaAplicadaEsperada.AddDays(5); // dentro de lo pedido, fuera del recorte
+
+        await PublicarTurnoAsync(solicitudDentro, empleadoId, fechaDentro, "[TEST] Turno Dentro De La Cota");
+        await PublicarTurnoAsync(solicitudFuera, empleadoId, fechaFuera, "[TEST] Turno Fuera De La Cota");
+
+        // Espera a que AMBAS vistas esten materializadas antes de verificar el recorte: si no
+        // esperaramos, la ausencia de "fuera" podria deberse a lag asincrono y no al recorte mismo.
+        var dentroMaterializado = await EsperarTurnoMaterializadoAsync(empleadoId, fechaDentro, ct);
+        dentroMaterializado.Should().BeTrue(
+            $"la vista de {empleadoId} en {fechaDentro} deberia materializarse dentro del timeout");
+
+        var fueraMaterializado = await EsperarTurnoMaterializadoAsync(empleadoId, fechaFuera, ct);
+        fueraMaterializado.Should().BeTrue(
+            $"la vista de {empleadoId} en {fechaFuera} deberia materializarse dentro del timeout");
+
+        var response = await _client.GetAsync(Ruta(desde, hastaSolicitado, empleadoId), ct);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var respuesta = await response.Content.ReadFromJsonAsync<ListaTurnosDiariosSmoke>(
+            JsonOptions, cancellationToken: ct);
+        respuesta.Should().NotBeNull();
+
+        // Assert: CA-3 -- recorte SIEMPRE hacia adelante desde `desde`.
+        respuesta!.DesdeAplicado.Should().Be(desde);
+        respuesta.HastaAplicado.Should().Be(hastaAplicadaEsperada);
+        respuesta.RangoRecortado.Should().BeTrue();
+
+        // El turno dentro del rango recortado aparece; el que queda fuera NO, aunque su vista ya
+        // este materializada (verificado arriba) -- prueba que el recorte restringe la consulta.
+        respuesta.Turnos.Should().Contain(t => t.UltimaSolicitudId == solicitudDentro);
+        respuesta.Turnos.Should().NotContain(t => t.UltimaSolicitudId == solicitudFuera);
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/ComposicionServiciosTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/ComposicionServiciosTests.cs
@@ -34,6 +34,7 @@ using JasperFx.MultiTenancy; // TenancyStyle (NO Marten.*: vive en JasperFx.Mult
 using Marten;
 using Microsoft.Extensions.DependencyInjection;
 using ObtenerTurnoDiarioEndpoint = Bitakora.ControlAsistencia.ControlHoras.ObtenerTurnoDiario.FunctionEndpoint;
+using ListarTurnosDiariosEndpoint = Bitakora.ControlAsistencia.ControlHoras.ListarTurnosDiarios.FunctionEndpoint;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.Tests.Infraestructura;
 
@@ -241,5 +242,27 @@ public class ComposicionServiciosTests
         mapping.TableName.QualifiedName.Should().Be("control_horas.mt_doc_turnodiarioview");
         mapping.TenancyStyle.Should().Be(TenancyStyle.Conjoined);
         mapping.IdMember.Name.Should().Be(nameof(TurnoDiarioView.Id));
+    }
+
+    // Issue #290 CA-7: test de composicion de la segunda Function GET del BC, hermano del de
+    // ObtenerTurnoDiario (#289 CA-7, comentario arriba) y de MEF-ADR-0029. Misma vista materializada
+    // TurnoDiarioView, ninguna proyeccion nueva -- solo una nueva superficie de consulta
+    // (session.Query en vez de session.LoadAsync). ActivatorUtilities.CreateInstance reproduce la
+    // activacion por tipo que hace el host de Azure Functions isolated worker, sin levantar el host
+    // real (Alt 1 de MEF-ADR-0029).
+    //
+    // Se prueba solo la RESOLUCION de IDocumentStore/ITenantResolver por constructor -- no el
+    // comportamiento de Run (parseo de desde/hasta/empleadoId, recorte de rango, session.Query y
+    // mapeo a ListaTurnosDiarios), que es responsabilidad de projection-implementer y del smoke test
+    // (CA-8), no de este guardrail de wiring.
+    [Fact]
+    public async Task AgregarServiciosControlHoras_ResuelveElEndpointDeListarTurnosDiarios_CuandoElContenedorEstaCompuesto()
+    {
+        await using var provider = ComponerServiceProvider();
+        await using var scope = provider.CreateAsyncScope();
+
+        var act = () => ActivatorUtilities.CreateInstance<ListarTurnosDiariosEndpoint>(scope.ServiceProvider);
+
+        act.Should().NotThrow();
     }
 }

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ListarTurnosDiarios/FunctionEndpointTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ListarTurnosDiarios/FunctionEndpointTests.cs
@@ -1,0 +1,82 @@
+// Issue #290 CA-2: validacion del borde HTTP de ListarTurnosDiarios (desde/hasta obligatorios y
+// con formato yyyy-MM-dd, rango invertido rechazado). Hasta este archivo, CA-2 solo estaba cubierto
+// por el smoke test contra dev -- que exige deploy y no corre en el CI del PR. Estos casos son los
+// unicos del endpoint que NO dependen de Marten: cortocircuitan antes de abrir la QuerySession, asi
+// que se prueban sobre el mismo FunctionEndpoint real que activa el host (precedente:
+// RegistrarMarcacionFunction/FunctionEndpointTests, mismo proyecto).
+//
+// El IDocumentStore y el ITenantResolver se pasan nulos a proposito: si un cambio futuro moviera la
+// apertura de la sesion ANTES de la validacion, estos tests se pondrian rojos -- que es exactamente
+// la senal que se quiere (validar el request antes de tocar la base de datos).
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.ControlHoras.ListarTurnosDiarios;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Tests.ListarTurnosDiarios;
+
+public class FunctionEndpointTests
+{
+    private static FunctionEndpoint Endpoint() => new(store: null!, tenantResolver: null!);
+
+    private static HttpRequest FakeHttpRequest(string queryString)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.QueryString = new QueryString(queryString);
+        return context.Request;
+    }
+
+    private static async Task<BadRequestObjectResult> EjecutarEsperandoBadRequest(string queryString)
+    {
+        var resultado = await Endpoint().Run(FakeHttpRequest(queryString), CancellationToken.None);
+
+        return resultado.Should().BeOfType<BadRequestObjectResult>().Subject;
+    }
+
+    [Fact]
+    public async Task ListarTurnosDiarios_Retorna400_CuandoFaltaElParametroDesde()
+    {
+        var resultado = await EjecutarEsperandoBadRequest("?hasta=2026-06-10");
+
+        // El mensaje nombra el parametro que falta: un cliente que recibe "400" a secas no sabe
+        // cual de los dos corregir.
+        resultado.Value.Should().BeOfType<string>().Which.Should().Contain("desde");
+    }
+
+    [Fact]
+    public async Task ListarTurnosDiarios_Retorna400_CuandoFaltaElParametroHasta()
+    {
+        var resultado = await EjecutarEsperandoBadRequest("?desde=2026-06-01");
+
+        resultado.Value.Should().BeOfType<string>().Which.Should().Contain("hasta");
+    }
+
+    [Fact]
+    public async Task ListarTurnosDiarios_Retorna400_CuandoDesdeTieneFormatoInvalido()
+    {
+        // dd-MM-yyyy en vez de yyyy-MM-dd, mismo caso que ObtenerTurnoDiario (#289).
+        var resultado = await EjecutarEsperandoBadRequest("?desde=01-06-2026&hasta=2026-06-10");
+
+        resultado.Value.Should().BeOfType<string>().Which.Should().Contain("yyyy-MM-dd");
+    }
+
+    [Fact]
+    public async Task ListarTurnosDiarios_Retorna400_CuandoHastaTieneFormatoInvalido()
+    {
+        var resultado = await EjecutarEsperandoBadRequest("?desde=2026-06-01&hasta=10-06-2026");
+
+        resultado.Value.Should().BeOfType<string>().Which.Should().Contain("hasta");
+    }
+
+    [Fact]
+    public async Task ListarTurnosDiarios_Retorna400_CuandoHastaEsAnteriorADesde()
+    {
+        // Rango invertido: decision documentada en FunctionEndpoint.cs (400, no lista vacia). El
+        // issue #290 lo dejo como "propuesta revisable" sin CA; este test congela la eleccion para
+        // que un cambio de contrato sea deliberado y no un efecto colateral.
+        var resultado = await EjecutarEsperandoBadRequest("?desde=2026-06-10&hasta=2026-06-05");
+
+        resultado.Value.Should().BeOfType<string>().Which.Should().Contain("anterior");
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ListarTurnosDiarios/RangoConsultaTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ListarTurnosDiarios/RangoConsultaTests.cs
@@ -1,0 +1,71 @@
+// Issue #290 CA-3/CA-4: logica pura de recorte del rango de ListarTurnosDiarios. Sin Marten, sin
+// Postgres, sin QuerySession -- funciona sobre DateOnly (skills/projections/read-apis.md: la cota
+// y el recorte son logica de la Function, no de la proyeccion, que no cambia en este issue). Cada
+// oraculo se arma a mano (MEF-ADR-0002): nunca se deriva ejecutando RangoConsulta.Recortar sobre
+// si mismo.
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.ControlHoras.ListarTurnosDiarios;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Tests.ListarTurnosDiarios;
+
+public class RangoConsultaTests
+{
+    [Fact]
+    public void Recortar_DevuelveHastaSinCambios_CuandoElRangoEstaDentroDeLaCotaDe31Dias()
+    {
+        var desde = new DateOnly(2026, 8, 1);
+        var hasta = new DateOnly(2026, 8, 10);
+
+        var resultado = RangoConsulta.Recortar(desde, hasta);
+
+        resultado.Should().Be(new RangoAplicado(new DateOnly(2026, 8, 10), false));
+    }
+
+    [Fact]
+    public void Recortar_DevuelveHastaSinCambios_CuandoElRangoEsExactamente31DiasInclusive()
+    {
+        // CA-4: 31 dias inclusive (desde + 30 dias) es el limite exacto de la cota, no la excede.
+        var desde = new DateOnly(2026, 8, 1);
+        var hasta = new DateOnly(2026, 8, 31);
+
+        var resultado = RangoConsulta.Recortar(desde, hasta);
+
+        resultado.Should().Be(new RangoAplicado(new DateOnly(2026, 8, 31), false));
+    }
+
+    [Fact]
+    public void Recortar_RecortaHaciaAdelanteDesdeDesde_CuandoElRangoExcedeLargamenteLaCotaDe31Dias()
+    {
+        var desde = new DateOnly(2026, 8, 1);
+        var hasta = new DateOnly(2026, 12, 31);
+
+        var resultado = RangoConsulta.Recortar(desde, hasta);
+
+        // CA-3: hastaAplicado = desde + 30 dias (31 dias inclusive), rangoRecortado: true. El
+        // recorte es hacia ADELANTE desde `desde` -- nunca hacia atras desde `hasta`.
+        resultado.Should().Be(new RangoAplicado(new DateOnly(2026, 8, 31), true));
+    }
+
+    [Fact]
+    public void Recortar_RecortaUnSoloDiaDeExceso_CuandoElRangoSuperaLaCotaPorUnSoloDia()
+    {
+        var desde = new DateOnly(2026, 8, 1);
+        var hasta = new DateOnly(2026, 9, 1); // 32 dias inclusive: un dia por encima de la cota
+
+        var resultado = RangoConsulta.Recortar(desde, hasta);
+
+        resultado.Should().Be(new RangoAplicado(new DateOnly(2026, 8, 31), true));
+    }
+
+    [Fact]
+    public void Recortar_DevuelveElMismoDia_CuandoDesdeYHastaCoincidenFormaUnDiaTodos()
+    {
+        // Forma (c) del issue: "quien trabaja hoy y en que turno" -- desde == hasta.
+        var desde = new DateOnly(2026, 8, 5);
+
+        var resultado = RangoConsulta.Recortar(desde, desde);
+
+        resultado.Should().Be(new RangoAplicado(desde, false));
+    }
+}


### PR DESCRIPTION
## Resumen

Pipeline TDD completado:
- Fase roja: tests escritos con stubs
- Fase verde: implementación completa
- Smoke tests: escritos para endpoints detectados
- Fase refactor: revisión de calidad

## Decisiones del pipeline

<details>
<summary>Projection Test Writer (fase roja) — 7m 7s</summary>

# Resumen -- projection-test-writer (issue #290, fase roja)

## Contexto

Issue #290 depende de #289 (ya mergeado, PR #292) y **no** materializa nada nuevo: reutiliza
`TurnoDiarioView`/`TurnoDiarioProjection` tal cual quedaron. El propio issue lo deja explicito
en "Capas de test esperadas": *"No hay unit tests de proyeccion nuevos ni ampliacion del
config-test: este issue no toca la proyeccion ni el seam del worker."*

## Tests creados

### 1. Unit tests de logica pura de recorte de rango (CA-3/CA-4)

`tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ListarTurnosDiarios/RangoConsultaTests.cs`

5 casos, cada uno con oraculo armado a mano (MEF-ADR-0002):

- `Recortar_DevuelveHastaSinCambios_CuandoElRangoEstaDentroDeLaCotaDe31Dias`
- `Recortar_DevuelveHastaSinCambios_CuandoElRangoEsExactamente31DiasInclusive` (limite exacto, CA-4)
- `Recortar_RecortaHaciaAdelanteDesdeDesde_CuandoElRangoExcedeLargamenteLaCotaDe31Dias` (CA-3)
- `Recortar_RecortaUnSoloDiaDeExceso_CuandoElRangoSuperaLaCotaPorUnSoloDia` (boundary +1)
- `Recortar_DevuelveElMismoDia_CuandoDesdeYHastaCoincidenFormaUnDiaTodos` (forma c del issue)

Deliberadamente **no** hay test para `hasta < desde` (rango invertido): el propio issue lo deja
"no cubierto por ningun CA a proposito... decidir en implementacion... Propuesta revisable" --
escribir un oraculo aqui seria inventar una regla que el issue explicitamente no fija.

### 2. Test de composicion del FunctionEndpoint GET (CA-7)

Agregado a `tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/ComposicionServiciosTests.cs`
(mismo archivo donde vive el guardrail hermano de `ObtenerTurnoDiario` del issue #289 -- no se crea
un archivo nuevo, se sigue el precedente ya establecido en este dominio):

- `AgregarServiciosControlHoras_ResuelveElEndpointDeListarTurnosDiarios_CuandoElContenedorEstaCompuesto`:
  `ActivatorUtilities.CreateInstance<ListarTurnosDiariosEndpoint>` sobre el contenedor real
  (`AgregarServiciosControlHoras`), sin infra desplegada -- hermano de MEF-ADR-0029. Prueba solo la
  RESOLUCION de `IDocumentStore`/`ITenantResolver` por constructor, no el comportamiento de `Run`.

### 3. NO se tocaron (por diseño del issue)

- `tests/Bitakora.ControlAsistencia.Projections.Tests/ControlHoras/TurnoDiarioProjectionTests.cs`
- `tests/Bitakora.ControlAsistencia.Projections.Tests/ConfiguracionMartenProjectionsTests.cs`

## Stubs minimos de compilacion creados

Todos en `src/Bitakora.ControlAsistencia.ControlHoras/ListarTurnosDiarios/` (feature folder nuevo,
naming.md: sin sufijo `Function`, un namespace por query):

- **`FunctionEndpoint.cs`**: `[Function("ListarTurnosDiarios")]`, `GET control-horas/turnos-diarios`
  (sin `{id}`, mismo segmento de recurso que `ObtenerTurnoDiario`), `AuthorizationLevel.Anonymous`.
  Constructor `(IDocumentStore store, ITenantResolver tenantResolver)` igual al de `ObtenerTurnoDiario`
  -- necesario para que el test de composicion (CA-7) tenga algo que resolver. `Run` es
  `throw new NotImplementedException()` con `_ = store; _ = tenantResolver;` previos (mismo patron
  que dejo el projection-test-writer de #289, para evitar CS9113 sobre el parametro de constructor
  primario sin lectura).
- **`ListaTurnosDiarios.cs`**: record plano del envelope de respuesta (`DesdeAplicado`,
  `HastaAplicado`, `RangoRecortado`, `Turnos: IReadOnlyList<TurnoDiarioRespuesta>`). Sin
  comportamiento propio -- reutiliza `TurnoDiarioRespuesta` de #289 (namespace `ObtenerTurnoDiario`),
  no se redeclara. Vive en el Function App, no en `ReadModels` (el issue lo aclara explicitamente:
  "NO es un read model").
- **`RangoConsulta.cs`**: `RangoAplicado` (record struct `HastaAplicado`/`RangoRecortado`) +
  `RangoConsulta.Recortar(DateOnly desde, DateOnly hasta)` con `CotaDias = 31` como constante
  publica. `Recortar` es el unico metodo con `throw new NotImplementedException()` -- es el que
  hace fallar los 5 tests de la seccion 1.

No se toco ningun `.csproj`: `ControlHoras` ya referencia `ReadModels` desde #289 (Marten,
`InformacionEmpleado`/`DetalleTurno`), y el globbing SDK-style recoge los archivos nuevos sin
declaracion explicita.

## Cobertura de criterios de aceptacion (fase roja)

| CA | Cubierto por | Nota |
|---|---|---|
| CA-1 | -- (implementacion) | Constructor del stub ya declara `IDocumentStore`/`ITenantResolver`; el `session.Query` real lo escribe projection-implementer. |
| CA-2 | -- (implementacion) | No hay unit test de parseo de query string en esta fase (ver "Desviaciones"). |
| CA-3 | `RangoConsultaTests` (2 casos) | Recorte hacia adelante, `rangoRecortado: true`. |
| CA-4 | `RangoConsultaTests` (2 casos, incl. limite exacto) | `rangoRecortado: false`. |
| CA-5 | -- (implementacion) | Omision de dias sin turno es logica de `Run`, no testeada en unit puro. |
| CA-6 | -- (implementacion) | `ListaTurnosDiarios` ya declara la forma sin `Id`; el mapeo real lo hace projection-implementer. |
| CA-7 | `ComposicionServiciosTests` (nuevo test) | Resolucion del `FunctionEndpoint` desde el contenedor real. |
| CA-8 | Fuera de alcance de este agente | Smoke test lo escribe `smoke-test-writer` en otra etapa del pipeline. |
| CA-9 | Verificado con `dotnet build` (ver abajo) | `dotnet test` no se corrio (se sabe que falla). |

## Verificacion de compilacion

- `dotnet build src/Bitakora.ControlAsistencia.ControlHoras/...csproj` -> 0 advertencias, 0 errores.
- `dotnet build tests/Bitakora.ControlAsistencia.ControlHoras.Tests/...csproj` -> 0 advertencias, 0 errores.
- `dotnet build ControlAsistencias.slnx` -> compilacion correcta (los 5 warnings reportados son
  preexistentes en `Programacion`/`Programacion.Tests`, no introducidos por este cambio).
- No se corrio `dotnet test` (instruccion explicita del rol: se sabe que `RangoConsultaTests`
  fallara por el `NotImplementedException` de `RangoConsulta.Recortar`).

## Desviaciones del plan del planner / decisiones de criterio

1. **Cobertura de "capas de test esperadas" que exceden el catalogo formal de mi rol.** El issue
   #290 lista tres capas de test ("Unit tests de la logica de recorte del rango", "Test de
   composicion de la Function GET", "Smoke test") y aclara que **no** hay unit tests de proyeccion
   nuevos ni ampliacion del config-test. Mi catalogo de responsabilidades ("Que escribes") nombra
   explicitamente solo unit tests de proyeccion, config-test del worker y composicion de la
   Function GET -- no menciona "logica pura de una Function GET" como categoria. Dado que
   `tdd-pipeline.sh` despacha a `projection-test-writer`/`projection-implementer` como el **unico**
   par de agentes de la fase roja/verde para un issue `tipo:projection` (no hay un `test-writer`
   adicional corriendo en paralelo sobre este mismo issue), decidi escribir tambien los tests de
   `RangoConsulta` -- de lo contrario esa capa de test explicitamente pedida por el issue quedaria
   sin autor. Se documenta aqui por transparencia (regla 6 del agente: autoridad para resolver
   contradicciones estructurales entre el issue y la doctrina del Skill).
2. **Ubicacion del test de composicion.** El Skill no fija un archivo concreto para "composicion de
   la Function GET"; se siguio el precedente ya sentado por el propio dominio en el issue #289
   (agregar el test a `ComposicionServiciosTests.cs` existente, junto al guardrail hermano de
   `ObtenerTurnoDiario`) en vez de crear un archivo nuevo, para no fragmentar el mismo tipo de
   guardrail en dos lugares distintos del mismo ensamblado.
3. **No se testeo el rango invertido (`hasta < desde`).** El issue lo marca explicitamente como "no
   cubierto por ningun CA a proposito" y deja la decision (400 vs lista vacia) a la implementacion.
   Escribir un test aqui equivaldria a prescribir una regla que el issue no fija -- se deja fuera de
   la fase roja a proposito, y projection-implementer debera documentar la eleccion que haga.
4. **No se creo ningun test unitario de parseo del query string (`desde`/`hasta`/`empleadoId` como
   `string`).** El issue marca ese punto como "Propuesta revisable" y depende de verificar
   empiricamente el binding de `DateOnly` en el modelo aislado de Functions (riesgo abierto de la
   investigacion del planner) -- verificacion que le corresponde a projection-implementer, no a
   esta fase. `RangoConsulta.Recortar` recibe `DateOnly` ya parseados, aislando la logica pura
   testeable de esa incertidumbre de infraestructura.

</details>

<details>
<summary>Projection Implementer (fase verde) — 7m 29s</summary>

# stage-2-projection-implementer -- issue #290

## Enfoque

Fase verde read-side sobre los archivos que dejo `projection-test-writer` en fase roja
(commit `c5f574b`). No se toco ningun test. Se implemento:

1. `RangoConsulta.Recortar` (`src/.../ListarTurnosDiarios/RangoConsulta.cs`): logica pura de
   recorte del rango de fechas. `hastaMaxima = desde.AddDays(CotaDias - 1)` (31 dias INCLUSIVE,
   CA-4); si `hasta` la excede, se recorta a `hastaMaxima` con `RangoRecortado = true` (CA-3).
   Siempre hacia adelante desde `desde`, nunca relativo a "hoy".
2. `FunctionEndpoint.Run` de `ListarTurnosDiarios` (`src/.../ListarTurnosDiarios/FunctionEndpoint.cs`):
   - Parsea `desde`/`hasta` del query string con `DateOnly.TryParseExact("yyyy-MM-dd")` (mismo
     patron que `ObtenerTurnoDiario` de #289) -- ausencia o formato invalido -> 400 (CA-2).
   - `empleadoId` opcional leido de `req.Query`.
   - Aplica `RangoConsulta.Recortar` (CA-3/CA-4).
   - Abre `store.QuerySession(tenantResolver.TenantId)` -- **nunca** un tenant de la request
     (MEF-ADR-0028, CA-1).
   - Compone la query en pasos (`IQueryable<TurnoDiarioView>` declarado explicitamente, no
     `var`, para permitir la reasignacion condicional del `Where` de `empleadoId`) sobre
     `session.Query<TurnoDiarioView>()` (via (a'), read-apis.md), sin proyeccion ni read model
     nuevos -- `TurnoDiarioView`/`TurnoDiarioProjection` de #289 no se tocaron.
   - `OrderBy(v => v.Fecha)` para un orden determinista de la lista.
   - Mapea cada `TurnoDiarioView` a `TurnoDiarioRespuesta` (el mismo DTO de #289, sin `Id`, CA-6)
     y arma el envelope `ListaTurnosDiarios` (`DesdeAplicado`, `HastaAplicado`, `RangoRecortado`,
     `Turnos`).
   - Nunca 404: sin resultados devuelve `200` con `turnos: []` (CA-5), porque la ausencia de
     `TurnoDiarioView` para un dia ya produce naturalmente ese hueco sin relleno.

No se toco el seam del worker (`ConfiguracionMartenProjectionsControlHoras`) ni la clase
`TurnoDiarioProjection`: este issue es solo superficie de consulta sobre una vista ya
materializada por #289, tal como indicaba el plan.

## Decisiones de diseno

- **Rango invertido (`hasta` < `desde`)**: el issue lo dejaba como "propuesta revisable", sin
  CA que lo cubriera. Se decidio devolver **400** ("El parametro 'hasta' no puede ser anterior a
  'desde'") en vez de una lista vacia -- coherente con el resto del contrato de validacion del
  endpoint (ausencia de `desde`/`hasta` -> 400) y evita esconder en silencio lo que casi siempre
  es un error del cliente.
- **Composicion de la query en pasos** (`IQueryable<TurnoDiarioView> query = ...; if (...) query =
  query.Where(...);`): adoptada la "propuesta revisable" del planner literalmente -- mas legible
  que anidar el filtro condicional de `empleadoId` dentro de una unica expresion LINQ.
- **Lectura manual de `req.Query`** en vez de confiar en binding automatico de query string a
  parametros del metodo: no hay precedente en el repo de model binding implicito de query string
  (los `HttpRequest req, string param` existentes en el codebase todos bindean parametros de
  *ruta*, no de query string), asi que se prefirio el camino explicito y ya usado en otros
  Function Apps del marco.
- **`OrderBy(v => v.Fecha)`**: no exigido por ningun CA explicito, pero necesario para que la
  respuesta sea deterministica (sin orden, Postgres no garantiza el orden de retorno de un scan).

## Verificacion empirica del "punto abierto" (read-apis.md, MEF-ADR-0035 seccion 4)

El issue #290 dejaba un riesgo abierto explicito de la investigacion del planner: *"Que Marten
traduzca `v.Fecha >= desde && v.Fecha <= hasta` a SQL no esta verificado"*. Se verifico
empiricamente antes de dar por buena la implementacion:

- Se levanto un contenedor Postgres 17 desechable via `docker run` (puerto local, sin tocar el
  repo) y un proyecto de consola aislado (`/tmp`, eliminado al terminar) referenciando
  `Marten 9.12.0` (la misma version que usa el worker).
- Se probo `session.Query<T>().Where(v => v.Fecha >= desde && v.Fecha <= hasta)` sobre un tipo con
  forma equivalente a `TurnoDiarioView` (con `DateOnly Fecha` y un `EmpleadoId` anidado): **si**
  traduce correctamente a SQL, tanto sola como compuesta con `v.Empleado.EmpleadoId == empleadoId`
  (igualdad de string anidada) y con `OrderBy(v => v.Fecha)` subsiguiente.
- Conclusion: el riesgo abierto **queda cerrado** para Marten 9.12.0. No hizo falta ningun
  workaround (comparar sobre el `Id` del documento o cambiar el tipo expuesto en la vista).
- El contenedor y el proyecto de verificacion se destruyeron al terminar -- no dejan rastro en el
  repo ni en el historial de Docker local.
- Sobre el otro punto abierto de MEF-ADR-0035 seccion 4/read-apis.md (si el `IDocumentStore` del
  write-side necesita registro adicional para resolver `TView`): ya estaba cerrado desde #289 (el
  comentario del `.csproj` documenta que `FindOrResolveDocumentType` converge sin registro
  explicito adicional), y esta implementacion lo reconfirma: `session.Query<TurnoDiarioView>()`
  no requirio ningun cambio en `ComposicionServicios.cs`.

## ADRs consultados

- MEF-ADR-0035 (doctrina read-side) y `skills/projections/read-apis.md` -- via (a') filtro/lista,
  patron de sesion tenant-scoped, punto abierto del registro de `TView`.
- MEF-ADR-0028 -- `QuerySession` acotada al tenant de `ITenantResolver`, nunca a un tenant de la
  request.
- MEF-ADR-0006 y `skills/projections/naming.md` -- naming `Listar{X}s`, verbo HTTP explicito, un
  namespace por query.
- MEF-ADR-0029 -- test de composicion ya escrito por `projection-test-writer`
  (`ComposicionServiciosTests`), no modificado.
- MEF-ADR-0034 -- confirmado que no se toca el seam del worker ni la proyeccion existente.

## Desviaciones

Ninguna desviacion consciente de un ADR, del Skill o del plan del planner. Las dos decisiones de
diseno documentadas arriba (rango invertido -> 400, composicion de la query en pasos) estaban
explicitamente marcadas como "propuesta revisable" en el issue, no como una regla ya fijada.

## Resultado

- `dotnet build` de la solucion completa: **0 errores, 0 warnings nuevos** (los 4 warnings
  `NU1902` de `OpenTelemetry.Api` son preexistentes, no relacionados con este cambio).
- `dotnet test` de `Bitakora.ControlAsistencia.ControlHoras.Tests`: **349/349 verde**, incluye los
  5 tests de `RangoConsultaTests` (CA-3/CA-4) y los 8 de `ComposicionServiciosTests` (incluido el
  nuevo `AgregarServiciosControlHoras_ResuelveElEndpointDeListarTurnosDiarios_...`, CA-7).
- `dotnet test` de toda la solucion: **586 correctos, 9 omitidos (Postgres/ServiceBus locales no
  configurados, esperado), 1 con error**. Ese unico error
  (`ObtenerTurnoDiarioSmokeTests.ObtenerTurnoDiario_Retorna404_...`, esperaba 404 y recibio 500) es
  un smoke test **preexistente de #289** contra el entorno dev desplegado -- se confirmo que falla
  identicamente con `git stash` aplicado (es decir, sin ninguno de los cambios de este issue), asi
  que es un problema del entorno dev fuera del alcance de este issue, no una regresion introducida
  aqui.
- No se creo ningun smoke test para `ListarTurnosDiarios` (CA-8 del issue): `projection-test-writer`
  no dejo ese archivo en su lista de entregables de fase roja, y esta tarea es estrictamente hacer
  pasar los tests ya escritos, no escribir tests nuevos.
- Formateo: MCP de JetBrains no disponible (IDE no abierto); se uso `dotnet format` sobre los dos
  archivos tocados, sin cambios adicionales de formato.

</details>
<details>
<summary>Smoke Test Writer — 6m 10s</summary>

_(El agente no generó resumen)_

</details>
<details>
<summary>Reviewer (fase refactor) — 12m 21s</summary>

## ES Reviewer - Revision

### Evaluacion general
- Calidad: **buena**
- Cambios realizados: **si** (commit `2827ded`)

El diff de #290 es una superficie de consulta pura sobre una vista ya materializada por #289. No
toca el worker, ni la proyeccion, ni el seam de composicion read-side, tal como el issue pedia. La
doctrina read-side esta bien aplicada. Los hallazgos son de cobertura y elegancia, mas un riesgo
heredado de #289 que se escala al final.

### Cumplimiento de ADRs aplicables

| ADR | Cumplimiento | Observacion |
|---|---|---|
| MEF-ADR-0035: doctrina read-side | ok | Via (a') `session.Query<TurnoDiarioView>()` (LINQ) sobre `QuerySession`, exactamente la fila de la tabla de read APIs canonicas para filtro/lista. No se usa `FetchLatest` ni se abre `LightweightSession`. Read model sin cambios (record plano en `ReadModels`, sin `partial`), clase de proyeccion companion intacta en el worker. |
| MEF-ADR-0006 (enmienda #363) / `naming.md` | ok | `ListarTurnosDiarios` con el plural real del español en ambas palabras; feature folder propio sin sufijo `Function`; clase `FunctionEndpoint`; `Route = "control-horas/turnos-diarios"` explicito y verbo `"get"` declarado. Reutiliza el segmento de recurso de `ObtenerTurnoDiario`, como manda `naming.md`. El caso "NO VERIFICADO" de plantilla identica con verbos disjuntos **no aplica**: verificado que la unica Function HTTP previa del dominio es `RegistrarMarcacion` sobre `control-horas/marcaciones` con `"post"` explicito. |
| MEF-ADR-0028 / CA-ADR-0027: tenancy | ok | `store.QuerySession(tenantResolver.TenantId)`. Ningun `tenantId` se lee del query string; `empleadoId`/`desde`/`hasta` si vienen del request y son el filtro del recurso, no el tenant. Mitigacion BOLA/IDOR intacta. |
| MEF-ADR-0029: test de composicion | ok | `AgregarServiciosControlHoras_ResuelveElEndpointDeListarTurnosDiarios_...` sobre el contenedor real via `ActivatorUtilities.CreateInstance`, hermano del de #289, sin infra desplegada (Alt 1 del ADR). |
| MEF-ADR-0018: Rule of Three | ok | Sin paginacion, sin tope de resultados, sin indice sobre `Fecha`. El envelope deja el seam para agregarlos sin breaking change, que es justamente lo que el ADR sostiene. |
| MEF-ADR-0013: smoke tests contra dev | ok | Cubren las tres formas (b), (c), (d) + validacion + lista vacia, con `Polling` acotado y `Assert.SkipWhen` donde corresponde. Ver "Convenciones del pipeline". |
| MEF-ADR-0016: naming de tests | **desviacion NO declarada -- corregida** | El smoke test nuevo traia `DebeEstarDisponible_CuandoSeConsultaHealthCheck` (prefijo `Debe...`, proscrito). Eliminado (ver "Desviaciones detectadas"). El resto de los tests nuevos cumple `<Sujeto>_<LoQuePasa>_Cuando<Condicion>`. |
| MEF-ADR-0034: worker de proyecciones | ok | Confirmado que el diff no toca `ConfiguracionMartenProjectionsControlHoras`, `TurnoDiarioProjection`, ni `TurnoDiarioView`. Los tests del worker no se modificaron. La serializacion entre `tipo:projection` que exigia el ADR se respeto (#290 fue despues de #289). |
| MEF-ADR-0012: estilo de modelado | ok | Ver checklist de antipatrones abajo. |

Checklist explicito de antipatrones de MEF-ADR-0012 (recorrido item por item sobre el diff):

1. **Propiedad publica nueva en VO/aggregate consumida solo por un servicio externo**: no hay. Ningun VO ni aggregate del dominio se modifico.
2. **Clase estatica que opera sobre datos crudos de un VO/aggregate**: `RangoConsulta` es estatica, pero opera sobre `DateOnly` primitivos que llegan del query string -- no sobre el estado interno de ningun VO ni aggregate. Es politica de borde HTTP (la cota de la consulta), no logica de dominio extraida de un objeto. No aplica la proscripcion.
3. **Getter expuesto solo para tests**: no hay. Los tests nuevos verifican comportamiento (`IActionResult` devuelto, `RangoAplicado` retornado), no estado interno.
4. **`InternalsVisibleTo` hacia dominio**: no hay.
5. **`[JsonConstructor]` en ctor privado**: no hay. Ningun tipo nuevo requiere serializacion custom.
6. **`record` con `IReadOnlyList<T>` en la igualdad**: `ListaTurnosDiarios` lo tiene (`Turnos`). Evaluado y **no es hallazgo**: es un DTO de respuesta HTTP que solo se serializa -- nunca se compara por igualdad, ni se persiste, ni cruza el bus. La proscripcion apunta a VOs cuya igualdad estructural es parte del contrato.
7. **Evento con marker de bus cargando modelo rico**: no hay eventos nuevos en el diff. `IPrivateEvent`/`IPublicEvent` no se tocan.

### Desviaciones de ADRs

**Desviaciones declaradas por el implementer** (`stage-2-projection-implementer.md`): el resumen dice
explicitamente *"Ninguna desviacion consciente de un ADR, del Skill o del plan del planner"*. Las dos
decisiones de diseno que registra (rango invertido -> 400; composicion de la query en pasos) estaban
marcadas como **"Propuesta revisable"** en el issue, asi que no son desviaciones sino elecciones que
el plan delegaba.

- **Rango invertido -> 400**: **aceptable**. Es coherente con el resto del contrato de validacion del
  endpoint y evita confundir "no hay datos" con "pediste un rango imposible". Se congelo con un test
  en CI (antes solo estaba en el smoke test).
- **Composicion de la query en pasos**: **aceptable**. Es literalmente lo que el issue propuso como
  alternativa valida; el `IQueryable<TurnoDiarioView>` explicito es necesario para la reasignacion
  condicional y esta comentado.

**Desviaciones detectadas por el reviewer (NO declaradas por el implementer)**:

#### Desviacion: MEF-ADR-0016 (convencion de naming de tests)
- **Regla del ADR**: `<Sujeto>_<LoQuePasa>[_Cuando<Condicion>]`; el prefijo `Debe...` esta proscrito.
- **Desviacion encontrada en el diff**: `ListarTurnosDiariosSmokeTests.DebeEstarDisponible_CuandoSeConsultaHealthCheck`
  (test nuevo, escrito por `smoke-test-writer` copiando el precedente de `ObtenerTurnoDiarioSmokeTests`).
- **Accion tomada**: **corregida en refactor** -- el test se elimino en vez de renombrarse, porque era
  ademas triplemente redundante: `HealthSmokeTests.DebeEstarDisponible_...` ya existe como clase
  dedicada, y `ApiFixture.InitializeAsync` **ya falla la suite completa** si `/api/health` no responde
  200 antes de correr cualquier test. Ningun CA depende de el.
- **Status**: pendiente de evaluacion del usuario.

Nota de precedente: `ObtenerTurnoDiarioSmokeTests` (#289) tiene la misma duplicacion y el mismo
prefijo `Debe...`. **Precedente != autoridad**: no se replico aqui, pero tampoco se toco ese archivo
(fuera del alcance de este issue). Queda como deuda menor.

### Precedentes consultados por el implementer

| Precedente | ADR aplicable | Veredicto |
|---|---|---|
| `ObtenerTurnoDiario/FunctionEndpoint.cs` (#289) -- patron de sesion tenant-scoped y parseo de `DateOnly` | MEF-ADR-0035 §5, MEF-ADR-0028 | **alineado**. La `QuerySession` se abre con `tenantResolver.TenantId` y el `DateOnly` se parsea con formato explicito. |
| `ObtenerTurnoDiario/TurnoDiarioRespuesta.cs` reutilizado sin redeclarar | MEF-ADR-0018 (Rule of Three) | **alineado**. CA-6 pedia exactamente ese DTO; duplicarlo habria sido el error. |
| `ComposicionServiciosTests` como sede del test de composicion | MEF-ADR-0029 | **alineado**. Concentra los guardrails de wiring del dominio en un solo archivo. |
| `ObtenerTurnoDiarioSmokeTests` como plantilla del smoke test | MEF-ADR-0013, MEF-ADR-0016 | **alineado en estructura, VIOLA MEF-ADR-0016 en el health check duplicado**. Ver desviacion arriba: se corto la propagacion. |
| Verificacion empirica de la traduccion LINQ de `DateOnly` contra Postgres real | MEF-ADR-0035 §4 (punto abierto) | **alineado**. El issue marcaba ese riesgo como abierto y el implementer lo cerro empiricamente sin dejar rastro en el repo. Correcto: era el unico riesgo tecnico real del issue. |

### Convenciones del pipeline (no ADRs)

| Convencion | Estado | Observacion |
|---|---|---|
| Cada test con `Then()` + `And<>()` | n/a | No hay tests de command handler en este issue (es read-side puro). Los tests son de logica pura, composicion de DI y borde HTTP. |
| Overloads correctos para stream IDs compuestos | n/a | Sin `Given/When/Then` en el diff. |
| Fakes manuales (no NSubstitute) | ok | Cero NSubstitute. Los tests nuevos de borde HTTP usan `DefaultHttpContext` real y dependencias nulas explicitas (ver "Tests agregados"). |
| Feature folders (produccion y tests) | ok | `src/.../ListarTurnosDiarios/` y su espejo `tests/.../ListarTurnosDiarios/`. Un archivo por responsabilidad. |
| Smoke tests: SkipWhen, secrets, cobertura | ok | `Assert.SkipWhen(!serviceBus.IsConfigured, ...)` en los 3 tests que siembran por bus; `appsettings.json` con connection strings vacios; `smoke-tests-dominio.yml` inyecta `ServiceBus__ConnectionString`/`Postgres__ConnectionString`; aserciones filtradas siempre por `SolicitudId`/`empleadoId` unicos, nunca por posicion; un solo archivo por comando/query. **Sin suscripcion `smoke-tests` nueva que exigir**: este issue no publica a ningun topic, solo siembra en `programacion-turno-diario-solicitada` (ya provisionado desde #289) y lee por HTTP. |
| Proyecciones read-side: partial, inmutabilidad, read APIs, naming | ok | Nada que verificar sobre `partial`/inmutabilidad: la proyeccion y el read model no se tocan. Read API y naming: ver tabla de ADRs. |
| Tests via ToString/comportamiento | ok | No se expuso ningun getter para testear. |
| Sin numeros magicos | ok | `RangoConsulta.CotaDias = 31` con nombre y XML doc; `FormatoFecha = "yyyy-MM-dd"` como constante. El smoke test afirma la cota como literal (`desde.AddDays(30)`) a proposito, para no ser tautologico contra `CotaDias`. |
| Condiciones en positivo (guardas if/else afirmativas) | ok (corregido) | `TryLeerFecha` tenia la guarda compuesta en negativo (`!TryGetValue || !TryParseExact`) con el cuerpo de fallo primero; se invirtio a positivo. Los `if (!TryLeerFecha(...)) return ...` del `Run` se conservan: son guard clauses de early-return, la excepcion explicita de la regla. |

### Elegancia del codigo

El codigo llego en buen estado -- idiomatico, con comentarios que explican el *porque* y no el *que*.
Los ajustes fueron de compacidad y legibilidad, ninguno de correctitud:

- **Compacidad**: el parrafo de CA-1 sobre tenancy estaba duplicado casi palabra por palabra entre el
  comentario de cabecera de la clase y el comentario inline sobre `store.QuerySession`. Se dejo solo
  el inline (esta pegado al codigo que describe).
- **Legibilidad / idiomatismo**: `req.Query.TryGetValue("empleadoId", out var crudo) ? crudo.ToString() : null`
  -> `req.Query["empleadoId"].ToString()`. `StringValues` ya devuelve cadena vacia cuando el parametro
  no viene, asi que el ternario y el `string?` sobraban; el `string.IsNullOrEmpty` posterior sigue
  cubriendo ausente y vacio por igual. Mismo criterio en `TryLeerFecha`.
- **Legibilidad**: `TryLeerFecha` pasa de una guarda compuesta en negativo con asignacion defensiva
  (`fecha = default`) a una condicion en positivo con salida temprana en el fallo. Desaparece la
  asignacion defensiva y el cuerpo del metodo se lee en el orden en que ocurre.
- **Eficiencia**: sin hallazgos. El recorte se aplica **antes** del `Where`, asi que la cota de 31 dias
  restringe de verdad la consulta SQL en vez de filtrar en memoria -- que es lo que el issue pedia y
  lo que el smoke test de la forma (d) verifica. `OrderBy` va al servidor. No hay loops anidados ni
  N+1.
- **Robustez**: los tres caminos de 400 estan antes de abrir la sesion, asi que un request invalido
  nunca toca la base de datos. No hay `catch` vacios ni swallowing.
- **Limpieza**: 0 warnings nuevos del compilador; sin `Console.WriteLine`, sin codigo comentado, sin
  usings sobrantes en los archivos nuevos; ningun caracter U+2500.

### Criticas y hallazgos

1. **[mayor -- corregido] CA-2 sin ninguna cobertura en el CI del PR.** La validacion de
   `desde`/`hasta` (obligatorios, formato, rango invertido) solo estaba cubierta por smoke tests, y
   `ci.yml` corre unicamente `tests/Bitakora.ControlAsistencia.*.Tests/` -- los `*.SmokeTests` se
   ejecutan post-deploy en `smoke-tests-dominio.yml`. Es decir: un PR podia romper CA-2 y pasar el
   CI en verde. **Corregido**: se agrego `ListarTurnosDiarios/FunctionEndpointTests.cs` con los cinco
   casos de 400. No cae en el carve-out del endpoint GET frente al coverage gate (#371): ese carve-out
   cubre endpoints que *solo delegan* a `LoadAsync`/`Query`, y este tiene logica de validacion propia.

2. **[menor -- corregido] El smoke test del recorte dependia de otra Function.**
   `EsperarTurnoMaterializadoAsync` sensaba la materializacion llamando a `ObtenerTurnoDiario` (#289),
   asi que el veredicto de un test de #290 quedaba atado a la salud de un endpoint ajeno -- y hoy ese
   endpoint esta devolviendo 500 en dev (hallazgo 5). **Corregido**: ahora sensa con el propio
   `ListarTurnosDiarios` sobre un rango de un solo dia (`desde == hasta`), que nunca activa el recorte,
   asi que la espera sigue siendo independiente de lo que se quiere probar.

3. **[menor -- corregido] Health check triplicado y con naming proscrito.** Ver "Desviaciones
   detectadas".

4. **[cosmetico -- no corregido] `RangoConsulta` (estatica) + `RangoAplicado` (record struct) son dos
   tipos para un concepto.** Un solo `readonly record struct RangoConsulta(DateOnly Desde, DateOnly Hasta, bool Recortado)`
   con la factoria dentro haria el mapeo al envelope 1:1 (hoy el `Run` mezcla `desde` suelto con
   `rangoAplicado.HastaAplicado`). **No se aplico**: obligaria a reescribir los oraculos de
   `RangoConsultaTests`, que son tests de la fase roja, y el diseno actual no viola ningun ADR ni
   dificulta la lectura. Queda anotado por si un issue futuro toca esta superficie.

5. **[mayor -- fuera del alcance de este diff, se escala] `ObtenerTurnoDiario` devuelve 500 en dev
   donde deberia devolver 404.** `ObtenerTurnoDiarioSmokeTests.ObtenerTurnoDiario_Retorna404_...`
   falla contra dev con `InternalServerError`; el test hermano de formato invalido **si** pasa, lo que
   confirma que la ruta esta desplegada y que lo que revienta es el
   `session.LoadAsync<TurnoDiarioView>` sobre el store del write-side. El implementer verifico con
   `git stash` que falla identico sin los cambios de #290, asi que **no es una regresion de este
   issue**. Pero es un riesgo directo para #290: si la causa raiz es que el write-side no puede
   resolver la tabla `control_horas.mt_doc_turnodiarioview` en dev (tabla aun no creada por el worker,
   o `AutoCreateSchemaObjects` restrictivo con `builder.Environment.IsDevelopment() == false` en el
   deploy), entonces `session.Query<TurnoDiarioView>()` fallara igual y **CA-5 devolvera 500 en vez de
   200 con `[]` despues del deploy**. Es exactamente el "punto abierto" que MEF-ADR-0035 §4 dejo para
   el implementador, y el guardrail de composicion (`...ResuelveTurnoDiarioViewSobreLaTablaQueMaterializaElWorker...`)
   no lo cubre porque no abre conexion a Postgres.
   **Recomendacion**: abrir issue de bug (`/bug`) sobre el 500 de `ObtenerTurnoDiario` en dev, y **leer
   el veredicto de los smoke tests de #290 despues del deploy antes de cerrar el issue** -- si
   `ListarTurnosDiarios_Retorna200ConListaVacia_...` devuelve 500, es el mismo defecto, no un defecto
   de este PR.

6. **[informativo] `dotnet format --verify-no-changes` sale con codigo 2**, por 9 diagnosticos IDE0005
   (usings innecesarios) en archivos **preexistentes y ajenos a este diff**
   (`DesgloseFranjaSerializacionTests`, `IntervaloTemporalSerializacionMartenTests`,
   `TurnoCreadoSerializacionTests`, etc.). Ninguno de los tres archivos tocados por este issue aparece
   en la lista. No se corrigieron: seria un refactor de codigo no relacionado con la HU.

### Refactorings aplicados

Cada uno con `dotnet test` verde inmediatamente despues; ninguno hubo que revertir.

1. `FunctionEndpoint.cs`: eliminado el parrafo de CA-1 duplicado en el header de clase.
2. `FunctionEndpoint.cs`: `req.Query["empleadoId"].ToString()` en lugar de `TryGetValue` + ternario.
3. `FunctionEndpoint.cs`: `TryLeerFecha` reescrito con la condicion en positivo, sin `fecha = default`
   defensivo, con el mensaje de error explicado en un comentario (ausente y mal formado comparten 400
   a proposito).
4. `ListarTurnosDiariosSmokeTests.cs`: `EsperarTurnoMaterializadoAsync` -> `EsperarTurnoEnLaListaAsync`,
   que sensa sobre el propio endpoint y ademas filtra por `SolicitudId` (antes solo miraba el status
   code, asi que un turno de otra corrida en la misma fecha lo habria dado por materializado).
5. `ListarTurnosDiariosSmokeTests.cs`: eliminado el health check duplicado; agregada al header la nota
   de "rojos hasta el deploy" que el precedente de #289 si documenta y este archivo omitia -- importa
   para leer bien el CI.

### Cobertura de criterios de aceptacion

| Criterio | Estado | Test(s) |
|---|---|---|
| CA-1: Function `ListarTurnosDiarios` (GET, Anonymous) con `session.Query` sobre `QuerySession` acotada al tenant de `ITenantResolver` | cubierto | `AgregarServiciosControlHoras_ResuelveElEndpointDeListarTurnosDiarios_CuandoElContenedorEstaCompuesto` (resolucion real de `IDocumentStore`/`ITenantResolver`); el uso del tenant resuelto es verificable por lectura del codigo -- no hay superficie para falsificarlo desde el request |
| CA-2: `desde`/`hasta` obligatorios -> 400; `empleadoId` opcional | cubierto (reforzado en esta fase) | `ListarTurnosDiarios_Retorna400_CuandoFaltaElParametroDesde`, `..._CuandoFaltaElParametroHasta`, `..._CuandoDesdeTieneFormatoInvalido`, `..._CuandoHastaTieneFormatoInvalido`, `..._CuandoHastaEsAnteriorADesde` (unit, CI) + los homonimos del smoke test. `empleadoId` opcional: `ListarTurnosDiarios_IncluyeElTurnoDelEmpleado_CuandoSeConsultaUnDiaConTodosLosEmpleados` (ausente) vs `..._CuandoSeConsultaPorRangoYEmpleado` (presente) |
| CA-3: rango > 31 dias se recorta hacia adelante, 200, `hastaAplicado = desde + 30`, `rangoRecortado: true` | cubierto | `Recortar_RecortaHaciaAdelanteDesdeDesde_CuandoElRangoExcedeLargamenteLaCotaDe31Dias`, `Recortar_RecortaUnSoloDiaDeExceso_CuandoElRangoSuperaLaCotaPorUnSoloDia` + `ListarTurnosDiarios_RecortaHaciaAdelanteYExcluyeLoQueQuedaFuera_CuandoElRangoExcedeLaCotaDe31Dias` (verifica que el recorte **restringe la consulta**, no solo que se declara en el envelope) |
| CA-4: rango dentro de la cota -> `desdeAplicado`/`hastaAplicado` = lo pedido, `rangoRecortado: false` | cubierto | `Recortar_DevuelveHastaSinCambios_CuandoElRangoEstaDentroDeLaCotaDe31Dias`, `..._CuandoElRangoEsExactamente31DiasInclusive` (limite exacto), `Recortar_DevuelveElMismoDia_CuandoDesdeYHastaCoincidenFormaUnDiaTodos` + los tres smoke tests de camino feliz |
| CA-5: dias sin turno se omiten; sin resultados -> `[]` con 200, nunca 404 | cubierto | `ListarTurnosDiarios_Retorna200ConListaVacia_CuandoNoHayTurnoAsignadoParaEseEmpleado` (lista vacia con 200) y `..._CuandoSeConsultaPorRangoYEmpleado` (rango de 15 dias con 1 turno -> `ContainSingle`, que es la omision de huecos). **Sujeto al hallazgo 5**: el veredicto real se lee post-deploy |
| CA-6: cada elemento es `TurnoDiarioRespuesta` de #289, sin el `Id` | cubierto por construccion + smoke | `TurnoDiarioRespuesta` se reutiliza sin redeclarar y no tiene miembro `Id` -- garantia de compilacion. Los smoke tests deserializan sobre una forma local que tampoco lo tiene y afirman `Empleado`/`Fecha`/`DetalleTurno`/`UltimaSolicitudId` |
| CA-7: test de composicion de la Function | cubierto | `AgregarServiciosControlHoras_ResuelveElEndpointDeListarTurnosDiarios_CuandoElContenedorEstaCompuesto` |
| CA-8: smoke test de las tres formas con espera acotada | cubierto | Forma (b): `..._CuandoSeConsultaPorRangoYEmpleado`; forma (c): `..._CuandoSeConsultaUnDiaConTodosLosEmpleados`; forma (d) con recorte: `..._CuandoElRangoExcedeLaCotaDe31Dias`. Los tres con `Polling` de 30s y `Assert.SkipWhen` |
| CA-9: `dotnet build` sin errores ni warnings nuevos, `dotnet test` verde | cubierto con salvedad | Build: 0 errores, 0 warnings nuevos (los 4 `NU1902` de `OpenTelemetry.Api` y el `CS0414` de `CatalogoTurnos` son preexistentes). Tests: **591 correctos / 12 omitidos / 6 con error**, y los 6 son smoke tests contra dev -- 5 de `ListarTurnosDiarios` devolviendo 404 porque la Function aun no esta desplegada (identico al precedente documentado de #289) y 1 preexistente de `ObtenerTurnoDiario` (hallazgo 5). El CI del PR no corre `*.SmokeTests`, asi que la suite que si corre esta **100% verde** (354/354 en `ControlHoras.Tests`) |

### Tests agregados

- `tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ListarTurnosDiarios/FunctionEndpointTests.cs`
  (5 `[Fact]`): los cinco caminos de 400 del borde HTTP -- `desde` ausente, `hasta` ausente, `desde`
  mal formado, `hasta` mal formado y rango invertido. Ademas del status code, cada uno afirma que el
  mensaje nombra el parametro ofensor: es la clase de bug (copy/paste del literal `"desde"` en el
  chequeo de `"hasta"`) que un assert de solo status code deja pasar. `IDocumentStore` y
  `ITenantResolver` se pasan nulos **a proposito y documentado**: los cinco caminos cortocircuitan
  antes de abrir la sesion, asi que si alguien invierte ese orden en el futuro estos tests se ponen
  rojos -- que es exactamente la senal deseada. Precedente de estructura:
  `RegistrarMarcacionFunction/FunctionEndpointTests.cs`, mismo proyecto.
- Tests de contrato (igualdad / round-trip de serializacion): **no aplican**. El diff no introduce
  ningun `IEquatable<T>` ni ningun `ConfigurarSerializacion`; `ListaTurnosDiarios` y `RangoAplicado`
  son DTOs planos que viajan por el serializador por defecto del host.

</details>

## Cobertura

| Archivo | Cobertura | Umbral | Estado |
|---|---|---|---|
| FunctionEndpoint.cs | - | excluido | - |
| ListaTurnosDiarios.cs | - | excluido | - |
| RangoConsulta.cs | - | no evaluado | - |
## Commits

2827ded refactor(hu-290): cubre CA-2 en CI y simplifica el borde de ListarTurnosDiarios
8145945 test(hu-290): smoke tests para ListarTurnosDiarios
58dd1d9 feat(hu-290): proyeccion read-side para listar turnos diarios vigentes (fase verde)
c5f574b test(hu-290): tests read-side para listar los turnos diarios vigentes (fase roja)

Closes #290