### PR TITLE
Serializar el action de smoke tests para que no corra dos dominios a la vez

### DIFF
--- a/.github/workflows/smoke-tests-dominio.yml
+++ b/.github/workflows/smoke-tests-dominio.yml
@@ -35,6 +35,31 @@ on:
       POSTGRES_CONNECTION_STRING:
         required: false
 
+# Serializa las tres rutas que invocan este reusable (deploy-control-horas.yml,
+# deploy-programacion.yml y la matrix de smoke-tests.yml) contra el mismo Service Bus de dev y su
+# unica suscripcion 'smoke-tests' -- issue #313. Dos suites corriendo a la vez se roban
+# mutuamente el mensaje que cada una espera (cada CompleteMessageAsync de una destruye el
+# mensaje que la otra necesitaba).
+#
+# El grupo va AQUI, a nivel de ESTE workflow llamado, y no como jobs.<job_id>.concurrency en el
+# job 'uses:' de cada caller: la documentacion de GitHub Actions sobre reusable workflows solo
+# lista jobs.<job_id>.concurrency como valido en el job que hace la llamada, pero la comunidad
+# (github/community#30708) confirma que ese punto no serializa invocaciones del reusable como
+# cabria esperar -- lo que si funciona es declarar 'concurrency' en el propio workflow llamado.
+#
+# El nombre del grupo es un literal fijo a proposito: un workflow llamado hereda
+# ${{ github.workflow }} del CALLER (Deploy ControlHoras, Deploy Programacion o Smoke Tests
+# (todos los dominios)), asi que interpolarlo aca produciria un grupo distinto por invocador y
+# anularia la serializacion que este cambio busca.
+#
+# cancel-in-progress: false (CA-3) -- una corrida encolada espera a la que esta verificando un
+# deploy en curso, nunca la cancela. Con 2 invocadores simultaneos como maximo hoy, el default de
+# 'queue' (una corrida pendiente por grupo) alcanza; si se suma un tercer invocador (#314), revisar
+# 'queue: max'.
+concurrency:
+  group: smoke-tests-dev
+  cancel-in-progress: false
+
 jobs:
   smoke-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/smoke-tests-dominio.yml
+++ b/.github/workflows/smoke-tests-dominio.yml
@@ -41,24 +41,37 @@ on:
 # mutuamente el mensaje que cada una espera (cada CompleteMessageAsync de una destruye el
 # mensaje que la otra necesitaba).
 #
-# El grupo va AQUI, a nivel de ESTE workflow llamado, y no como jobs.<job_id>.concurrency en el
-# job 'uses:' de cada caller: la documentacion de GitHub Actions sobre reusable workflows solo
-# lista jobs.<job_id>.concurrency como valido en el job que hace la llamada, pero la comunidad
-# (github/community#30708) confirma que ese punto no serializa invocaciones del reusable como
-# cabria esperar -- lo que si funciona es declarar 'concurrency' en el propio workflow llamado.
+# El grupo va AQUI, en el workflow LLAMADO, porque es el unico punto por el que pasan las tres
+# rutas de disparo: un solo bloque las cubre. Que un workflow llamado reserve su propio grupo,
+# independiente del run que lo invoca, esta evidenciado en github/community#30708: alli el sintoma
+# es que el caller se cancela a si mismo cuando ambos piden el mismo grupo -- prueba de que la
+# reserva del llamado ocurre de verdad y por invocacion.
 #
-# El nombre del grupo es un literal fijo a proposito: un workflow llamado hereda
-# ${{ github.workflow }} del CALLER (Deploy ControlHoras, Deploy Programacion o Smoke Tests
-# (todos los dominios)), asi que interpolarlo aca produciria un grupo distinto por invocador y
-# anularia la serializacion que este cambio busca.
+# El nombre del grupo es un literal fijo a proposito, y no ${{ github.workflow }}: un workflow
+# llamado hereda en ese contexto el nombre del CALLER (Deploy ControlHoras, Deploy Programacion o
+# Smoke Tests (todos los dominios)). Interpolarlo aca daria un grupo distinto por invocador
+# -- anulando la serializacion -- y ademas chocaria con el grupo del caller si este declarara uno.
+# Es justamente la correccion que recomienda ese hilo.
 #
-# cancel-in-progress: false (CA-3) -- una corrida encolada espera a la que esta verificando un
-# deploy en curso, nunca la cancela. Con 2 invocadores simultaneos como maximo hoy, el default de
-# 'queue' (una corrida pendiente por grupo) alcanza; si se suma un tercer invocador (#314), revisar
-# 'queue: max'.
+# cancel-in-progress: false (CA-3) -- la corrida encolada espera; nunca cancela a la que esta
+# verificando un deploy en curso.
+#
+# queue: max (CA-4) -- el default 'queue: single' admite UNA sola corrida pendiente por grupo, y la
+# tercera en llegar cancela a la que estaba esperando, que queda reportada como 'cancelled' en el
+# check. Con tres invocadores eso es alcanzable hoy: un apply de infra dispara los dos deploys y
+# basta un workflow_dispatch de "Smoke Tests (todos los dominios)" en esa ventana. 'max' admite
+# hasta 100 pendientes en orden FIFO segun cuando cada una entro al grupo. Solo es valido con
+# cancel-in-progress en false; combinarlo con true es error de validacion del workflow.
+# https://github.blog/changelog/2026-05-07-github-actions-concurrency-groups-now-allow-larger-queues/
+#
+# OJO si corres actionlint local: hasta 1.7.12 su schema no conoce 'queue' y lo reporta como
+# 'unexpected key ... expected one of "cancel-in-progress", "group"'. Es atraso del linter frente al
+# release de mayo 2026, no un error del workflow -- no borres la linea por ese hallazgo. Ningun
+# workflow de este repo corre actionlint como gate.
 concurrency:
   group: smoke-tests-dev
   cancel-in-progress: false
+  queue: max
 
 jobs:
   smoke-tests:

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -17,6 +17,11 @@ jobs:
     needs: discovery
     strategy:
       fail-fast: false
+      # CA-2 (issue #313): un dominio a la vez. El concurrency del reusable smoke-tests-dominio.yml
+      # ya serializa las invocaciones entre si, pero max-parallel lo deja explicito tambien aqui:
+      # sin el, ambas legs de la matrix arrancarian juntas y solo una avanzaria mientras la otra
+      # queda encolada -- no es un fallo, pero oculta en el arranque lo que el CA pide visible.
+      max-parallel: 1
       matrix:
         include: ${{ fromJson(needs.discovery.outputs.matrix) }}
     uses: ./.github/workflows/smoke-tests-dominio.yml

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -17,10 +17,11 @@ jobs:
     needs: discovery
     strategy:
       fail-fast: false
-      # CA-2 (issue #313): un dominio a la vez. El concurrency del reusable smoke-tests-dominio.yml
-      # ya serializa las invocaciones entre si, pero max-parallel lo deja explicito tambien aqui:
-      # sin el, ambas legs de la matrix arrancarian juntas y solo una avanzaria mientras la otra
-      # queda encolada -- no es un fallo, pero oculta en el arranque lo que el CA pide visible.
+      # CA-2 (issue #313): un dominio a la vez. Se solapa con el concurrency del reusable
+      # smoke-tests-dominio.yml, y aun asi hace falta: sin el, las dos legs arrancan juntas, la
+      # segunda queda pendiente en el grupo 'smoke-tests-dev' y ocupa un cupo de la cola que este
+      # run no necesitaba tomar -- cupo que le sirve a los deploys, que si compiten por el grupo
+      # desde runs distintos. Serializar aca deja el orden explicito y no gasta ese cupo.
       max-parallel: 1
       matrix:
         include: ${{ fromJson(needs.discovery.outputs.matrix) }}


### PR DESCRIPTION
## Resumen

Pipeline tooling completado:
- Writer: implementacion de la tarea
- Reviewer: revision de calidad

## Decisiones del pipeline

<details>
<summary>Writer -- 3m 30s</summary>

# Stage 1 (writer) -- Issue #313

## Que se hizo

Se serializo la ejecucion del reusable `smoke-tests-dominio.yml` para que dos suites de
smoke tests nunca corran a la vez contra el mismo Service Bus de dev.

### Cambios

1. **`.github/workflows/smoke-tests-dominio.yml`**: se agrego un bloque `concurrency` a
   nivel de workflow (no a nivel de job del caller):
   ```yaml
   concurrency:
     group: smoke-tests-dev
     cancel-in-progress: false
   ```
   Cubre con un solo cambio las tres rutas de disparo (CA-1): `deploy-control-horas.yml`,
   `deploy-programacion.yml` y la matrix de `smoke-tests.yml`.

2. **`.github/workflows/smoke-tests.yml`**: se agrego `max-parallel: 1` a `strategy` del job
   `smoke-test` (CA-2), explicito ademas de lo que ya cubre el concurrency del reusable.

### Investigacion sobre el punto abierto del issue

El issue pedia verificar si `concurrency` en un reusable workflow (`workflow_call`) se
honra por invocacion o si queda "absorbido" por el run padre. Se verifico contra:

- Doc oficial de GitHub Actions ("Reusing workflow configurations"): lista
  `jobs.<job_id>.concurrency` como el unico mecanismo de concurrencia valido *en el job del
  caller que hace `uses:`*, y advierte que si se usa el mismo `group` que el called workflow
  con `cancel-in-progress: true`, se cancela la corrida que ya esta en marcha.
- Discusion de la comunidad de GitHub (github/community#30708): confirma en la practica que
  declarar `concurrency` en el job `uses:` del caller **no serializa** las invocaciones del
  reusable como se esperaria; lo que si funciona es declarar `concurrency` **en el propio
  workflow llamado**, a nivel de workflow -- exactamente el "Plan A" que proponia el issue.
  Advertencia clave de ese hilo: un workflow llamado hereda `${{ github.workflow }}` del
  *caller*, asi que usar esa expresion en el nombre del grupo produce un grupo distinto por
  invocador (ControlHoras / Programacion / la matrix) y anula la serializacion. Por eso el
  `group` quedo como literal fijo (`smoke-tests-dev`), no interpolado.

Con esto, el Plan A del issue queda confirmado (no hizo falta caer al Plan B de
`jobs.<job_id>.concurrency` en cada uno de los tres callers).

### Por que no se toco `queue`

Con el maximo de 2 invocadores simultaneos de hoy, el default de `concurrency` (una corrida
pendiente por grupo, la tercera cancela a la intermedia) alcanza -- tal como preveia el
issue. `queue: max` queda para cuando se sume un tercer invocador (issue #314).

## Verificacion

- `python3 -c "import yaml; yaml.safe_load(...)"` sobre ambos archivos: OK.
- `actionlint` sobre ambos archivos: sin hallazgos nuevos (el unico warning, SC2086 en
  `smoke-tests.yml:14`, es preexistente y no relacionado a este cambio).
- Sin caracteres no-ASCII introducidos (grep verificado).

## Alcance respetado

Solo se tocaron los dos archivos previstos en el issue
(`.github/workflows/smoke-tests-dominio.yml` y `.github/workflows/smoke-tests.yml`). No se
tocaron fixtures, Terraform, codigo de produccion ni el modelo de mensajeria.

## Pendiente / fuera de alcance

Ninguno. Los 6 criterios de aceptacion quedan cubiertos por estos dos cambios; CA-6 (una
corrida de infra dispara ambos deploys y los dos smoke tests terminan en verde, uno despues
del otro) solo se puede confirmar observando un run real en GitHub Actions, no localmente.

</details>

<details>
<summary>Reviewer -- 6m 39s</summary>

# Stage 2 - Reviewer - Issue #313

Serializar el action de smoke tests para que no corra dos dominios a la vez.

**Veredicto**: aprobado con tres correcciones aplicadas (commit `b917c9b`). El enfoque
del writer -- `concurrency` en el reusable + `max-parallel: 1` en la matrix -- es el
correcto y quedo confirmado contra la documentacion oficial. La correccion de fondo es
una: el default de `queue` no alcanzaba para CA-4.

## Alcance: limpio

Esta rama aporta exactamente dos archivos, ambos en zona permitida:

- `.github/workflows/smoke-tests-dominio.yml`
- `.github/workflows/smoke-tests.yml`

No se toco `tests/**`, `infra/**`, `src/**`, ni ninguna ruta prohibida
(`commands/`, `skills/`, `agents/`, `hooks/`, `.claude-plugin/`, `docs/adr/`).

Nota para no confundir al lector del diff: `git diff main` muestra tambien
`infra-cd.yml` e `infra-ci.yml`, pero esos cambios vienen de `5e604fe` (pin de
Terraform), ya presente en `origin/main`. No son de este issue.

## Verificacion del punto que el issue dejaba abierto

El issue pedia verificar al implementar si un workflow invocado por `workflow_call`
honra `concurrency` por invocacion. **Si lo honra**, y la evidencia es
`github/community#30708`: el sintoma reportado alli es que el caller se cancela a si
mismo cuando caller y llamado piden el mismo grupo. Que la reserva del llamado pueda
cancelar al caller prueba que ocurre de verdad y que es independiente del run que
invoca. No hizo falta el plan B (`jobs.<job_id>.concurrency`).

Tambien queda confirmado que un workflow llamado hereda el nombre del **caller** en
`${{ github.workflow }}`, asi que el literal fijo `smoke-tests-dev` no es una
preferencia estilistica: es lo que hace que la serializacion funcione.

## Correcciones aplicadas

### 1. `queue: max` -- CA-4 no se cumplia (correctness)

El writer se apoyaba en el default de `queue`, con el argumento de que "hoy el maximo
concurrente es 2". El default es `queue: single`: **una** sola corrida pendiente por
grupo, y cuando llega una tercera, *"any existing pending job or workflow run in the
same group is canceled and replaced"*. Esa corrida cancelada aparece como `cancelled`
en el check, que es exactamente lo que CA-4 prohibe.

El escenario de tres es alcanzable hoy, no despues de #314: CA-1 enumera tres origenes
que no son mutuamente excluyentes. Un apply de infra dispara los dos deploys (2 en
vuelo) y basta un `workflow_dispatch` de *Smoke Tests (todos los dominios)* -- o un
push que toque ambos dominios -- dentro de esa ventana de ~1 min para llegar a 3.

`queue: max` da hasta 100 pendientes en orden FIFO segun el momento en que cada una
entro al grupo, y es valido con `cancel-in-progress: false` (solo con `true` es error
de validacion). Costo cero, y cierra CA-3/CA-4 sin dejar deuda condicionada a #314.

### 2. Cita mal atribuida (calidad, y regla de CLAUDE.md)

El comentario invocaba `github/community#30708` como confirmacion de que
`jobs.<job_id>.concurrency` en el caller "no serializa invocaciones del reusable". El
hilo no dice eso: trata de una autocancelacion por grupo compartido via
`github.workflow`. Ademas afirmaba que la documentacion "solo lista
`jobs.<job_id>.concurrency` como valido en el job que hace la llamada", cosa que no
pude verificar -- la pagina de reusable workflows no menciona `concurrency`.

Se reescribio para citar el hilo por lo que si establece, que ademas **respalda** la
decision tomada. CLAUDE.md exige fuentes verificables y no presentar opinion como
hecho verificado; un comentario que un mantenedor futuro va a creer no puede apoyarse
en una atribucion equivocada.

### 3. `max-parallel: 1` descrito como cosmetico (calidad)

Decia *"no es un fallo, pero oculta en el arranque lo que el CA pide visible"*. Es una
subestimacion: sin `max-parallel`, la segunda leg queda pendiente en
`smoke-tests-dev` y ocupa un cupo de la cola que este run no necesita tomar, cupo que
los deploys si se disputan desde runs distintos. Comentario corregido.

### 4. Nota sobre actionlint (preventiva)

`actionlint` 1.7.12 todavia no conoce `queue` y lo reporta como
`unexpected key "queue" for "concurrency" section`. Es atraso del linter frente al
release de mayo 2026, no un error del workflow. Se dejo la nota en el archivo para que
ese hallazgo no motive borrar la linea. Ningun workflow del repo corre actionlint como
gate (verificado con grep sobre `.github/`, `scripts/` y `.claude/`).

## Estado de los criterios de aceptacion

| CA | Estado | Como queda cubierto |
|---|---|---|
| CA-1 | Cumple | `concurrency` en el reusable, unico punto por el que pasan los tres origenes de disparo |
| CA-2 | Cumple | `max-parallel: 1` en la matrix de `smoke-tests.yml` |
| CA-3 | Cumple | `cancel-in-progress: false` |
| CA-4 | Cumple **tras la correccion** | `queue: max`; con el default una tercera llegada dejaba una corrida en `cancelled` |
| CA-5 | Cumple | `smoke-tests` es un job aparte con `needs: deploy`; los callers no declaran `concurrency`, asi que build + publish siguen en paralelo entre dominios |
| CA-6 | Verificable solo en ejecucion | Requiere un apply de infra real que dispare ambos deploys |

CA-6 no es verificable localmente: depende de un apply de infra en dev. Lo dejo
explicito en lugar de darlo por cumplido.

## Verificaciones corridas

- `python3 -c "yaml.safe_load(...)"` sobre ambos archivos: parsean.
- `actionlint` sobre `.github/workflows/*.yml`: los unicos hallazgos son preexistentes
  y en lineas que este issue no toca (SC2086 en `smoke-tests.yml:14`, SC2129 en
  `ci.yml:72`), mas el falso positivo de `queue` ya explicado. No los arreglo: son
  ajenos al alcance del issue y meterlos ensucia el diff.
- Solo ASCII en ambos archivos (`grep -nP '[^\x00-\x7F]'` sin resultados).
- Sin codigo C# en el cambio, asi que no aplica build ni `dotnet test`.

## Limite que sigue abierto (ya reconocido en el issue)

Serializar no cierra la ventana del todo: el TTL de las suscripciones es de 5 min y una
suite dura ~1 min, asi que los mensajes de la corrida anterior siguen vivos cuando
arranca la siguiente. Lo que cambia es que el `PurgeAsync` de las suites pasa a ser
determinista. Si el sintoma reaparece, el siguiente paso es ese TTL, no los fixtures.

## Fuentes

- [Workflow syntax: `concurrency`](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax) -- claves `group`, `cancel-in-progress`, `queue`; semantica de `single` vs `max`
- [Concurrency groups now allow larger queues](https://github.blog/changelog/2026-05-07-github-actions-concurrency-groups-now-allow-larger-queues/) -- `queue: max`, 100 pendientes, FIFO, requiere `cancel-in-progress` false o ausente
- [Concurrency (concepts)](https://docs.github.com/en/actions/concepts/workflows-and-actions/concurrency) -- por defecto una sola corrida pendiente y las adicionales cancelan la anterior
- [community#30708](https://github.com/orgs/community/discussions/30708) -- `github.workflow` hereda el nombre del caller; el llamado reserva grupo propio

</details>

## Commits

b917c9b refactor(issue-313): cerrar CA-4 con queue: max y corregir las citas del concurrency
4f3496b fix(issue-313): serializar el reusable de smoke tests contra el Service Bus de dev

Closes #313