### PR TITLE
Alinear la forma de mt_version del read-side de ControlHoras con la que materializa el worker

### DIFF
--- a/src/Bitakora.ControlAsistencia.ControlHoras/Infraestructura/ComposicionServicios.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Infraestructura/ComposicionServicios.cs
@@ -3,6 +3,7 @@ using Azure.Monitor.OpenTelemetry.Exporter;
 using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 using Bitakora.ControlAsistencia.PrivateEvents.ControlHoras;
 using Bitakora.ControlAsistencia.PublicEvents.ControlHoras;
+using Bitakora.ControlAsistencia.ReadModels.ControlHoras;
 using Cosmos.EventDriven.CritterStack;
 using Cosmos.EventDriven.CritterStack.AzureServiceBus;
 using Cosmos.EventSourcing.CritterStack;
@@ -75,6 +76,33 @@ public static class ComposicionServicios
             // mapping exista antes de la primera lectura, en vez de depender de que un append lo
             // haya poblado (issue #237 seccion "Consecuencia asumida").
             options.Events.AddEventTypes(IdentidadEventosControlHoras.TiposPersistidos);
+
+            // Issue #294: declara del lado LECTURA la forma de mt_version que el worker ya impuso
+            // del lado escritura -- el reverso del principio de #268, donde el worker replicaba lo
+            // que el write-side poseia. Aqui la tabla la posee la proyeccion, y este Function App
+            // solo la consulta (ObtenerTurnoDiario, ListarTurnosDiarios).
+            //
+            // Marten aplica ProjectionDocumentPolicy a todo documento que sea target de una
+            // proyeccion registrada en ese store: UseNumericRevisions = true, Metadata.Revision
+            // (mt_version bigint) habilitada y Metadata.Version (mt_version uuid) DESHABILITADA. No
+            // es opt-in ni depende de IRevisioned ni del lifecycle: la doc lo declara como la
+            // excepcion a que el versionado sea opt-in
+            // (https://martendb.io/documents/concurrency, "Numeric Revisioned Documents") y el
+            // codigo lo hace incondicional (Marten/Events/Projections/ProjectionDocumentPolicy.cs).
+            //
+            // El worker registra TurnoDiarioProjection, asi que creo mt_version como bigint. Este
+            // store NO la registra ni puede hacerlo -- TurnoDiarioProjection vive en el ensamblado
+            // del worker y referenciarlo violaria CA-ADR-0029 --, asi que sin esta linea esperaria
+            // mt_version uuid sobre la MISMA tabla fisica. Con AutoCreate en su default
+            // CreateOrUpdate el sintoma no es un 404: Marten intenta "alter column mt_version type
+            // uuid" en CADA request, Postgres lo rechaza con 42804 (no hay cast automatico
+            // bigint -> uuid) y los dos GET responden 500 de forma permanente. Eso fue lo que
+            // ocurrio en dev tras el deploy de #290.
+            //
+            // Se declara por documento y no via Policies para no alterar la forma de ningun otro
+            // documento de este store. El par de config-tests (este lado y el del worker) congela
+            // los mismos valores literales, que es la dimension que el par de #289 dejo abierta.
+            options.Schema.For<TurnoDiarioView>().UseNumericRevisions(true);
 
             if (options.Serializer() is Marten.Services.SystemTextJsonSerializer stj)
             {

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/ComposicionServiciosTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/ComposicionServiciosTests.cs
@@ -244,6 +244,43 @@ public class ComposicionServiciosTests
         mapping.IdMember.Name.Should().Be(nameof(TurnoDiarioView.Id));
     }
 
+    // Issue #294: la guarda de arriba pineaba tabla, tenancy e Id -- las tres convergian -- pero no
+    // la forma de la columna de version, y por ahi se colo el fallo. Marten aplica
+    // ProjectionDocumentPolicy a todo documento que sea target de una proyeccion REGISTRADA en ese
+    // store: le pone UseNumericRevisions = true, habilita Metadata.Revision (mt_version bigint) y
+    // DESHABILITA Metadata.Version (mt_version uuid). No es opt-in ni depende de IRevisioned ni del
+    // lifecycle -- la doc lo declara como la excepcion a que el versionado sea opt-in
+    // (https://martendb.io/documents/concurrency, "Numeric Revisioned Documents") y el codigo lo
+    // hace incondicional (Marten/Events/Projections/ProjectionDocumentPolicy.cs).
+    //
+    // El worker registra TurnoDiarioProjection, asi que crea mt_version como bigint. Este Function
+    // App NO la registra -- no puede: TurnoDiarioProjection vive en el ensamblado del worker y
+    // referenciarlo violaria CA-ADR-0029 -- asi que sin declaracion explicita esperaria mt_version
+    // uuid sobre la MISMA tabla. Con AutoCreate en su default CreateOrUpdate, Marten no devuelve un
+    // 404: intenta "alter column mt_version type uuid" en cada request, Postgres lo rechaza con
+    // 42804 (no hay cast automatico bigint -> uuid) y los dos GET responden 500 permanentemente.
+    // Eso es exactamente lo que ocurrio en dev tras el deploy de #290.
+    //
+    // Oraculo literal y espejo de ConfiguracionMartenProjectionsTests
+    // .ConfigurarControlHoras_MaterializaTurnoDiarioViewConRevisionNumerica, que congela los mismos
+    // cuatro valores desde el worker. Juntos cierran la dimension que el par anterior dejo abierta.
+    [Fact]
+    public async Task AgregarServiciosControlHoras_EsperaLaMismaColumnaDeVersionQueMaterializaElWorker_CuandoElContenedorEstaCompuesto()
+    {
+        await using var provider = ComponerServiceProvider();
+        await using var scope = provider.CreateAsyncScope();
+
+        var mapping = scope.ServiceProvider.GetRequiredService<IDocumentStore>()
+            .Options.FindOrResolveDocumentType(typeof(TurnoDiarioView));
+
+        // Las dos columnas comparten el nombre fisico mt_version y solo una puede estar habilitada:
+        // por eso el oraculo mide ambas. Medir solo Revision dejaria pasar el caso en que las dos
+        // queden activas, que es justo la divergencia que produjo el 500.
+        mapping.Metadata.Revision.Enabled.Should().BeTrue();
+        mapping.Metadata.Revision.Type.Should().Be("bigint");
+        mapping.Metadata.Version.Enabled.Should().BeFalse();
+    }
+
     // Issue #290 CA-7: test de composicion de la segunda Function GET del BC, hermano del de
     // ObtenerTurnoDiario (#289 CA-7, comentario arriba) y de MEF-ADR-0029. Misma vista materializada
     // TurnoDiarioView, ninguna proyeccion nueva -- solo una nueva superficie de consulta

--- a/tests/Bitakora.ControlAsistencia.Projections.Tests/ConfiguracionMartenProjectionsTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Projections.Tests/ConfiguracionMartenProjectionsTests.cs
@@ -328,6 +328,34 @@ public class ConfiguracionMartenProjectionsTests
         mapping.IdMember.Name.Should().Be(nameof(TurnoDiarioView.Id));
     }
 
+    // Issue #294, mitad worker de la dimension que el par de #289 dejo abierta: la guarda de arriba
+    // pinea tabla, tenancy e Id, y las tres convergian -- el 500 en dev entro por la forma de
+    // mt_version, que nadie media.
+    //
+    // Este lado NO declara nada para que estos valores sean asi: los impone Marten al registrar
+    // TurnoDiarioProjection, via ProjectionDocumentPolicy, sobre todo documento target de una
+    // proyeccion registrada en el store (https://martendb.io/documents/concurrency, "Numeric
+    // Revisioned Documents"; Marten/Events/Projections/ProjectionDocumentPolicy.cs). O sea que este
+    // es el lado que DEFINE la forma fisica de la tabla, y el write-side es el que debe replicarla.
+    // Por eso el oraculo se congela aqui tambien: si una version futura de Marten cambiara el tipo
+    // por defecto de Metadata.Revision, este test se pondria rojo junto con su hermano
+    // ComposicionServiciosTests.AgregarServiciosControlHoras_EsperaLaMismaColumnaDeVersionQueMaterializaElWorker...
+    // en vez de dejar que la divergencia llegue a dev como un 42804 por request.
+    [Fact]
+    public void ConfigurarControlHoras_MaterializaTurnoDiarioViewConRevisionNumerica()
+    {
+        using var provider = ProviderDeControlHoras();
+
+        var mapping = provider.GetRequiredService<IControlHorasProjectionStore>()
+            .Options.FindOrResolveDocumentType(typeof(TurnoDiarioView));
+
+        // Mismos literales que congela el write-side. Las dos columnas comparten el nombre fisico
+        // mt_version y solo una puede estar habilitada, de ahi que se midan ambas.
+        mapping.Metadata.Revision.Enabled.Should().BeTrue();
+        mapping.Metadata.Revision.Type.Should().Be("bigint");
+        mapping.Metadata.Version.Enabled.Should().BeFalse();
+    }
+
     // --- Seam de nivel BC (CA-4) ---
 
     // Las guardas de arriba invocan cada Configurar{Dominio} directamente, asi que quedan verdes


### PR DESCRIPTION
## Que arregla

Los 6 smoke tests de `ObtenerTurnoDiario` y `ListarTurnosDiarios` fallaban con **HTTP 500** contra dev, en los tres deploys consecutivos posteriores al merge de #288, #289 y #290. El 500 aparecia tambien en los casos que esperaban ausencia de datos, lo que descartaba un problema de datos o de proyeccion sin materializar.

Excepcion real (84 `Npgsql.PostgresException` en 4 horas, rol `func-asist-dev-control-horas`):

```
42804: column "mt_version" cannot be cast automatically to type uuid
  al ejecutar: alter table control_horas.mt_doc_turnodiarioview alter column mt_version type uuid;
```

Marten intentaba migrar el schema **en cada request** (`EnsureStorageExistsAsync`, dentro de `LoadAsync` y `ToListAsync`), Postgres rechazaba el cast y el request moria en 500.

El worker de proyecciones estaba **sano**: 10.966 eventos de telemetria, cero excepciones, y el shard `TurnoDiarioView:All` ejecutando updates durante los propios smoke tests.

## Causa raiz

Marten aplica `ProjectionDocumentPolicy` a todo documento que sea target de una proyeccion **registrada en ese store**: `UseNumericRevisions = true`, habilita `Metadata.Revision` (`mt_version bigint`) y **deshabilita** `Metadata.Version` (`mt_version uuid`). No es opt-in, no depende de `IRevisioned` ni del lifecycle.

- Doc: https://martendb.io/documents/concurrency ("Numeric Revisioned Documents") -- lo declara como la excepcion a que el versionado sea opt-in.
- Codigo: `Marten/Events/Projections/ProjectionDocumentPolicy.cs`.

Verificado empiricamente comparando el mapping de `TurnoDiarioView` en ambos stores (Marten 9.12.0), antes del fix:

| Propiedad | Worker (crea la tabla) | Function App (la lee) |
|---|---|---|
| `UseNumericRevisions` | `True` | `False` |
| `Metadata.Revision` -> `mt_version bigint` | `Enabled=True` | `Enabled=False` |
| `Metadata.Version` -> `mt_version uuid` | `Enabled=False` | `Enabled=True` |
| `TableName` | `control_horas.mt_doc_turnodiarioview` | igual |
| `TenancyStyle` | `Conjoined` | igual |

Misma columna fisica, tipos incompatibles. El worker registra `TurnoDiarioProjection` y crea `bigint`; el Function App no la registra y exigia `uuid`.

## Que cambia

Una linea de configuracion en `ComposicionServicios`, mas los comentarios que explican el mecanismo:

```csharp
options.Schema.For<TurnoDiarioView>().UseNumericRevisions(true);
```

Se declara **por documento** y no via `Policies` para no alterar la forma de ningun otro documento del store. No se registra la proyeccion en el store lector -- que seria la via mas robusta segun Marten -- porque `TurnoDiarioProjection` vive en el ensamblado del worker y referenciarlo violaria **CA-ADR-0029**.

Es el reverso del principio de #268: alli el worker replicaba lo que el write-side poseia; aqui la tabla la posee la proyeccion y el lado que consulta la replica.

Convergencia verificada tras el fix: `Metadata.Revision` habilitada y `bigint`, `Metadata.Version` deshabilitada, `UseNumericRevisions = True` -- identicas al worker.

## Por que el CI no lo atrapo, y que lo atrapa ahora

El riesgo estaba anticipado: existia un par de guardrails cruzados con el comentario *"que ambos lados converjan en la MISMA tabla fisica y la MISMA tenancy no lo garantiza ningun compilador"*. Comparaban `TableName`, `TenancyStyle` e `IdMember`, y las tres **convergian**. Ninguno comparaba la forma de la columna de version.

Este PR agrega la mitad que faltaba en **ambos** lados del par, congelando los mismos literales:

- `ComposicionServiciosTests.AgregarServiciosControlHoras_EsperaLaMismaColumnaDeVersionQueMaterializaElWorker_...`
- `ConfiguracionMartenProjectionsTests.ConfigurarControlHoras_MaterializaTurnoDiarioViewConRevisionNumerica`

El del worker pasa sin el fix (es Marten quien le impone esos valores) y actua como ancla: si una version futura de Marten cambiara el tipo por defecto de `Metadata.Revision`, los dos se ponen rojos juntos en el CI del PR en vez de dejar que la divergencia llegue a dev como un 42804 por request.

Es el mismo patron del issue #219, ya documentado en la cabecera de `ComposicionServiciosTests`: "el hueco solo se detecto DESPUES del deploy, en los smoke tests contra dev (HTTP 500 en toda funcion)".

## Verificacion

- `dotnet build ControlAsistencias.slnx --configuration Release`: 0 errores.
- Suite unitaria completa en Release: **572 tests, 0 fallos** (ControlHoras 355, Programacion 127, Projections 43, PrivateEvents 34, PublicEvents 13).
- Guarda nueva del write-side confirmada **roja antes** del fix (`Expected mapping.Metadata.Revision.Enabled to be True, but found False`) y **verde despues**.
- Convergencia de los dos mappings comprobada por inspeccion directa del `DocumentMapping` en ambos stores.

Los smoke tests contra dev (CA-2 del issue) **no se han ejecutado todavia**: corren en el workflow de deploy tras el merge a main. Son la verificacion pendiente de que el 500 desaparece en el entorno real.

## Limites conocidos

- **`UseVersionFromMatchingStream` sigue divergiendo** (worker `True`, write-side `False`). No genera columnas ni participa del DDL, y el write-side nunca escribe este documento -- solo lo consulta --, asi que es inocuo. Se dejo fuera del oraculo a proposito.
- **No se toco `AutoCreate`**, que sigue en su default `CreateOrUpdate` en todos los procesos. Es lo que convierte una divergencia de schema en un ALTER por request en vez de un fallo al arrancar. La recomendacion oficial de Marten para produccion es `AutoCreate.None` via `CritterStackDefaults` (https://martendb.io/configuration/optimized_artifact_workflow), pero eso afecta a todos los dominios y merece su propio issue -- no lo meto aqui.
- **La tabla en dev no necesita migracion**: ya existe con `mt_version bigint`, que es la forma correcta. El fix hace que el lector deje de pedir el cast; no hay datos que mover.

Closes #294
