### PR TITLE
Correr los smoke tests despues del deploy del worker de proyecciones

### DIFF
--- a/.github/workflows/deploy-projections.yml
+++ b/.github/workflows/deploy-projections.yml
@@ -200,31 +200,50 @@ jobs:
           #   az containerapp logs show -n ca-asist-dev -g rg-controlasistencias-dev --follow
 
   smoke-tests:
-    # (issue #314) 'Verificar la revision activa' solo prueba que el contenedor arranco
-    # (provisioningState/runningState del Container App), no que las proyecciones sigan
-    # materializando lo que los GET de lectura esperan. Este job cierra ese hueco: corre DESPUES
-    # de 'deploy' y depende de el via 'needs', nunca en paralelo (CA-3). Si 'deploy' no corre (el
-    # push no toco el worker, ver filtro de 'paths' arriba) o falla, este job se salta solo -- no
-    # hace falta un 'if' explicito (CA-4).
+    # (issue #314) 'Verificar la revision activa' comprueba el CONTRATO DE DESPLIEGUE -- que la
+    # revision mas nueva corre exactamente la imagen que este run publico y quedo activa --, no que
+    # las proyecciones sigan materializando lo que los GET de lectura esperan. provisioningState y
+    # runningState ni siquiera se afirman ahi: se imprimen como informacion. La nota final de ese
+    # paso lo dice sin rodeos: un fallo de arranque del worker (secreto sin resolver, credenciales
+    # de Postgres, permisos DDL) NO lo detecta, porque la revision se aprovisiona igual. Este job
+    # cierra ese hueco ejerciendo los GET de verdad (CA-1).
+    #
+    # 'needs: deploy' (CA-3) lo pone DESPUES del deploy, nunca en paralelo; y si 'deploy' falla o
+    # queda saltado, un job cuyo 'needs' no se cumplio no arranca, asi que la suite no corre sin
+    # motivo (CA-4) sin necesidad de un 'if' explicito. Ojo con la diferencia frente a
+    # deploy-control-horas.yml: aqui 'deploy' no tiene guarda 'if' propia. El push que no toca el
+    # worker se filtra antes, en el 'paths' de arriba, y en ese caso no arranca el workflow entero.
     needs: deploy
     uses: ./.github/workflows/smoke-tests-dominio.yml
     with:
-      # ControlHoras es hoy el unico dominio con una proyeccion registrada
-      # (TurnoDiarioProjection es la unica entrada del worker en Program.cs), asi que basta su
-      # suite de smoke tests para cubrir lo que este worker materializa.
+      # ControlHoras es hoy el unico dominio con una proyeccion CONCRETA: el unico
+      # 'opts.Projections.Add<>' del worker es TurnoDiarioProjection, y vive en
+      # src/Bitakora.ControlAsistencia.Projections/Infraestructura/ConfiguracionMartenProjectionsControlHoras.cs.
+      # Ese es el archivo a revisar cuando esta eleccion se ponga en duda, NO Program.cs: Program.cs
+      # solo llama ConfigurarEventos, que registra el named store y el daemon de los DOS dominios
+      # -- el de Programacion existe y arranca, pero todavia no materializa nada. Asi que la suite
+      # de ControlHoras cubre todo lo que este worker proyecta.
       #
       # Desviacion documentada frente a la propuesta del issue de reusar
       # .github/smoke-tests-dominios.json (la matriz de "todos los dominios" que consume
-      # smoke-tests.yml): esa matriz incluye tambien Programacion, que no tiene ninguna
-      # proyeccion registrada -- correr su suite aca probaria un dominio sin relacion con lo que
-      # el worker acaba de desplegar. Cuando Programacion adopte proyecciones, este job deberia
-      # migrar a esa matriz para no mantener dos listas del mismo hecho en paralelo.
+      # smoke-tests.yml): esa matriz incluye tambien Programacion, cuya suite probaria un dominio
+      # sin ninguna proyeccion detras de este deploy. Cuando Programacion registre su primera
+      # proyeccion, este job deberia migrar a esa matriz para no mantener dos listas del mismo
+      # hecho en paralelo.
       base_url: https://func-asist-dev-control-horas.azurewebsites.net
       test_project: tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/
       # expected_sha vacio a proposito (CA-2): /api/version lo expone el Function App de
       # ControlHoras, no el worker de proyecciones -- un deploy de este worker no cambia ese
       # valor, asi que esperar un SHA aca solo agotaria el timeout de 120s sin motivo. El
       # reusable ya degrada a esperar HTTP 200 en /api/health cuando expected_sha llega vacio.
+      #
+      # Consecuencia a vigilar (la carrera worker/consulta que anticipa el issue): ese health check
+      # pega contra el Function App, que este run NO redespliega, asi que responde 200 casi de
+      # inmediato y no le da margen a la revision nueva del worker para tomar el advisory lock de
+      # HotCold que la anterior esta liberando. El margen real lo pone el presupuesto de Polling de
+      # los tests que consultan turnos -- 30s, el campo 'Timeout' de ObtenerTurnoDiarioSmokeTests y
+      # ListarTurnosDiariosSmokeTests. Si este job sale intermitente, ese es el primer numero a
+      # mirar, antes de sospechar de la suite o del deploy.
       expected_sha: ''
     secrets:
       SERVICEBUS_CONNECTION_STRING: ${{ secrets.SERVICEBUS_CONNECTION_STRING }}

--- a/.github/workflows/deploy-projections.yml
+++ b/.github/workflows/deploy-projections.yml
@@ -198,3 +198,34 @@ jobs:
           # de Postgres, permisos DDL sobre el schema) NO lo detecta este job -- la revision se
           # aprovisiona igual. Verlo requiere los logs del contenedor:
           #   az containerapp logs show -n ca-asist-dev -g rg-controlasistencias-dev --follow
+
+  smoke-tests:
+    # (issue #314) 'Verificar la revision activa' solo prueba que el contenedor arranco
+    # (provisioningState/runningState del Container App), no que las proyecciones sigan
+    # materializando lo que los GET de lectura esperan. Este job cierra ese hueco: corre DESPUES
+    # de 'deploy' y depende de el via 'needs', nunca en paralelo (CA-3). Si 'deploy' no corre (el
+    # push no toco el worker, ver filtro de 'paths' arriba) o falla, este job se salta solo -- no
+    # hace falta un 'if' explicito (CA-4).
+    needs: deploy
+    uses: ./.github/workflows/smoke-tests-dominio.yml
+    with:
+      # ControlHoras es hoy el unico dominio con una proyeccion registrada
+      # (TurnoDiarioProjection es la unica entrada del worker en Program.cs), asi que basta su
+      # suite de smoke tests para cubrir lo que este worker materializa.
+      #
+      # Desviacion documentada frente a la propuesta del issue de reusar
+      # .github/smoke-tests-dominios.json (la matriz de "todos los dominios" que consume
+      # smoke-tests.yml): esa matriz incluye tambien Programacion, que no tiene ninguna
+      # proyeccion registrada -- correr su suite aca probaria un dominio sin relacion con lo que
+      # el worker acaba de desplegar. Cuando Programacion adopte proyecciones, este job deberia
+      # migrar a esa matriz para no mantener dos listas del mismo hecho en paralelo.
+      base_url: https://func-asist-dev-control-horas.azurewebsites.net
+      test_project: tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/
+      # expected_sha vacio a proposito (CA-2): /api/version lo expone el Function App de
+      # ControlHoras, no el worker de proyecciones -- un deploy de este worker no cambia ese
+      # valor, asi que esperar un SHA aca solo agotaria el timeout de 120s sin motivo. El
+      # reusable ya degrada a esperar HTTP 200 en /api/health cuando expected_sha llega vacio.
+      expected_sha: ''
+    secrets:
+      SERVICEBUS_CONNECTION_STRING: ${{ secrets.SERVICEBUS_CONNECTION_STRING }}
+      POSTGRES_CONNECTION_STRING: ${{ secrets.POSTGRES_CONNECTION_STRING }}

--- a/.github/workflows/smoke-tests-dominio.yml
+++ b/.github/workflows/smoke-tests-dominio.yml
@@ -35,22 +35,24 @@ on:
       POSTGRES_CONNECTION_STRING:
         required: false
 
-# Serializa las tres rutas que invocan este reusable (deploy-control-horas.yml,
-# deploy-programacion.yml y la matrix de smoke-tests.yml) contra el mismo Service Bus de dev y su
-# unica suscripcion 'smoke-tests' -- issue #313. Dos suites corriendo a la vez se roban
+# Serializa las cuatro rutas que invocan este reusable (deploy-control-horas.yml,
+# deploy-programacion.yml, deploy-projections.yml -- issue #314 -- y la matrix de
+# smoke-tests.yml) contra el mismo Service Bus de dev y su unica suscripcion 'smoke-tests' --
+# issue #313. Dos suites corriendo a la vez se roban
 # mutuamente el mensaje que cada una espera (cada CompleteMessageAsync de una destruye el
 # mensaje que la otra necesitaba).
 #
-# El grupo va AQUI, en el workflow LLAMADO, porque es el unico punto por el que pasan las tres
+# El grupo va AQUI, en el workflow LLAMADO, porque es el unico punto por el que pasan las cuatro
 # rutas de disparo: un solo bloque las cubre. Que un workflow llamado reserve su propio grupo,
 # independiente del run que lo invoca, esta evidenciado en github/community#30708: alli el sintoma
 # es que el caller se cancela a si mismo cuando ambos piden el mismo grupo -- prueba de que la
 # reserva del llamado ocurre de verdad y por invocacion.
 #
 # El nombre del grupo es un literal fijo a proposito, y no ${{ github.workflow }}: un workflow
-# llamado hereda en ese contexto el nombre del CALLER (Deploy ControlHoras, Deploy Programacion o
-# Smoke Tests (todos los dominios)). Interpolarlo aca daria un grupo distinto por invocador
-# -- anulando la serializacion -- y ademas chocaria con el grupo del caller si este declarara uno.
+# llamado hereda en ese contexto el nombre del CALLER (Deploy ControlHoras, Deploy Programacion,
+# Deploy Projections o Smoke Tests (todos los dominios)). Interpolarlo aca daria un grupo distinto
+# por invocador -- anulando la serializacion -- y ademas chocaria con el grupo del caller si este
+# declarara uno.
 # Es justamente la correccion que recomienda ese hilo.
 #
 # cancel-in-progress: false (CA-3) -- la corrida encolada espera; nunca cancela a la que esta

--- a/.github/workflows/smoke-tests-dominio.yml
+++ b/.github/workflows/smoke-tests-dominio.yml
@@ -38,9 +38,8 @@ on:
 # Serializa las cuatro rutas que invocan este reusable (deploy-control-horas.yml,
 # deploy-programacion.yml, deploy-projections.yml -- issue #314 -- y la matrix de
 # smoke-tests.yml) contra el mismo Service Bus de dev y su unica suscripcion 'smoke-tests' --
-# issue #313. Dos suites corriendo a la vez se roban
-# mutuamente el mensaje que cada una espera (cada CompleteMessageAsync de una destruye el
-# mensaje que la otra necesitaba).
+# issue #313. Dos suites corriendo a la vez se roban mutuamente el mensaje que cada una espera
+# (cada CompleteMessageAsync de una destruye el mensaje que la otra necesitaba).
 #
 # El grupo va AQUI, en el workflow LLAMADO, porque es el unico punto por el que pasan las cuatro
 # rutas de disparo: un solo bloque las cubre. Que un workflow llamado reserve su propio grupo,
@@ -60,10 +59,13 @@ on:
 #
 # queue: max (CA-4) -- el default 'queue: single' admite UNA sola corrida pendiente por grupo, y la
 # tercera en llegar cancela a la que estaba esperando, que queda reportada como 'cancelled' en el
-# check. Con tres invocadores eso es alcanzable hoy: un apply de infra dispara los dos deploys y
-# basta un workflow_dispatch de "Smoke Tests (todos los dominios)" en esa ventana. 'max' admite
-# hasta 100 pendientes en orden FIFO segun cuando cada una entro al grupo. Solo es valido con
-# cancel-in-progress en false; combinarlo con true es error de validacion del workflow.
+# check. Con cuatro invocadores eso es alcanzable con UN solo push: los tres deploy-*.yml incluyen
+# 'src/Bitakora.ControlAsistencia.PublicEvents/**', 'src/Bitakora.ControlAsistencia.PrivateEvents/**'
+# y 'global.json' en su filtro de 'paths', asi que un push a main que toque cualquiera de esas rutas
+# los dispara a los tres a la vez y los tres terminan pidiendo este grupo. Con 'queue: single' uno
+# de ellos moriria como 'cancelled'. 'max' admite hasta 100 pendientes en orden FIFO segun cuando
+# cada una entro al grupo. Solo es valido con cancel-in-progress en false; combinarlo con true es
+# error de validacion del workflow.
 # https://github.blog/changelog/2026-05-07-github-actions-concurrency-groups-now-allow-larger-queues/
 #
 # OJO si corres actionlint local: hasta 1.7.12 su schema no conoce 'queue' y lo reporta como


### PR DESCRIPTION
## Resumen

Pipeline tooling completado:
- Writer: implementacion de la tarea
- Reviewer: revision de calidad

## Decisiones del pipeline

<details>
<summary>Writer -- 3m 28s</summary>

# Stage 1 (writer) -- Issue #314

## Cambios

- **`.github/workflows/deploy-projections.yml`**: se agrega el job `smoke-tests`, que
  `needs: deploy` e invoca `smoke-tests-dominio.yml` con:
  - `base_url: https://func-asist-dev-control-horas.azurewebsites.net`
  - `test_project: tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/`
  - `expected_sha: ''` (CA-2 -- degrada al chequeo de `/api/health`)
  - los secrets `SERVICEBUS_CONNECTION_STRING` y `POSTGRES_CONNECTION_STRING`, igual que
    los otros dos deploys.

- **`.github/workflows/smoke-tests-dominio.yml`**: se corrige el comentario del bloque
  `concurrency` que enumeraba "las tres rutas" invocadoras -- ahora son cuatro
  (se agrega `deploy-projections.yml` a la lista y al conteo).

## Decision de diseno: ControlHoras fijo, no la matriz de todos los dominios

El issue proponia como alternativa preferida reusar `.github/smoke-tests-dominios.json`
(la misma matriz que consume `smoke-tests.yml`) para no mantener dos listas en paralelo
cuando Programacion adopte proyecciones. Se opto por la desviacion que el issue marca
como aceptable si se documenta: fijar la suite de ControlHoras directamente.

**Por que**: hoy `TurnoDiarioProjection` es la unica proyeccion registrada en el worker
(Program.cs), y esa matriz incluye tambien Programacion. Reusarla correria smoke tests de
Programacion en cada deploy de proyecciones, sin ninguna relacion con lo que el worker
acaba de desplegar -- ademas de requerir el job `discovery` + `strategy.matrix` que usa
`smoke-tests.yml`, complejidad que no se justifica para un solo dominio. Queda anotado en
el propio workflow que cuando Programacion adopte proyecciones, este job deberia migrar a
la matriz.

## CA cubiertos

- **CA-1**: el job corre los 12 smoke tests de `ControlHoras.SmokeTests` (turno diario +
  listado) y el workflow queda en rojo si fallan (comportamiento estandar de un job que
  falla).
- **CA-2**: `expected_sha: ''` -- el reusable ya soporta ese valor y degrada a
  `/api/health`. No se toco `smoke-tests-dominio.yml` en su logica, solo el comentario de
  concurrency.
- **CA-3**: `needs: deploy` garantiza el orden y evita paralelismo.
- **CA-4**: no hizo falta un `if` explicito. El trigger `push` con `paths` no dispara el
  workflow completo si el push no toca el worker, y si `deploy` no corre o falla, un job
  con `needs: deploy` se salta automaticamente (mismo patron que usan
  `deploy-control-horas.yml` y `deploy-programacion.yml`).
- **CA-5**: se hereda gratis. `smoke-tests-dominio.yml` ya declara su propio
  `concurrency: { group: smoke-tests-dev, cancel-in-progress: false, queue: max }`
  (issue #313), que aplica por invocacion sin importar el caller. No hizo falta tocar el
  bloque de concurrency en si -- `queue: max` ya admite hasta 100 pendientes en FIFO,
  asi que un cuarto invocador no requiere subir ningun limite.
- **CA-6**: verificacion end-to-end (push que solo toque
  `src/Bitakora.ControlAsistencia.Projections/**` dispara deploy y luego smoke tests, ambos
  en verde) **no se pudo ejecutar** en este stage -- requiere un push real a `main` en
  GitHub Actions, fuera del alcance de un worktree local. Validado localmente en su lugar:
  - YAML valido (`python3 -c "import yaml; ..."` sobre ambos archivos).
  - `actionlint` sobre ambos archivos: el unico hallazgo es el falso positivo ya conocido
    y documentado (`queue` no reconocido por versiones de actionlint anteriores a la
    release de mayo 2026) -- ningun error nuevo.

## Verificacion

- No se modifico codigo C#, asi que no aplica `dotnet build`.
- `python3 -c "import yaml; yaml.safe_load(...)"` sobre los dos workflows: OK.
- `actionlint .github/workflows/deploy-projections.yml .github/workflows/smoke-tests-dominio.yml`:
  solo el falso positivo documentado de `queue`.
- Grep de caracteres Unicode decorativos (`─`, guiones largos) en ambos archivos: ninguno.

## Fuera de alcance / no tocado

- No se agregaron tests nuevos (los 12 ya existian).
- No se toco el worker ni las proyecciones (`src/Bitakora.ControlAsistencia.Projections/`,
  `ReadModels/`).
- No se toco la verificacion de revision activa que ya hace `deploy-projections.yml`.
- No se toco `deploy-control-horas.yml` ni `deploy-programacion.yml`.
- No hizo falta crear ningun draft issue en el repo del plugin Mefisto -- esta tarea es
  pura configuracion de workflows del consumidor, dentro del alcance permitido.

</details>

<details>
<summary>Reviewer -- 6m 21s</summary>

# Stage 2 -- Reviewer: issue #314

Correr los smoke tests despues del deploy del worker de proyecciones.

## Veredicto

**Aprobado con correcciones aplicadas.** La solucion del writer es la correcta y esta bien
encajada en el patron existente: el job nuevo es gemelo del de `deploy-control-horas.yml` y
`deploy-programacion.yml` (mismo nombre `smoke-tests`, mismo `needs: deploy`, mismo `uses`, mismos
`secrets` explicitos). No hubo que cambiar nada funcional. Lo que se corrigio fueron **tres
afirmaciones del comentario que no resisten verificacion contra el codigo** y **dos puntos que la
propia edicion del writer dejo desalineados** en el reusable.

Commit de correcciones: `eef496d`.

## Cumplimiento de los criterios de aceptacion

| CA | Estado | Evidencia |
|---|---|---|
| CA-1 -- corren los smoke tests que cubren los GET, rojo si fallan | Cumple | Job `smoke-tests` invoca `smoke-tests-dominio.yml` con la suite de ControlHoras (12 tests de `ObtenerTurnoDiario` + `ListarTurnosDiarios`). El reusable corre `dotnet test` sin `--ignore-exit-code`, asi que un fallo tumba el job. |
| CA-2 -- gate de version no bloquea (`expected_sha` vacio) | Cumple | `expected_sha: ''` verificado como cadena vacia tras parsear el YAML; el reusable degrada al loop de HTTP 200 sobre `/api/health`. |
| CA-3 -- corre despues del deploy, con `needs` | Cumple | `needs: deploy`. |
| CA-4 -- si el deploy se salta, los smoke tests tambien | Cumple | Un job con `needs` insatisfecho no arranca. Ver matiz abajo: en este workflow `deploy` no tiene guarda `if`, el filtrado ocurre antes en `paths`. |
| CA-5 -- respeta la serializacion de #313 | Cumple | La serializacion vive en el `concurrency` del reusable (`group: smoke-tests-dev`, `cancel-in-progress: false`, `queue: max`), por donde pasa toda invocacion. El nuevo invocador la hereda sin configurar nada. |
| CA-6 -- verificacion end-to-end | **No verificable en esta etapa** | Requiere un push a `main` que toque `src/Bitakora.ControlAsistencia.Projections/**`. Solo se puede observar despues del merge del PR. |

## Correcciones aplicadas

### 1. Justificacion de la suite: apuntaba al archivo equivocado (`deploy-projections.yml`)

El writer escribio que "TurnoDiarioProjection es la unica entrada del worker en Program.cs". Es
falso. `Program.cs` no registra ninguna proyeccion: solo llama `ConfigurarEventos`, que a su vez
llama `ConfigurarProgramacion` **y** `ConfigurarControlHoras` -- los dos dominios tienen named store
y `AddAsyncDaemon(DaemonMode.HotCold)`.

Por que importa mas que un detalle de redaccion: quien mañana quiera revisar si esta eleccion de
suite sigue valida abriria `Program.cs` siguiendo el comentario, veria Programacion registrado y
concluiria que el comentario esta mentiendo -- cuando la **conclusion** si es correcta. El hecho
verificable es que el unico `opts.Projections.Add<>` del worker es `TurnoDiarioProjection`, en
`ConfiguracionMartenProjectionsControlHoras.cs`; el seam de Programacion existe y arranca su daemon
pero no materializa nada. El comentario ahora apunta a ese archivo y explica por que `Program.cs` no
es el lugar a mirar.

La desviacion frente a reusar `.github/smoke-tests-dominios.json` sigue documentada, que es lo que
el issue pedia, y con el gatillo de migracion afinado: "cuando Programacion registre su primera
proyeccion", no "cuando adopte proyecciones" (el store ya esta adoptado).

### 2. Descripcion del job hermano: subestimaba el hueco (`deploy-projections.yml`)

Decia que "Verificar la revision activa" solo prueba que el contenedor arranco
"(provisioningState/runningState del Container App)". Leyendo el paso: afirma que el nombre de
revision no este vacio, que la imagen no sea el placeholder, que la imagen sea **exactamente** la
publicada y que `properties.active == true`. `provisioningState` y `runningState` unicamente se
imprimen con `echo`, nunca se afirman.

O sea: ese paso verifica el *contrato de despliegue*, y el hueco real es el que su propia nota final
ya declaraba -- un fallo de arranque del worker (secreto sin resolver, credenciales de Postgres,
permisos DDL) no lo detecta porque la revision se aprovisiona igual. El argumento a favor de este
issue es **mas fuerte** que el que el comentario daba.

### 3. Razon de CA-4: invocaba un mecanismo que este workflow no tiene (`deploy-projections.yml`)

Decia "Si 'deploy' no corre (el push no toco el worker, ver filtro de 'paths' arriba) ... este job se
salta solo". En `deploy-control-horas.yml` eso es literal: `determinar-alcance` puede dejar `deploy`
saltado via `if`. Aqui `deploy` **no tiene guarda `if`**: si el `paths` no coincide, no se salta un
job, no arranca el workflow completo. Reescrito para decir lo que `needs: deploy` realmente compra
(deploy fallido o saltado -> este job no arranca) y señalar la diferencia con el otro workflow.

### 4. Carrera worker/consulta: documentada con el numero concreto (`deploy-projections.yml`)

El issue la marco como "el punto a vigilar". Queda anotada, porque hay un detalle no obvio: el health
check de `expected_sha: ''` pega contra el **Function App**, que este run no redespliega, asi que
responde 200 casi de inmediato y **no da ningun margen** a la revision nueva del worker para tomar el
advisory lock de HotCold que la anterior esta liberando. El margen real es el presupuesto de
`Polling` de los tests: **30s** (campo `Timeout` en `ObtenerTurnoDiarioSmokeTests` y
`ListarTurnosDiariosSmokeTests`, verificado). Si el job sale intermitente, ese es el primer numero a
mirar.

No se toco ese timeout: el issue dice explicitamente que los tests "deberian tolerarlo" y prohibe
tocar `tests/**`. Subirlo sin evidencia de intermitencia seria tuning especulativo.

### 5. Reusable: conteo desalineado por la propia edicion (`smoke-tests-dominio.yml`)

El writer actualizo el encabezado a "cuatro rutas" pero dejo el parrafo de `queue: max` diciendo
"Con tres invocadores". Ademas su escenario era mas debil de lo necesario ("un apply de infra dispara
los dos deploys y basta un workflow_dispatch"). Verificado parseando los tres `deploy-*.yml`: los
tres comparten `src/.../PublicEvents/**`, `src/.../PrivateEvents/**` y `global.json` en su filtro de
`paths`, asi que **un solo push** a cualquiera de esas rutas dispara los tres y los tres piden este
grupo -- con `queue: single` uno moriria como `cancelled`. Ese es el argumento fuerte a favor de
`queue: max`, y es exactamente el que anticipaba la nota de dependencia de #314.

Tambien se reflowearon dos parrafos que la edicion anterior dejo con cortes ragged a media linea.

## Calidad y reutilizacion de patrones

- **Reutilizacion**: correcta. Ninguna duplicacion nueva de logica; el job delega todo al reusable.
  Los literales `base_url`/`test_project` se repiten respecto a `deploy-control-horas.yml`, pero eso
  ya era el patron establecido del repo (los tres deploys los fijan inline), y el issue acepto
  explicitamente la desviacion documentada frente a la matriz.
- **Secretos**: pasa `SERVICEBUS_CONNECTION_STRING` **y** `POSTGRES_CONNECTION_STRING`, como
  `deploy-control-horas.yml`. Correcto: la suite de ControlHoras usa `PostgresFixture`.
  (`deploy-programacion.yml` solo pasa el de Service Bus, pero esa es su suite, no un patron a
  copiar.)
- **Naming**: `smoke-tests`, idéntico al de los otros dos deploys.
- **Convenciones del repo**: solo ASCII, sin `─` ni decorativos Unicode (verificado con grep).

## Verificaciones ejecutadas

| Verificacion | Resultado |
|---|---|
| Parseo YAML de los 3 workflows implicados | OK |
| `needs` / `uses` / `with` / `secrets` del job nuevo | Resuelven como se espera; `expected_sha` es cadena vacia |
| Existencia de las rutas referenciadas (reusable y proyecto de tests) | Ambas existen |
| `dotnet build tests/...ControlHoras.SmokeTests/ -c Release` | Compilacion correcta, 0 advertencias, 0 errores |
| Solo ASCII en los archivos tocados | OK |
| Rutas prohibidas (`src/`, `docs/adr/`, `agents/`, `skills/`, ...) | Ninguna tocada; el diff vs `main` son solo los 2 workflows |

No se corrieron los smoke tests localmente: son black-box contra el entorno dev desplegado y exigen
las connection strings de Service Bus y Postgres (MEF-ADR-0013). Su ejecucion real es justamente lo
que este issue automatiza.

## Pendiente para despues del merge

CA-6 es lo unico que queda abierto y no se puede cerrar antes del merge: hay que confirmar en Actions
que un push que solo toque `src/Bitakora.ControlAsistencia.Projections/**` dispara `deploy` y a
continuacion `smoke-tests`, ambos en verde. Al observarlo, vigilar el margen de 30s descrito arriba.

</details>

## Commits

eef496d refactor(issue-314): corregir las justificaciones verificables del job de smoke tests
008303d feat(issue-314): correr smoke tests de ControlHoras tras el deploy del worker de proyecciones

Closes #314