### PR TITLE
Pinnear la version de Terraform CLI en los workflows de infraestructura

### DIFF
--- a/.github/workflows/infra-cd.yml
+++ b/.github/workflows/infra-cd.yml
@@ -46,7 +46,8 @@ jobs:
           # Sin este pin, plan (PR) y apply (merge) son dos instalaciones independientes en
           # momentos distintos: un release de Terraform entremedio corre el apply con un CLI
           # que nadie uso en el plan. Bump deliberado en su propio PR, igual que el lock file
-          # del provider (#301).
+          # del provider (#301), y SIEMPRE en los dos workflows a la vez: subirlo solo aca deja
+          # el plan de infra-ci.yml en otra version y reintroduce la divergencia que el pin cierra.
           terraform_version: "1.15.8"
 
       - name: Terraform Init

--- a/.github/workflows/infra-cd.yml
+++ b/.github/workflows/infra-cd.yml
@@ -41,6 +41,13 @@ jobs:
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v4
+        with:
+          # Pinneado a lo que CI ya instalaba via `latest` (issue #303), no a la version local.
+          # Sin este pin, plan (PR) y apply (merge) son dos instalaciones independientes en
+          # momentos distintos: un release de Terraform entremedio corre el apply con un CLI
+          # que nadie uso en el plan. Bump deliberado en su propio PR, igual que el lock file
+          # del provider (#301).
+          terraform_version: "1.15.8"
 
       - name: Terraform Init
         working-directory: infra/environments/dev

--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -46,7 +46,8 @@ jobs:
           # Sin este pin, plan (PR) y apply (merge) son dos instalaciones independientes en
           # momentos distintos: un release de Terraform entremedio corre el apply con un CLI
           # que nadie uso en el plan. Bump deliberado en su propio PR, igual que el lock file
-          # del provider (#301).
+          # del provider (#301), y SIEMPRE en los dos workflows a la vez: subirlo solo aca deja
+          # el apply de infra-cd.yml en otra version y reintroduce la divergencia que el pin cierra.
           terraform_version: "1.15.8"
 
       - name: Terraform Init

--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -41,6 +41,13 @@ jobs:
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v4
+        with:
+          # Pinneado a lo que CI ya instalaba via `latest` (issue #303), no a la version local.
+          # Sin este pin, plan (PR) y apply (merge) son dos instalaciones independientes en
+          # momentos distintos: un release de Terraform entremedio corre el apply con un CLI
+          # que nadie uso en el plan. Bump deliberado en su propio PR, igual que el lock file
+          # del provider (#301).
+          terraform_version: "1.15.8"
 
       - name: Terraform Init
         working-directory: infra/environments/dev


### PR DESCRIPTION
## Resumen

Pipeline tooling completado:
- Writer: implementacion de la tarea
- Reviewer: revision de calidad

## Decisiones del pipeline

<details>
<summary>Writer -- 0m 53s</summary>

# Stage 1 - Writer: Issue #303

## Que se hizo

Se agrego `terraform_version: "1.15.8"` al paso `Setup Terraform`
(`hashicorp/setup-terraform@v4`) en:

- `.github/workflows/infra-ci.yml`
- `.github/workflows/infra-cd.yml`

Junto al pin, un comentario explica el criterio (se pinnea lo que CI ya
instalaba via `latest`, no la version local) y como se sube (bump
deliberado en su propio PR, igual que el lock file del provider de #301).

## Criterios de aceptacion

- **CA-1**: verificado -- ambos workflows declaran `terraform_version: "1.15.8"`.
- **CA-2**: verificado -- son los unicos dos usos de `setup-terraform` en `.github/workflows/`, ambos cubiertos.
- **CA-3**: verificado -- comentario presente con el criterio y el mecanismo de bump.
- **CA-4**: verificado -- `git status` solo muestra los dos workflows modificados; `infra/` y `providers.tf` no se tocaron.

## Validaciones

- `python3 -c "yaml.safe_load(...)"` sobre ambos archivos: OK, sintaxis valida.
- No aplica `dotnet build` (no se modifico codigo C#).
- No hay validacion CI pre-merge posible para este PR (documentado en el issue): `infra-ci.yml` solo dispara con `paths: ['infra/**']` y este PR no toca `infra/`.

## Fuera de alcance (anotado, no ejecutado)

- `required_version = ">= 1.6"` en `infra/environments/dev/providers.tf` sigue laxo. Vive bajo `infra/`, fuera de la allowlist de este pipeline; se evalua en #304 (migracion a azurerm v5).

## Commit

`1187e38` -- `tooling(ci): pinnear terraform_version 1.15.8 en setup-terraform`

</details>

<details>
<summary>Reviewer -- 3m 37s</summary>

# Stage 2 - Reviewer: Issue #303

## Veredicto

**Aprobado con una correccion aplicada.** El cambio del writer es correcto, minimo y
consistente con los patrones del repo. No hubo que revertir nada.

## Verificacion de criterios de aceptacion

| CA | Estado | Como se verifico |
|---|---|---|
| CA-1 | Cumple | `yaml.safe_load` sobre ambos archivos: el paso `setup-terraform` resuelve a `{'terraform_version': '1.15.8'}` en `infra-ci.yml` e `infra-cd.yml`. Se valido el YAML parseado, no solo el texto. |
| CA-2 | Cumple | `grep -rn -A8 "setup-terraform" .github/workflows/` devuelve exactamente 2 ocurrencias, ambas pinneadas. De los 8 workflows, solo 3 mencionan Terraform; el tercero (`deploy-projections.yml`) lo nombra unicamente en comentarios sobre `ignore_changes` de la imagen (#249), no invoca el CLI ni la action. |
| CA-3 | Cumple | El comentario declara el criterio ("lo que CI ya instalaba via `latest`, no la version local") y el mecanismo de bump ("PR deliberado, igual que el lock file del provider"). Reforzado por la correccion de abajo. |
| CA-4 | Cumple | `git diff main...HEAD --name-only` lista solo los dos workflows. `infra/`, `providers.tf` y el lock file intactos. |

## Verificacion del valor pinneado (lo que mas importaba)

El issue afirma que 1.15.8 es "lo que CI ya corre" y que por eso el pin es un no-op de
comportamiento. Lo comprobe contra fuentes de HashiCorp en vez de asumirlo:

- `checkpoint-api.hashicorp.com/v1/check/terraform` -> `current_version: 1.15.8`.
- `api.releases.hashicorp.com/v1/releases/terraform` -> por encima de 1.15.8 solo hay
  prereleases (1.16.0-beta1, 1.17.0-alpha...), que `latest` no instala.
- Log del apply `30920275219` (hoy, 14:42 UTC): `terraform_version: latest`.

Conclusion: `latest` resolvia a 1.15.8 en la ultima corrida real, asi que el pin no cambia
el binario de CI. Tambien confirme que la version local es **1.14.4** (`terraform version`),
o sea que pinnear la local habria sido el downgrade silencioso que el issue advierte.

## Correccion aplicada

Commit `5e604fe` -- agrega una linea al comentario de **ambos** workflows advirtiendo que
el bump va en los dos archivos a la vez.

**Por que no es cosmetico**: todo el valor del pin descansa en que los dos archivos
declaren el mismo valor. Si alguien sube solo `infra-ci.yml`, el plan del PR corre con un
CLI y el apply del merge con otro -- exactamente la divergencia que este issue cierra, pero
ahora silenciosa porque "ya esta pinneado". Peor aun en el orden inverso: si el plan escribe
el state con un CLI mas nuevo, el apply con el viejo falla en duro ("state snapshot was
created by Terraform vX, which is newer than current"). Nada en el repo acopla los dos
archivos, asi que la unica defensa disponible es que el comentario lo diga. El texto es
simetrico entre archivos, siguiendo el estilo de los comentarios de `ARM_USE_OIDC`, que ya
se espejan cambiando "plan"/"apply".

## Calidad: lo que se reviso y se dejo como estaba

- **Ubicacion del comentario (dentro del bloque `with:`, encima de la clave)**: correcta.
  Es el patron ya establecido en estos mismos dos archivos, donde el bloque de 6 lineas de
  `ARM_USE_OIDC` vive dentro de `env:` justo encima de su clave, y los comentarios de
  `permissions:` hacen lo mismo. Mantenerlo preserva la consistencia.
- **Comillas dobles en `"1.15.8"`**: el repo usa comillas simples para pins de version
  (`dotnet-version: '10.0.x'`), asi que hay una inconsistencia menor de estilo. **No la
  cambie**: el issue prescribe literalmente `terraform_version: "1.15.8"` en el CA-1, y
  desviarse por estetica contradiria el criterio verificable. Las comillas ademas son
  defensivas (evitan que un futuro `1.16` se parsee como float).
- **Duplicacion del comentario entre los dos archivos**: intencional y consistente con el
  repo, que ya duplica verbatim el bloque de `ARM_USE_OIDC`. GitHub Actions no tiene
  mecanismo de include para esto.
- **No hay codigo C#**: no aplica `dotnet build` ni `dotnet test`.

## Notas para quien mergee

- **El CA-1 se verifica con `grep -A8`, no con `-A3`.** El comando del issue quedo corto
  porque se escribio antes de que existiera el comentario: hoy hay 6 lineas entre `uses:` y
  el valor, asi que `-A3` no alcanza a mostrar `terraform_version`. Es un desfase del
  comando de verificacion, no del cambio -- acortar el comentario para que entre en `-A3`
  habria sacrificado el razonamiento que pide el CA-3.
- **Este PR no puede validarse en CI**, como anticipa el issue: `infra-ci.yml` dispara con
  `paths: ['infra/**']` y aca solo se tocan workflows. La primera corrida que ejercita el
  pin sera la de #304. El riesgo es bajo: 1.15.8 existe (verificado arriba) y, si no
  existiera, `setup-terraform` falla ruidosamente en vez de caer a otra version.

## Fuera de alcance (anotado, no ejecutado)

- `required_version = ">= 1.6"` en `infra/environments/dev/providers.tf` sigue laxo. Vive
  bajo `infra/`, fuera de la allowlist de este pipeline; se evalua en #304.
- `hashicorp/setup-terraform@v4` sigue pinneado por major, coherente con los otros 7
  workflows. Frente transversal aparte.

</details>

## Commits

5e604fe tooling(ci): advertir que el pin de Terraform se sube en los dos workflows
1187e38 tooling(ci): pinnear terraform_version 1.15.8 en setup-terraform

Closes #303