### PR TITLE
Restaurar el sampler de OpenTelemetry y descartar el span de polling del daemon de Marten

### DIFF
--- a/docs/adr/ca-adr-0009-control-costos-application-insights.md
+++ b/docs/adr/ca-adr-0009-control-costos-application-insights.md
@@ -129,6 +129,26 @@ expresa encadenando un **segundo** `.WithTracing(...)` posterior al `.UseAzureMo
 `ParentBased(TraceIdRatioBased(ratio))`, ratio configurable via `TELEMETRY_SAMPLING_RATIO` (default
 0.2) -- ahora si efectivo.
 
+**El orden es fragil por naturaleza, asi que queda protegido por guardrail y no por convencion.**
+Cualquier reordenamiento futuro (o una version del exporter que cambie cuando registra su sampler)
+volveria a dejar el sampler del proyecto sin instalar, compilando y con los tests unitarios en
+verde: es el modo de falla que costo dos meses de ingestion completa. Los tests de composicion de
+ambos procesos (`ConfiguracionObservabilidadProjectionsTests`, `ComposicionServiciosTests`,
+MEF-ADR-0029) leen el sampler **efectivo** del `TracerProvider` resuelto del contenedor y afirman
+que no es `RateLimitedSampler` y que el ratio -- configurado y por defecto -- llego hasta el. La
+tecnica es determinista: compara tipos y lee `Sampler.Description`, sin muestrear actividades contra
+un ratio fraccionario. Esto deroga el "limite conocido" que esos archivos declaraban antes ("el
+sampler compuesto vive dentro de `TracerProviderSdk`, que OpenTelemetry no expone publicamente...
+queda cubierto por revision de codigo"): la revision de codigo no podia atrapar este defecto, porque
+el codigo visible era correcto.
+
+**Estado real de `TELEMETRY_SAMPLING_RATIO` frente a la tabla "Valores por ambiente" de arriba.** La
+variable no esta declarada en Terraform en **ningun** ambiente (verificado con `az functionapp config
+appsettings list`), asi que los valores de esa fila expresan la intencion de diseno, no lo que corre:
+hoy los tres ambientes usan el default de codigo (0.2). Declararla por ambiente queda fuera del
+alcance del issue #308 a proposito -- recalibrar el ratio se decide **despues** de medir con el
+sampler ya efectivo, no antes.
+
 **Alternativa considerada y descartada: configurar `AzureMonitorExporterOptions` en vez de
 reordenar.** Poner `o.TracesPerSecond = null; o.SamplingRatio = ratio;` hace que
 `UseAzureMonitorExporter()` instale `ApplicationInsightsSampler` en vez de `RateLimitedSampler`. Es

--- a/docs/adr/ca-adr-0009-control-costos-application-insights.md
+++ b/docs/adr/ca-adr-0009-control-costos-application-insights.md
@@ -98,3 +98,67 @@ al 100%. Mitigaciones:
 
 Capas 3 y 4 sin cambios. Esta adaptacion aplica al dominio ControlHoras; los demas dominios
 mantienen el modelo clasico hasta que se instrumenten igual.
+
+## Actualizacion (2026-08-04, issue #308): la Capa 2 descrita arriba nunca estuvo activa
+
+La actualizacion anterior describia la Capa 2 bajo OpenTelemetry como
+`ParentBased(TraceIdRatioBased(ratio))`, wireado con `SetSampler(...)` **antes** de
+`UseAzureMonitorExporter()`. Midiendo 24h de ingestion real en dev se encontro que ese sampler
+**nunca llegaba a instalarse**: `UseAzureMonitorExporter()` (`Azure.Monitor.OpenTelemetry.Exporter`
+1.8.1) llama `SetSampler(...)` internamente, y como `AzureMonitorExporterOptions.TracesPerSecond`
+tiene default `5.0`, siempre construye un `RateLimitedSampler` que pisa al sampler que este seam
+configuraba. Verificado en runtime leyendo el sampler efectivo del `TracerProvider` resuelto:
+
+```
+Sampler efectivo con el wiring anterior: Azure.Monitor.OpenTelemetry.Exporter.Internals.RateLimitedSampler
+Sampler que el codigo del proyecto pretendia instalar: OpenTelemetry.Trace.ParentBasedSampler
+```
+
+Consecuencia medida: el "sampler de ratio 0.2" nunca recortaba nada. Lo que realmente corria era un
+techo de 5 traces/s (~432k/dia), y los procesos operaban muy por debajo de ese techo (~1,4-1,6/s),
+asi que **no habia sampling efectivo en absoluto** desde que se adopto OpenTelemetry -- toda la
+telemetria de trazas se exportaba integra. `TELEMETRY_SAMPLING_RATIO` era, en la practica, una
+variable inerte: aunque se hubiera puesto en algun recurso (no lo estaba), el valor se calculaba y
+se descartaba.
+
+**Correccion (de orden, no de contenido).** `SetSampler(...)` del proyecto debe ejecutarse
+**despues** de `UseAzureMonitorExporter()`, no antes. En la forma `IOpenTelemetryBuilder` esto se
+expresa encadenando un **segundo** `.WithTracing(...)` posterior al `.UseAzureMonitorExporter()`
+(cada llamada a `WithTracing` registra un callback de configuracion sobre el mismo
+`TracerProviderBuilder`; el que se registra al final es el que gana). El sampler sigue siendo
+`ParentBased(TraceIdRatioBased(ratio))`, ratio configurable via `TELEMETRY_SAMPLING_RATIO` (default
+0.2) -- ahora si efectivo.
+
+**Alternativa considerada y descartada: configurar `AzureMonitorExporterOptions` en vez de
+reordenar.** Poner `o.TracesPerSecond = null; o.SamplingRatio = ratio;` hace que
+`UseAzureMonitorExporter()` instale `ApplicationInsightsSampler` en vez de `RateLimitedSampler`. Es
+la via idiomatica del exporter y tiene una ventaja real: `ApplicationInsightsSampler` estampa el
+campo `sampleRate` en cada item para que Application Insights **extrapole** los conteos (a
+diferencia de `TraceIdRatioBasedSampler`, que subcuenta las metricas sin ese campo). Se descarto
+porque `ApplicationInsightsSampler` es `internal`
+(`Azure.Monitor.OpenTelemetry.Exporter.Internals`) y no se puede componer con el filtro de la
+siguiente seccion (envolverlo para descartar un span por nombre). **Se asume la subcuenta de
+metricas** como consecuencia conocida de esta decision: los conteos de trazas en Application
+Insights para estos dos procesos no reflejan el volumen real por encima de 1/ratio -- solo el
+volumen efectivamente exportado, sin extrapolar.
+
+## Actualizacion (2026-08-04, issue #308): filtro del span de polling del daemon (worker de Projections)
+
+El worker de proyecciones (`Bitakora.ControlAsistencia.Projections`) corre el daemon HotCold de
+Marten, que emite una actividad `marten.daemon.highwatermark` cada ~5s sin valor diagnostico. Con
+la Capa 2 corregida (arriba) ese span pasa a competir por el mismo ratio de sampling que las
+actividades con valor real, y su hijo Postgres (`Npgsql`) explicaba el 95% de los spans Postgres del
+worker en la medicion de 24h que motivo este issue.
+
+Se agrego `SamplerQueDescartaPollingDelDaemon`, que envuelve el sampler de ratio y descarta esa
+actividad especifica por nombre (`Drop`, sin delegar) dejando pasar el resto de la fuente `Marten`
+sin alterar el ratio configurado. Un `Drop` en la actividad raiz basta para que su hija Npgsql ni
+siquiera se instancie (verificado empiricamente: `ParentBasedSampler` resuelve al hijo por el
+contexto del padre sin `Recorded`, y devuelve `AlwaysOffSampler`) -- no hace falta un
+`BaseProcessor<Activity>` adicional para filtrar el hijo por separado.
+
+Este filtro **solo se aplica en el worker de Projections** (MEF-ADR-0018, Rule of Three): es el unico
+proceso que corre el daemon HotCold. `ControlHoras` y `Programacion` no lo necesitan -- no emiten
+ese span -- y no se generaliza el wrapper a ellos hasta que exista un segundo consumidor real.
+
+Capas 3 y 4 sin cambios.

--- a/src/Bitakora.ControlAsistencia.ControlHoras/Infraestructura/ComposicionServicios.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Infraestructura/ComposicionServicios.cs
@@ -13,6 +13,7 @@ using FluentValidation;
 using Marten;
 using Microsoft.Azure.Functions.Worker.OpenTelemetry;
 using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry;
 using OpenTelemetry.Trace;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.Infraestructura;
@@ -141,15 +142,27 @@ public static class ComposicionServicios
                 ? ratio
                 : 0.2;
 
+        // Issue #308 (hallazgo 1): UseAzureMonitorExporter() llama SetSampler internamente
+        // (Azure.Monitor.OpenTelemetry.Exporter 1.8.1) con RateLimitedSampler porque
+        // AzureMonitorExporterOptions.TracesPerSecond tiene default 5.0. Si el SetSampler del
+        // proyecto se escribe ANTES de UseAzureMonitorExporter() (como estaba), ese SetSampler
+        // interno lo pisa y el sampler configurado aqui nunca se instala -- verificado en runtime.
+        // La correccion es de ORDEN: un segundo .WithTracing(...) DESPUES de
+        // .UseAzureMonitorExporter() para que el SetSampler de este seam sea el que gane.
+        // A diferencia de Projections (que envuelve el sampler con SamplerQueDescartaPollingDelDaemon
+        // porque el worker corre el daemon HotCold de Marten), ControlHoras no corre ningun daemon
+        // -- MEF-ADR-0018 Rule of Three: el filtro tiene un solo consumidor real y no se generaliza
+        // aqui.
         services.AddOpenTelemetry()
             .WithTracing(tracing => tracing
-                .SetSampler(new ParentBasedSampler(new TraceIdRatioBasedSampler(samplingRatio)))
                 .AddSource("Wolverine")
                 .AddSource("Marten")
                 .AddSource("Npgsql")
                 .AddSource("Bitakora.ControlAsistencia.ControlHoras.*"))
             .UseFunctionsWorkerDefaults()
-            .UseAzureMonitorExporter();
+            .UseAzureMonitorExporter()
+            .WithTracing(tracing => tracing
+                .SetSampler(new ParentBasedSampler(new TraceIdRatioBasedSampler(samplingRatio))));
 
         // Serializacion JSON global: camelCase hacia el cliente, case-insensitive en lectura
         services.Configure<JsonSerializerOptions>(options =>

--- a/src/Bitakora.ControlAsistencia.Projections/Infraestructura/ConfiguracionObservabilidadProjections.cs
+++ b/src/Bitakora.ControlAsistencia.Projections/Infraestructura/ConfiguracionObservabilidadProjections.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using Azure.Monitor.OpenTelemetry.Exporter;
+using OpenTelemetry;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 
@@ -64,14 +65,27 @@ public static class ConfiguracionObservabilidadProjections
         var samplingRatio = ResolverRatioDeSampling(
             Environment.GetEnvironmentVariable(VariableRatioSampling));
 
+        // Issue #308 (hallazgo 1): UseAzureMonitorExporter() llama SetSampler internamente
+        // (Azure.Monitor.OpenTelemetry.Exporter 1.8.1) con RateLimitedSampler porque
+        // AzureMonitorExporterOptions.TracesPerSecond tiene default 5.0. Si el SetSampler del
+        // proyecto se escribe ANTES de UseAzureMonitorExporter() (como estaba), ese SetSampler
+        // interno lo pisa y el sampler configurado aqui nunca se instala -- verificado en runtime.
+        // La correccion es de ORDEN: un segundo .WithTracing(...) DESPUES de
+        // .UseAzureMonitorExporter() para que el SetSampler de este seam sea el que gane.
         services.AddOpenTelemetry()
             .ConfigureResource(ConfigurarRecurso)
             .WithTracing(tracing => tracing
-                .SetSampler(new ParentBasedSampler(new TraceIdRatioBasedSampler(samplingRatio)))
                 .AddSource("Marten")
                 .AddSource("Npgsql")
                 .AddSource(PatronFuentePropia))
-            .UseAzureMonitorExporter();
+            .UseAzureMonitorExporter()
+            .WithTracing(tracing => tracing
+                // Issue #308 (hallazgo 2): el daemon HotCold de Marten emite un span de polling sin
+                // valor diagnostico cada 5s (marten.daemon.highwatermark) del que cuelga el 95% de
+                // los spans Postgres del worker. Se envuelve el sampler de ratio para descartar esa
+                // actividad puntual sin afectar al resto de la fuente Marten.
+                .SetSampler(new SamplerQueDescartaPollingDelDaemon(
+                    new ParentBasedSampler(new TraceIdRatioBasedSampler(samplingRatio)))));
 
         return services;
     }

--- a/src/Bitakora.ControlAsistencia.Projections/Infraestructura/SamplerQueDescartaPollingDelDaemon.cs
+++ b/src/Bitakora.ControlAsistencia.Projections/Infraestructura/SamplerQueDescartaPollingDelDaemon.cs
@@ -26,19 +26,24 @@ public sealed class SamplerQueDescartaPollingDelDaemon : Sampler
     // esta corrigiendo.
     internal const string NombreSpanPollingDaemon = "marten.daemon.highwatermark";
 
-    // Visible en tests via InternalsVisibleTo (Projections.csproj). Permite verificar CA-3
-    // (TELEMETRY_SAMPLING_RATIO llega al sampler efectivo) inspeccionando directamente el sampler
-    // envuelto, sin necesitar reflection adicional mas alla del unico paso ya inevitable: leer la
-    // propiedad interna `Sampler` de TracerProviderSdk (OpenTelemetry no la expone publicamente).
-    internal Sampler Delegado { get; }
+    private readonly Sampler _delegado;
 
     public SamplerQueDescartaPollingDelDaemon(Sampler delegado)
     {
-        Delegado = delegado;
+        _delegado = delegado;
+
+        // Description compuesta al estilo de la propia OpenTelemetry (ParentBasedSampler produce
+        // "ParentBased{TraceIdRatioBasedSampler{0.200000}}"): el sampler envuelto queda visible en
+        // la unica superficie que la clase base ya expone publicamente, en vez de publicar el
+        // delegado como propiedad para que los tests afirmen estado interno (MEF-ADR-0012,
+        // Tell-don't-Ask). Tiene valor para el caller real, no solo para el test: es la cadena con
+        // la que el SDK describe el sampler instalado en sus diagnosticos, y es la que el guardrail
+        // CA-3 lee para comprobar que TELEMETRY_SAMPLING_RATIO llega al sampler efectivo.
+        Description = $"{nameof(SamplerQueDescartaPollingDelDaemon)}{{{delegado.Description}}}";
     }
 
     public override SamplingResult ShouldSample(in SamplingParameters samplingParameters) =>
         samplingParameters.Name == NombreSpanPollingDaemon
             ? new SamplingResult(SamplingDecision.Drop)
-            : Delegado.ShouldSample(in samplingParameters);
+            : _delegado.ShouldSample(in samplingParameters);
 }

--- a/src/Bitakora.ControlAsistencia.Projections/Infraestructura/SamplerQueDescartaPollingDelDaemon.cs
+++ b/src/Bitakora.ControlAsistencia.Projections/Infraestructura/SamplerQueDescartaPollingDelDaemon.cs
@@ -1,0 +1,43 @@
+using OpenTelemetry.Trace;
+
+namespace Bitakora.ControlAsistencia.Projections.Infraestructura;
+
+/// <summary>
+/// Issue #308 (hallazgo 2): el 95% de los spans Postgres del worker cuelgan del span raiz del
+/// daemon HotCold de Marten (`marten.daemon.highwatermark`, un ciclo cada 5s sin valor
+/// diagnostico). Este sampler envuelve al sampler de ratio (CA-ADR-0009 Capa 2,
+/// ConfiguracionObservabilidadProjections.ConfigurarObservabilidad) y descarta esa actividad SIN
+/// delegar -- Drop en la raiz basta para que el hijo Npgsql ni siquiera se instancie (verificado
+/// empiricamente por el planner: "hijo npgsql -> Activity NULL"), asi que no hace falta un
+/// BaseProcessor ni filtrar el hijo por separado.
+///
+/// STUB de compilacion (fase roja, test-writer): ShouldSample lanza NotImplementedException.
+/// Lo implementa projection-implementer. Solo un consumidor (el worker de proyecciones, que corre
+/// el daemon) -- MEF-ADR-0018 Rule of Three: NO se generaliza a los Function Apps
+/// (ControlHoras/Programacion), que no corren daemon y por tanto no emiten este span.
+/// </summary>
+public sealed class SamplerQueDescartaPollingDelDaemon : Sampler
+{
+    // Issue #308, nota tecnica: JasperFx.Events.Daemon.HighWater.HighWaterAgent construye el
+    // nombre del span como `_settings.OtelPrefix + ".daemon.highwatermark"`. No existe como
+    // literal en ningun ensamblado del marco (JasperFx.Events 2.18.1 / Marten 9.12.0) -- el
+    // guardrail CA-6 (SamplerQueDescartaPollingDelDaemonTests) contrasta esta constante contra
+    // `new StoreOptions().Projections.OtelPrefix` de la API real para que un cambio futuro de
+    // OtelPrefix no deje este filtro inerte en silencio, el mismo modo de falla que este issue
+    // esta corrigiendo.
+    internal const string NombreSpanPollingDaemon = "marten.daemon.highwatermark";
+
+    // Visible en tests via InternalsVisibleTo (Projections.csproj). Permite verificar CA-3
+    // (TELEMETRY_SAMPLING_RATIO llega al sampler efectivo) inspeccionando directamente el sampler
+    // envuelto, sin necesitar reflection adicional mas alla del unico paso ya inevitable: leer la
+    // propiedad interna `Sampler` de TracerProviderSdk (OpenTelemetry no la expone publicamente).
+    internal Sampler Delegado { get; }
+
+    public SamplerQueDescartaPollingDelDaemon(Sampler delegado)
+    {
+        Delegado = delegado;
+    }
+
+    public override SamplingResult ShouldSample(in SamplingParameters samplingParameters) =>
+        throw new NotImplementedException();
+}

--- a/src/Bitakora.ControlAsistencia.Projections/Infraestructura/SamplerQueDescartaPollingDelDaemon.cs
+++ b/src/Bitakora.ControlAsistencia.Projections/Infraestructura/SamplerQueDescartaPollingDelDaemon.cs
@@ -11,10 +11,9 @@ namespace Bitakora.ControlAsistencia.Projections.Infraestructura;
 /// empiricamente por el planner: "hijo npgsql -> Activity NULL"), asi que no hace falta un
 /// BaseProcessor ni filtrar el hijo por separado.
 ///
-/// STUB de compilacion (fase roja, test-writer): ShouldSample lanza NotImplementedException.
-/// Lo implementa projection-implementer. Solo un consumidor (el worker de proyecciones, que corre
-/// el daemon) -- MEF-ADR-0018 Rule of Three: NO se generaliza a los Function Apps
-/// (ControlHoras/Programacion), que no corren daemon y por tanto no emiten este span.
+/// Solo un consumidor (el worker de proyecciones, que corre el daemon) -- MEF-ADR-0018 Rule of
+/// Three: NO se generaliza a los Function Apps (ControlHoras/Programacion), que no corren daemon
+/// y por tanto no emiten este span.
 /// </summary>
 public sealed class SamplerQueDescartaPollingDelDaemon : Sampler
 {
@@ -39,5 +38,7 @@ public sealed class SamplerQueDescartaPollingDelDaemon : Sampler
     }
 
     public override SamplingResult ShouldSample(in SamplingParameters samplingParameters) =>
-        throw new NotImplementedException();
+        samplingParameters.Name == NombreSpanPollingDaemon
+            ? new SamplingResult(SamplingDecision.Drop)
+            : Delegado.ShouldSample(in samplingParameters);
 }

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/ComposicionServiciosTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/ComposicionServiciosTests.cs
@@ -19,6 +19,7 @@
 // downcast: IDocumentStore.Options (IReadOnlyStoreOptions) -> Events (IReadOnlyEventStoreOptions)
 // -> MetadataConfig (IReadonlyMetadataConfig).
 
+using System.Globalization;
 using System.Reflection;
 using System.Text;
 using AwesomeAssertions;
@@ -48,11 +49,14 @@ public class ComposicionServiciosTests
     private const string ServiceBusConnectionStringDummy =
         "Endpoint=sb://dummy.servicebus.windows.net/;SharedAccessKeyName=dummy;SharedAccessKey=dummy";
 
-    // Issue #308: nombre de variable de entorno del sampling (CA-ADR-0009 Capa 2). Se repite como
-    // literal inline en ComposicionServicios.cs (a diferencia de Projections, que lo extrae a una
-    // constante testeable) -- ver comentario de ese archivo. El literal se fija aqui una sola vez
-    // para no repetirlo en cada test.
+    // Issue #308: nombre de la variable de entorno y default del ratio de sampling (CA-ADR-0009
+    // Capa 2). Ambos se repiten como literal inline en ComposicionServicios.cs -- a diferencia de
+    // Projections, que los extrae a constantes internas testeables -- porque este dominio no declara
+    // InternalsVisibleTo hacia su proyecto de tests. Se fijan aqui una sola vez para no repetirlos
+    // en cada test; si algun dia el dominio abre sus internals, estas dos constantes se reemplazan
+    // por las de produccion.
     private const string VariableRatioSampling = "TELEMETRY_SAMPLING_RATIO";
+    private const double RatioSamplingPorDefecto = 0.2;
 
     private static ServiceProvider ComponerServiceProvider()
     {
@@ -88,9 +92,10 @@ public class ComposicionServiciosTests
     // Issue #308: lee la propiedad interna `Sampler` de TracerProviderSdk (OpenTelemetry.dll no la
     // expone publicamente). Determinista -- compara tipos y lee Sampler.Description (publica) --,
     // no requiere muestrear actividades reales contra un ratio fraccionario. Duplicado deliberado
-    // del mismo helper en Bitakora.ControlAsistencia.Projections.Tests
-    // (SamplerQueDescartaPollingDelDaemonTests): son proyectos de test distintos, sin un ensamblado
-    // compartido entre ambos (CA-ADR-0029: Contracts.Tests fue eliminado).
+    // del mismo helper en Bitakora.ControlAsistencia.Projections.Tests (SamplerEfectivo.De): son
+    // proyectos de test distintos, sin un ensamblado compartido entre ambos (CA-ADR-0029:
+    // Contracts.Tests fue eliminado). Dos sitios -- MEF-ADR-0018 Rule of Three: se tolera la
+    // duplicacion hasta que aparezca un tercer consumidor que justifique un ensamblado comun.
     private static Sampler ObtenerSamplerEfectivo(TracerProvider tracerProvider)
     {
         var propiedad = tracerProvider.GetType()
@@ -396,7 +401,31 @@ public class ComposicionServiciosTests
 
             var samplerEfectivo = ObtenerSamplerEfectivo(tracerProvider);
 
-            samplerEfectivo.Description.Should().Contain("0.500000");
+            samplerEfectivo.Description.Should().Contain(FormatearRatio(0.5));
         });
     }
+
+    // La otra mitad de CA-3, y la que mas importa hoy: TELEMETRY_SAMPLING_RATIO no esta puesta en
+    // ningun recurso desplegado (medido en el issue #308), asi que el camino que efectivamente corre
+    // en dev es el del DEFAULT. Sin este guardrail, el sampler efectivo podria quedar con un ratio
+    // distinto al declarado y solo se veria como un volumen de ingestion inesperado -- el mismo modo
+    // de falla silenciosa que este issue corrige.
+    [Fact]
+    public void AgregarServiciosControlHoras_PropagaElRatioPorDefecto_AlSamplerEfectivo_CuandoLaVariableEstaAusente()
+    {
+        ConVariableDeEntorno(VariableRatioSampling, null, () =>
+        {
+            using var provider = ComponerServiceProvider();
+            var tracerProvider = provider.GetRequiredService<TracerProvider>();
+
+            var samplerEfectivo = ObtenerSamplerEfectivo(tracerProvider);
+
+            samplerEfectivo.Description.Should().Contain(FormatearRatio(RatioSamplingPorDefecto));
+        });
+    }
+
+    // TraceIdRatioBasedSampler embebe el ratio en su Description con formato F6 invariante
+    // ("TraceIdRatioBasedSampler{0.200000}"), verificado contra OpenTelemetry 1.16.0.
+    private static string FormatearRatio(double ratio) =>
+        ratio.ToString("F6", CultureInfo.InvariantCulture);
 }

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/ComposicionServiciosTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/ComposicionServiciosTests.cs
@@ -19,6 +19,7 @@
 // downcast: IDocumentStore.Options (IReadOnlyStoreOptions) -> Events (IReadOnlyEventStoreOptions)
 // -> MetadataConfig (IReadonlyMetadataConfig).
 
+using System.Reflection;
 using System.Text;
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
@@ -33,6 +34,7 @@ using FluentValidation;
 using JasperFx.MultiTenancy; // TenancyStyle (NO Marten.*: vive en JasperFx.MultiTenancy)
 using Marten;
 using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry.Trace;
 using ObtenerTurnoDiarioEndpoint = Bitakora.ControlAsistencia.ControlHoras.ObtenerTurnoDiario.FunctionEndpoint;
 using ListarTurnosDiariosEndpoint = Bitakora.ControlAsistencia.ControlHoras.ListarTurnosDiarios.FunctionEndpoint;
 
@@ -46,6 +48,12 @@ public class ComposicionServiciosTests
     private const string ServiceBusConnectionStringDummy =
         "Endpoint=sb://dummy.servicebus.windows.net/;SharedAccessKeyName=dummy;SharedAccessKey=dummy";
 
+    // Issue #308: nombre de variable de entorno del sampling (CA-ADR-0009 Capa 2). Se repite como
+    // literal inline en ComposicionServicios.cs (a diferencia de Projections, que lo extrae a una
+    // constante testeable) -- ver comentario de ese archivo. El literal se fija aqui una sola vez
+    // para no repetirlo en cada test.
+    private const string VariableRatioSampling = "TELEMETRY_SAMPLING_RATIO";
+
     private static ServiceProvider ComponerServiceProvider()
     {
         var services = new ServiceCollection();
@@ -57,6 +65,41 @@ public class ComposicionServiciosTests
 
         return services.BuildServiceProvider(
             new ServiceProviderOptions { ValidateOnBuild = true, ValidateScopes = true });
+    }
+
+    // Fija el valor de la variable de entorno mientras corre la accion y lo restaura despues (null
+    // la elimina). Mismo patron que ConfiguracionObservabilidadProjectionsTests.ConVariableDeEntorno
+    // (issue #250/#308): sin esto, el escenario de ratio configurado no seria determinista frente a
+    // tests corriendo en paralelo.
+    private static void ConVariableDeEntorno(string nombre, string? valor, Action accion)
+    {
+        var original = Environment.GetEnvironmentVariable(nombre);
+        Environment.SetEnvironmentVariable(nombre, valor);
+        try
+        {
+            accion();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(nombre, original);
+        }
+    }
+
+    // Issue #308: lee la propiedad interna `Sampler` de TracerProviderSdk (OpenTelemetry.dll no la
+    // expone publicamente). Determinista -- compara tipos y lee Sampler.Description (publica) --,
+    // no requiere muestrear actividades reales contra un ratio fraccionario. Duplicado deliberado
+    // del mismo helper en Bitakora.ControlAsistencia.Projections.Tests
+    // (SamplerQueDescartaPollingDelDaemonTests): son proyectos de test distintos, sin un ensamblado
+    // compartido entre ambos (CA-ADR-0029: Contracts.Tests fue eliminado).
+    private static Sampler ObtenerSamplerEfectivo(TracerProvider tracerProvider)
+    {
+        var propiedad = tracerProvider.GetType()
+            .GetProperty("Sampler", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException(
+                "TracerProviderSdk ya no expone la propiedad interna 'Sampler' " +
+                "(OpenTelemetry 1.16.0) -- actualizar este helper de reflection.");
+
+        return (Sampler)propiedad.GetValue(tracerProvider)!;
     }
 
     [Fact]
@@ -301,5 +344,59 @@ public class ComposicionServiciosTests
         var act = () => ActivatorUtilities.CreateInstance<ListarTurnosDiariosEndpoint>(scope.ServiceProvider);
 
         act.Should().NotThrow();
+    }
+
+    // --- Sampler efectivo del TracerProvider (issue #308 CA-2, CA-3) ---
+    //
+    // Hallazgo 1 del issue #308: UseAzureMonitorExporter llama SetSampler internamente
+    // (Azure.Monitor.OpenTelemetry.Exporter 1.8.1) con RateLimitedSampler porque
+    // AzureMonitorExporterOptions.TracesPerSecond tiene default 5.0. Escrito en el orden actual de
+    // este seam (SetSampler ANTES de UseAzureMonitorExporter), ese SetSampler interno pisa al
+    // ParentBasedSampler{TraceIdRatioBasedSampler{ratio}} que CA-ADR-0009 Capa 2 describe -- nunca
+    // llega a instalarse. La correccion es de ORDEN (un segundo .WithTracing(...) despues de
+    // .UseAzureMonitorExporter()), asi que el guardrail verifica el sampler EFECTIVO resuelto del
+    // contenedor, no que el codigo "llame a SetSampler" (eso ya lo hacia el seam roto).
+    //
+    // A diferencia de Projections (que envuelve el sampler de ratio con
+    // SamplerQueDescartaPollingDelDaemon porque el worker corre el daemon HotCold de Marten),
+    // ControlHoras no corre ningun daemon -- MEF-ADR-0018 Rule of Three: el filtro tiene un solo
+    // consumidor real (el worker) y no se generaliza aqui. El sampler efectivo esperado es
+    // directamente el ParentBasedSampler configurado por el proyecto, sin wrapper.
+    [Fact]
+    public void AgregarServiciosControlHoras_ResuelveElSamplerConfiguradoPorElProyecto_EnVezDeRateLimitedSampler()
+    {
+        // TracerProvider se registra Singleton (default de OpenTelemetry): no requiere un scope
+        // Wolverine (IAsyncDisposable) para resolverse, a diferencia de ICommandRouter/
+        // IPrivateEventRouter arriba -- Dispose() sincrono del ServiceProvider raiz basta.
+        using var provider = ComponerServiceProvider();
+        var tracerProvider = provider.GetRequiredService<TracerProvider>();
+
+        var samplerEfectivo = ObtenerSamplerEfectivo(tracerProvider);
+
+        // Oraculo por nombre completo, no por referencia al tipo (es internal en otro ensamblado:
+        // Azure.Monitor.OpenTelemetry.Exporter.Internals.RateLimitedSampler no se puede nombrar
+        // desde este proyecto). Verificado en runtime (issue #308) que este es exactamente el tipo
+        // que gana hoy con el wiring actual.
+        samplerEfectivo.GetType().FullName.Should().NotBe(
+            "Azure.Monitor.OpenTelemetry.Exporter.Internals.RateLimitedSampler");
+        samplerEfectivo.Should().BeOfType<ParentBasedSampler>();
+    }
+
+    // CA-3: complementa (no reemplaza) el parsing inline del ratio que ya vive en
+    // ComposicionServicios.cs -- verifica que el ratio efectivamente llega al sampler compuesto que
+    // el contenedor resuelve, no solo que se calcula correctamente. Determinista via
+    // Sampler.Description (propiedad publica: "ParentBased{TraceIdRatioBasedSampler{F6}}").
+    [Fact]
+    public void AgregarServiciosControlHoras_PropagaElRatioDeSamplingConfigurado_AlSamplerEfectivo()
+    {
+        ConVariableDeEntorno(VariableRatioSampling, "0.5", () =>
+        {
+            using var provider = ComponerServiceProvider();
+            var tracerProvider = provider.GetRequiredService<TracerProvider>();
+
+            var samplerEfectivo = ObtenerSamplerEfectivo(tracerProvider);
+
+            samplerEfectivo.Description.Should().Contain("0.500000");
+        });
     }
 }

--- a/tests/Bitakora.ControlAsistencia.Projections.Tests/Infraestructura/ConfiguracionObservabilidadProjectionsTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Projections.Tests/Infraestructura/ConfiguracionObservabilidadProjectionsTests.cs
@@ -19,16 +19,23 @@
 //
 // Limites conocidos de esta clase (documentados, no huecos accidentales):
 //
-// 1. Que el ratio resuelto llegue efectivamente al ParentBasedSampler/TraceIdRatioBasedSampler no
-//    se verifica: el sampler compuesto vive dentro de TracerProviderSdk, que OpenTelemetry no
-//    expone publicamente. Ejercitarlo end-to-end exigiria muestrear actividades reales contra un
-//    ratio fraccionario -- probabilistico y flaky. Queda cubierto por revision de codigo.
-// 2. Que Program.cs invoque el seam (CA-4) tampoco: Program.cs son top-level statements y el
-//    worker no tiene equivalente a WebApplicationFactory (limite que MEF-ADR-0029 ya reconoce).
-//    Lo mas cerca que llega esta clase es componer juntos los dos seams del worker
-//    (ConfigurarEventos + ConfigurarObservabilidad), que es lo que Program.cs encadena; el enlace
-//    literal queda cubierto por revision de codigo (CA-4) y por el arranque real post-deploy
+// 1. Que Program.cs invoque el seam (CA-4 del issue #250) no se verifica: Program.cs son
+//    top-level statements y el worker no tiene equivalente a WebApplicationFactory (limite que
+//    MEF-ADR-0029 ya reconoce). Lo mas cerca que llega esta clase es componer juntos los dos seams
+//    del worker (ConfigurarEventos + ConfigurarObservabilidad), que es lo que Program.cs encadena;
+//    el enlace literal queda cubierto por revision de codigo y por el arranque real post-deploy
 //    (MEF-ADR-0013).
+//
+// Issue #308: el limite "el sampler compuesto vive dentro de TracerProviderSdk, que OpenTelemetry
+// no expone publicamente" que este archivo declaraba antes resulto SUPERABLE -- ver
+// ObtenerSamplerEfectivo (SamplerQueDescartaPollingDelDaemonTests, helper compartido via
+// reflection sobre la propiedad interna Sampler) y los tests "ConfigurarObservabilidad_Resuelve*"
+// mas abajo. Es determinista (compara tipos y lee Description, que es publica), no probabilistico:
+// no hace falta muestrear actividades reales contra un ratio fraccionario. La revision de codigo
+// NO detecto el hallazgo 1 del issue #308 (UseAzureMonitorExporter pisa el sampler por dentro)
+// precisamente porque el codigo visible de este seam era correcto -- el defecto estaba en la
+// implementacion interna del exporter. De ahi que el guardrail deje de asumir que ese limite es
+// permanente.
 using System.Diagnostics;
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.Projections.Infraestructura;
@@ -143,6 +150,55 @@ public class ConfiguracionObservabilidadProjectionsTests
         provider.GetService<TracerProvider>().Should().NotBeNull();
         provider.GetService<IProgramacionProjectionStore>().Should().NotBeNull();
         provider.GetService<IControlHorasProjectionStore>().Should().NotBeNull();
+    }
+
+    // --- Sampler efectivo del TracerProvider (issue #308 CA-1, CA-3) ---
+    //
+    // Hallazgo 1 del issue: UseAzureMonitorExporter llama SetSampler internamente
+    // (Azure.Monitor.OpenTelemetry.Exporter 1.8.1) con RateLimitedSampler cuando
+    // AzureMonitorExporterOptions.TracesPerSecond tiene valor (default 5.0, SIEMPRE lo tiene salvo
+    // que el codigo lo ponga en null explicitamente). Escrito en el orden actual de este seam
+    // (SetSampler ANTES de UseAzureMonitorExporter), ese SetSampler interno pisa al que el proyecto
+    // configura -- el ParentBasedSampler{TraceIdRatioBasedSampler{ratio}} que CA-ADR-0009 Capa 2
+    // describe nunca llega a instalarse. La correccion es de ORDEN (un segundo .WithTracing(...)
+    // despues de .UseAzureMonitorExporter()), no de contenido: por eso el guardrail verifica el
+    // sampler EFECTIVO del contenedor, no que el codigo "llame a SetSampler" (eso ya lo hacia el
+    // seam roto).
+    [Fact]
+    public void ConfigurarObservabilidad_ResuelveElSamplerConfiguradoPorElProyecto_EnVezDeRateLimitedSampler()
+    {
+        using var provider = ComponerServiceProvider();
+        var tracerProvider = provider.GetRequiredService<TracerProvider>();
+
+        var samplerEfectivo = SamplerQueDescartaPollingDelDaemonTests.ObtenerSamplerEfectivo(tracerProvider);
+
+        // Oraculo por nombre completo, no por referencia al tipo (es internal en otro ensamblado:
+        // Azure.Monitor.OpenTelemetry.Exporter.Internals.RateLimitedSampler no se puede nombrar
+        // desde este proyecto). Verificado en runtime (issue #308) que este es exactamente el tipo
+        // que gana hoy con el wiring actual.
+        samplerEfectivo.GetType().FullName.Should().NotBe(
+            "Azure.Monitor.OpenTelemetry.Exporter.Internals.RateLimitedSampler");
+        samplerEfectivo.Should().BeOfType<SamplerQueDescartaPollingDelDaemon>();
+    }
+
+    // CA-3: complementa (no reemplaza) ResolverRatioDeSampling_* de mas abajo -- aquellos verifican
+    // solo el PARSING del valor de entorno; este verifica que el ratio resuelto efectivamente llega
+    // al sampler compuesto que el contenedor resuelve. Antes del issue #308 esto se declaraba como
+    // limite conocido (no observable sin acceder a TracerProviderSdk); dejo de serlo con
+    // ObtenerSamplerEfectivo + Sampler.Description (propiedad publica: "TraceIdRatioBasedSampler{F6}").
+    [Fact]
+    public void ConfigurarObservabilidad_PropagaElRatioDeSamplingConfigurado_AlSamplerEfectivo()
+    {
+        ConVariableDeEntorno(ConfiguracionObservabilidadProjections.VariableRatioSampling, "0.5", () =>
+        {
+            using var provider = ComponerServiceProvider();
+            var tracerProvider = provider.GetRequiredService<TracerProvider>();
+
+            var samplerEfectivo = (SamplerQueDescartaPollingDelDaemon)
+                SamplerQueDescartaPollingDelDaemonTests.ObtenerSamplerEfectivo(tracerProvider);
+
+            samplerEfectivo.Delegado.Description.Should().Contain("0.500000");
+        });
     }
 
     // El patron de la fuente propia (CA-2) va sin punto antes del asterisco a proposito. Verificado

--- a/tests/Bitakora.ControlAsistencia.Projections.Tests/Infraestructura/ConfiguracionObservabilidadProjectionsTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Projections.Tests/Infraestructura/ConfiguracionObservabilidadProjectionsTests.cs
@@ -27,16 +27,17 @@
 //    (MEF-ADR-0013).
 //
 // Issue #308: el limite "el sampler compuesto vive dentro de TracerProviderSdk, que OpenTelemetry
-// no expone publicamente" que este archivo declaraba antes resulto SUPERABLE -- ver
-// ObtenerSamplerEfectivo (SamplerQueDescartaPollingDelDaemonTests, helper compartido via
-// reflection sobre la propiedad interna Sampler) y los tests "ConfigurarObservabilidad_Resuelve*"
-// mas abajo. Es determinista (compara tipos y lee Description, que es publica), no probabilistico:
-// no hace falta muestrear actividades reales contra un ratio fraccionario. La revision de codigo
+// no expone publicamente" que este archivo declaraba antes resulto SUPERABLE -- ver el helper
+// SamplerEfectivo.De (reflection sobre la propiedad interna Sampler) y los tests
+// "ConfigurarObservabilidad_*ElSampler*" mas abajo. Es determinista (compara tipos y lee
+// Description, que es publica), no probabilistico: no hace falta muestrear actividades reales
+// contra un ratio fraccionario. La revision de codigo
 // NO detecto el hallazgo 1 del issue #308 (UseAzureMonitorExporter pisa el sampler por dentro)
 // precisamente porque el codigo visible de este seam era correcto -- el defecto estaba en la
 // implementacion interna del exporter. De ahi que el guardrail deje de asumir que ese limite es
 // permanente.
 using System.Diagnostics;
+using System.Globalization;
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.Projections.Infraestructura;
 using Microsoft.Extensions.DependencyInjection;
@@ -170,7 +171,7 @@ public class ConfiguracionObservabilidadProjectionsTests
         using var provider = ComponerServiceProvider();
         var tracerProvider = provider.GetRequiredService<TracerProvider>();
 
-        var samplerEfectivo = SamplerQueDescartaPollingDelDaemonTests.ObtenerSamplerEfectivo(tracerProvider);
+        var samplerEfectivo = SamplerEfectivo.De(tracerProvider);
 
         // Oraculo por nombre completo, no por referencia al tipo (es internal en otro ensamblado:
         // Azure.Monitor.OpenTelemetry.Exporter.Internals.RateLimitedSampler no se puede nombrar
@@ -185,7 +186,9 @@ public class ConfiguracionObservabilidadProjectionsTests
     // solo el PARSING del valor de entorno; este verifica que el ratio resuelto efectivamente llega
     // al sampler compuesto que el contenedor resuelve. Antes del issue #308 esto se declaraba como
     // limite conocido (no observable sin acceder a TracerProviderSdk); dejo de serlo con
-    // ObtenerSamplerEfectivo + Sampler.Description (propiedad publica: "TraceIdRatioBasedSampler{F6}").
+    // SamplerEfectivo.De + Sampler.Description (propiedad publica, que el wrapper compone con la del
+    // sampler de ratio que envuelve:
+    // "SamplerQueDescartaPollingDelDaemon{ParentBased{TraceIdRatioBasedSampler{F6}}}").
     [Fact]
     public void ConfigurarObservabilidad_PropagaElRatioDeSamplingConfigurado_AlSamplerEfectivo()
     {
@@ -194,12 +197,36 @@ public class ConfiguracionObservabilidadProjectionsTests
             using var provider = ComponerServiceProvider();
             var tracerProvider = provider.GetRequiredService<TracerProvider>();
 
-            var samplerEfectivo = (SamplerQueDescartaPollingDelDaemon)
-                SamplerQueDescartaPollingDelDaemonTests.ObtenerSamplerEfectivo(tracerProvider);
+            var samplerEfectivo = SamplerEfectivo.De(tracerProvider);
 
-            samplerEfectivo.Delegado.Description.Should().Contain("0.500000");
+            samplerEfectivo.Description.Should().Contain(FormatearRatio(0.5));
         });
     }
+
+    // La otra mitad de CA-3, y la que mas importa hoy: TELEMETRY_SAMPLING_RATIO no esta puesta en
+    // ningun recurso desplegado (medido en el issue #308), asi que el camino que efectivamente corre
+    // en dev es el del DEFAULT. Sin este guardrail, el sampler efectivo podria quedar con un ratio
+    // distinto al que RatioSamplingPorDefecto declara y solo se veria como un volumen de ingestion
+    // inesperado -- el mismo modo de falla silenciosa que este issue corrige.
+    [Fact]
+    public void ConfigurarObservabilidad_PropagaElRatioPorDefecto_AlSamplerEfectivo_CuandoLaVariableEstaAusente()
+    {
+        ConVariableDeEntorno(ConfiguracionObservabilidadProjections.VariableRatioSampling, null, () =>
+        {
+            using var provider = ComponerServiceProvider();
+            var tracerProvider = provider.GetRequiredService<TracerProvider>();
+
+            var samplerEfectivo = SamplerEfectivo.De(tracerProvider);
+
+            samplerEfectivo.Description.Should().Contain(
+                FormatearRatio(ConfiguracionObservabilidadProjections.RatioSamplingPorDefecto));
+        });
+    }
+
+    // TraceIdRatioBasedSampler embebe el ratio en su Description con formato F6 invariante
+    // ("TraceIdRatioBasedSampler{0.200000}"), verificado contra OpenTelemetry 1.16.0.
+    private static string FormatearRatio(double ratio) =>
+        ratio.ToString("F6", CultureInfo.InvariantCulture);
 
     // El patron de la fuente propia (CA-2) va sin punto antes del asterisco a proposito. Verificado
     // contra OpenTelemetry 1.16.0: "X.*" se ancla como ^X\..*$ y descarta una ActivitySource

--- a/tests/Bitakora.ControlAsistencia.Projections.Tests/Infraestructura/SamplerEfectivo.cs
+++ b/tests/Bitakora.ControlAsistencia.Projections.Tests/Infraestructura/SamplerEfectivo.cs
@@ -1,0 +1,31 @@
+// Issue #308: helper de test (no es una clase de tests) para leer el sampler que quedo realmente
+// instalado en un TracerProvider construido. Lo consume ConfiguracionObservabilidadProjectionsTests
+// (CA-1, CA-3) y vive aparte -- no dentro de una clase de tests -- porque el sujeto que describe es
+// el TracerProvider, no el sampler del daemon: cualquier guardrail futuro sobre el wiring OTel del
+// worker lo necesita igual, y ninguna clase de tests deberia ser el hogar de utilidades que otra
+// clase de tests consume.
+using System.Reflection;
+using OpenTelemetry.Trace;
+
+namespace Bitakora.ControlAsistencia.Projections.Tests.Infraestructura;
+
+internal static class SamplerEfectivo
+{
+    /// <summary>
+    /// Lee la propiedad interna `Sampler` de `TracerProviderSdk` (OpenTelemetry.dll no la expone
+    /// publicamente). Determinista: permite comparar tipos y leer `Sampler.Description` (publica),
+    /// sin muestrear actividades reales contra un ratio fraccionario. Este acceso no publico es lo
+    /// que vuelve verificable el hallazgo 1 del issue #308 -- que `UseAzureMonitorExporter()` pisaba
+    /// el sampler del proyecto -- que la revision de codigo no podia atrapar.
+    /// </summary>
+    internal static Sampler De(TracerProvider tracerProvider)
+    {
+        var propiedad = tracerProvider.GetType()
+            .GetProperty("Sampler", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException(
+                "TracerProviderSdk ya no expone la propiedad interna 'Sampler' " +
+                "(OpenTelemetry 1.16.0) -- actualizar este helper de reflection.");
+
+        return (Sampler)propiedad.GetValue(tracerProvider)!;
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Projections.Tests/Infraestructura/SamplerQueDescartaPollingDelDaemonTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Projections.Tests/Infraestructura/SamplerQueDescartaPollingDelDaemonTests.cs
@@ -1,0 +1,190 @@
+// Issue #308: guardrail para el sampler que filtra el span de polling del daemon HotCold de
+// Marten (CA-4, CA-5, CA-6). Dos niveles de verificacion, deliberadamente:
+//
+// a) ShouldSample_* -- unitario, directo sobre el sampler, construyendo SamplingParameters a
+//    mano. Rapido y determinista, pero no prueba el efecto de cascada sobre el hijo Npgsql (un
+//    Drop en el padre no implica per se que OpenTelemetry se abstenga de instanciar la Activity
+//    hija -- eso lo decide el runtime de Activity/ActivityListener, no el sampler).
+// b) CascadaDePolling_* -- de integracion, con ActivitySource reales + un colector de actividades
+//    en memoria (BaseProcessor<Activity>) montado sobre un TracerProvider real. Reproduce
+//    exactamente el wiring que el planner verifico empiricamente: "padre daemon -> Activity
+//    creada, Recorded=False; hijo npgsql -> Activity NULL; Exportados: solo el escenario con
+//    trabajo real". Sin este nivel, un test unitario en verde no demuestra que el hijo Npgsql
+//    tambien se descarta (CA-4) ni que las demas actividades de Marten sobreviven (CA-5).
+//
+// El delegado en CascadaDePolling_* es ParentBasedSampler(TraceIdRatioBasedSampler(1.0)) --
+// el MISMO tipo compuesto que produce ConfigurarObservabilidad, con ratio 1.0 para que sea
+// determinista (Notas tecnicas del issue). Es deliberado, no un detalle de implementacion:
+// la razon por la que el hijo Npgsql sale NULL (CA-4) es que ParentBasedSampler mira
+// parentContext.TraceFlags y, como el padre quedo en Drop (TraceFlags sin Recorded),
+// devuelve AlwaysOffSampler para el hijo -- verificado empiricamente reproduciendo este
+// wiring exacto en un scratch aislado antes de escribir este archivo. Con AlwaysOnSampler
+// como delegado el hijo NO se descartaria (ignora el contexto del padre), asi que ese
+// sampler simplificado no sirve para probar la cascada real; los tests unitarios de
+// ShouldSample de mas abajo si lo usan, porque ahi no importa el contexto del padre.
+using System.Diagnostics;
+using System.Reflection;
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Projections.Infraestructura;
+using Marten;
+using OpenTelemetry;
+using OpenTelemetry.Trace;
+
+namespace Bitakora.ControlAsistencia.Projections.Tests.Infraestructura;
+
+public class SamplerQueDescartaPollingDelDaemonTests
+{
+    // Colector en memoria: hace las veces de "exporter" para poder inspeccionar, sin Application
+    // Insights ni infra real, que actividades sobrevivieron el pipeline completo de sampling.
+    private sealed class ColectorDeActividades : BaseProcessor<Activity>
+    {
+        public List<Activity> Actividades { get; } = [];
+
+        public override void OnEnd(Activity data) => Actividades.Add(data);
+    }
+
+    // --- ShouldSample directo (CA-4, CA-5) ---
+
+    [Fact]
+    public void ShouldSample_RetornaDrop_CuandoElNombreEsElPollingDelDaemon()
+    {
+        var sampler = new SamplerQueDescartaPollingDelDaemon(new AlwaysOnSampler());
+        var parametros = new SamplingParameters(
+            default, default, SamplerQueDescartaPollingDelDaemon.NombreSpanPollingDaemon, ActivityKind.Internal);
+
+        var resultado = sampler.ShouldSample(in parametros);
+
+        resultado.Decision.Should().Be(SamplingDecision.Drop);
+    }
+
+    [Fact]
+    public void ShouldSample_DelegaAlSamplerEnvuelto_CuandoElNombreNoEsElPollingDelDaemon()
+    {
+        var sampler = new SamplerQueDescartaPollingDelDaemon(new AlwaysOnSampler());
+        var parametros = new SamplingParameters(
+            default, default, "marten.turnodiarioview.all.page.loading", ActivityKind.Internal);
+
+        var resultado = sampler.ShouldSample(in parametros);
+
+        resultado.Decision.Should().Be(SamplingDecision.RecordAndSample);
+    }
+
+    [Fact]
+    public void ShouldSample_DelegaAlSamplerEnvuelto_CuandoElNombreEsDeOtraFuenteComoNpgsql()
+    {
+        // El sampler NO conoce el source, solo el nombre de la actividad: la proteccion del hijo
+        // Npgsql (CA-4) no depende de que este sampler distinga sources, sino de que el padre haya
+        // quedado en Drop (ver CascadaDePolling_* abajo, verificacion de efecto real).
+        var sampler = new SamplerQueDescartaPollingDelDaemon(new AlwaysOnSampler());
+        var parametros = new SamplingParameters(default, default, "some-sql-command", ActivityKind.Client);
+
+        var resultado = sampler.ShouldSample(in parametros);
+
+        resultado.Decision.Should().Be(SamplingDecision.RecordAndSample);
+    }
+
+    // --- Cascada real padre (daemon) / hijo (Npgsql) (CA-4, CA-5) ---
+
+    private static Sampler CrearDelegadoRealDeterminista(double ratio) =>
+        new ParentBasedSampler(new TraceIdRatioBasedSampler(ratio));
+
+    [Fact]
+    public void CascadaDePolling_CreaLaActividadDelDaemonSinRecorded_YSuHijaDeNpgsqlNiSeInstancia()
+    {
+        var sampler = new SamplerQueDescartaPollingDelDaemon(CrearDelegadoRealDeterminista(1.0));
+        var colector = new ColectorDeActividades();
+        using var fuenteMarten = new ActivitySource(nameof(SamplerQueDescartaPollingDelDaemonTests) + ".Marten");
+        using var fuenteNpgsql = new ActivitySource(nameof(SamplerQueDescartaPollingDelDaemonTests) + ".Npgsql");
+        using var provider = Sdk.CreateTracerProviderBuilder()
+            .SetSampler(sampler)
+            .AddSource(fuenteMarten.Name)
+            .AddSource(fuenteNpgsql.Name)
+            .AddProcessor(colector)
+            .Build();
+
+        using (var actividadDaemon = fuenteMarten.StartActivity(
+                   SamplerQueDescartaPollingDelDaemon.NombreSpanPollingDaemon))
+        {
+            // El span raiz SI se instancia (PropagationData: sin padre, el runtime necesita el
+            // contexto para poder propagarlo a los hijos) pero queda Recorded=False -- no llega
+            // al colector/exporter. Verificado empiricamente reproduciendo este wiring exacto.
+            actividadDaemon.Should().NotBeNull();
+            actividadDaemon!.Recorded.Should().BeFalse();
+
+            using var actividadNpgsql = fuenteNpgsql.StartActivity("execute-batch");
+
+            // El hijo SI hereda el contexto (TraceId del padre, sin Recorded) y el delegado real
+            // (ParentBasedSampler) lo resuelve por ese contexto sin Recorded -> AlwaysOffSampler:
+            // ActivitySamplingResult.None -> ni siquiera se instancia.
+            actividadNpgsql.Should().BeNull();
+        }
+
+        colector.Actividades.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void CascadaDePolling_ConservaLasActividadesDeMartenQueNoSonElPollingDelDaemon()
+    {
+        var sampler = new SamplerQueDescartaPollingDelDaemon(CrearDelegadoRealDeterminista(1.0));
+        var colector = new ColectorDeActividades();
+        using var fuenteMarten = new ActivitySource(nameof(SamplerQueDescartaPollingDelDaemonTests) + ".MartenReal");
+        using var provider = Sdk.CreateTracerProviderBuilder()
+            .SetSampler(sampler)
+            .AddSource(fuenteMarten.Name)
+            .AddProcessor(colector)
+            .Build();
+
+        using (fuenteMarten.StartActivity("marten.turnodiarioview.all.page.loading"))
+        {
+        }
+
+        using (fuenteMarten.StartActivity("marten.turnodiarioview.all.page.grouping"))
+        {
+        }
+
+        colector.Actividades.Should().HaveCount(2);
+        colector.Actividades.Select(a => a.OperationName).Should().BeEquivalentTo(
+            ["marten.turnodiarioview.all.page.loading", "marten.turnodiarioview.all.page.grouping"]);
+    }
+
+    // --- Guardrail CA-6: el nombre no puede quedar como literal huerfano ---
+
+    [Fact]
+    public void NombreSpanPollingDaemon_CoincideConOtelPrefixDeMartenMasElSufijoDeHighWaterAgent()
+    {
+        // Oraculo independiente (MEF-ADR-0002): se arma contra la API real de Marten
+        // (StoreOptions().Projections.OtelPrefix), no contra el mismo literal que la constante ya
+        // fija -- de lo contrario esta guarda pasaria siempre, incluso si Marten cambiara
+        // OtelPrefix, que es exactamente el modo de falla silenciosa que el issue #308 corrige.
+        var otelPrefix = new StoreOptions().Projections.OtelPrefix;
+
+        SamplerQueDescartaPollingDelDaemon.NombreSpanPollingDaemon.Should()
+            .Be($"{otelPrefix}.daemon.highwatermark");
+    }
+
+    // --- Delegado accesible para inspeccion desde tests de composicion (CA-3) ---
+
+    [Fact]
+    public void Delegado_ExponeElSamplerConElQueSeConstruyo()
+    {
+        var interno = new AlwaysOnSampler();
+        var sampler = new SamplerQueDescartaPollingDelDaemon(interno);
+
+        sampler.Delegado.Should().BeSameAs(interno);
+    }
+
+    // Helper de reflection reusado por ConfiguracionObservabilidadProjectionsTests para leer el
+    // Sampler efectivo del TracerProvider resuelto del contenedor. Se documenta aqui, junto al
+    // sampler que ese guardrail debe encontrar, para que ambos archivos no diverjan sobre como
+    // acceder a la propiedad interna.
+    internal static Sampler ObtenerSamplerEfectivo(TracerProvider tracerProvider)
+    {
+        var propiedad = tracerProvider.GetType()
+            .GetProperty("Sampler", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException(
+                "TracerProviderSdk ya no expone la propiedad interna 'Sampler' " +
+                "(OpenTelemetry 1.16.0) -- actualizar este helper de reflection.");
+
+        return (Sampler)propiedad.GetValue(tracerProvider)!;
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Projections.Tests/Infraestructura/SamplerQueDescartaPollingDelDaemonTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Projections.Tests/Infraestructura/SamplerQueDescartaPollingDelDaemonTests.cs
@@ -23,7 +23,6 @@
 // sampler simplificado no sirve para probar la cascada real; los tests unitarios de
 // ShouldSample de mas abajo si lo usan, porque ahi no importa el contexto del padre.
 using System.Diagnostics;
-using System.Reflection;
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.Projections.Infraestructura;
 using Marten;
@@ -34,6 +33,11 @@ namespace Bitakora.ControlAsistencia.Projections.Tests.Infraestructura;
 
 public class SamplerQueDescartaPollingDelDaemonTests
 {
+    // Spans reales de la fuente Marten medidos en las 24h del issue #308 (70 y 48 ocurrencias frente
+    // a los ~69k del polling del daemon): la senal que el filtro NO puede apagar (CA-5).
+    private const string SpanProyeccionLoading = "marten.turnodiarioview.all.page.loading";
+    private const string SpanProyeccionGrouping = "marten.turnodiarioview.all.page.grouping";
+
     // Colector en memoria: hace las veces de "exporter" para poder inspeccionar, sin Application
     // Insights ni infra real, que actividades sobrevivieron el pipeline completo de sampling.
     private sealed class ColectorDeActividades : BaseProcessor<Activity>
@@ -62,7 +66,7 @@ public class SamplerQueDescartaPollingDelDaemonTests
     {
         var sampler = new SamplerQueDescartaPollingDelDaemon(new AlwaysOnSampler());
         var parametros = new SamplingParameters(
-            default, default, "marten.turnodiarioview.all.page.loading", ActivityKind.Internal);
+            default, default, SpanProyeccionLoading, ActivityKind.Internal);
 
         var resultado = sampler.ShouldSample(in parametros);
 
@@ -134,17 +138,16 @@ public class SamplerQueDescartaPollingDelDaemonTests
             .AddProcessor(colector)
             .Build();
 
-        using (fuenteMarten.StartActivity("marten.turnodiarioview.all.page.loading"))
+        using (fuenteMarten.StartActivity(SpanProyeccionLoading))
         {
         }
 
-        using (fuenteMarten.StartActivity("marten.turnodiarioview.all.page.grouping"))
+        using (fuenteMarten.StartActivity(SpanProyeccionGrouping))
         {
         }
 
-        colector.Actividades.Should().HaveCount(2);
         colector.Actividades.Select(a => a.OperationName).Should().BeEquivalentTo(
-            ["marten.turnodiarioview.all.page.loading", "marten.turnodiarioview.all.page.grouping"]);
+            [SpanProyeccionLoading, SpanProyeccionGrouping]);
     }
 
     // --- Guardrail CA-6: el nombre no puede quedar como literal huerfano ---
@@ -162,29 +165,20 @@ public class SamplerQueDescartaPollingDelDaemonTests
             .Be($"{otelPrefix}.daemon.highwatermark");
     }
 
-    // --- Delegado accesible para inspeccion desde tests de composicion (CA-3) ---
+    // --- El sampler envuelto queda descrito en la superficie publica (soporte de CA-3) ---
 
     [Fact]
-    public void Delegado_ExponeElSamplerConElQueSeConstruyo()
+    public void Description_EmbebeLaDelSamplerEnvuelto()
     {
-        var interno = new AlwaysOnSampler();
-        var sampler = new SamplerQueDescartaPollingDelDaemon(interno);
+        // El wrapper no publica el delegado (MEF-ADR-0012, Tell-don't-Ask): lo describe. Asi el
+        // guardrail de composicion (ConfiguracionObservabilidadProjectionsTests, CA-3) puede leer el
+        // ratio configurado del sampler efectivo por su API publica, sin afirmar estado interno.
+        var envuelto = new ParentBasedSampler(new TraceIdRatioBasedSampler(0.5));
 
-        sampler.Delegado.Should().BeSameAs(interno);
-    }
+        var sampler = new SamplerQueDescartaPollingDelDaemon(envuelto);
 
-    // Helper de reflection reusado por ConfiguracionObservabilidadProjectionsTests para leer el
-    // Sampler efectivo del TracerProvider resuelto del contenedor. Se documenta aqui, junto al
-    // sampler que ese guardrail debe encontrar, para que ambos archivos no diverjan sobre como
-    // acceder a la propiedad interna.
-    internal static Sampler ObtenerSamplerEfectivo(TracerProvider tracerProvider)
-    {
-        var propiedad = tracerProvider.GetType()
-            .GetProperty("Sampler", BindingFlags.NonPublic | BindingFlags.Instance)
-            ?? throw new InvalidOperationException(
-                "TracerProviderSdk ya no expone la propiedad interna 'Sampler' " +
-                "(OpenTelemetry 1.16.0) -- actualizar este helper de reflection.");
-
-        return (Sampler)propiedad.GetValue(tracerProvider)!;
+        sampler.Description.Should()
+            .Contain(nameof(SamplerQueDescartaPollingDelDaemon)).And
+            .Contain(envuelto.Description);
     }
 }


### PR DESCRIPTION
## Resumen

Pipeline TDD completado:
- Fase roja: tests escritos con stubs
- Fase verde: implementación completa
- Fase refactor: revisión de calidad

## Decisiones del pipeline

<details>
<summary>Test Writer (fase roja) — 15m 58s</summary>

## ES Test Writer - Decisiones (issue #308)

### Naturaleza de la tarea

Este issue **no** involucra command handlers de event sourcing ni aggregates: es un fix de
composicion de OpenTelemetry (orden del wiring `SetSampler`/`UseAzureMonitorExporter`) mas un
sampler nuevo que filtra el span de polling del daemon de Marten. Los tests siguen el patron de
"test de composicion del contenedor DI" (MEF-ADR-0029), ya establecido en el proyecto para
`ConfiguracionObservabilidadProjectionsTests` y `ComposicionServiciosTests` (ControlHoras) -- no el
DSL Given/When/Then de MEF-ADR-0002. Por eso ningun test de este cambio usa `Then(...)`/`And<>()`
del harness `Cosmos.EventSourcing.Testing.Utilities`: no aplica a esta categoria de test, igual que
no aplicaba a los archivos que ya existian antes de este issue.

### Tests creados

**`SamplerQueDescartaPollingDelDaemonTests.cs`** (nuevo, Projections.Tests) -- 8 tests:
- `ShouldSample_RetornaDrop_CuandoElNombreEsElPollingDelDaemon` (CA-4) -- unitario directo
- `ShouldSample_DelegaAlSamplerEnvuelto_CuandoElNombreNoEsElPollingDelDaemon` (CA-5)
- `ShouldSample_DelegaAlSamplerEnvuelto_CuandoElNombreEsDeOtraFuenteComoNpgsql` (CA-4, aclara que el
  sampler no distingue source)
- `CascadaDePolling_CreaLaActividadDelDaemonSinRecorded_YSuHijaDeNpgsqlNiSeInstancia` (CA-4,
  integracion con ActivitySource real + colector en memoria)
- `CascadaDePolling_ConservaLasActividadesDeMartenQueNoSonElPollingDelDaemon` (CA-5, integracion)
- `NombreSpanPollingDaemon_CoincideConOtelPrefixDeMartenMasElSufijoDeHighWaterAgent` (CA-6,
  guardrail contra `new StoreOptions().Projections.OtelPrefix`)
- `Delegado_ExponeElSamplerConElQueSeConstruyo` (soporte de CA-3)
- Helper interno `ObtenerSamplerEfectivo(TracerProvider)` -- reflection sobre la propiedad
  `internal Sampler Sampler` de `TracerProviderSdk` (OpenTelemetry no la expone publicamente),
  reusado por `ConfiguracionObservabilidadProjectionsTests`.

**`ConfiguracionObservabilidadProjectionsTests.cs`** (modificado, Projections.Tests) -- +2 tests:
- `ConfigurarObservabilidad_ResuelveElSamplerConfiguradoPorElProyecto_EnVezDeRateLimitedSampler`
  (CA-1)
- `ConfigurarObservabilidad_PropagaElRatioDeSamplingConfigurado_AlSamplerEfectivo` (CA-3)
- Actualizado el bloque "Limites conocidos": el punto que declaraba "no se puede verificar el
  ratio efectivo sin acceder a TracerProviderSdk" se reescribio -- resulto superable con
  reflection determinista, no probabilistica.

**`ComposicionServiciosTests.cs`** (modificado, ControlHoras.Tests) -- +2 tests:
- `AgregarServiciosControlHoras_ResuelveElSamplerConfiguradoPorElProyecto_EnVezDeRateLimitedSampler`
  (CA-2)
- `AgregarServiciosControlHoras_PropagaElRatioDeSamplingConfigurado_AlSamplerEfectivo` (CA-3)
- Agregado helper `ConVariableDeEntorno` (no existia en este archivo) y `ObtenerSamplerEfectivo`
  duplicado deliberadamente (Projections.Tests y ControlHoras.Tests son ensamblados distintos, sin
  proyecto de test compartido -- CA-ADR-0029 elimino `Contracts.Tests`).

### Stubs creados

- `SamplerQueDescartaPollingDelDaemon` (`src/.../Projections/Infraestructura/`): sealed class que
  hereda `Sampler`. Constante `internal const string NombreSpanPollingDaemon` fijada al valor real
  (no throw), propiedad `internal Sampler Delegado { get; }` asignada en el constructor (plumbing,
  no logica), y `ShouldSample` con `throw new NotImplementedException()`.

### Decision de diseno: verificacion del sampler efectivo por reflection (determinista, no probabilistica)

El limite que el archivo de test declaraba antes de este issue ("el sampler compuesto vive dentro
de TracerProviderSdk, que OpenTelemetry no expone publicamente... probabilistico y flaky") se
verifico **superable**: `TracerProviderSdk.Sampler` es una propiedad `internal` (no `private`), asi
que `GetType().GetProperty("Sampler", BindingFlags.NonPublic | BindingFlags.Instance)` la alcanza
sin muestrear actividades reales. Ademas, `Sampler.Description` es **publica** (heredada de la clase
base `Sampler`) y los samplers del framework la fijan con el ratio embebido: `TraceIdRatioBasedSampler`
-> `"TraceIdRatioBasedSampler{0.500000}"` (formato `F6`), `ParentBasedSampler` -> `"ParentBased{...}"`.
Combinando ambos hallazgos, CA-1/CA-2/CA-3 quedan deterministas sin necesidad de la alternativa de
"actividades con ratio 1.0/0.0" que sugerian las notas tecnicas del issue.

### Decision de diseno: verificacion empirica de la cascada padre/hijo antes de fijar el test

Antes de escribir `CascadaDePolling_*`, reproduje el wiring exacto (sampler custom + delegado real)
en un scratch `dotnet run` aislado (fuera del repo, descartado despues) para confirmar el
comportamiento real de OpenTelemetry 1.16.0, no asumirlo del texto del issue. Resultado medido:

- El padre (`marten.daemon.highwatermark`, root span) **SI se instancia** (no null) pero con
  `Recorded=false` -- `PropagateOrIgnoreData` retorna `PropagationData` cuando no hay padre, para
  poder propagar el contexto a los hijos.
- El hijo (Npgsql) sale **NULL** (ni se instancia) SOLO si el delegado del sampler es
  `ParentBasedSampler` real: este mira `parentContext.TraceFlags` (sin `Recorded`, porque el padre
  quedo en Drop) y devuelve `AlwaysOffSampler` para el hijo -> `ActivitySamplingResult.None`.

Esto corrigio mi diseno inicial (que usaba `AlwaysOnSampler` como delegado en los tests de cascada,
lo cual NO habria reproducido el efecto: `AlwaysOnSampler` ignora el contexto del padre y el hijo
Npgsql habria sobrevivido siempre). Los tests de cascada usan
`new ParentBasedSampler(new TraceIdRatioBasedSampler(1.0))` como delegado -- el mismo tipo compuesto
que produce el seam real, ratio 1.0 para determinismo. Los tests unitarios de `ShouldSample`
(que no pasan por el runtime de `Activity`) siguen usando `AlwaysOnSampler`, donde el contexto del
padre es irrelevante.

### Fuera de alcance de este agente (no son tests de codigo)

- **CA-7** (enmienda de `docs/adr/ca-adr-0009-control-costos-application-insights.md`): es
  documentacion de arquitectura, no un test. Corresponde al implementer (fase verde) actualizar el
  ADR segun el hallazgo del issue.
- **CA-8** (verificacion post-deploy en dev, 24h despues del merge): no es ejecutable en CI/tests
  unitarios -- es un smoke test / verificacion manual posterior al deploy real.

### Cobertura de criterios

| Criterio de aceptacion | Test(s) |
|---|---|
| CA-1 (sampler efectivo Projections) | `ConfigurarObservabilidad_ResuelveElSamplerConfiguradoPorElProyecto_EnVezDeRateLimitedSampler` |
| CA-2 (sampler efectivo ControlHoras) | `AgregarServiciosControlHoras_ResuelveElSamplerConfiguradoPorElProyecto_EnVezDeRateLimitedSampler` |
| CA-3 (ratio observable, ambos dominios) | `ConfigurarObservabilidad_PropagaElRatioDeSamplingConfigurado_AlSamplerEfectivo`, `AgregarServiciosControlHoras_PropagaElRatioDeSamplingConfigurado_AlSamplerEfectivo`, `Delegado_ExponeElSamplerConElQueSeConstruyo` |
| CA-4 (descarta daemon + hijo Npgsql) | `ShouldSample_RetornaDrop_CuandoElNombreEsElPollingDelDaemon`, `CascadaDePolling_CreaLaActividadDelDaemonSinRecorded_YSuHijaDeNpgsqlNiSeInstancia` |
| CA-5 (conserva actividades Marten reales) | `ShouldSample_DelegaAlSamplerEnvuelto_CuandoElNombreNoEsElPollingDelDaemon`, `CascadaDePolling_ConservaLasActividadesDeMartenQueNoSonElPollingDelDaemon` |
| CA-6 (guardrail OtelPrefix) | `NombreSpanPollingDaemon_CoincideConOtelPrefixDeMartenMasElSufijoDeHighWaterAgent` |
| CA-7 | Fuera de alcance de test-writer (documentacion ADR) |
| CA-8 | Fuera de alcance de test-writer (verificacion post-deploy) |

### Verificacion de fase roja

`dotnet test` (informativo, no parte del flujo de entrega) sobre ambos proyectos confirmo el
resultado esperado:

- `Projections.Tests`: 52 total, **7 en rojo** (los que ejercitan comportamiento nuevo: 5 por
  `NotImplementedException` de `ShouldSample`, 2 por el wiring de composicion que aun no se
  corrigio), 45 en verde (preexistentes intactos + wiring trivial del stub que ya es correcto:
  constante, asignacion del constructor).
- `ControlHoras.Tests`: 357 total, **2 en rojo** (los agregados por CA-2/CA-3), 355 en verde
  (ningun test preexistente se rompio).

`dotnet build` de la solucion completa (`ControlAsistencias.slnx`) compila sin errores.

### Desviaciones del plan del planner

| Sugerencia del issue | Desviacion aplicada | Razon tecnica | Consecuencia |
|---|---|---|---|
| "Interfaz publica propuesta": `ctor(Sampler delegado)`, `override ShouldSample`, `internal const string NombreSpanPollingDaemon` | Se agrego `internal Sampler Delegado { get; }` (no listado en la propuesta) | CA-3 exige verificar que el ratio configurado llega al sampler efectivo cuando este va envuelto en `SamplerQueDescartaPollingDelDaemon` (Projections). Sin una via para inspeccionar el sampler envuelto, ese CA seria imposible de comprobar sin reflection adicional sobre el wrapper mismo. `internal` (no `public`) preserva el espiritu de la propuesta del planner; `Projections.csproj` ya declara `InternalsVisibleTo` hacia `Projections.Tests`, asi que no requirio cambios de proyecto. | CA-3 queda cubierto en ambos dominios con el mismo patron (leer `Description`, publica). Documentado tambien como comentario XML en el propio stub. |
| Notas tecnicas: "verificacion por comportamiento (exporter en memoria + actividades deterministas con ratio 1.0 y 0.0)" como alternativa aceptable a la reflection | Se usaron AMBAS tecnicas, no una sola: reflection determinista para CA-1/CA-2/CA-3 (mas simple, un solo punto de acceso no publico) y actividades deterministas con `ParentBasedSampler(TraceIdRatioBasedSampler(1.0))` + colector en memoria para CA-4/CA-5 (la cascada padre/hijo no es observable solo con reflection: depende del runtime real de `Activity`) | Cada tecnica cubre una dimension distinta: la reflection lee "que sampler quedo instalado"; el colector en memoria observa "que actividades sobrevivieron el pipeline completo". Ninguna sustituye a la otra. | Cobertura mas completa que eligiendo una sola tecnica; sin ella, CA-4 (efecto cascada sobre el hijo Npgsql) habria quedado sin demostrar. |

</details>

<details>
<summary>Implementer (fase verde) — 7m 10s</summary>

## ES Implementer - Decisiones

### Enfoque de implementacion

Dos correcciones independientes pero fusionadas por dependencia funcional (el filtro no puede
demostrar su efecto sin el orden de wiring corregido primero):

1. **Orden del wiring OTel** (`ConfiguracionObservabilidadProjections.ConfigurarObservabilidad` y
   `ComposicionServicios.AgregarServiciosControlHoras`): se movio `SetSampler(...)` de ANTES a
   DESPUES de `UseAzureMonitorExporter()`. En la forma `IOpenTelemetryBuilder` esto se expresa
   encadenando un segundo `.WithTracing(...)` posterior a `.UseAzureMonitorExporter()` -- cada
   llamada a `WithTracing` registra un callback de configuracion sobre el mismo
   `TracerProviderBuilder`, y el registrado al final gana. Requirio agregar `using OpenTelemetry;`
   en ambos archivos (el metodo de extension vive en `OpenTelemetry.OpenTelemetryBuilderSdkExtensions`,
   no en `OpenTelemetry.Trace` como los demas tipos ya importados).

2. **`SamplerQueDescartaPollingDelDaemon.ShouldSample`** (Projections): implementacion directa
   segun el contrato que el test-writer ya fijo -- compara `samplingParameters.Name` contra la
   constante `NombreSpanPollingDaemon`; si coincide devuelve `new SamplingResult(SamplingDecision.Drop)`
   sin delegar, si no delega a `Delegado.ShouldSample(in samplingParameters)`. Sin logica adicional:
   el test-writer ya habia verificado empiricamente (comentarios en el test) que un `Drop` en la
   raiz basta para que el hijo Npgsql ni siquiera se instancie.

### Decisiones de diseno

- El wrapper `SamplerQueDescartaPollingDelDaemon` solo se usa en Projections. ControlHoras usa el
  `ParentBasedSampler(TraceIdRatioBasedSampler(ratio))` directo, sin envolver -- ControlHoras no
  corre el daemon HotCold de Marten (MEF-ADR-0018 Rule of Three, ya señalado en el issue y en el
  test).
- No se toco `Programacion/ComposicionServicios`: confirmado en la investigacion del planner que
  ese seam no llama `UseAzureMonitorExporter()` ni `SetSampler`, solo `AddSource` -- fuera de
  alcance de este issue.
- No se cambio el valor del ratio por defecto (sigue en 0.2): el issue explicitamente dice que
  recalibrar se decide despues de medir con el sampler ya funcionando.

### ADRs consultados

- CA-ADR-0009 (control de costos Application Insights) -- enmendado, ver seccion siguiente.
- MEF-ADR-0029 (seams de composicion) -- los dos cambios viven en los seams existentes
  (`ConfiguracionObservabilidadProjections`, `ComposicionServicios`), no en `Program.cs`. Verificado
  que ningun cambio toco `Program.cs`.
- MEF-ADR-0016 (convencion de nombres de test) -- no aplica al implementer directamente (son tests
  del test-writer, ya escritos); se verifico que los nombres existentes siguen el patron
  `<Sujeto>_<LoQuePasa>_Cuando<Condicion>`.
- MEF-ADR-0018 (Rule of Three) -- aplicado: el sampler filtrante (`SamplerQueDescartaPollingDelDaemon`)
  solo se instancia en Projections, no se generalizo a ControlHoras/Programacion.

### Desviaciones de ADRs

Ninguna desviacion -- todos los ADRs aplicados al pie de la letra.

### Desviaciones del plan del planner

Ninguna desviacion -- se siguio la interfaz publica propuesta (`SamplerQueDescartaPollingDelDaemon`
en `Projections/Infraestructura/`, con `ctor(Sampler delegado)`, `NombreSpanPollingDaemon` interna,
`ShouldSample` con Drop-o-delega) tal como el test-writer la dejo fijada en los tests.

### Precedentes consultados

- `ConfiguracionObservabilidadProjectionsTests` y `ComposicionServiciosTests` (tests ya escritos por
  el test-writer): usados como oraculo exacto de la interfaz esperada (nombre de constantes,
  visibilidad `internal`, comportamiento de `ShouldSample`). Sin desviaciones detectadas frente a
  MEF-ADR-0012 en estos archivos.
- Decompilacion de `Azure.Monitor.OpenTelemetry.Exporter.OpenTelemetryBuilderExtensions` (v1.8.1,
  via `ilspycmd`) para confirmar el mecanismo exacto por el que `UseAzureMonitorExporter()` pisa el
  sampler (`ConfigureOpenTelemetryTracerProvider` registrado internamente con `RateLimitedSampler`
  cuando `TracesPerSecond.HasValue`) -- confirma el hallazgo 1 del issue tal cual estaba descrito,
  sin discrepancias.

### Infraestructura modificada

Ninguna. Este issue no publica ni consume eventos nuevos -- solo corrige el wiring de
OpenTelemetry en dos seams existentes. No se tocó `infra/environments/dev/main.tf`.

### Complejidad encontrada

- El primer intento de compilacion fallo con `CS1061: IOpenTelemetryBuilder no contiene una
  definicion para WithTracing` en ambos archivos -- el metodo de extension vive en el namespace
  `OpenTelemetry` (clase `OpenTelemetryBuilderSdkExtensions`), no en `OpenTelemetry.Trace` (donde
  ya estaban los usings de `Sampler`/`TracerProviderBuilder`/etc). Se resolvio agregando
  `using OpenTelemetry;` en ambos archivos. No es una desviacion de ADR, solo un ajuste de using
  para que el segundo `.WithTracing(...)` encadenado compilara.
- `dotnet test` en este entorno (.NET 10, Microsoft.Testing.Platform) no acepta `--filter` clasico
  de VSTest; se uso `dotnet test --project <csproj>` sin filtro adicional (los proyectos de test son
  pequeños, correr la suite completa de cada uno fue mas rapido que investigar `--filter-class`).

### Resultado

- Tests pasando: 622/622 (610 correctos + 12 omitidos por falta de infraestructura local
  ServiceBus/Postgres en smoke tests, comportamiento esperado y preexistente, no relacionado con
  este issue).
- CA-1 a CA-7 verificados por los tests unitarios/de composicion en verde.
- CA-8 (verificacion post-deploy en dev, 24h despues del merge) queda fuera del alcance de esta
  fase -- es una verificacion posterior al despliegue, no ejecutable en el pipeline TDD local.

</details>
<details>
<summary>Reviewer (fase refactor) — 15m 9s</summary>

## ES Reviewer - Revision (issue #308)

### Evaluacion general
- Calidad: **buena** (el diff de las fases roja y verde resuelve el problema correcto con la
  tecnica correcta; los hallazgos son de encapsulamiento y de cobertura de un borde, no de
  correccion)
- Cambios realizados: **si** (commit `84f9f39`)
- Baseline al arrancar: verde (622 tests, 0 errores, 12 omitidos por infra de smoke tests ausente).
  Al cerrar: verde, **624 tests** (612 correctos, 12 omitidos). Sin reporte de bloqueo heredado.

### Cumplimiento de ADRs aplicables

| ADR | Cumplimiento | Observacion |
|---|---|---|
| CA-ADR-0009: control de costos Application Insights | ok (enmendado por el implementer, ampliado por el reviewer) | La enmienda describe la Capa 2 que efectivamente corre, el motivo del orden (`SetSampler` despues del exporter), la alternativa descartada (`ApplicationInsightsSampler` es `internal`) y la subcuenta de metricas asumida -- CA-7 cubierto. Agregue dos precisiones (ver "Refactorings"). |
| MEF-ADR-0029: seams de composicion / test de composicion del contenedor DI | ok | Los dos cambios viven en `ConfiguracionObservabilidadProjections.ConfigurarObservabilidad` y `ComposicionServicios.AgregarServiciosControlHoras`; verificado que **ningun** `Program.cs` fue tocado (`git diff c151511 --name-only`). Los guardrails nuevos son de la categoria que este ADR fija: construyen el `IServiceCollection` real y resuelven del contenedor con `ValidateOnBuild`/`ValidateScopes`. |
| MEF-ADR-0016: naming de tests | ok | Los 12 tests involucrados siguen `<Sujeto>_<LoQuePasa>[_Cuando<Condicion>]`. Los que agregue tambien (`ConfigurarObservabilidad_PropagaElRatioPorDefecto_AlSamplerEfectivo_CuandoLaVariableEstaAusente`, `Description_EmbebeLaDelSamplerEnvuelto`). Sin `Debe...`, sin `[Theory]`. |
| MEF-ADR-0018: Rule of Three / autoridad de extraccion | ok | El sampler filtrante se instancia **solo** en el worker (unico proceso con daemon HotCold: `AddAsyncDaemon(DaemonMode.HotCold)` en los dos stores de `Projections`) y no se generalizo a los Function Apps. La duplicacion del helper de reflection entre `Projections.Tests` y `ControlHoras.Tests` (dos sitios, sin ensamblado de test compartido) se mantiene deliberadamente -- no pedi extraccion, solo documente la razon en el sitio duplicado. |
| MEF-ADR-0012: encapsulamiento / Tell-don't-Ask (no listado en el issue, pero aplicable al tipo nuevo) | **desviacion NO declarada -- corregida** | `internal Sampler Delegado { get; }` existia unicamente para que los tests afirmaran estado interno. Ver detalle abajo. |

El issue **si** trae seccion `## ADRs aplicables` y esta completa para el alcance declarado. Nota
para el planner: cuando un issue introduce un **tipo nuevo** (aqui `SamplerQueDescartaPollingDelDaemon`),
MEF-ADR-0012 aplica aunque el issue sea de infraestructura; conviene listarlo por defecto.

### Desviaciones de ADRs

**Desviaciones declaradas por el implementer**: ninguna. Su resumen dice "todos los ADRs aplicados
al pie de la letra" y lo verifique contra el diff: es exacto para los cuatro ADRs que el issue lista.

**Desviaciones declaradas por el test-writer** (frente al plan del planner, no frente a un ADR):

#### Desviacion: interfaz publica propuesta -- se agrego `internal Sampler Delegado { get; }`
- **Regla / sugerencia**: la "Interfaz publica propuesta" del issue enumeraba `ctor(Sampler delegado)`,
  `override ShouldSample` y `internal const NombreSpanPollingDaemon`. Nada mas.
- **Desviacion aplicada**: propiedad `internal Sampler Delegado { get; }` para poder verificar CA-3
  sobre el sampler envuelto.
- **Razon del test-writer**: sin una via para inspeccionar el sampler envuelto, CA-3 exigiria
  reflection adicional sobre el wrapper.
- **Evaluacion del reviewer**: **cuestionable, y corregida.** La razon es real (CA-3 necesita ver el
  ratio) pero la solucion elegida choca con MEF-ADR-0012: un miembro cuyo unico consumidor es un test
  que afirma estado interno. Existia una via Tell-don't-Ask que no se exploro: `Sampler.Description`
  es **publica** en la clase base y es exactamente el mecanismo que la propia OpenTelemetry usa para
  describir samplers compuestos (`ParentBasedSampler` produce
  `"ParentBased{TraceIdRatioBasedSampler{0.200000}}"`). Compuse la `Description` del wrapper con la
  del delegado y el getter desaparecio; CA-3 quedo verificado por API publica y el test de
  composicion perdio un cast.
- **Status**: corregida en refactor. Tests verdes.

**Desviaciones detectadas por el reviewer (NO declaradas)**:

#### Desviacion: MEF-ADR-0012, antipatron "getter expuesto solo para que los tests verifiquen estado interno"
- **Regla del ADR**: el estado interno no se publica para satisfacer una asercion; el objeto se
  interroga por comportamiento.
- **Desviacion encontrada en el diff**: `SamplerQueDescartaPollingDelDaemon.cs:33`
  (`internal Sampler Delegado { get; }`), con el comentario que lo delataba textualmente ("Visible en
  tests via InternalsVisibleTo... Permite verificar CA-3 inspeccionando directamente el sampler
  envuelto"). Unicos consumidores: dos tests.
- **Accion tomada**: corregida en refactor (campo privado `_delegado` + `Description` compuesta).
- **Status**: resuelta, no requiere evaluacion del usuario.

Fuera de estas dos caras del mismo hallazgo: **ninguna otra desviacion** -- los cuatro ADRs
aplicables se cumplen.

### Precedentes consultados por el implementer

| Precedente | ADR aplicable | Veredicto |
|---|---|---|
| `ConfiguracionObservabilidadProjectionsTests` / `ComposicionServiciosTests` (tests de la fase roja, usados como oraculo de interfaz) | MEF-ADR-0029, MEF-ADR-0012 | **alineado con MEF-ADR-0029; arrastraba la desviacion de MEF-ADR-0012** descrita arriba. El implementer los tomo como oraculo exacto -- correcto para la firma, pero el precedente no era autoridad sobre el encapsulamiento. Corregido. |
| Decompilacion de `Azure.Monitor.OpenTelemetry.Exporter.OpenTelemetryBuilderExtensions` 1.8.1 (`ilspycmd`) | n/a (evidencia de framework) | **alineado y ademas re-verificado por mi**: la prueba de mutacion (abajo) reproduce en este repo el sampler `RateLimitedSampler` que el hallazgo 1 describe. |
| `ConfiguracionObservabilidadProjections` (issues #250/#263) como forma del seam | MEF-ADR-0029 | alineado. |

### Convenciones del pipeline (no ADRs)

| Convencion | Estado | Observacion |
|---|---|---|
| Cada test con `Then()` + `And<>()` | n/a | Ningun test de este issue es de command handler / DSL Given-When-Then (MEF-ADR-0002). Son tests de composicion del contenedor (MEF-ADR-0029) y unitarios de un sampler. El test-writer lo justifico y coincido: forzar el DSL aqui no aplica. |
| Overloads correctos para stream IDs compuestos | n/a | No hay aggregates ni streams en el diff. |
| Fakes manuales (no NSubstitute) | ok | Cero NSubstitute. Las dobles son tipos reales del SDK (`AlwaysOnSampler`, `ParentBasedSampler`) y un `BaseProcessor<Activity>` propio (`ColectorDeActividades`) como colector en memoria -- la eleccion correcta: el sujeto bajo prueba es el pipeline real de OpenTelemetry. |
| Feature folders (produccion y tests) | ok | `src/.../Projections/Infraestructura/` con espejo exacto en `tests/.../Projections.Tests/Infraestructura/`. Wiring en `Infraestructura/`, fuera del alcance medido por MEF-ADR-0014. |
| Smoke tests: SkipWhen, secrets, cobertura | n/a | El diff no agrega ni modifica smoke tests, no publica ni consume eventos, no toca `infra/`. La verificacion equivalente para este issue es CA-8 (post-deploy, ver abajo). |
| Proyecciones read-side: partial, inmutabilidad, read APIs, naming | n/a | No hay read models ni proyecciones nuevas; el diff toca el worker solo en su seam de observabilidad. |
| Tests via ToString/comportamiento | ok tras el refactor | Antes: un test afirmaba `sampler.Delegado` (estado). Ahora: `sampler.Description` (comportamiento observable por API publica). |
| Sin numeros magicos | ok tras el refactor | Extraje `SpanProyeccionLoading`/`SpanProyeccionGrouping` (el literal se repetia 3 veces) y `RatioSamplingPorDefecto` + `FormatearRatio` en los tests de ControlHoras. Queda un literal aceptado a proposito: el FQN `"Azure.Monitor.OpenTelemetry.Exporter.Internals.RateLimitedSampler"` -- es `internal` en otro ensamblado y no se puede nombrar por tipo; el literal **es** el oraculo. |
| Condiciones en positivo (guardas if/else afirmativas) | ok | `ShouldSample` es una expresion condicional en positivo (`Name == NombreSpan ? Drop : delegar`), sin negacion ni `if`/`else` invertido. |

### Elegancia del codigo

- **Idiomatismo (mejorado)**: el wrapper ahora se describe como lo hacen los samplers compuestos del
  propio SDK. `ShouldSample` sigue siendo una unica expresion condicional -- compacta y sin ruido.
- **Compacidad (mejorada)**: `HaveCount(2)` era redundante frente a `BeEquivalentTo([a, b])` (que ya
  exige misma cardinalidad); tres apariciones del mismo literal de span colapsaron a dos constantes;
  el cast `(SamplerQueDescartaPollingDelDaemon)` del test de composicion desaparecio.
- **Legibilidad (mejorada)**: `ConfiguracionObservabilidadProjectionsTests` invocaba
  `SamplerQueDescartaPollingDelDaemonTests.ObtenerSamplerEfectivo(...)` -- una clase de tests
  llamando a otra. El helper se movio a `SamplerEfectivo.De(tracerProvider)`, que lee como lo que
  hace y cuyo sujeto (el `TracerProvider`) es el correcto.
- **Robustez**: el helper de reflection ya fallaba con un mensaje accionable si `TracerProviderSdk`
  dejara de exponer `Sampler` -- bien resuelto por el test-writer, no lo toque. No agregue
  `ArgumentNullException.ThrowIfNull(delegado)` a proposito: con NRT activo el contrato ya esta
  expresado en la firma, el tipo se construye en un unico seam y la `Description` compuesta hace que
  un `null` reviente en el constructor, no en el hot path de sampling.
- **Eficiencia**: `ShouldSample` corre por cada actividad; es una comparacion de string y una
  delegacion, sin allocations en el camino del `Drop`. Nada que optimizar.
- **Limpieza**: `dotnet build` sin un solo warning `CS*`; quite un `using System.Reflection;` que
  quedo huerfano al mover el helper; `dotnet format --verify-no-changes` no reporta **ningun**
  hallazgo sobre los archivos de este diff.
- **Verbosidad**: los comentarios son extensos, pero es la norma establecida en estos archivos y aqui
  cargan la evidencia forense de una falla silenciosa de dos meses. Deliberadamente **no** los pode;
  solo corregi dos reflows y una referencia que quedo obsoleta al mover el helper.

### Criticas y hallazgos

1. **(mayor, corregido)** MEF-ADR-0012: `Delegado` publicado para uso exclusivo de tests. Detalle
   arriba. Es el hallazgo que este checklist de antipatrones existe para atrapar -- mismo patron que
   el incidente del PR #155.
2. **(mayor, corregido) Hueco de cobertura en CA-3**: los dos tests de la fase roja solo ejercitaban
   el ratio **configurado** (`0.5`). El camino que efectivamente corre en dev y prod es el del
   **default**, porque `TELEMETRY_SAMPLING_RATIO` no esta declarada en ningun recurso (medido en el
   issue). Un default que no llegara al sampler efectivo se veria solo como volumen de ingestion
   inesperado -- exactamente el modo de falla que este issue cierra. Agregue el guardrail del default
   en ambos procesos.
3. **(menor, corregido)** Legibilidad del helper compartido entre clases de test (extraido a
   `SamplerEfectivo`).
4. **(menor, corregido)** Literales de span repetidos y `HaveCount` redundante.
5. **(menor, corregido) CA-7 incompleto en un punto material**: la tabla "Valores por ambiente" del
   ADR sigue listando `TELEMETRY_SAMPLING_RATIO` = 0.2/0.2/0.1, lo que se lee como si prod corriera a
   0.1. Ningun ambiente la declara, asi que los tres usan el default de codigo. Lo anote en la
   enmienda; sin eso, el ADR quedaba "coincidiendo con lo que corre" en la prosa y contradiciendose
   en la tabla.
6. **(observacion, no corregida) Hueco residual del guardrail CA-6**: contrasta la constante contra
   `new StoreOptions().Projections.OtelPrefix`, es decir contra el **default** de Marten, no contra
   las opciones que el worker configura. Verifique que nadie asigna `OtelPrefix` en el repo (`grep`
   sobre `src/`), asi que hoy son el mismo valor y el guardrail cumple su proposito. Si alguna vez
   alguien lo configurara en `ConfiguracionMartenProjections*`, el guardrail seguiria verde y el
   filtro quedaria inerte. No lo endureci: exigiria alcanzar `OtelPrefix` a traves de
   `IReadOnlyStoreOptions` (no lo expone) o resolver el store real, y el riesgo actual es teorico.
   Candidato a nota tecnica si algun issue futuro toca la configuracion del daemon.
7. **(observacion, fuera de alcance)** `dotnet build` reporta `NU1902` (vulnerabilidad moderada
   conocida) por `OpenTelemetry.Api` 1.14.0 en `Bitakora.ControlAsistencia.Programacion` y su
   proyecto de tests -- preexistente y ajeno a este issue (los dos procesos que este diff toca ya
   estan en 1.16.0). Ese dominio, ademas, sigue sin exporter ni sampler (confirme: solo `AddSource`),
   consistente con el alcance declarado. Merece issue propio.
8. **(observacion, fuera de alcance)** `dotnet format` reporta 9 `IDE0005` (usings innecesarios) en
   archivos de tests de serializacion ajenos a este diff. No los toque (regla de alcance); son deuda
   preexistente.
9. **Comentario que el issue marcaba como apoyado en premisa falsa**: el de
   `PatronFuentePropia_CapturaLaActividad_*` ("ese lleva el sampler de ratio 0.2, que volveria la
   asercion probabilistica"). Lo revise: era falso **antes** del fix (el contenedor llevaba
   `RateLimitedSampler`) y el fix lo vuelve **verdadero**. No requiere cambio; lo dejo consignado
   para que no se relea como pendiente.

### Refactorings aplicados

Commit `84f9f39` (`refactor(hu-308): ...`):

1. `SamplerQueDescartaPollingDelDaemon`: campo privado `_delegado` + `Description` compuesta al
   estilo de `ParentBasedSampler`; se elimina `internal Sampler Delegado { get; }`.
   *Justificacion*: MEF-ADR-0012 (no publicar estado interno para uso de tests) sin perder la
   verificabilidad de CA-3, que ahora usa API publica.
2. Extraccion de `ObtenerSamplerEfectivo` a `SamplerEfectivo.De` en un archivo propio de
   `Projections.Tests/Infraestructura/`. *Justificacion*: una clase de tests no debe alojar
   utilidades que otra clase de tests consume; el sujeto del helper es el `TracerProvider`.
3. Constantes `SpanProyeccionLoading`/`SpanProyeccionGrouping` y eliminacion del `HaveCount(2)`
   redundante. *Justificacion*: literal repetido 3 veces; asercion duplicada.
4. `FormatearRatio` + `RatioSamplingPorDefecto` en los tests de ControlHoras; en Projections la
   asercion se ata a `ConfiguracionObservabilidadProjections.RatioSamplingPorDefecto`.
   *Justificacion*: el "0.200000" esperado deriva de la constante de produccion, no de un literal.
5. CA-ADR-0009: dos parrafos nuevos -- (a) el orden fragil queda protegido por los guardrails de
   composicion y por que la revision de codigo no podia atrapar el defecto; (b) el estado real de
   `TELEMETRY_SAMPLING_RATIO` frente a la tabla de valores por ambiente.
6. Dos reflows de comentario y una referencia obsoleta al helper movido.

**Refactorings considerados y NO aplicados** (con razon):
- Extraer `VariableRatioSampling`/`RatioSamplingPorDefecto` a constantes `internal` en
  `ControlHoras/Infraestructura/ComposicionServicios.cs` (como si hace Projections): requeriria
  agregar `InternalsVisibleTo` a `ControlHoras.csproj` o subir los miembros a `public`. Cambio de
  superficie fuera del alcance del issue; documente la asimetria y su causa en el test.
- Unificar el helper de reflection duplicado entre los dos proyectos de test: MEF-ADR-0018 Rule of
  Three -- dos sitios, y no existe ensamblado de tests compartido (CA-ADR-0029 elimino
  `Contracts.Tests`). Se mantiene duplicado, con la razon anotada en ambos.
- Bajar `SamplerQueDescartaPollingDelDaemon` de `public` a `internal`: seria mas estrecho, pero es un
  cambio de superficie publica sin ADR que lo exija.

### Verificacion por mutacion (no habitual, la hice por la naturaleza del issue)

Todo este issue trata de un guardrail que hay que creer. Asi que en vez de confiar en el verde,
devolvi el `SetSampler` de Projections a su posicion anterior (antes de `UseAzureMonitorExporter()`)
y corri el proyecto:

```
error: 3
  ConfigurarObservabilidad_ResuelveElSamplerConfiguradoPorElProyecto_EnVezDeRateLimitedSampler
    Expected ... not to be "Azure.Monitor.OpenTelemetry.Exporter.Internals.RateLimitedSampler"
  ConfigurarObservabilidad_PropagaElRatioDeSamplingConfigurado_AlSamplerEfectivo
    Expected samplerEfectivo.Description "RateLimitedSampler" to contain "0.500000"
  ConfigurarObservabilidad_PropagaElRatioPorDefecto_AlSamplerEfectivo_CuandoLaVariableEstaAusente
    Expected samplerEfectivo.Description "RateLimitedSampler" to contain "0.200000"
```

Dos conclusiones: los guardrails **no** son vacuos (detectan la regresion exacta que el issue
corrige), y el hallazgo 1 del planner queda reproducido de forma independiente en este repo -- el
sampler efectivo con el wiring anterior es, literalmente, `RateLimitedSampler`. Mutacion revertida
con `git checkout --` y suite verde de nuevo.

### Cobertura de criterios de aceptacion

| Criterio | Estado | Test(s) |
|---|---|---|
| CA-1: sampler efectivo del worker no es `RateLimitedSampler` | cubierto (+ mutacion) | `ConfigurarObservabilidad_ResuelveElSamplerConfiguradoPorElProyecto_EnVezDeRateLimitedSampler` |
| CA-2: idem para ControlHoras | cubierto | `AgregarServiciosControlHoras_ResuelveElSamplerConfiguradoPorElProyecto_EnVezDeRateLimitedSampler` |
| CA-3: `TELEMETRY_SAMPLING_RATIO` deja de ser inerte | cubierto (**ampliado en esta fase**) | Configurado: `ConfigurarObservabilidad_PropagaElRatioDeSamplingConfigurado_AlSamplerEfectivo`, `AgregarServiciosControlHoras_PropagaElRatioDeSamplingConfigurado_AlSamplerEfectivo`. Default (agregado por el reviewer): `ConfigurarObservabilidad_PropagaElRatioPorDefecto_AlSamplerEfectivo_CuandoLaVariableEstaAusente`, `AgregarServiciosControlHoras_PropagaElRatioPorDefecto_AlSamplerEfectivo_CuandoLaVariableEstaAusente`. Soporte: `Description_EmbebeLaDelSamplerEnvuelto`. Parsing (preexistente): `ResolverRatioDeSampling_*` |
| CA-4: `marten.daemon.highwatermark` no se exporta, ni su hija Npgsql | cubierto en dos niveles | `ShouldSample_RetornaDrop_CuandoElNombreEsElPollingDelDaemon`, `ShouldSample_DelegaAlSamplerEnvuelto_CuandoElNombreEsDeOtraFuenteComoNpgsql`, `CascadaDePolling_CreaLaActividadDelDaemonSinRecorded_YSuHijaDeNpgsqlNiSeInstancia` |
| CA-5: las demas actividades de `Marten` si se exportan | cubierto | `ShouldSample_DelegaAlSamplerEnvuelto_CuandoElNombreNoEsElPollingDelDaemon`, `CascadaDePolling_ConservaLasActividadesDeMartenQueNoSonElPollingDelDaemon` |
| CA-6: guardrail si Marten cambia `OtelPrefix` | cubierto (con hueco residual documentado, hallazgo 6) | `NombreSpanPollingDaemon_CoincideConOtelPrefixDeMartenMasElSufijoDeHighWaterAgent` |
| CA-7: enmienda de CA-ADR-0009 | cubierto (ampliado) | Documental: dos secciones nuevas del implementer + dos parrafos del reviewer (guardrails del orden; estado real de la variable frente a la tabla por ambiente) |
| CA-8: verificacion post-deploy en dev a 24h | **pendiente por diseno** | No ejecutable en el pipeline TDD. Requiere, 24h despues del merge: `marten.daemon.highwatermark` en 0 en `AppDependencies`, spans `postgresql` del rol `Bitakora.ControlAsistencia.Projections` de ~72k/dia a ~3k/dia, y `marten.turnodiarioview.*` todavia presentes. Debe quedar como tarea de seguimiento al cerrar el issue. |

### Tests agregados

- `ConfigurarObservabilidad_PropagaElRatioPorDefecto_AlSamplerEfectivo_CuandoLaVariableEstaAusente`
  (Projections.Tests) -- borde faltante de CA-3: el default es el camino que realmente corre.
- `AgregarServiciosControlHoras_PropagaElRatioPorDefecto_AlSamplerEfectivo_CuandoLaVariableEstaAusente`
  (ControlHoras.Tests) -- idem para el otro proceso.
- `Description_EmbebeLaDelSamplerEnvuelto` (reemplaza `Delegado_ExponeElSamplerConElQueSeConstruyo`):
  misma garantia -- el sampler envuelto es observable -- pero por comportamiento publico en vez de
  estado interno.
- Tests de contrato de igualdad (`IgualdadTestBase<T>`) y de round-trip de serializacion: **n/a**.
  El diff no introduce value objects, ni `IEquatable`, ni `ConfigurarSerializacion`, ni eventos con
  marker de bus (`IPrivateEvent`/`IPublicEvent`) -- `SamplerQueDescartaPollingDelDaemon` es un
  componente de infraestructura que nunca se serializa ni cruza el bus.

</details>

## Cobertura

| Archivo | Cobertura | Umbral | Estado |
|---|---|---|---|
| ComposicionServicios.cs | - | no evaluado | - |
| ConfiguracionObservabilidadProjections.cs | - | no evaluado | - |
| SamplerQueDescartaPollingDelDaemon.cs | - | no evaluado | - |
## Commits

84f9f39 refactor(hu-308): describir el sampler envuelto en vez de exponerlo, y cerrar CA-3 sobre el ratio por defecto
fd84f2b feat(hu-308): restaurar el sampler de OpenTelemetry y descartar el polling del daemon (fase verde)
aac1f68 test(hu-308): tests para sampler efectivo del wiring OTel y filtro del daemon (fase roja)

Closes #308