### PR TITLE
infra(dev): #305 Eliminar el diff perpetuo que modifica los dos Function Apps en cada apply de infraestructura

### DIFF
--- a/infra/modules/function-app/main.tf
+++ b/infra/modules/function-app/main.tf
@@ -50,17 +50,39 @@ resource "azurerm_linux_function_app" "this" {
   storage_account_name          = var.storage_account_name
   storage_uses_managed_identity = true
 
+  # La version del runtime de Functions se fija aqui, no en app_settings: el
+  # provider escribe este valor en la key FUNCTIONS_EXTENSION_VERSION del app
+  # setting por su cuenta. Declararla tambien a mano en app_settings genera un
+  # diff perpetuo entre las dos vias (issue #305). Se deja explicita en vez de
+  # apoyarse en el default documentado ("~4") para que la version del runtime
+  # quede visible en el HCL.
+  functions_extension_version = "~4"
+
   site_config {
     application_stack {
       dotnet_version              = "10.0"
       use_dotnet_isolated_runtime = true
     }
+
+    # La connection string de Application Insights se declara aqui, no en
+    # app_settings: la doc de azurerm_linux_function_app indica que para
+    # configuracion de Application Insights se use
+    # application_insights_connection_string/application_insights_key, y que
+    # el provider escribe el valor en la key APPLICATIONINSIGHTS_CONNECTION_STRING
+    # del app setting por su cuenta ("For application insight related settings,
+    # please use application_insights_connection_string and
+    # application_insights_key, terraform will assign the value to the key
+    # APPINSIGHTS_INSTRUMENTATIONKEY and APPLICATIONINSIGHTS_CONNECTION_STRING
+    # in app setting" -- registry.terraform.io, docs/resources/linux_function_app,
+    # seccion app_settings). Declararla tambien a mano en app_settings genera
+    # un diff perpetuo entre las dos vias (issue #305): site_config.application_insights_connection_string
+    # es Computed y el provider la rellena leyendo el app setting existente en
+    # Azure, por lo que un app_settings sin esta clave la nulifica en cada plan.
+    application_insights_connection_string = var.app_insights_connection_string
   }
 
   app_settings = merge(
     {
-      APPLICATIONINSIGHTS_CONNECTION_STRING  = var.app_insights_connection_string
-      FUNCTIONS_EXTENSION_VERSION            = "~4"
       FUNCTIONS_WORKER_RUNTIME               = "dotnet-isolated"
       WEBSITE_USE_PLACEHOLDER_DOTNETISOLATED = "1"
       WEBSITE_RUN_FROM_PACKAGE               = "1"


### PR DESCRIPTION
## Infraestructura

Implementa los cambios de infraestructura del issue #305.

- **Ambiente**: dev
- **Estado**: HCL escrito y revisado localmente (sin plan ni apply local); pendiente de aplicar por CI
- **Pipeline**: iac-pipeline.sh

## Decisiones del pipeline

<details>
<summary>infra-writer -- 2m 5s</summary>

_(El agente no genero resumen)_

</details>

<details>
<summary>infra-reviewer -- 3m 18s</summary>

_(El agente no genero resumen)_

</details>

## Cambios Terraform

 infra/modules/function-app/main.tf | 26 ++++++++++++++++++++++++--
 1 file changed, 24 insertions(+), 2 deletions(-)

## Commits

ec70f66 infra(dev): eliminar el diff perpetuo de app_settings en function-app

> **Apply pendiente en CI**: este PR no cierra el issue #305. El `terraform apply` lo ejecuta el workflow **Infra CD** al mergear este PR a `main` (MEF-ADR-0022); el issue se cierra automaticamente cuando ese apply termine exitosamente.