### PR TITLE
Reconciliar la autenticacion de CI hacia Azure con la plantilla OIDC vigente del harness

### DIFF
--- a/.github/workflows/deploy-control-horas.yml
+++ b/.github/workflows/deploy-control-horas.yml
@@ -141,6 +141,9 @@ jobs:
     needs: [determinar-alcance, build-and-test]
     if: needs.determinar-alcance.outputs.debe_desplegar == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     outputs:
       sha: ${{ github.event.workflow_run.head_sha || github.sha }}
     steps:
@@ -181,7 +184,9 @@ jobs:
       - name: Azure Authentication
         uses: azure/login@v3
         with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Deploy to Azure Functions
         uses: Azure/functions-action@v1

--- a/.github/workflows/deploy-control-horas.yml
+++ b/.github/workflows/deploy-control-horas.yml
@@ -142,7 +142,12 @@ jobs:
     if: needs.determinar-alcance.outputs.debe_desplegar == 'true'
     runs-on: ubuntu-latest
     permissions:
+      # Declarar 'permissions' a nivel de job pone en 'none' todo scope que no se liste, asi
+      # que 'contents: read' es obligatorio para que actions/checkout siga clonando.
       contents: read
+      # Emite el token federado que azure/login canjea por OIDC, sin client secret
+      # (MEF-ADR-0022). El bloque va por JOB y no a nivel de workflow a proposito: el job
+      # 'determinar-alcance' necesita 'pull-requests: read', que este reparto no le quita.
       id-token: write
     outputs:
       sha: ${{ github.event.workflow_run.head_sha || github.sha }}

--- a/.github/workflows/deploy-programacion.yml
+++ b/.github/workflows/deploy-programacion.yml
@@ -141,6 +141,9 @@ jobs:
     needs: [determinar-alcance, build-and-test]
     if: needs.determinar-alcance.outputs.debe_desplegar == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     outputs:
       sha: ${{ github.event.workflow_run.head_sha || github.sha }}
     steps:
@@ -181,7 +184,9 @@ jobs:
       - name: Azure Authentication
         uses: azure/login@v3
         with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Deploy to Azure Functions
         uses: Azure/functions-action@v1

--- a/.github/workflows/deploy-programacion.yml
+++ b/.github/workflows/deploy-programacion.yml
@@ -142,7 +142,12 @@ jobs:
     if: needs.determinar-alcance.outputs.debe_desplegar == 'true'
     runs-on: ubuntu-latest
     permissions:
+      # Declarar 'permissions' a nivel de job pone en 'none' todo scope que no se liste, asi
+      # que 'contents: read' es obligatorio para que actions/checkout siga clonando.
       contents: read
+      # Emite el token federado que azure/login canjea por OIDC, sin client secret
+      # (MEF-ADR-0022). El bloque va por JOB y no a nivel de workflow a proposito: el job
+      # 'determinar-alcance' necesita 'pull-requests: read', que este reparto no le quita.
       id-token: write
     outputs:
       sha: ${{ github.event.workflow_run.head_sha || github.sha }}

--- a/.github/workflows/deploy-projections.yml
+++ b/.github/workflows/deploy-projections.yml
@@ -88,7 +88,12 @@ jobs:
     needs: build-and-test
     runs-on: ubuntu-latest
     permissions:
+      # Declarar 'permissions' a nivel de job pone en 'none' todo scope que no se liste, asi
+      # que 'contents: read' es obligatorio para que actions/checkout siga clonando.
       contents: read
+      # Emite el token federado que azure/login canjea por OIDC, sin client secret
+      # (MEF-ADR-0022). Basta para los pasos de 'az' y 'docker push' de abajo: van contra el
+      # ACR (plano de Azure), no contra la API de GitHub ni contra GHCR.
       id-token: write
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/deploy-projections.yml
+++ b/.github/workflows/deploy-projections.yml
@@ -12,13 +12,6 @@
 #      "Revisions in Azure Container Apps" de Microsoft Learn), lo que garantiza que el
 #      contenedor arranque de cero y lea el secreto vigente.
 #
-# Desviacion declarada frente a MEF-ADR-0022: ese ADR exige que CI se autentique contra Azure
-# por OIDC (azure/login con client-id/tenant-id/subscription-id, sin secret de password). Este
-# workflow usa `creds: secrets.AZURE_CREDENTIALS` en su lugar, igual que deploy-control-horas.yml
-# y deploy-programacion.yml hacen hoy. Migrar a OIDC es un cambio transversal (federated
-# credentials del SP + los tres secrets + los cuatro workflows a la vez) que no pertenece a este
-# issue; se hara en un issue aparte que migre los cuatro workflows juntos.
-#
 # Rollback de imagen: la imagen NO la gobierna Terraform (issue #249 le puso
 # `lifecycle { ignore_changes = [template[0].container[0].image] }` al Container App), asi que
 # revertir jamas se hace tocando HCL ni corriendo `terraform apply`. Se hace re-publicando el
@@ -94,13 +87,18 @@ jobs:
   deploy:
     needs: build-and-test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v6
 
       - name: Azure Authentication
         uses: azure/login@v3
         with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Resolver el ACR del resource group
         run: |

--- a/.github/workflows/infra-cd.yml
+++ b/.github/workflows/infra-cd.yml
@@ -13,6 +13,9 @@ concurrency:
 
 permissions:
   contents: read
+  # Emite el token federado que consume ARM_USE_OIDC (MEF-ADR-0022). Aca no hay paso de
+  # azure/login: Terraform lee por su cuenta ACTIONS_ID_TOKEN_REQUEST_URL/TOKEN, que este
+  # scope habilita. Va a nivel de workflow porque el archivo tiene un unico job.
   id-token: write
 
 jobs:
@@ -22,6 +25,12 @@ jobs:
       ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      # Una sola linea cubre provider Y backend: el provider azurerm detecta solo las
+      # ACTIONS_ID_TOKEN_REQUEST_* del runtime de Actions (guia service_principal_oidc) y el
+      # backend azurerm expone el mismo use_oidc, asi que el token federado sirve al init con
+      # el backend keyless por AAD (use_azuread_auth en providers.tf) y al apply. NO agregar
+      # env extra ni un use_oidc en el bloque backend: seria redundante. Sin ARM_CLIENT_SECRET
+      # a proposito -- si reaparece, el provider vuelve a autenticar por secret (MEF-ADR-0022).
       ARM_USE_OIDC: true
       TF_VAR_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       TF_VAR_postgresql_admin_password: ${{ secrets.POSTGRESQL_ADMIN_PASSWORD }}

--- a/.github/workflows/infra-cd.yml
+++ b/.github/workflows/infra-cd.yml
@@ -13,15 +13,16 @@ concurrency:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   terraform-apply:
     runs-on: ubuntu-latest
     env:
       ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-      ARM_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
       ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      ARM_USE_OIDC: true
       TF_VAR_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       TF_VAR_postgresql_admin_password: ${{ secrets.POSTGRESQL_ADMIN_PASSWORD }}
 

--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -11,7 +11,11 @@ concurrency:
 
 permissions:
   contents: read
+  # Requerido por el paso de github-script que publica el plan como comentario del PR.
   pull-requests: write
+  # Emite el token federado que consume ARM_USE_OIDC (MEF-ADR-0022). Aca no hay paso de
+  # azure/login: Terraform lee por su cuenta ACTIONS_ID_TOKEN_REQUEST_URL/TOKEN, que este
+  # scope habilita. Va a nivel de workflow porque el archivo tiene un unico job.
   id-token: write
 
 jobs:
@@ -21,6 +25,12 @@ jobs:
       ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      # Una sola linea cubre provider Y backend: el provider azurerm detecta solo las
+      # ACTIONS_ID_TOKEN_REQUEST_* del runtime de Actions (guia service_principal_oidc) y el
+      # backend azurerm expone el mismo use_oidc, asi que el token federado sirve al init con
+      # el backend keyless por AAD (use_azuread_auth en providers.tf) y al plan. NO agregar
+      # env extra ni un use_oidc en el bloque backend: seria redundante. Sin ARM_CLIENT_SECRET
+      # a proposito -- si reaparece, el provider vuelve a autenticar por secret (MEF-ADR-0022).
       ARM_USE_OIDC: true
       TF_VAR_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       TF_VAR_postgresql_admin_password: ${{ secrets.POSTGRESQL_ADMIN_PASSWORD }}

--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -12,15 +12,16 @@ concurrency:
 permissions:
   contents: read
   pull-requests: write
+  id-token: write
 
 jobs:
   terraform-plan:
     runs-on: ubuntu-latest
     env:
       ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-      ARM_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
       ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      ARM_USE_OIDC: true
       TF_VAR_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       TF_VAR_postgresql_admin_password: ${{ secrets.POSTGRESQL_ADMIN_PASSWORD }}
 


### PR DESCRIPTION
## Resumen

Pipeline tooling completado:
- Writer: implementacion de la tarea
- Reviewer: revision de calidad

## Decisiones del pipeline

<details>
<summary>Writer -- 2m 27s</summary>

# Stage 1 (writer) — Issue #297: reconciliar autenticacion de CI hacia Azure con OIDC

## Que se hizo

Se migraron los 5 workflows de `.github/workflows/` de autenticacion por secret/password a OIDC, siguiendo el plan del issue al pie de la letra (diffeado contra el estado ya verificado, sin regenerar nada).

### Paso 1 — `infra-ci.yml`
- Se quito `ARM_CLIENT_SECRET` del `env:` del job `terraform-plan`.
- Se agrego `ARM_USE_OIDC: true` al mismo `env:`.
- Se agrego `id-token: write` al bloque `permissions:` (nivel workflow, que es donde ya vivia), conservando `contents: read` y `pull-requests: write` (los necesita el paso de `github-script` que comenta el plan en el PR).

### Paso 2 — `infra-cd.yml`
- Mismo mecanismo: se quito `ARM_CLIENT_SECRET`, se agrego `ARM_USE_OIDC: true`.
- `permissions:` (nivel workflow) queda `contents: read` + `id-token: write`. No se agrego `issues: write` ni `pull-requests: read` — la version del harness los lleva porque cierra el issue tras el apply, y este workflow no lo hace (verificado: no hay `gh issue close`).

### Paso 3 — los tres `deploy-*.yml`
- `deploy-control-horas.yml` y `deploy-programacion.yml`: se agrego un bloque `permissions: {contents: read, id-token: write}` al job `deploy` (el que hace `azure/login`). El job `determinar-alcance` ya tenia su propio `permissions: {contents: read, pull-requests: read}` desde #262 — no se toco, sigue resolviendo el alcance via la API de GitHub sin verse afectado por el nuevo bloque del job `deploy` (permisos por job, no por workflow).
- `deploy-projections.yml`: no tiene `determinar-alcance`, asi que solo se agrego `permissions: {contents: read, id-token: write}` al job `deploy` que hace `azure/login`. El job `build-and-test` no se toco.
- En los tres, el paso "Azure Authentication" paso de `creds: ${{ secrets.AZURE_CREDENTIALS }}` a `client-id` + `tenant-id` + `subscription-id` leidos de `AZURE_CLIENT_ID` / `AZURE_TENANT_ID` / `AZURE_SUBSCRIPTION_ID`.
- Se reescribio la cabecera de `deploy-projections.yml` (lineas 15-20 originales): se elimino la seccion "Desviacion declarada frente a MEF-ADR-0022", porque la desviacion deja de existir.

### Paso 4 (limpieza de secrets)
**No ejecutado**, tal como indica el plan: `gh secret delete AZURE_CREDENTIALS` y `gh secret delete AZURE_CLIENT_SECRET` quedan fuera de este PR a proposito (Riesgo 2 del issue — los 4 de los 5 workflows solo se validan post-merge, asi que el rollback debe seguir disponible revirtiendo un commit sin tocar Azure).

## Verificacion hecha

- `grep -rn "AZURE_CREDENTIALS\|AZURE_CLIENT_SECRET" .github/workflows/` → sin resultados (CA-1).
- `ARM_USE_OIDC: true` presente y `ARM_CLIENT_SECRET` ausente en `infra-ci.yml` e `infra-cd.yml` (CA-2).
- Los tres `deploy-*.yml` usan `azure/login` con `client-id`/`tenant-id`/`subscription-id` (CA-3).
- `permissions` por job confirmado: `determinar-alcance` conserva `contents: read` + `pull-requests: read`; el job de `azure/login` en cada uno de los 3 deploys tiene `contents: read` + `id-token: write`; ningun `deploy-*.yml` declara `permissions` a nivel workflow; `infra-ci.yml` conserva `pull-requests: write` (CA-4).
- CA-5 (verde en main tras merge) y una parte de CA-2/CA-3 para `infra-ci`/`infra-cd` (que solo disparan con `paths: infra/**`) **no se pueden verificar en este stage** — quedan para verificacion post-merge segun el Riesgo 2 del issue.
- Los 5 YAML se validaron sintacticamente con `python3 -c "import yaml; yaml.safe_load(...)"` — los 5 parsean sin error.
- Se confirmo que la expresion del readiness gate (`github.event.workflow_run.head_sha || github.sha`, MEF-ADR-0031) no se toco en ninguno de los 3 deploys.
- Se confirmo que `smoke-tests-dominio.yml`, `smoke-tests.yml`, `ci.yml` y todo `infra/` quedaron sin cambios (`git status`/`git diff --stat` vacios sobre esas rutas).

## Fuera de alcance (segun el issue, no ejecutado aqui)

- `gh secret delete AZURE_CREDENTIALS` / `AZURE_CLIENT_SECRET` (Paso 4, manual, post-verificacion en main).
- Cualquier cambio a `infra/` (backend keyless, README) — eso es #298, ya cerrado por separado.
- No se creo ningun draft hacia el repo del harness: todo el trabajo cabia en el alcance permitido de `/tooling` sobre este repo consumidor.

## Archivos modificados

- `.github/workflows/infra-ci.yml`
- `.github/workflows/infra-cd.yml`
- `.github/workflows/deploy-control-horas.yml`
- `.github/workflows/deploy-programacion.yml`
- `.github/workflows/deploy-projections.yml`

Commit: `efaf29d` — "tooling(ci): migrar los 5 workflows de CI/CD a autenticacion OIDC".

</details>

<details>
<summary>Reviewer -- 6m 24s</summary>

# Stage 2 - Reviewer: issue #297 (autenticacion de CI hacia Azure por OIDC)

**Veredicto: aprobado.** El writer migro los 5 workflows correctamente. No hubo que corregir
ningun defecto funcional; mis cambios son **solo comentarios** (verificado: el YAML parseado
es identico al del commit del writer en los 8 workflows del repo).

## Criterios de aceptacion

| CA | Estado | Como se verifico |
|---|---|---|
| CA-1 | Cumple | `grep -rn "AZURE_CREDENTIALS\|AZURE_CLIENT_SECRET" .github/workflows/` -> sin resultados |
| CA-2 | Cumple | `infra-ci`/`infra-cd` declaran `ARM_USE_OIDC: true`; `ARM_CLIENT_SECRET` ausente en ambos |
| CA-3 | Cumple | los 3 `deploy-*` pasan `client-id`+`tenant-id`+`subscription-id` a `azure/login@v3` (parseado con PyYAML, no grep) |
| CA-4 | Cumple | `determinar-alcance`: `contents: read`+`pull-requests: read`; job de `azure/login`: `id-token: write`+`contents: read`; **ningun `deploy-*` tiene `permissions` a nivel workflow**; `infra-ci` conserva `pull-requests: write` |
| CA-5 | **No verificable aqui** | solo se observa post-merge (los 3 `deploy-*` corren en `push` a main). Ver "Riesgo residual" |
| CA-6 | Cumple | la seccion "Desviacion declarada frente a MEF-ADR-0022" ya no existe en `deploy-projections.yml` |

Validaciones extra ejecutadas:

- **`actionlint` sobre los 5 modificados: exit 0, cero hallazgos.** Esto tambien confirma que
  `ARM_USE_OIDC: true` sin comillas es valido para `env:` (el schema oficial admite boolean y
  lo coacciona a string), igual que en la plantilla del harness.
- **MEF-ADR-0031 intacto**: `github.event.workflow_run.head_sha || github.sha` sigue apareciendo
  4 veces en cada deploy del write-side, identico a HEAD~1. No se toco.
- **Rutas prohibidas**: ninguna. El commit del writer toca solo `.github/workflows/`.
- **Simetria** entre los dos deploys del write-side: el cambio se aplico identico en ambos (las
  unicas diferencias que quedan son preexistentes: el wrap de un comentario y que
  `programacion` no pasa `POSTGRES_CONNECTION_STRING` al reutilizable).
- **No hay codigo C# en el diff**, asi que no corri `dotnet build`/`dotnet test`: no aplica.

## Hallazgos

### 1. La premisa del RIESGO 1 del issue ya estaba obsoleta (a favor del cambio)

El issue afirma que los deploys "no declaran `permissions`" y que declararlos romperia
`determinar-alcance`. **Falso a HEAD~1**: ese job ya traia su propio bloque por job
(`contents: read` + `pull-requests: read` + `GH_TOKEN: ${{ github.token }}`), heredado de #262.

Consecuencia: el modo de fallo que el issue temia (`debe_desplegar=false` espurio) nunca fue
alcanzable en este cambio, porque un bloque por job gana sobre el de workflow. El writer hizo
lo correcto al no tocar el job. Lo anoto porque **CA-5 se apoyaba en esa premisa**: la
verificacion post-merge sigue siendo necesaria para el login OIDC, pero no por el reparto de
permisos.

### 2. Dos comentarios en `infra/` quedaron obsoletos - fuera de mi alcance de escritura

Ambos anticipan este issue como futuro, y ya ocurrio:

- `infra/environments/dev/providers.tf:26-31` - *"Hoy el token AAD lo emiten las credenciales
  ARM_* del workflow; cuando el issue #297 introduzca `ARM_USE_OIDC`, el mismo token federado
  servira al provider azurerm y a este backend"*.
- `infra/README.md:133` - *"La migracion de los workflows a OIDC la completa el issue #297"*.

**No los corregi a proposito.** `infra/` no esta en la allowlist de este pipeline (ni en la del
writer) y el issue lo excluye explicitamente ("No toca: `infra/`"). Es exactamente la frontera
disjunta entre `tooling-pipeline.sh` e `iac-pipeline.sh` que el issue documenta. **Recomendacion:
un issue de seguimiento pequeno via `/infra`** para actualizar esos dos comentarios; es
documentacion, no comportamiento, asi que no bloquea el merge.

### 3. Divergencias con la plantilla que son correctas (no drift)

- **`infra-ci`/`infra-cd` conservan `permissions` a nivel de workflow**, mientras la plantilla
  (`infra-base-scaffolder.md:1849,1934`) lo pone por job. Equivalente en comportamiento: cada
  archivo tiene **un unico job**. Ademas Paso 1/Paso 2 del issue lo prescriben asi. No es defecto.
- **`infra-ci`/`infra-cd` no llaman `azure/login`**, la plantilla si. Correcto: aca no se
  ejecuta ningun comando `az` (solo `terraform init/plan/apply`), y Terraform obtiene el token
  federado por su cuenta desde `ACTIONS_ID_TOKEN_REQUEST_*`. La plantilla lo necesita porque su
  version siembra secretos en Key Vault con `az`.
- **`infra-cd` no lleva `issues: write` ni `pull-requests: read`**, a diferencia de la plantilla.
  Correcto y ya razonado en el issue: nuestra version no cierra el issue tras el apply
  (verificado: no hay `gh issue close`).
- **`smoke-tests-dominio.yml` y `smoke-tests.yml` sin tocar.** Correcto: no autentican contra
  Azure (solo connection strings de ServiceBus/Postgres). No recibieron `id-token: write`.

### 4. Permisos suficientes en los jobs `deploy` - auditado paso por paso

Estrechar el token de "default del repo" a `contents: read` + `id-token: write` podia romper
algun paso. Revise los tres:

- `control-horas` / `programacion`: restore, build, publish, validar artefacto, `azure/login`,
  `Azure/functions-action@v1`. Ninguno llama a la API de GitHub.
- `projections`: `az acr list`, `az acr login`, `docker build/push`, `az containerapp
  update/show`. El push va al **ACR de Azure, no a GHCR**, asi que no hace falta
  `packages: write`.

Sin regresiones. El reutilizable `smoke-tests` tampoco se afecta: hereda del nivel de workflow
del llamador, que sigue sin bloque.

### 5. Drift preexistente que no toque

`actions/checkout@v6` / `setup-dotnet@v5` en el repo vs `@v7` en la plantilla, y
`hashicorp/setup-terraform@v4` vs `@v3`. Preexistente, ajeno a la autenticacion y fuera del
alcance de #297.

## Correcciones que aplique

Solo legibilidad, sobre los bloques nuevos. La instruccion del issue era *"diffear contra la
plantilla, no editar a ciegas"*, y la plantilla vigente **anota ambas lineas de `permissions`*
(`domain-scaffolder.md:2434-2435`); el writer las dejo desnudas. Dos cosas quedaban no obvias
para el siguiente lector:

1. **Por que se repite `contents: read`.** Declarar `permissions` en un job pone en `none` todo
   scope no listado, asi que omitirlo rompe `actions/checkout`. Sin la nota parece redundante y
   es candidato a "limpieza" que rompe el checkout.
2. **Por que `infra-ci`/`infra-cd` piden `id-token: write` sin tener `azure/login`.** Documente
   que Terraform lee `ACTIONS_ID_TOKEN_REQUEST_URL/TOKEN` directamente.
3. **Que `ARM_USE_OIDC` cubre provider Y backend con una linea**, con el "NO agregar env extra
   ni un `use_oidc` en el bloque backend" explicito - es la trampa que el issue documenta en sus
   notas tecnicas y la que evita que alguien "complete" la config con lineas redundantes.

Tambien deje asentado en los dos deploys del write-side por que el bloque va **por job y no a
nivel de workflow**, para que no se hoistee mas adelante.

## Riesgo residual (no bloquea)

- **Los 5 se validan post-merge.** `infra-ci.yml` dispara solo con `paths: ['infra/**']` y este
  PR toca solo `.github/workflows/`, asi que no hay canario pre-merge. Al mergear se validan los
  3 `deploy-*`; `infra-ci`/`infra-cd` esperan al siguiente PR que toque `infra/`.
- **Rollback**: revertir el commit de workflows. `AZURE_CREDENTIALS` y `AZURE_CLIENT_SECRET`
  siguen existiendo, asi que no hay que tocar Azure ni recrear secrets.
- **Paso 4 (`gh secret delete`) correctamente diferido**: fuera de este PR por diseno. No lo
  ejecute.
- **Subject del federated credential sin verificar empiricamente** para los deploys disparados
  por `workflow_run`. Si falla, el issue ya indica el camino: leer el claim `sub` del token en
  el log antes de agregar credenciales a ciegas.

</details>

## Commits

c9fecbb tooling(review): documentar el razonamiento de los permissions y de ARM_USE_OIDC
efaf29d tooling(ci): migrar los 5 workflows de CI/CD a autenticacion OIDC

Closes #297