### PR TITLE
Apagar la recoleccion de metricas de durabilidad de Wolverine

### DIFF
--- a/src/Bitakora.ControlAsistencia.ControlHoras/Infraestructura/ComposicionServicios.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Infraestructura/ComposicionServicios.cs
@@ -39,18 +39,21 @@ public static class ComposicionServicios
             {
                 // Issue #309: apaga el polling de metricas de profundidad de cola de Wolverine
                 // (PersistenceMetrics.StartPolling, PeriodicTimer de 5s que llama
-                // store.Admin.FetchCountsAsync() -- origen de 4 de las 8 consultas Postgres
-                // repetitivas medidas en dev, 4.320 spans/6h cada una). Se conserva la durabilidad
-                // real: recovery, scheduled jobs y dead letters siguen activos (DurabilityAgentEnabled
-                // y Mode no se tocan aqui). Nadie consume hoy esas metricas (sin dashboard ni
-                // alerta) y CheckHealthAsync llama FetchCountsAsync por su cuenta, asi que el
-                // health check no depende de este polling.
+                // store.Admin.FetchCountsAsync()) -- origen de 4 de las 8 consultas Postgres
+                // repetitivas medidas en dev, 4.320 spans/6h cada una. Nadie las consume hoy (sin
+                // dashboard ni alerta) y CheckHealthAsync llama FetchCountsAsync por su cuenta, asi
+                // que el health check no depende de este polling.
                 //
-                // Debe fijarse en ESTE callback (el que recibe AgregarWolverineParaComandosServerless)
-                // porque corre ANTES de que Cosmos.EventSourcing.CritterStack 2.3.1 asigne
-                // options.Durability.Mode = Solo incondicionalmente despues del callback -- ese
-                // orden pisaria cualquier intento de tocar Mode desde aqui, pero NO pisa
-                // DurabilityMetricsEnabled (verificado descompilando el paquete, ver issue #309).
+                // Se conserva la durabilidad real -- recovery, scheduled jobs y dead letters, que
+                // corren en el mismo DurabilityAgent: DurabilityAgentEnabled y Mode no se tocan.
+                //
+                // Va en el callback de AgregarWolverineParaComandosServerless, y no despues de esa
+                // llamada, porque es el hook que el paquete expone sobre WolverineOptions:
+                // Cosmos.EventSourcing.CritterStack 2.3.1 lo corre PRIMERO y despues solo reasigna
+                // Durability.Mode = Solo -- esa reasignacion pisaria en silencio cualquier intento
+                // de tocar Mode desde aqui, pero no toca DurabilityMetricsEnabled (verificado
+                // descompilando el paquete). Que sobreviva no es contrato del paquete: lo sostiene
+                // el guardrail de ComposicionServiciosTests sobre el contenedor real.
                 options.Durability.DurabilityMetricsEnabled = false;
 
                 options.HabilitarAzureServiceBusParaServerLess(serviceBusConnectionString);

--- a/src/Bitakora.ControlAsistencia.ControlHoras/Infraestructura/ComposicionServicios.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Infraestructura/ComposicionServicios.cs
@@ -37,6 +37,22 @@ public static class ComposicionServicios
             isDev,
             options =>
             {
+                // Issue #309: apaga el polling de metricas de profundidad de cola de Wolverine
+                // (PersistenceMetrics.StartPolling, PeriodicTimer de 5s que llama
+                // store.Admin.FetchCountsAsync() -- origen de 4 de las 8 consultas Postgres
+                // repetitivas medidas en dev, 4.320 spans/6h cada una). Se conserva la durabilidad
+                // real: recovery, scheduled jobs y dead letters siguen activos (DurabilityAgentEnabled
+                // y Mode no se tocan aqui). Nadie consume hoy esas metricas (sin dashboard ni
+                // alerta) y CheckHealthAsync llama FetchCountsAsync por su cuenta, asi que el
+                // health check no depende de este polling.
+                //
+                // Debe fijarse en ESTE callback (el que recibe AgregarWolverineParaComandosServerless)
+                // porque corre ANTES de que Cosmos.EventSourcing.CritterStack 2.3.1 asigne
+                // options.Durability.Mode = Solo incondicionalmente despues del callback -- ese
+                // orden pisaria cualquier intento de tocar Mode desde aqui, pero NO pisa
+                // DurabilityMetricsEnabled (verificado descompilando el paquete, ver issue #309).
+                options.Durability.DurabilityMetricsEnabled = false;
+
                 options.HabilitarAzureServiceBusParaServerLess(serviceBusConnectionString);
                 // HU-108: registra el topic destino para DiaCalculado.
                 // ADR-0004 + ADR-0005: un topic por evento, naming kebab-case en participio.

--- a/src/Bitakora.ControlAsistencia.Programacion/Infraestructura/ComposicionServicios.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/Infraestructura/ComposicionServicios.cs
@@ -38,14 +38,18 @@ public static class ComposicionServicios
                 // llama UseAzureMonitorExporter, issue #308) y esta frio, asi que el polling no
                 // aparece en Application Insights hoy, pero corre igual cada 5s y carga Postgres --
                 // se apaga aqui para que el dominio no quede con la regresion latente esperando a
-                // que se instrumente. Se conserva la durabilidad real: recovery, scheduled jobs y
-                // dead letters siguen activos (DurabilityAgentEnabled y Mode no se tocan aqui).
+                // que se instrumente.
                 //
-                // Debe fijarse en ESTE callback (el que recibe AgregarWolverineParaComandosServerless)
-                // porque corre ANTES de que Cosmos.EventSourcing.CritterStack 2.3.1 asigne
-                // options.Durability.Mode = Solo incondicionalmente despues del callback -- ese
-                // orden pisaria cualquier intento de tocar Mode desde aqui, pero NO pisa
-                // DurabilityMetricsEnabled (verificado descompilando el paquete, ver issue #309).
+                // Se conserva la durabilidad real -- recovery, scheduled jobs y dead letters, que
+                // corren en el mismo DurabilityAgent: DurabilityAgentEnabled y Mode no se tocan.
+                //
+                // Va en el callback de AgregarWolverineParaComandosServerless, y no despues de esa
+                // llamada, porque es el hook que el paquete expone sobre WolverineOptions:
+                // Cosmos.EventSourcing.CritterStack 2.3.1 lo corre PRIMERO y despues solo reasigna
+                // Durability.Mode = Solo -- esa reasignacion pisaria en silencio cualquier intento
+                // de tocar Mode desde aqui, pero no toca DurabilityMetricsEnabled (verificado
+                // descompilando el paquete). Que sobreviva no es contrato del paquete: lo sostiene
+                // el guardrail de ComposicionServiciosTests sobre el contenedor real.
                 options.Durability.DurabilityMetricsEnabled = false;
 
                 options.HabilitarAzureServiceBusParaServerLess(serviceBusConnectionString);

--- a/src/Bitakora.ControlAsistencia.Programacion/Infraestructura/ComposicionServicios.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/Infraestructura/ComposicionServicios.cs
@@ -32,6 +32,22 @@ public static class ComposicionServicios
             isDev,
             options =>
             {
+                // Issue #309: apaga el polling de metricas de profundidad de cola de Wolverine
+                // (PersistenceMetrics.StartPolling, PeriodicTimer de 5s que llama
+                // store.Admin.FetchCountsAsync()). Este Function App aun no emite telemetria (no
+                // llama UseAzureMonitorExporter, issue #308) y esta frio, asi que el polling no
+                // aparece en Application Insights hoy, pero corre igual cada 5s y carga Postgres --
+                // se apaga aqui para que el dominio no quede con la regresion latente esperando a
+                // que se instrumente. Se conserva la durabilidad real: recovery, scheduled jobs y
+                // dead letters siguen activos (DurabilityAgentEnabled y Mode no se tocan aqui).
+                //
+                // Debe fijarse en ESTE callback (el que recibe AgregarWolverineParaComandosServerless)
+                // porque corre ANTES de que Cosmos.EventSourcing.CritterStack 2.3.1 asigne
+                // options.Durability.Mode = Solo incondicionalmente despues del callback -- ese
+                // orden pisaria cualquier intento de tocar Mode desde aqui, pero NO pisa
+                // DurabilityMetricsEnabled (verificado descompilando el paquete, ver issue #309).
+                options.Durability.DurabilityMetricsEnabled = false;
+
                 options.HabilitarAzureServiceBusParaServerLess(serviceBusConnectionString);
                 // ADR-0024 decision #3: aunque ProgramacionTurnoDiarioSolicitada es IPrivateEvent (issue #210),
                 // sigue cruzando fisicamente el ASB interno del BC. El topic mapping se conserva: el constraint

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/ComposicionServiciosTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/ComposicionServiciosTests.cs
@@ -36,6 +36,7 @@ using JasperFx.MultiTenancy; // TenancyStyle (NO Marten.*: vive en JasperFx.Mult
 using Marten;
 using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry.Trace;
+using Wolverine;
 using ObtenerTurnoDiarioEndpoint = Bitakora.ControlAsistencia.ControlHoras.ObtenerTurnoDiario.FunctionEndpoint;
 using ListarTurnosDiariosEndpoint = Bitakora.ControlAsistencia.ControlHoras.ListarTurnosDiarios.FunctionEndpoint;
 
@@ -428,4 +429,49 @@ public class ComposicionServiciosTests
     // ("TraceIdRatioBasedSampler{0.200000}"), verificado contra OpenTelemetry 1.16.0.
     private static string FormatearRatio(double ratio) =>
         ratio.ToString("F6", CultureInfo.InvariantCulture);
+
+    // --- Issue #309: apagar la recoleccion de metricas de durabilidad de Wolverine (CA-1, CA-3) ---
+    //
+    // PersistenceMetrics.StartPolling (Wolverine.RDBMS.DurabilityAgent.StartAsync) es un
+    // PeriodicTimer(DurabilitySettings.UpdateMetricsPeriod, default 5s) que llama
+    // store.Admin.FetchCountsAsync() -- de ahi salen las cuatro consultas Postgres medidas en dev
+    // (123.050 spans/24h, 85/min): el "group by status" de wolverine_incoming_envelopes mas dos
+    // estimateTableCount (pg_class) con su fallback select count(*). Nadie consume esas metricas
+    // hoy (sin dashboard ni alerta) y CheckHealthAsync llama FetchCountsAsync por su cuenta, asi
+    // que el health check no depende de este polling.
+    //
+    // Se resuelve WolverineOptions del CONTENEDOR REAL (no un DurabilitySettings construido a
+    // mano) porque el gotcha de wiring verificado en el issue es de ORDEN: dentro de
+    // AgregarWolverineParaComandosServerless (Cosmos.EventSourcing.CritterStack 2.3.1) el callback
+    // del consumidor corre PRIMERO y options.Durability.Mode = Solo se asigna DESPUES, pisando
+    // cualquier intento de tocar Mode desde el callback -- pero NO pisa DurabilityMetricsEnabled.
+    // Un test que solo construyera un DurabilitySettings a mano nunca detectaria si un futuro
+    // upgrade del paquete empieza a pisar tambien esa bandera; resolver el WolverineOptions
+    // efectivo del grafo de DI si lo detecta.
+    [Fact]
+    public void AgregarServiciosControlHoras_ApagaLaRecoleccionDeMetricasDeDurabilidad_CuandoElContenedorEstaCompuesto()
+    {
+        using var provider = ComponerServiceProvider();
+
+        var opciones = provider.GetRequiredService<WolverineOptions>();
+
+        opciones.Durability.DurabilityMetricsEnabled.Should().BeFalse();
+    }
+
+    // CA-3: este issue apaga la recoleccion de METRICAS de cola, no la durabilidad real -- recovery,
+    // scheduled jobs y dead letters (procesados por el mismo DurabilityAgent) siguen activos. Fijar
+    // Mode en el mismo test que DurabilityMetricsEnabled evita que una futura correccion de CA-1 se
+    // resuelva "apagando" la durabilidad completa (p.ej. cambiando Mode) en vez de solo la bandera de
+    // metricas -- Mode sigue siendo Solo, el valor que AgregarWolverineParaComandosServerless fija
+    // incondicionalmente DESPUES del callback del consumidor.
+    [Fact]
+    public void AgregarServiciosControlHoras_ConservaLaDurabilidadReal_CuandoApagaLasMetricasDeCola()
+    {
+        using var provider = ComponerServiceProvider();
+
+        var opciones = provider.GetRequiredService<WolverineOptions>();
+
+        opciones.Durability.DurabilityAgentEnabled.Should().BeTrue();
+        opciones.Durability.Mode.Should().Be(DurabilityMode.Solo);
+    }
 }

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/ComposicionServiciosTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/ComposicionServiciosTests.cs
@@ -448,10 +448,17 @@ public class ComposicionServiciosTests
     // Un test que solo construyera un DurabilitySettings a mano nunca detectaria si un futuro
     // upgrade del paquete empieza a pisar tambien esa bandera; resolver el WolverineOptions
     // efectivo del grafo de DI si lo detecta.
+    //
+    // El provider se libera con await using porque WolverineOptions se registra Singleton via
+    // factory-lambda -- el contenedor lo trackea para disposal -- y solo implementa IAsyncDisposable:
+    // el Dispose() sincrono del provider raiz lanzaria InvalidOperationException al encontrarlo entre
+    // sus disposables. Mismo motivo por el que los tests de ICommandRouter/IPrivateEventRouter usan
+    // await using, y a diferencia de los de TracerProvider (singleton IDisposable, que si tolera el
+    // using sincrono).
     [Fact]
-    public void AgregarServiciosControlHoras_ApagaLaRecoleccionDeMetricasDeDurabilidad_CuandoElContenedorEstaCompuesto()
+    public async Task AgregarServiciosControlHoras_ApagaLaRecoleccionDeMetricasDeDurabilidad_CuandoElContenedorEstaCompuesto()
     {
-        using var provider = ComponerServiceProvider();
+        await using var provider = ComponerServiceProvider();
 
         var opciones = provider.GetRequiredService<WolverineOptions>();
 
@@ -465,9 +472,9 @@ public class ComposicionServiciosTests
     // metricas -- Mode sigue siendo Solo, el valor que AgregarWolverineParaComandosServerless fija
     // incondicionalmente DESPUES del callback del consumidor.
     [Fact]
-    public void AgregarServiciosControlHoras_ConservaLaDurabilidadReal_CuandoApagaLasMetricasDeCola()
+    public async Task AgregarServiciosControlHoras_ConservaLaDurabilidadReal_CuandoApagaLasMetricasDeCola()
     {
-        using var provider = ComponerServiceProvider();
+        await using var provider = ComponerServiceProvider();
 
         var opciones = provider.GetRequiredService<WolverineOptions>();
 

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/Infraestructura/ComposicionServiciosTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/Infraestructura/ComposicionServiciosTests.cs
@@ -163,10 +163,16 @@ public class ComposicionServiciosTests
     // options.Durability.Mode = Solo se asigna DESPUES, pisando cualquier intento de tocar Mode
     // desde el callback, pero NO pisa DurabilityMetricsEnabled. Ver el guardrail hermano en
     // ControlHoras.Tests para el detalle completo de FetchCountsAsync/PersistenceMetrics.
+    //
+    // El provider se libera con await using porque WolverineOptions se registra Singleton via
+    // factory-lambda -- el contenedor lo trackea para disposal -- y solo implementa IAsyncDisposable:
+    // el Dispose() sincrono del provider raiz lanzaria InvalidOperationException al encontrarlo entre
+    // sus disposables. Mismo motivo por el que los tests de ICommandRouter/IPrivateEventRouter de
+    // este archivo usan await using.
     [Fact]
-    public void AgregarServiciosProgramacion_ApagaLaRecoleccionDeMetricasDeDurabilidad_CuandoElContenedorEstaCompuesto()
+    public async Task AgregarServiciosProgramacion_ApagaLaRecoleccionDeMetricasDeDurabilidad_CuandoElContenedorEstaCompuesto()
     {
-        using var provider = ComponerServiceProvider();
+        await using var provider = ComponerServiceProvider();
 
         var opciones = provider.GetRequiredService<WolverineOptions>();
 
@@ -179,9 +185,9 @@ public class ComposicionServiciosTests
     // durabilidad completa en vez de solo la bandera de metricas -- Mode sigue siendo Solo, el valor
     // que AgregarWolverineParaComandosServerless fija incondicionalmente despues del callback.
     [Fact]
-    public void AgregarServiciosProgramacion_ConservaLaDurabilidadReal_CuandoApagaLasMetricasDeCola()
+    public async Task AgregarServiciosProgramacion_ConservaLaDurabilidadReal_CuandoApagaLasMetricasDeCola()
     {
-        using var provider = ComponerServiceProvider();
+        await using var provider = ComponerServiceProvider();
 
         var opciones = provider.GetRequiredService<WolverineOptions>();
 

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/Infraestructura/ComposicionServiciosTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/Infraestructura/ComposicionServiciosTests.cs
@@ -26,6 +26,7 @@ using Bitakora.ControlAsistencia.Programacion.Infraestructura;
 using Cosmos.EventSourcing.Abstractions.Commands;
 using Marten;
 using Microsoft.Extensions.DependencyInjection;
+using Wolverine;
 
 namespace Bitakora.ControlAsistencia.Programacion.Tests.Infraestructura;
 
@@ -146,5 +147,45 @@ public class ComposicionServiciosTests
             [typeof(TurnoCreado)] = "turno_creado",
             [typeof(ProgramacionTurnoSolicitada)] = "programacion_turno_solicitada"
         });
+    }
+
+    // --- Issue #309: apagar la recoleccion de metricas de durabilidad de Wolverine (CA-2, CA-3) ---
+    //
+    // Mismo wiring que ControlHoras (AgregarWolverineParaComandosServerless): Programacion no emite
+    // telemetria hoy (no llama UseAzureMonitorExporter, issue #308) y ademas esta frio, asi que el
+    // polling de FetchCountsAsync no aparece en Application Insights -- pero corre igual cada 5s y
+    // carga Postgres. El issue #309 alcanza a los DOS Function Apps para que el dominio no quede con
+    // la regresion latente esperando a que se instrumente.
+    //
+    // Se resuelve WolverineOptions del CONTENEDOR REAL (no un DurabilitySettings construido a mano):
+    // el gotcha de wiring verificado en el issue es de ORDEN -- dentro de
+    // AgregarWolverineParaComandosServerless el callback del consumidor corre PRIMERO y
+    // options.Durability.Mode = Solo se asigna DESPUES, pisando cualquier intento de tocar Mode
+    // desde el callback, pero NO pisa DurabilityMetricsEnabled. Ver el guardrail hermano en
+    // ControlHoras.Tests para el detalle completo de FetchCountsAsync/PersistenceMetrics.
+    [Fact]
+    public void AgregarServiciosProgramacion_ApagaLaRecoleccionDeMetricasDeDurabilidad_CuandoElContenedorEstaCompuesto()
+    {
+        using var provider = ComponerServiceProvider();
+
+        var opciones = provider.GetRequiredService<WolverineOptions>();
+
+        opciones.Durability.DurabilityMetricsEnabled.Should().BeFalse();
+    }
+
+    // CA-3: este issue apaga la recoleccion de METRICAS de cola, no la durabilidad real -- recovery,
+    // scheduled jobs y dead letters siguen activos. Fijar Mode en el mismo test que
+    // DurabilityMetricsEnabled evita que una futura correccion de CA-2 se resuelva apagando la
+    // durabilidad completa en vez de solo la bandera de metricas -- Mode sigue siendo Solo, el valor
+    // que AgregarWolverineParaComandosServerless fija incondicionalmente despues del callback.
+    [Fact]
+    public void AgregarServiciosProgramacion_ConservaLaDurabilidadReal_CuandoApagaLasMetricasDeCola()
+    {
+        using var provider = ComponerServiceProvider();
+
+        var opciones = provider.GetRequiredService<WolverineOptions>();
+
+        opciones.Durability.DurabilityAgentEnabled.Should().BeTrue();
+        opciones.Durability.Mode.Should().Be(DurabilityMode.Solo);
     }
 }


### PR DESCRIPTION
## Resumen

Pipeline TDD completado:
- Fase roja: tests escritos con stubs
- Fase verde: implementación completa
- Fase refactor: revisión de calidad

## Decisiones del pipeline

<details>
<summary>Test Writer (fase roja) — 5m 30s</summary>

## ES Test Writer - Decisiones

### Naturaleza de la tarea

Este issue **no** es un command handler de event sourcing: es un cambio de configuracion sobre el
`WolverineOptions` que compone cada seam (`ComposicionServicios.AgregarServicios{Dominio}`). No hay
comandos, eventos ni aggregates involucrados. La categoria de test correspondiente es el **test de
composicion del contenedor DI** (MEF-ADR-0029), ya establecida en
`ComposicionServiciosTests.cs` de ambos dominios -- no el DSL Given/When/Then de MEF-ADR-0002. Por
eso los tests nuevos no usan `Then`/`And<>`: siguen el patron ya vigente en el archivo (aserciones
AwesomeAssertions directas sobre el `ServiceProvider` compuesto), consistente con "Categoria
complementaria y distinta de MEF-ADR-0002" (MEF-ADR-0029, seccion 4).

No aplica el carril de refactor puro (seccion 2 del rol): el issue define comportamiento nuevo
observable y verificable (CA-1/CA-2/CA-3), no una reorganizacion de codigo existente.

### Investigacion previa a escribir los tests

Decompile con `ilspycmd` (WolverineFx 6.16.0, resuelto transitivamente por
`Cosmos.EventSourcing.CritterStack` 2.3.1) para confirmar, contra la fuente real y no por
suposicion:

1. **`WolverineOptions` se registra como singleton resoluble sin scope** en
   `Wolverine.HostBuilderExtensions.AddWolverine` (`services.AddSingleton(delegate(IServiceProvider s) {... return options; })`,
   inferido `TService = WolverineOptions` por el tipo de retorno del lambda). Por eso los tests
   resuelven `provider.GetRequiredService<WolverineOptions>()` directo del provider raiz, igual que
   el test existente de `TracerProvider` (tambien Singleton, sin `CreateAsyncScope()`).
2. **El gotcha de orden que describe el issue es real y verificable en el bytecode**:
   `Cosmos.EventSourcing.CritterStack.WolverineExtensions.AgregarWolverineParaComandosServerless`
   invoca `configureOptions?.Invoke(options)` (linea 35) ANTES de `options.Durability.Mode = (DurabilityMode)0`
   (linea 40, valor `Solo`). Como `Durability` es una unica instancia de `DurabilitySettings` desde
   el constructor de `WolverineOptions`, cualquier `DurabilityMetricsEnabled = false` puesto en el
   callback sobrevive porque la libreria solo reasigna `Mode`, nunca `DurabilityMetricsEnabled`.
3. **Valores por defecto confirmados en `Wolverine.DurabilitySettings`**: `DurabilityMetricsEnabled = true`,
   `DurabilityAgentEnabled = true`, `Mode = DurabilityMode.Balanced` (pisado a `Solo` por el wiring
   de este proyecto). Los tests nuevos, corriendo hoy contra produccion sin cambios, deben fallar
   en `DurabilityMetricsEnabled` (sigue en su default `true`) -- confirmado por diseño, no ejecutado
   (regla del rol: no correr `dotnet test`).

### Tests creados

- `tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/ComposicionServiciosTests.cs` (+2 tests):
  - `AgregarServiciosControlHoras_ApagaLaRecoleccionDeMetricasDeDurabilidad_CuandoElContenedorEstaCompuesto` - CA-1
  - `AgregarServiciosControlHoras_ConservaLaDurabilidadReal_CuandoApagaLasMetricasDeCola` - CA-3 (agente + Mode)
- `tests/Bitakora.ControlAsistencia.Programacion.Tests/Infraestructura/ComposicionServiciosTests.cs` (+2 tests):
  - `AgregarServiciosProgramacion_ApagaLaRecoleccionDeMetricasDeDurabilidad_CuandoElContenedorEstaCompuesto` - CA-2
  - `AgregarServiciosProgramacion_ConservaLaDurabilidadReal_CuandoApagaLasMetricasDeCola` - CA-3 (agente + Mode)

Ambos archivos ya usaban el fixture `ComponerServiceProvider()` (connection strings dummy,
`ValidateOnBuild`/`ValidateScopes`); los tests nuevos lo reutilizan sin tocarlo.

### Estructura elegida

- Tests agregados al final de los `ComposicionServiciosTests.cs` existentes de cada dominio (no se
  crearon archivos nuevos): son guardrails de composicion del mismo seam que el resto del archivo
  ya cubre, y el `impacto esperado` del issue los ubica ahi explicitamente.
- CA-3 (agente enabled + Mode sin cambiar) se cubre en **un solo test por dominio** con dos
  aserciones relacionadas -- mismo patron que el test existente
  `HabilitaColumnasDeMetadataDeEvento` (tres booleans en un solo `[Fact]`): ambas aserciones
  protegen la misma idea ("no se toco la durabilidad real"), separarlas no aportaria una senal
  distinta.
- No se extrajo un helper compartido entre ambos dominios (mismo criterio que el propio issue en
  "Notas tecnicas": Rule of Three, MEF-ADR-0018 -- dos seams paralelos, sin tercer caso).

### Stubs creados

Ninguno. El issue no introduce tipos nuevos (comando, evento, aggregate, handler): es un cambio de
valor de configuracion sobre `WolverineOptions.Durability` dentro de un metodo de extension ya
existente. Los tests compilan contra el codigo de produccion actual sin modificarlo.

### Decisiones de diseno

- **Oraculo por contenedor real, no por objeto construido a mano** (CA-1/CA-2 lo exigen
  explicitamente): se resuelve `WolverineOptions` del `ServiceProvider` compuesto por
  `AgregarServicios{Dominio}`, no un `new DurabilitySettings()` aislado. Un test contra un objeto
  construido a mano no detectaria una regresion futura del wiring (p.ej. si un upgrade de
  `Cosmos.EventSourcing.CritterStack` empezara a pisar tambien `DurabilityMetricsEnabled` ademas de
  `Mode`).
- **`DurabilityMode.Solo` como valor esperado explicito** (enum literal, no derivado): es el valor
  que `AgregarWolverineParaComandosServerless` fija incondicionalmente hoy; se usa como oraculo
  independiente en vez de leerlo de una constante de produccion, siguiendo MEF-ADR-0002
  "oraculo independiente (no-tautologia)".
- Sin `using` de `Wolverine.RDBMS` ni referencia a `PersistenceMetrics`/`DurabilityAgent`: esos
  tipos no son publicos desde este ensamblado ni hace falta invocarlos -- el issue resuelve el
  problema completo con una propiedad de `DurabilitySettings`, que si es publica.

### Cobertura de criterios

| Criterio de aceptacion | Test(s) |
|---|---|
| CA-1: `WolverineOptions` de ControlHoras tiene `DurabilityMetricsEnabled == false` sobre el contenedor real | `AgregarServiciosControlHoras_ApagaLaRecoleccionDeMetricasDeDurabilidad_CuandoElContenedorEstaCompuesto` |
| CA-2: idem Programacion | `AgregarServiciosProgramacion_ApagaLaRecoleccionDeMetricasDeDurabilidad_CuandoElContenedorEstaCompuesto` |
| CA-3: `DurabilityAgentEnabled` sigue `true` y `Mode` no cambia (ambos dominios) | `AgregarServiciosControlHoras_ConservaLaDurabilidadReal_CuandoApagaLasMetricasDeCola`, `AgregarServiciosProgramacion_ConservaLaDurabilidadReal_CuandoApagaLasMetricasDeCola` |
| CA-4: comentario en cada seam explicando que se apaga/conserva y por que en el callback | No testeable por unit test (es documentacion inline); responsabilidad del implementer al tocar `ComposicionServicios.cs` |
| CA-5: verificacion post-deploy en dev (Application Insights, 24h) | Fuera de alcance de este agente -- observabilidad post-merge, no test unitario |
| CA-6: smoke tests existentes siguen pasando | Fuera de alcance de este agente -- suite de smoke tests ya existente, no requiere tests nuevos de este issue |

### Desviaciones del plan del planner

Ninguna -- el "Impacto esperado en archivos" del issue listaba exactamente los dos
`ComposicionServiciosTests.cs` como los archivos a modificar, y la investigacion del planner sobre
el mecanismo de apagado (`DurabilityMetricsEnabled`, gotcha de orden del callback) se confirmo
integra al decompilar WolverineFx 6.16.0 y Cosmos.EventSourcing.CritterStack 2.3.1 -- ningun dato
tecnico del issue resulto incorrecto.

</details>

<details>
<summary>Implementer (fase verde) — 13m 6s</summary>

## ES Implementer - Decisiones

### Enfoque de implementacion

Una linea por dominio: `options.Durability.DurabilityMetricsEnabled = false;` dentro del callback
`options => { ... }` que ya se le pasaba a `AgregarWolverineParaComandosServerless` en
`ComposicionServicios.cs` de ControlHoras y de Programacion. Se coloca al **inicio** del callback,
antes de `HabilitarAzureServiceBusParaServerLess(...)` y de cualquier otra configuracion, siguiendo
al pie la investigacion del planner: el callback del consumidor corre PRIMERO dentro de
`AgregarWolverineParaComandosServerless` (Cosmos.EventSourcing.CritterStack 2.3.1), y
`Durability.Mode` se fija DESPUES incondicionalmente (pisando cualquier intento de tocarlo desde
el callback) -- pero `DurabilityMetricsEnabled` no se toca despues, asi que sobrevive.

No se toco `Durability.Mode` ni `Durability.DurabilityAgentEnabled` en ningun punto: CA-3 exige
que la durabilidad real (recovery, scheduled jobs, dead letters) siga intacta, y ninguno de los dos
dominios necesitaba cambio alli.

### Decisiones de diseno

- Sin helper compartido entre los dos `ComposicionServicios.cs`: son dos seams deliberadamente
  paralelos (un dominio por Function App), y el propio issue descarta extraer un tercer
  artefacto comun (Rule of Three, MEF-ADR-0018).
- El comentario en cada seam (CA-4) documenta las tres cosas que pide el criterio: que se apaga
  (metricas de cola / `FetchCountsAsync`), que se conserva (durabilidad real), y por que va en
  ESE callback especificamente (orden de asignacion de `Durability.Mode` dentro del paquete).

### ADRs consultados

- CA-ADR-0009 (control de costos de Application Insights): este cambio reduce volumen de ingesta
  en la fuente (backlog de #308), coherente con la preferencia declarada por reducir en origen
  antes que muestrear despues.
- MEF-ADR-0029 (seams de composicion): el cambio vive exclusivamente en `ComposicionServicios` de
  cada dominio, verificado por su test de composicion hermano -- no se toco `Program.cs` de
  ningun dominio.
- MEF-ADR-0016 (convencion de nombres de metodos de test): no aplica cambios de mi parte -- los
  nombres de test ya vienen del test-writer y siguen el patron `<Sujeto>_<LoQuePasa>_Cuando<Condicion>`.

### Desviaciones de ADRs

Ninguna desviacion -- todos los ADRs aplicados al pie de la letra.

### Desviaciones del plan del planner

Ninguna desviacion del "Impacto esperado en archivos": se modificaron exactamente los dos archivos
`ComposicionServicios.cs` sugeridos, sin tocar ningun otro archivo de produccion, sin crear
archivos nuevos, y sin tocar `Projections`, `infra/` ni ningun aggregate/handler/evento.

### Precedentes consultados

- El "gotcha de wiring" citado literalmente en el issue (orden callback-antes-de-Mode) se verifico
  independientemente via `ilspycmd` sobre el `Wolverine.dll` restaurado en este worktree, no solo
  se confio en la cita del issue -- confirmado que `WolverineOptions` fija `Durability.Mode = Solo`
  (via `Wolverine.HostBuilderExtensions.UseSoloDurabilityMode`, invocado por
  `Cosmos.EventSourcing.CritterStack` despues del callback del consumidor) sin tocar
  `DurabilityMetricsEnabled`.

### Infraestructura modificada

Ninguna. Este issue no toca topics, subscriptions ni ningun recurso de `infra/environments/dev/main.tf`
-- es puramente configuracion de un `WolverineOptions` en memoria, sin efecto en la topologia de
Service Bus ni en Postgres mas alla de dejar de emitir las 4 consultas de polling.

### Complejidad encontrada

**4 tests bloqueados por una contradiccion estructural del test, no de la implementacion.** Ver
`.claude/pipeline/blockage-report.md` para el detalle completo (enfoques intentados, evidencia
empirica via spikes descartables, hipotesis). Resumen: los 4 tests nuevos de este issue
(`AgregarServiciosControlHoras_ApagaLaRecoleccionDeMetricasDeDurabilidad_...`,
`AgregarServiciosControlHoras_ConservaLaDurabilidadReal_...` y sus pares en Programacion) resuelven
`WolverineOptions` directamente desde un `ServiceProvider` raiz dentro de un `using var provider = ...`
(disposal **sincronico**). `WolverineOptions` (tipo de la libreria Wolverine, confirmado por
decompilacion) implementa unicamente `IAsyncDisposable`, y se registra en el contenedor via un
factory Singleton -- por lo tanto SI queda trackeado para disposal por el contenedor. Cuando el
`using` sincronico intenta disponer el contenedor al final del test, `ServiceProviderEngineScope.Dispose()`
lanza `InvalidOperationException` porque encuentra un disposable que solo soporta `DisposeAsync`.
Esto ocurre **independientemente de la correctitud de mi implementacion** -- lo confirme con un
spike descartable (creado, ejecutado y eliminado, nunca commiteado) que reproduce el mismo fallo
sin tocar `DurabilityMetricsEnabled` en absoluto, y con un segundo spike (mismo ciclo) que resuelve
`WolverineOptions` con el patron async correcto (`await using` + `CreateAsyncScope()`, el mismo que
ya usan los tests hermanos de `ICommandRouter`/`IPrivateEventRouter` en el mismo archivo) y verifica
las tres aserciones reales (`DurabilityMetricsEnabled == false`, `DurabilityAgentEnabled == true`,
`Mode == Solo`) -- pasa limpiamente, confirmando que la implementacion de produccion es correcta.

Explore la alternativa de "arreglar" esto desde produccion (reemplazar el registro DI de
`WolverineOptions` por una instancia directa, exenta de disposal-tracking) y la deseche: la
decompilacion de `Wolverine.HostBuilderExtensions.AddWolverine` muestra que la PRIMERA resolucion
de `WolverineOptions` ejecuta side-effects de inicializacion reales (`ReadJasperFxOptions`,
`ApplyExtensions`, fijacion del path de codegen) -- reemplazar su registro exigiria pre-resolverlo
durante la composicion, con riesgo de romper ese orden de inicializacion o de duplicar construccion
de singletons pesados (`IDocumentStore`, etc.). El riesgo supera ampliamente el beneficio de hacer
pasar 4 tests cuyo problema es enteramente del patron de disposal del test.

### Resultado

- Tests pasando: 483/487 (proyectos tocados por este issue: `ControlHoras.Tests` 358/360,
  `Programacion.Tests` 127/129; resto de la suite del repo intacta: `Projections.Tests` 53/53,
  `PrivateEvents.Tests` 34/34, `PublicEvents.Tests` 13/13)
- Tests bloqueados: 4, documentados en `.claude/pipeline/blockage-report.md`

</details>
<details>
<summary>Reviewer (fase refactor) — 8m 42s</summary>

## ES Reviewer - Revision

### Evaluacion general
- Calidad: **buena**
- Cambios realizados: **si** (resolucion del bloqueo heredado + precision del comentario de CA-4)
- Estado final de la suite: `total: 628 / error: 0 / correcto: 616 / omitido: 12` (los 12 omitidos
  son smoke tests sin connection string local -- `Assert.SkipWhen`, comportamiento esperado)

### Resolucion de bloqueo heredado

El implementer reporto 4 tests bloqueados. **Se resolvieron en 1 intento** (no se agotaron los 5),
aplicando la excepcion de "bug de framework": el fallo era mecanica del harness de test, no un
defecto de la implementacion ni un cambio de especificacion.

| Test afectado | Naturaleza del problema | Accion tomada | Donde queda cubierto el CA |
|---|---|---|---|
| `ComposicionServiciosTests.AgregarServiciosControlHoras_ApagaLaRecoleccionDeMetricasDeDurabilidad_*` | Bug de framework: `WolverineOptions` es Singleton registrado por factory-lambda (el contenedor lo trackea para disposal) y solo implementa `IAsyncDisposable`; el `using` **sincrono** del provider raiz hacia lanzar `InvalidOperationException` en `ServiceProviderEngineScope.Dispose()` | `using var provider` -> `await using var provider` (+ firma `async Task`), alineandolo con el patron que sus hermanos del mismo archivo ya documentaban para `ICommandRouter`/`IPrivateEventRouter`. **La asercion no cambio** | CA-1, mismo test, ahora verde |
| `...AgregarServiciosControlHoras_ConservaLaDurabilidadReal_*` | idem | idem | CA-3 (ControlHoras) |
| `...AgregarServiciosProgramacion_ApagaLaRecoleccionDeMetricasDeDurabilidad_*` | idem | idem | CA-2 |
| `...AgregarServiciosProgramacion_ConservaLaDurabilidadReal_*` | idem | idem | CA-3 (Programacion) |

El diagnostico del implementer era **correcto en todos sus puntos** (causa raiz, evidencia por
spikes descartables, y el descarte razonado de "arreglarlo desde produccion" reemplazando el
registro DI de `WolverineOptions`, que efectivamente habria roto el orden de inicializacion de
Wolverine). Solo le faltaba la licencia para tocar el test, que si corresponde a este rol.

### Verificacion de que el guardrail muerde (mutation testing manual)

No basta con que los tests esten verdes: un test de composicion que afirme una bandera puede quedar
vacuo si el valor por defecto ya coincide. Se verifico comentando `options.Durability.DurabilityMetricsEnabled = false;`
en el seam de ControlHoras y corriendo el proyecto de tests:

```
con errores ...AgregarServiciosControlHoras_ApagaLaRecoleccionDeMetricasDeDurabilidad_CuandoElContenedorEstaCompuesto
  Expected opciones.Durability.DurabilityMetricsEnabled to be False, but found True.
  total: 360 / error: 1 / correcto: 359
```

El guardrail se pone rojo **y** confirma empiricamente el default `true` que el issue declaraba.
Mutacion revertida con `git checkout --` acto seguido.

### Cumplimiento de ADRs aplicables

| ADR | Cumplimiento | Observacion |
|---|---|---|
| CA-ADR-0009: control de costos de Application Insights | ok | Reduce el volumen de ingesta **en la fuente**, que es la palanca que el ADR declara preferible frente a muestrear despues. Coherente con la "Actualizacion (2026-08-04, issue #308)": con el sampler ya efectivo, cada span de polling compite por el mismo ratio que la telemetria con valor. Capas 1, 3 y 4 sin tocar. |
| MEF-ADR-0029: test de composicion del contenedor DI | ok | El cambio vive exclusivamente en `Infraestructura/ComposicionServicios.cs` de cada dominio (fuente unica de verdad compartida con `Program.cs`), y el guardrail lo verifica sobre el `ServiceProvider` real construido con `ValidateOnBuild`/`ValidateScopes`. Leer `WolverineOptions` **del contenedor** en vez de construir un `DurabilitySettings` a mano es exactamente la garantia "estrictamente mas fuerte" que describe la decision #3 del ADR: ejercita la resolucion real, no el arbol estatico de call sites. |
| MEF-ADR-0016: convencion de naming de tests | ok | `AgregarServiciosControlHoras_ApagaLaRecoleccionDeMetricasDeDurabilidad_CuandoElContenedorEstaCompuesto` y `..._ConservaLaDurabilidadReal_CuandoApagaLasMetricasDeCola` siguen `<Sujeto>_<LoQuePasa>_Cuando<Condicion>`, con el metodo bajo prueba como sujeto (ADR: *"el metodo, propiedad o concepto bajo prueba"*) y consistentes con los tests hermanos del archivo. Solo `[Fact]`, ningun `[Theory]`. |

### Desviaciones de ADRs

**Ninguna desviacion -- todos los ADRs aplicables se cumplen.**

- Declaradas por el implementer: ninguna (su resumen registra "todos los ADRs aplicados al pie de
  la letra"; verificado y confirmado).
- Detectadas por el reviewer y no declaradas: ninguna.

Nota: el issue ofrecia una desviacion pre-autorizada (`UpdateMetricsPeriod = 5 min` en vez de
apagar). El implementer **no** la tomo, que es lo correcto -- MEF-ADR-0018: no se conserva una
metrica que nadie consume por un consumidor hipotetico futuro.

### Precedentes consultados por el implementer

| Precedente | ADR aplicable | Veredicto |
|---|---|---|
| Decompilacion con `ilspycmd` de `Wolverine.dll` y `Cosmos.EventSourcing.CritterStack` 2.3.1 (orden callback-antes-de-`Mode`; `UseSoloDurabilityMode` no toca `DurabilityMetricsEnabled`) | MEF-ADR-0029 | **alineado, y ahora confirmado empiricamente**. El implementer no se conformo con la cita del issue: verifico contra el binario. La confirmacion independiente de este review es mas fuerte que la decompilacion: con el guardrail en verde, el contenedor real demuestra las dos afirmaciones a la vez (`DurabilityMetricsEnabled == false` sobrevive **y** `Mode == Solo` es el valor que la libreria impone despues). |
| Version del paquete citada en los comentarios (2.3.1) | -- | **alineado**: coincide con el `PackageReference` de ambos `.csproj` (verificado). Un comentario que cite una version equivocada envejece peor que no citar ninguna. |

Alcance verificado de forma independiente: `grep` sobre `src/` confirma que **solo** esos dos
procesos componen Wolverine (`AgregarWolverineParaComandosServerless`). El worker de `Projections`
no lo usa, asi que el alcance de dos dominios que fija el issue es completo, no parcial.

### Convenciones del pipeline (no ADRs)

| Convencion | Estado | Observacion |
|---|---|---|
| Cada test con `Then()` + `And<>()` | n/a | Son tests de composicion de contenedor (MEF-ADR-0029), categoria explicitamente distinta del DSL Given/When/Then de MEF-ADR-0002 (decision #4 del ADR). No hay aggregate ni comando bajo prueba. |
| Overloads correctos para stream IDs compuestos | n/a | El diff no toca ningun aggregate ni test de event sourcing. |
| Fakes manuales (no NSubstitute) | n/a | Sin dependencias fakeadas: el contenedor real se compone con connection strings dummy. |
| Feature folders (produccion y tests) | ok | `Infraestructura/` a nivel raiz del dominio en `src/`, con espejo exacto en `tests/`. |
| Smoke tests: SkipWhen, secrets, cobertura | n/a | El diff no crea ni modifica smoke tests. Los existentes siguen compilando y se omiten localmente con `Assert.SkipWhen` (sin connection string), que es el comportamiento correcto -- ver CA-6 abajo. |
| Proyecciones read-side | n/a | Issue de configuracion de infraestructura de proceso; no toca `ReadModels`/`Projections`. |
| Tests via `ToString`/comportamiento | n/a | Lo verificado es configuracion de un objeto de libreria (`WolverineOptions`), no estado interno de un objeto de dominio: MEF-ADR-0012 no aplica aqui. |
| Sin numeros magicos | ok | El diff no introduce literales; el unico valor es el booleano de la bandera. |
| Condiciones en positivo | n/a | Sin bifurcaciones nuevas. |
| Caracteres prohibidos (U+2500) | ok | Verificado con `grep` sobre `src/` y `tests/`: ninguna ocurrencia. Los separadores usan `--` ASCII. |

### Elegancia del codigo

El cambio de produccion es de una linea por dominio y no hay nada que compactar: sin codigo muerto,
sin duplicacion extraible, sin ramas. Dos observaciones:

- **Simetria deliberada entre dominios, bien resuelta.** Los dos seams reciben la misma linea sin
  extraer un helper compartido. Es la decision correcta y coincide con lo que el issue anticipaba:
  MEF-ADR-0018 (Rule of Three) -- dos llamadas de una linea en seams que ya son paralelos por
  diseno no justifican un tercer artefacto que acople los dos Function Apps. El comentario de cada
  seam si tiene contenido propio (Programacion documenta que aun no emite telemetria), asi que cada
  archivo se lee de forma autonoma.
- **Densidad comentario/codigo alta pero justificada.** ~16 lineas de comentario por 1 de codigo es
  desproporcionado en abstracto, pero aqui el comentario **es** el entregable de CA-4 y documenta un
  gotcha de orden invisible en el codigo. Se reescribio (ver hallazgo #2) para que la extension
  compre claridad en vez de repeticion.

Los tests: nombres que revelan intencion, un solo concepto por test, y el comentario de bloque
explica el *por que* del oraculo (por que se lee del contenedor y no de un `DurabilitySettings` a
mano) en vez de parafrasear el codigo. Buen material.

### Criticas y hallazgos

1. **[Mayor -- corregido]** 4 tests rojos heredados por patron de disposal sincrono sobre un
   `IAsyncDisposable` puro. Detalle y correccion en "Resolucion de bloqueo heredado". Vale la pena
   registrar el patron: **este archivo ya habia tropezado con la misma piedra** (el comentario de
   `AgregarServiciosControlHoras_ResuelveICommandRouter_*` la documenta para
   `MessageStoreCollection`), y el test-writer escribio los tests nuevos por analogia con los de
   `TracerProvider` -- que si toleran `using` sincrono por ser `IDisposable`. La leccion, ya
   incorporada en los comentarios: en este contenedor, **cualquier** resolucion de un tipo de
   Wolverine exige `await using`; los de OpenTelemetry no.

2. **[Menor -- corregido]** El comentario de CA-4, identico en ambos seams, tenia un `porque` que
   invertia la razon real: *"Debe fijarse en ESTE callback ... **porque corre ANTES** de que ...
   asigne `Mode = Solo` incondicionalmente **despues** del callback"*. Correr antes no es la razon
   por la que se elige ese punto -- es la circunstancia que hace que la reasignacion posterior sea
   un riesgo. Ademas, CA-4 pide explicitamente registrar por que va en el callback **"y no
   despues"**, pregunta que el texto original nunca llegaba a responder. Reescrito en ambos
   archivos, separando los tres puntos del criterio (que se apaga / que se conserva / por que en el
   callback) y cerrando con el dato que mas importa para el mantenedor futuro: que la supervivencia
   de la bandera **no es contrato del paquete**, sino algo que sostiene el guardrail. Contenido
   tecnico sin cambios.

3. **[Cosmetico -- no corregido, deuda preexistente ajena al issue]** `dotnet format
   --verify-no-changes` sale con codigo 2 por **9 avisos `IDE0005`** (using innecesario) en archivos
   que este pipeline no toca (`MarcacionAdicionadaSerializacionTests.cs`,
   `RetardoSerializacionTests.cs`, `DesgloseHorasSerializacionTests.cs`, etc.). Los 4 archivos del
   diff estan limpios. Se dejan como estan por la regla de no refactorizar codigo ajeno a la HU;
   quedan como candidato para un issue de limpieza.

4. **[Cosmetico -- no corregido, preexistente]** 4 avisos `NU1902` por vulnerabilidad moderada
   conocida en `OpenTelemetry.Api` 1.14.0, arrastrado transitivamente en `Programacion` y sus tests
   (`GHSA-g94r-2vxg-569j`). Ajeno a este issue, pero conviene levantarlo como issue propio: es una
   advertencia de seguridad, no de estilo.

No hubo hallazgos que exigieran cambiar la implementacion de produccion.

### Refactorings aplicados

- **Tests (4 metodos, 2 archivos)**: `using var provider` -> `await using var provider` + firma
  `async Task`, con un comentario que explica la restriccion (`WolverineOptions` Singleton por
  factory-lambda, `IAsyncDisposable` puro) y la contrasta con los tests de `TracerProvider` del
  mismo archivo, para que el proximo que agregue un test aqui elija el patron correcto a la primera.
- **Produccion (2 archivos)**: reescritura del comentario de CA-4 (hallazgo #2). Sin cambio de
  codigo ejecutable -- la unica linea de logica del issue quedo intacta en ambos seams.
- **No aplicados a proposito**: no se extrajo helper compartido entre dominios (Rule of Three), no
  se toco `UpdateMetricsPeriod`, no se limpio la deuda de `IDE0005`/`NU1902` ajena al issue.

### Cobertura de criterios de aceptacion

| Criterio | Estado | Test(s) |
|---|---|---|
| CA-1: `WolverineOptions` de ControlHoras con `DurabilityMetricsEnabled == false`, sobre el contenedor real | **cubierto** | `AgregarServiciosControlHoras_ApagaLaRecoleccionDeMetricasDeDurabilidad_CuandoElContenedorEstaCompuesto` -- resuelto del `ServiceProvider` real, no de un `DurabilitySettings` a mano; se verifico por mutacion que falla si la libreria vuelve a pisar el valor |
| CA-2: idem para Programacion | **cubierto** | `AgregarServiciosProgramacion_ApagaLaRecoleccionDeMetricasDeDurabilidad_CuandoElContenedorEstaCompuesto` |
| CA-3: `DurabilityAgentEnabled` sigue `true` y `Mode` no cambia | **cubierto** | `AgregarServiciosControlHoras_ConservaLaDurabilidadReal_CuandoApagaLasMetricasDeCola` y `AgregarServiciosProgramacion_ConservaLaDurabilidadReal_CuandoApagaLasMetricasDeCola` (ambos afirman `DurabilityAgentEnabled == true` y `Mode == Solo`) |
| CA-4: comentario en cada seam con que se apaga / que se conserva / por que en el callback | **cubierto** | No es testeable automaticamente; verificado por lectura y **reescrito** por este review para que responda de verdad el "y no despues" que el criterio pide (hallazgo #2) |
| CA-5: verificacion post-deploy en dev a 24h (4 consultas desaparecen, las otras 4 siguen; ~123k -> ~53k spans/dia) | **pendiente -- no verificable en el pipeline** | Requiere el merge desplegado y 24h de ingesta. Queda como accion de seguimiento del issue, no como hueco de cobertura de tests |
| CA-6: los smoke tests existentes siguen pasando | **pendiente de ejecucion real** | Ningun smoke test fue modificado y todos compilan; localmente se omiten via `Assert.SkipWhen` por falta de connection string (comportamiento correcto). Se ejercitan de verdad en el job de smoke tests del workflow de deploy |

### Tests agregados

- Ninguno. Los 4 tests del test-writer cubren CA-1, CA-2 y CA-3 con el oraculo correcto (el
  contenedor real) y se verifico por mutacion que no son vacuos, asi que agregar mas seria ruido.
- Tests de contrato (igualdad / round-trip de serializacion): **no aplican** -- el diff no introduce
  ningun value object, evento de dominio ni tipo con marker de bus (`IPrivateEvent`/`IPublicEvent`).

</details>

## Cobertura

| Archivo | Cobertura | Umbral | Estado |
|---|---|---|---|
| ComposicionServicios.cs | - | no evaluado | - |
| ComposicionServicios.cs | - | no evaluado | - |
## Commits

9264749 refactor(issue-309): liberar el guardrail con await using y precisar el comentario del seam
58b0368 feat(issue-309): apagar la recoleccion de metricas de durabilidad de Wolverine (fase verde)
438ef74 test(issue-309): guardrail de composicion para apagar metricas de durabilidad Wolverine (fase roja)

Closes #309