### PR TITLE
infra(dev): #301 Versionar el lock file de Terraform para que plan y apply resuelvan el mismo provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -503,7 +503,11 @@ scripts/.kql-audit.log
 # sensibles y es especifico del estado/backend). Ver issue #195.
 tfplan
 **/tfplan
-.terraform.lock.hcl
+
+# NO ignores .terraform.lock.hcl: el lock file de dependencias SI se commitea, para
+# que el plan (en el PR) y el apply (al mergear a main) usen exactamente las mismas
+# versiones/hashes de providers (HashiCorp, "Dependency Lock File": "You should include
+# this file in your version control repository"). No aparece aqui a proposito. Ver issue #301.
 *.tfvars
 
 # Azure Functions

--- a/infra/environments/dev/.terraform.lock.hcl
+++ b/infra/environments/dev/.terraform.lock.hcl
@@ -1,0 +1,45 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "4.81.0"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:XhToZua4gtih1Kv8RdStcfND83G4Tmb6GZFT4jEUhDU=",
+    "h1:olVprUWhmFTARlydw/r7VIx4fata2gy3zsAWfPGRrhg=",
+    "zh:0732e7b74264ddfa2b90ba69d01c283d3cbae9f72ed3e506c6ac92529fed7fd3",
+    "zh:12afb524e232fe4e3d6161927724af5dfa4831d71edd9c174917ca9b7377bfae",
+    "zh:169d619ae202c4145e02fb706fb7c3679445ab3e3ff722edbf89597517a8c92e",
+    "zh:6beb95a3ef2f2d9c76abaa48e5450e90686a3fb6a47f1cb0ff7c5e94b6960151",
+    "zh:705e075fb5ffc4bf66fd7cbabf1a65007a41621e80030a2c158a4c83b6046216",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:79a8d17fefe647040fcb9ee8821a4f09f395427c4fd49493489b9a93a9a1038e",
+    "zh:8cc3f900b3774c0ae37ae42365c4579a199cf9e5edf88e476fdf5ab1048f84ea",
+    "zh:dec373b9390fa95e257291acd018ed65a7d512b428645d35e22cdbe8b245a08b",
+    "zh:e60f1e9fb45df6defade2855ed6e68547409ea75d30655c556adb0c08579749b",
+    "zh:f901d12ec82f3f8b5880a27b5cbcd7bd0d97e60c9367a2d7ed82fdd1157b39ff",
+    "zh:facf68ea5bf0f2b8ba720e7fba5f86492e1d4c591100460bb91c3f79f391f4b6",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.9.0"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:OO+IuvQJSPmWdN8AyyIEvPJbLvDQpgX/zbktoa9KsJE=",
+    "h1:UlBuNVuCGJ39tTv2c5gz2NRZnQbXfbIWbTzWcth5o74=",
+    "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
+    "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
+    "zh:269eda8fe42daa7974d5a34d166c3ba9defe80cde86c01e4dadcfdf2e1f05e5f",
+    "zh:373f7c65566f8f2cc7f45d698654feb9d988996957e1266a69ca00c52d6d16d0",
+    "zh:5599d16804c41c83009ec621b6d6b6f74e102f5827678a4750f8809055546b61",
+    "zh:583be0440469a22bff70dcfa56593b01566860b29607437264adb51060cf46fc",
+    "zh:5f211d8ec3f2e1f414870d9584bfe26e6995560ef81c748f8447a48164767398",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b547fd16216761ef86efc3ed516ac5ac0c5c42b7c7eb24a08cef2d93f69ed5e",
+    "zh:7e7c0679daf2a382151d05068c8c3f0dae6b7b7dccf818827b73dd08638df2ef",
+    "zh:8089dec888a8038b9b4fb23b3df7e1057293dbc5b60b42cc47ff690d69d4b61b",
+    "zh:c51f15a031edfd6f23ce8ced3446ca7f8d8d647e2499890d7d5d10d5016d7257",
+    "zh:c94784f005708890dc6895afd53636ec00ec1e430b15d41e5aebfb1d4b39bd04",
+  ]
+}


### PR DESCRIPTION
## Infraestructura

Implementa los cambios de infraestructura del issue #301.

- **Ambiente**: dev
- **Estado**: HCL escrito y revisado localmente (sin plan ni apply local); pendiente de aplicar por CI
- **Pipeline**: iac-pipeline.sh

## Decisiones del pipeline

<details>
<summary>infra-writer -- 2m 22s</summary>

_(El agente no genero resumen)_

</details>

<details>
<summary>infra-reviewer -- 2m 46s</summary>

_(El agente no genero resumen)_

</details>

## Cambios Terraform

 infra/environments/dev/.terraform.lock.hcl | 45 ++++++++++++++++++++++++++++++
 1 file changed, 45 insertions(+)

## Commits

6607ec9 infra(dev): versionar el lock file de Terraform en azurerm 4.81.0

> **Apply pendiente en CI**: este PR no cierra el issue #301. El `terraform apply` lo ejecuta el workflow **Infra CD** al mergear este PR a `main` (MEF-ADR-0022); el issue se cierra automaticamente cuando ese apply termine exitosamente.