### PR TITLE
Enmendar CA-ADR-0029: cero referencias entre ensamblados de eventos (tres islas, canon MEF-ADR-0039)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,7 +152,7 @@ Si tu trabajo toca uno de estos temas, consulta el ADR correspondiente antes de 
 | Naming de funciones Azure (HTTP y Service Bus) | MEF-ADR-0006 |
 | Topics y subscriptions de Service Bus, un topic por evento | MEF-ADR-0001 |
 | Estrategia de testing con event sourcing, DSL de tests | MEF-ADR-0002 |
-| **Dónde va un evento nuevo: `PublicEvents` vs `PrivateEvents` vs `{Dominio}.DomainEvents`; qué referencia el worker de proyecciones; por qué un evento no conoce su comando** | CA-ADR-0029 |
+| **Dónde va un evento nuevo: `PublicEvents` vs `PrivateEvents` vs `{Dominio}.DomainEvents`; qué referencia el worker de proyecciones; por qué un evento no conoce su comando; cero referencias entre los tres ensamblados (tres islas); payload por rol** | CA-ADR-0029 (aplicación local), MEF-ADR-0039 (canon del marco) |
 | **Identidad del evento en el event store: el alias manda, registro explícito con `AddEventTypes`, mover un evento de namespace sin migrar datos; proscripción de `MapEventType` y de alterar `EventNamingStyle`** | CA-ADR-0029 (decisión #6) |
 | Mensajes en `.resx` por aggregate/handler | MEF-ADR-0009 |
 | Definition of Ready | MEF-ADR-0011 |

--- a/docs/adr/ca-adr-0029-ensamblados-de-eventos-por-rol.md
+++ b/docs/adr/ca-adr-0029-ensamblados-de-eventos-por-rol.md
@@ -45,22 +45,49 @@ por eso reemplaza a "lo compartido":
 Un ensamblado de eventos contiene los eventos y los tipos que los componen (su payload). No contiene
 aggregates, ni value objects de cálculo, ni comandos.
 
-### 2. Sentido de las dependencias
+### 2. Tres islas: cero referencias entre los ensamblados de eventos
+
+*Enmienda incorporada por el issue #317, que alinea esta decisión con el canon del marco
+(MEF-ADR-0039 decisión #2, ver decisión #7 de este ADR). Reescribe **in situ** la versión original
+de esta decisión -- el grafo encadenado de abajo --, que el marco descartó como Alt 5 de
+MEF-ADR-0039.*
+
+Los tres ensamblados de eventos de la decisión #1 -- `PublicEvents`, `PrivateEvents`,
+`{Dominio}.DomainEvents` -- son **tres islas**: cada uno declara **cero `<ProjectReference>`**, ni
+hacia los otros dos ni hacia ningún otro proyecto del repo. La composición ocurre exclusivamente en
+los dos proyectos que la necesitan:
 
 ```
-PublicEvents                                  <- futuro paquete NuGet, sin dependencias de proyecto
-   ^
-   |
-PrivateEvents                                 <- interno al BC
-   ^                    ^
-   |                    |
-Programacion.DomainEvents   ControlHoras.DomainEvents      <- uno por dominio
-   ^                            ^
-   |                            |
-Function App Programacion   Function App ControlHoras
-   \                            /
-    \____ Projections (worker) /                <- referencia ambos DomainEvents, ningún Function App
+PublicEvents        PrivateEvents        Programacion.DomainEvents      ControlHoras.DomainEvents
+(cero refs)          (cero refs)              (cero refs)                     (cero refs)
+
+Referenciados directamente, sin transitividad, por:
+
+Function App Programacion   ->  Programacion.DomainEvents + PrivateEvents + PublicEvents
+Function App ControlHoras   ->  ControlHoras.DomainEvents + PrivateEvents + PublicEvents
+
+Projections (worker)        ->  Programacion.DomainEvents + ControlHoras.DomainEvents + ReadModels
+                                 (nunca PublicEvents/PrivateEvents, nunca un Function App)
 ```
+
+- El **Function App** de cada dominio referencia los tres ensamblados de eventos directamente: su
+  propio `{Dominio}.DomainEvents`, más `PrivateEvents` y `PublicEvents` del BC.
+- El **worker de proyecciones** referencia `{Dominio}.DomainEvents` de cada dominio que proyecta más
+  `ReadModels` -- nunca `PublicEvents`/`PrivateEvents` ni el `.csproj` de un Function App.
+
+**Motivación del cambio -- por qué ya no hay cadena**: cada ensamblado evoluciona a una velocidad
+distinta. El bus público evoluciona bajo presión de consumidores externos y el versionado V2
+(MEF-ADR-0005); el bus interno evoluciona libre dentro del BC; el event store es el contrato más
+longevo de los tres -- el JSON persistido en `mt_events` se relee durante toda la vida del sistema
+(MEF-ADR-0036). Con el grafo encadenado (versión original de esta decisión), un cambio hacia afuera
+(evolucionar el contrato público) exigía revisar hacia adentro (el tipo persistido que lo
+referenciaba), y un evento persistido cuyo payload fuera un tipo de bus quedaba amarrado a la
+evolución de ese bus -- el modo de fallo concreto de ese acoplamiento se documenta en la decisión #5.
+
+**Estado real de este repo frente a esta decisión**: no se cumple todavía -- ver "Negativas y deuda
+asumida". El grafo encadenado original sigue construido en el código (`PrivateEvents` referencia
+`PublicEvents`; ambos `DomainEvents` referencian los dos buses). Migrar a cero referencias es el
+alcance de los issues #318 y #319; el enforcement mecánico de que no regrese, el issue #320.
 
 ### 3. Tres reglas que garantiza el grafo de compilación, no la disciplina
 
@@ -70,9 +97,18 @@ Function App Programacion   Function App ControlHoras
   (CA-ADR-0001, autonomía de dominio). Un `DomainEvents` compartido no daría esta garantía.
 - Nada en `PublicEvents` puede depender de un tipo interno, porque el grafo no lo permite.
 
-Se agrega una cuarta, del lado de los tests: `PublicEvents.Tests` referencia **únicamente**
-`PublicEvents`, de modo que si un test suyo llegara a necesitar `PrivateEvents` o un `DomainEvents`,
-el compilador delata que el tipo bajo prueba no es distribuible.
+Se agrega una cuarta, del lado de los tests, generalizada por el issue #317 a los dos ensamblados de
+bus (MEF-ADR-0039 decisión #7): cada uno tiene su propio proyecto de tests, que referencia
+**únicamente** su propio ensamblado. `PublicEvents.Tests` referencia únicamente `PublicEvents`, de
+modo que si un test suyo llegara a necesitar `PrivateEvents` o un `DomainEvents`, el compilador
+delata que el tipo bajo prueba no es distribuible como Published Language (MEF-ADR-0005).
+`PrivateEvents.Tests` referencia únicamente `PrivateEvents`, por el mismo motivo de aislamiento
+aunque sin la restricción de distribución externa (`PrivateEvents` nunca sale del BC): si un test
+suyo necesitara `PublicEvents`, un `DomainEvents` o un Function App, delataría que está probando
+composición de dominio, no el ensamblado del bus interno en sí mismo. Los `.csproj` de ambos
+proyectos de test ya declaran hoy esa única referencia (verificado en el análisis del issue #318);
+lo que todavía no cumple la regla es `PrivateEvents.csproj` mismo, que sigue referenciando
+`PublicEvents` (ver decisión #2 y "Negativas y deuda asumida").
 
 ### 4. Un ensamblado de eventos aloja la lista completa de serialización de su dominio
 
@@ -82,7 +118,7 @@ Function App las invoca en vez de declarar el resolver inline, y el worker puede
 lista en su propio store. Antes del refactor esa lista cruzaba dos proyectos y la mitad de
 Programación no existía como clase, lo que hacía imposible replicarla.
 
-### 5. Los eventos no conocen los comandos
+### 5. Los eventos no conocen los comandos; payload por rol -- un tipo no cruza ensamblados de eventos
 
 El factory de un evento persistido no recibe el comando que lo origina: recibe un tipo de entrada
 propio del ensamblado de eventos. `TurnoCreado.Crear(Guid, string, IReadOnlyList<DatosFranja>)`, y el
@@ -93,6 +129,33 @@ con ese mapeo, reusado por el handler y por sus tests.
 La razón es estructural, no estética: `CrearTurno` vive en la Function App, que referencia
 `Programacion.DomainEvents`, así que un factory que reciba el comando cierra un ciclo de referencias
 y no compila.
+
+*Generalización incorporada por el issue #317 (MEF-ADR-0039 decisión #6), a partir de las tres islas
+de la decisión #2.* El mismo argumento aplica a cualquier payload, no solo al comando. Bajo cero
+`ProjectReference` entre los tres ensamblados de eventos, **un tipo de payload no cruza ensamblados
+de eventos**: cuando el mismo dato viaja por el bus (tipo de `PublicEvents` o `PrivateEvents`) y
+además se persiste (tipo de `{Dominio}.DomainEvents`), cada ensamblado declara su **propio record
+plano** con ese dato -- duplicación deliberada, con paridad de campos -- en vez de importar el tipo
+del otro ensamblado. Todo el mapeo entre el tipo de bus y su equivalente persistido vive en el
+**Function App**, el único ensamblado que ve los tres.
+
+La motivación no es solo estructural: el bus público evoluciona bajo presión de consumidores
+externos y versionado V2 (MEF-ADR-0005), el bus interno evoluciona libre dentro del BC, y el event
+store es el contrato más longevo -- releído durante toda la vida del sistema (MEF-ADR-0036). Un
+payload compartido por referencia entre un evento de bus y uno persistido tiene además un **modo de
+fallo silencioso** verificado empíricamente en este repo (issue #270, ver "Negativas y deuda
+asumida" más abajo): System.Text.Json, al deserializar un payload anidado que no calza con el tipo
+esperado -- típicamente tras evolucionar un lado sin el otro --, no lanza excepción: deja los campos
+no resueltos en su valor default. Un campo en su valor default dentro de un evento ya persistido en
+`mt_events` es un dato corrupto que el sistema releerá durante toda su vida.
+
+**Estado real de este repo frente a esta regla**: no se cumple todavía (ver "Negativas y deuda
+asumida"). `TurnoDiarioAsignado` (persistido en `ControlHoras.DomainEvents`) embebe
+`InformacionEmpleado` (tipo de `PublicEvents`) y `DetalleTurno` (tipo de `PrivateEvents`) como
+payload anidado; `ProgramacionTurnoSolicitada` (persistido en `Programacion.DomainEvents`) hace lo
+mismo; y `FranjaOrdinaria.ToDetalle()`/`SubFranja.ToDetalle()` retornan
+`DetalleFranjaOrdinaria`/`DetalleSubFranja`, tipos de `PrivateEvents`. Pagar esta deuda es el alcance
+del issue #319.
 
 ### 6. El alias es la identidad del evento persistido, y se registra explícitamente
 
@@ -133,6 +196,24 @@ memoria): uno verifica que los tipos estén registrados en el store real que com
 **congela el alias contra literales** (`turno_creado`, `marcacion_registrada`, ...), de modo que el
 día en que un rename de clase cambie la identidad de un evento ya persistido se vea en la suite, no
 en producción.
+
+### 7. MEF-ADR-0039 es el canon del marco; este ADR es su aplicación local
+
+*Decisión incorporada por el issue #317.*
+
+MEF-ADR-0039, del harness (`eda-evsourcing-azure-harness`), generaliza la partición de ensamblados
+de eventos por rol como composición canónica para todo Bounded Context que el marco scaffoldea.
+Este ADR es la **aplicación local** de ese canon en este repo, no una fuente independiente de la
+regla: cuando este ADR y MEF-ADR-0039 coincidan, es porque este ADR fue la fuente de referencia
+empírica que informó al marco (ver "Referencias" de MEF-ADR-0039); cuando difieran, **gana el
+marco**, y la divergencia se paga en este repo, documentada como deuda abierta en "Negativas y deuda
+asumida" hasta que un issue local la resuelva.
+
+Esta regla anti-divergencia no es retroactiva a las decisiones que este ADR ya fijó y que
+MEF-ADR-0039 no contradice: la partición por rol (decisión #1), las listas de serialización por
+dominio (decisión #4) y la identidad del evento por alias (decisión #6) coinciden con el canon del
+marco y no requieren cambio. Donde el marco divergió de la versión original de este ADR -- el grafo
+encadenado de la decisión #2 -- esta misma enmienda ya reescribió la decisión local para alinearla.
 
 ## Alternativas consideradas
 
@@ -234,6 +315,22 @@ de **salida** hacia ControlHoras, no de entrada.
 - Los filtros `paths` de los tres workflows de deploy deben enumerar los ensamblados nuevos. Sin eso,
   un cambio en un evento no dispara el despliegue del proceso que lo consume: la misma staleness
   silenciosa que esos workflows ya documentaban para `global.json`.
+- **El grafo de referencias entre ensamblados de eventos todavía es el encadenado, no las tres islas
+  que la decisión #2 fija desde esta enmienda (issue #317). Deuda abierta, sin pagar.** Evidencia
+  concreta verificada en este repo: `PrivateEvents.csproj` tiene `<ProjectReference>` hacia
+  `PublicEvents.csproj`; `ControlHoras.DomainEvents.csproj` y `Programacion.DomainEvents.csproj`
+  tienen `<ProjectReference>` hacia ambos ensamblados de bus; `TurnoDiarioAsignado` (persistido)
+  embebe `InformacionEmpleado` (`PublicEvents`) y `DetalleTurno` (`PrivateEvents`) como payload
+  anidado; `ProgramacionTurnoSolicitada` (persistido) hace lo mismo;
+  `ProgramacionTurnoDiarioSolicitada` (bus privado) usa `InformacionEmpleado` (`PublicEvents`); y
+  `FranjaOrdinaria.ToDetalle()`/`SubFranja.ToDetalle()` retornan
+  `DetalleFranjaOrdinaria`/`DetalleSubFranja`, tipos de `PrivateEvents`. El retiro de la referencia
+  `PrivateEvents -> PublicEvents` es el issue #318; el retiro de las referencias de ambos
+  `DomainEvents` hacia los buses y la duplicación de payload por rol que las reemplaza, el issue
+  #319; el enforcement mecánico con tests de arquitectura que impida que el grafo regrese al
+  encadenado, el issue #320. Esta enmienda fija la doctrina primero, a propósito: no afirma un
+  cumplimiento que todavía no existe -- mismo aprendizaje que la purga nunca ejecutada que este ADR
+  ya documenta más arriba.
 
 ## Referencias
 
@@ -254,6 +351,12 @@ de **salida** hacia ControlHoras, no de entrada.
   `PublicEvents`/`PrivateEvents`.
 - MEF-ADR-0034 sección 5 (worker de proyecciones): fija que las clases de proyección viven en el
   worker y que este no puede alcanzar un Function App, la restricción que origina todo el refactor.
+- MEF-ADR-0039 (marco, composición canónica de ensamblados por rol del evento): **canon** del que
+  este ADR es aplicación local (decisión #7). Generaliza la partición por rol (decisión #1 de este
+  ADR) y sustituye el grafo encadenado de la versión original de la decisión #2 por tres islas con
+  cero `<ProjectReference>`; generaliza también la decisión #5 de este ADR como payload por rol.
+  Cuando el marco y este repo difieran en composición de ensamblados de eventos, gana el marco y la
+  divergencia se paga aquí.
 
 ## Control de cambios
 
@@ -276,3 +379,18 @@ de **salida** hacia ControlHoras, no de entrada.
   case-insensitive (`ServiceBusDeserializador`), falso para camelCase estricto --el modo de fallo es
   pérdida silenciosa de datos, no una excepción-- y depende del `PropertyNameCaseInsensitive = true`
   del consumidor, no de la forma del tipo.
+- 2026-08-05: enmienda (issue #317). Reescribe la decisión #2: de grafo encadenado (`PublicEvents <-
+  PrivateEvents <- {Dominio}.DomainEvents <- Function App`) a **tres islas** con cero
+  `<ProjectReference>` cada una, ni entre ellas ni hacia ningún otro proyecto del repo; el Function
+  App de cada dominio referencia los tres directamente y el worker de proyecciones solo
+  `{Dominio}.DomainEvents` + `ReadModels`. Generaliza la decisión #5 con la regla de **payload por
+  rol**: un tipo de payload no cruza ensamblados de eventos, con el mapeo entre bus y event store
+  concentrado en el Function App. Alinea la cuarta regla de la decisión #3 con MEF-ADR-0039 decisión
+  #7: la referencia única se declara explícita también para `PrivateEvents.Tests`, no solo para
+  `PublicEvents.Tests`. Agrega la decisión #7: MEF-ADR-0039 (marco) es el canon, este ADR es su
+  aplicación local, con regla anti-divergencia explícita ("gana el marco"). Registra como deuda
+  **abierta** (sin pagar) el estado real del grafo de referencias de este repo, con evidencia
+  concreta (`PrivateEvents.csproj -> PublicEvents.csproj`; ambos `DomainEvents` hacia los dos buses;
+  `TurnoDiarioAsignado`, `ProgramacionTurnoSolicitada`, `ProgramacionTurnoDiarioSolicitada`,
+  `FranjaOrdinaria`/`SubFranja`) y puntero a los issues que la pagan (#318, #319) y la congelan con
+  tests de arquitectura (#320). Enmienda puramente doctrinal: no modifica ningún `.csproj` ni código.

--- a/docs/adr/ca-adr-0029-ensamblados-de-eventos-por-rol.md
+++ b/docs/adr/ca-adr-0029-ensamblados-de-eventos-por-rol.md
@@ -54,8 +54,10 @@ MEF-ADR-0039.*
 
 Los tres ensamblados de eventos de la decisión #1 -- `PublicEvents`, `PrivateEvents`,
 `{Dominio}.DomainEvents` -- son **tres islas**: cada uno declara **cero `<ProjectReference>`**, ni
-hacia los otros dos ni hacia ningún otro proyecto del repo. La composición ocurre exclusivamente en
-los dos proyectos que la necesitan:
+hacia los otros dos ni hacia ningún otro proyecto del repo. Los `PackageReference` no quedan
+restringidos por esta decisión (los dos ensamblados de bus llevan el paquete de markers
+`IPublicEvent`/`IPrivateEvent`). La composición ocurre exclusivamente en los dos puntos que la
+necesitan -- el Function App de cada dominio y el worker de proyecciones:
 
 ```
 PublicEvents        PrivateEvents        Programacion.DomainEvents      ControlHoras.DomainEvents
@@ -67,13 +69,25 @@ Function App Programacion   ->  Programacion.DomainEvents + PrivateEvents + Publ
 Function App ControlHoras   ->  ControlHoras.DomainEvents + PrivateEvents + PublicEvents
 
 Projections (worker)        ->  Programacion.DomainEvents + ControlHoras.DomainEvents + ReadModels
-                                 (nunca PublicEvents/PrivateEvents, nunca un Function App)
+                                 (sin referencia directa a PublicEvents/PrivateEvents, nunca un
+                                  Function App; ver nota de transitividad via ReadModels abajo)
 ```
 
 - El **Function App** de cada dominio referencia los tres ensamblados de eventos directamente: su
   propio `{Dominio}.DomainEvents`, más `PrivateEvents` y `PublicEvents` del BC.
 - El **worker de proyecciones** referencia `{Dominio}.DomainEvents` de cada dominio que proyecta más
-  `ReadModels` -- nunca `PublicEvents`/`PrivateEvents` ni el `.csproj` de un Function App.
+  `ReadModels` -- ningún `<ProjectReference>` **directo** hacia `PublicEvents`/`PrivateEvents` ni
+  hacia el `.csproj` de un Function App (MEF-ADR-0034 sección 5, MEF-ADR-0039 decisión #4).
+
+El propósito declarado de ese grafo en el canon es que el worker no arrastre `PublicEvents`/
+`PrivateEvents` **ni transitivamente**. En este repo eso todavía no se cumple, por una vía que no
+es ninguno de los tres ensamblados de eventos: `ReadModels` referencia ambos buses desde el issue
+#289 (`TurnoDiarioView` reusa `InformacionEmpleado` de `PublicEvents` y `DetalleTurno` de
+`PrivateEvents` en vez de redeclararlos), así que el worker los ve por transitividad a través de
+`ReadModels`. La regla de cero `<ProjectReference>` de esta decisión **no** alcanza a `ReadModels`
+--no es un ensamblado de eventos--, y por eso esa referencia no es una violación de las tres islas;
+pero sí deja el propósito a medias, y queda registrada como deuda propia en "Negativas y deuda
+asumida": no la paga ninguno de los issues #318/#319/#320.
 
 **Motivación del cambio -- por qué ya no hay cadena**: cada ensamblado evoluciona a una velocidad
 distinta. El bus público evoluciona bajo presión de consumidores externos y el versionado V2
@@ -100,15 +114,24 @@ alcance de los issues #318 y #319; el enforcement mecánico de que no regrese, e
 Se agrega una cuarta, del lado de los tests, generalizada por el issue #317 a los dos ensamblados de
 bus (MEF-ADR-0039 decisión #7): cada uno tiene su propio proyecto de tests, que referencia
 **únicamente** su propio ensamblado. `PublicEvents.Tests` referencia únicamente `PublicEvents`, de
-modo que si un test suyo llegara a necesitar `PrivateEvents` o un `DomainEvents`, el compilador
-delata que el tipo bajo prueba no es distribuible como Published Language (MEF-ADR-0005).
-`PrivateEvents.Tests` referencia únicamente `PrivateEvents`, por el mismo motivo de aislamiento
-aunque sin la restricción de distribución externa (`PrivateEvents` nunca sale del BC): si un test
-suyo necesitara `PublicEvents`, un `DomainEvents` o un Function App, delataría que está probando
-composición de dominio, no el ensamblado del bus interno en sí mismo. Los `.csproj` de ambos
-proyectos de test ya declaran hoy esa única referencia (verificado en el análisis del issue #318);
-lo que todavía no cumple la regla es `PrivateEvents.csproj` mismo, que sigue referenciando
-`PublicEvents` (ver decisión #2 y "Negativas y deuda asumida").
+modo que si un test suyo llegara a necesitar `PrivateEvents` o un `DomainEvents`, eso delata que el
+tipo bajo prueba no es distribuible como Published Language (MEF-ADR-0005): un consumidor externo
+del paquete tampoco tendría ese otro ensamblado. `PrivateEvents.Tests` referencia únicamente
+`PrivateEvents`, por el mismo motivo de aislamiento aunque sin la restricción de distribución externa
+(`PrivateEvents` nunca sale del BC): si un test suyo necesitara `PublicEvents`, un `DomainEvents` o
+un Function App, delataría que está probando composición de dominio, no el ensamblado del bus interno
+en sí mismo.
+
+A diferencia de las tres primeras, **esta cuarta regla el grafo no la garantiza**: las tres islas de
+la decisión #2 solo cierran la vía accidental --ya no existe transitividad por la que un test alcance
+otro ensamblado de eventos sin declararla--, pero un `.csproj` de tests puede declarar la referencia
+que quiera, porque la decisión #2 restringe los `.csproj` de los tres ensamblados de eventos, no los
+de sus proyectos de test (MEF-ADR-0039 decisión #7). Por eso es un guardrail de diseño cuyo
+enforcement mecánico es el issue #320, junto con el de la decisión #2 (MEF-ADR-0039 decisión #10).
+Hoy ambos `.csproj` de test ya declaran esa única referencia (verificado por inspección directa:
+`PublicEvents.Tests -> PublicEvents`, `PrivateEvents.Tests -> PrivateEvents`); lo que todavía no
+cumple la regla es `PrivateEvents.csproj` mismo, que sigue referenciando `PublicEvents` (ver
+decisión #2 y "Negativas y deuda asumida").
 
 ### 4. Un ensamblado de eventos aloja la lista completa de serialización de su dominio
 
@@ -208,6 +231,13 @@ regla: cuando este ADR y MEF-ADR-0039 coincidan, es porque este ADR fue la fuent
 empírica que informó al marco (ver "Referencias" de MEF-ADR-0039); cuando difieran, **gana el
 marco**, y la divergencia se paga en este repo, documentada como deuda abierta en "Negativas y deuda
 asumida" hasta que un issue local la resuelva.
+
+Que "gana el marco" es una regla que **este repo adopta por decisión propia**, no una obligación que
+el marco imponga: MEF-ADR-0039 decisión #9 fija su alcance como *greenfield-only* y declara la
+migración de consumidores existentes **no-objetivo explícito** -- cada consumidor decide cuándo el
+costo se justifica. Esta enmienda y sus issues hermanos (#318, #319, #320) **son** esa decisión local
+de migrar, tomada aquí. Lo que la regla anti-divergencia fija es la dirección: el destino de la
+composición lo define el canon, y este repo no mantiene una variante propia en competencia.
 
 Esta regla anti-divergencia no es retroactiva a las decisiones que este ADR ya fijó y que
 MEF-ADR-0039 no contradice: la partición por rol (decisión #1), las listas de serialización por
@@ -331,6 +361,22 @@ de **salida** hacia ControlHoras, no de entrada.
   encadenado, el issue #320. Esta enmienda fija la doctrina primero, a propósito: no afirma un
   cumplimiento que todavía no existe -- mismo aprendizaje que la purga nunca ejecutada que este ADR
   ya documenta más arriba.
+- **El worker alcanza `PublicEvents`/`PrivateEvents` transitivamente vía `ReadModels`, y ningún issue
+  hermano lo paga. Deuda abierta, propia de esta enmienda.** `ReadModels.csproj` referencia ambos
+  buses desde el issue #289 CA-1 --decisión deliberada y justificada en su momento: `TurnoDiarioView`
+  reusa `InformacionEmpleado` (`PublicEvents`) y `DetalleTurno` (`PrivateEvents`) porque son
+  exactamente los DTOs planos destinados a cruzar fronteras, y el paquete de markers no arrastra
+  dependencias--. Como el worker referencia `ReadModels`, los dos ensamblados de bus le llegan por
+  transitividad, lo que cumple la letra de la decisión #2 (`ReadModels` no es un ensamblado de eventos,
+  así que el cero `<ProjectReference>` no lo alcanza; el worker no declara ninguna referencia directa
+  a un bus) pero no su propósito declarado en el canon: "no arrastrar transitivamente
+  `PrivateEvents`/`PublicEvents` a un proceso que no los necesita" (MEF-ADR-0039 decisión #2).
+  Resolverlo exigiría que `ReadModels` redeclare esos dos DTOs como records propios --el mismo patrón
+  de duplicación por rol de la decisión #5, aplicado al read-side--, y eso **revisaría** una decisión
+  vigente (#289 CA-1), no solo pagaría deuda: queda fuera del alcance de #318 (retiro
+  `PrivateEvents -> PublicEvents`), #319 (payload por rol en los `DomainEvents`) y #320 (tests de
+  arquitectura sobre los tres ensamblados y el worker). Sin issue asignado todavía; se registra aquí
+  para que #320 no escriba su suite asumiendo que el worker ya está limpio.
 
 ## Referencias
 
@@ -393,4 +439,10 @@ de **salida** hacia ControlHoras, no de entrada.
   concreta (`PrivateEvents.csproj -> PublicEvents.csproj`; ambos `DomainEvents` hacia los dos buses;
   `TurnoDiarioAsignado`, `ProgramacionTurnoSolicitada`, `ProgramacionTurnoDiarioSolicitada`,
   `FranjaOrdinaria`/`SubFranja`) y puntero a los issues que la pagan (#318, #319) y la congelan con
-  tests de arquitectura (#320). Enmienda puramente doctrinal: no modifica ningún `.csproj` ni código.
+  tests de arquitectura (#320). Registra además una segunda deuda abierta, sin issue asignado: el
+  worker alcanza ambos buses **transitivamente** vía `ReadModels` (issue #289 CA-1), lo que cumple la
+  letra de la decisión #2 pero no el propósito del canon. Aclara que la cuarta regla de la decisión #3
+  es un guardrail de diseño que el grafo **no** garantiza (la vía deliberada queda abierta; su
+  enforcement es el issue #320) y que "gana el marco" es una adopción local, no una imposición del
+  marco, que declara la migración de consumidores existentes no-objetivo (MEF-ADR-0039 decisión #9).
+  Enmienda puramente doctrinal: no modifica ningún `.csproj` ni código.


### PR DESCRIPTION
## Resumen

Pipeline tooling completado:
- Writer: implementacion de la tarea
- Reviewer: revision de calidad

## Decisiones del pipeline

<details>
<summary>Writer -- 0m 0s</summary>

# Stage 1 (writer) — Issue #317

## Resumen

Enmienda doctrinal a `docs/adr/ca-adr-0029-ensamblados-de-eventos-por-rol.md`, alineándolo con el
canon del marco (MEF-ADR-0039, leído desde el repo del harness vía `gh api` ya que el plugin
instalado 0.20.0 todavía no lo trae). Solo documentación: ningún `.csproj` ni código se modificó.

## Verificación previa (evidencia, sin tocar código)

Confirmé en el árbol de trabajo antes de escribir la enmienda:

- `PrivateEvents.csproj` tiene `<ProjectReference>` hacia `PublicEvents.csproj`.
- `ControlHoras.DomainEvents.csproj` y `Programacion.DomainEvents.csproj` referencian ambos
  ensamblados de bus (`PublicEvents` + `PrivateEvents`).
- `TurnoDiarioAsignado` (persistido, `ControlHoras.DomainEvents`) embebe `InformacionEmpleado`
  (`PublicEvents`) y `DetalleTurno` (`PrivateEvents`).
- `ProgramacionTurnoSolicitada` (persistido, `Programacion.DomainEvents`) usa los mismos dos tipos.
- `ProgramacionTurnoDiarioSolicitada` (bus privado) usa `InformacionEmpleado` (`PublicEvents`).
- `FranjaOrdinaria.ToDetalle()` / `SubFranja.ToDetalle()` retornan `DetalleFranjaOrdinaria` /
  `DetalleSubFranja`, tipos de `PrivateEvents`.
- `PublicEvents.Tests.csproj` y `PrivateEvents.Tests.csproj` ya declaran hoy una única
  `ProjectReference` a su propio ensamblado (la regla de la decisión #3 ya se cumple del lado de
  los tests, aunque no del lado de los ensamblados de origen).

Toda esta evidencia coincide con la que traía el contexto del issue; quedó citada literalmente en
el ADR.

## Cambios en `docs/adr/ca-adr-0029-ensamblados-de-eventos-por-rol.md`

- **Decisión #2** reescrita in situ: de grafo encadenado
  (`PublicEvents <- PrivateEvents <- {Dominio}.DomainEvents <- Function App`) a **tres islas** con
  cero `<ProjectReference>` cada una. Diagrama ASCII actualizado; el Function App de cada dominio
  referencia los tres directamente y el worker solo `{Dominio}.DomainEvents` + `ReadModels`. Incluye
  motivación (velocidades de evolución distintas) y nota de estado real (no se cumple todavía).
- **Decisión #3**: la "cuarta regla" (tests) generalizada — la referencia única ahora se declara
  explícita también para `PrivateEvents.Tests`, no solo `PublicEvents.Tests` (MEF-ADR-0039 decisión
  #7). Nota que los `.csproj` de test ya cumplen; lo que falta es `PrivateEvents.csproj` mismo.
- **Decisión #5** generalizada con la regla de **payload por rol**: un tipo de payload no cruza
  ensamblados de eventos; duplicación deliberada con paridad de campos; mapeo concentrado en el
  Function App. Cita la motivación (velocidades de evolución + modo de fallo silencioso de STJ,
  issue #270) y la evidencia concreta de incumplimiento actual.
- **Decisión #7 (nueva)**: declara MEF-ADR-0039 como canon del marco y este ADR como su aplicación
  local, con la regla anti-divergencia ("gana el marco, la divergencia se paga aquí").
- **"Negativas y deuda asumida"**: nueva entrada de deuda **abierta** (no pagada) documentando el
  grafo real de este repo frente a la doctrina de tres islas, con toda la evidencia concreta y
  punteros a los issues que la pagan (#318 retiro `PrivateEvents -> PublicEvents`, #319 retiro de
  ambos `DomainEvents` hacia los buses + duplicación de payload) y la congelan (#320, tests de
  arquitectura).
- **"Referencias"**: sumada entrada para MEF-ADR-0039.
- **"Control de cambios"**: nueva entrada fechada 2026-08-05 (issue #317) resumiendo toda la
  enmienda.

## Cambios en `CLAUDE.md`

- Fila del índice temático de ADRs para "Dónde va un evento nuevo..." actualizada: menciona ahora
  cero referencias (tres islas) y payload por rol, y cita `CA-ADR-0029 (aplicación local)` +
  `MEF-ADR-0039 (canon del marco)` en vez de solo `CA-ADR-0029`.

## Fuera de alcance (confirmado, no ejecutado en este issue)

- Retiro de `<ProjectReference>` en los `.csproj` reales (issues #318, #319).
- Tests de arquitectura que hagan cumplir el grafo (issue #320).

## Build

No aplica `dotnet build` — cambio puramente de documentación (`.md`), ningún `.cs` ni `.csproj`
tocado.

</details>

<details>
<summary>Reviewer -- 6m 35s</summary>

# Stage 2 -- Reviewer (issue #317)

Enmendar CA-ADR-0029: cero referencias entre ensamblados de eventos (tres islas, canon MEF-ADR-0039).

## Veredicto

**Aprobado con correcciones aplicadas.** Los 6 criterios de aceptacion quedan cubiertos. El writer
produjo prosa fiel al canon, pero afirmaba un cumplimiento que el repo no tiene (rompia CA-4) y
atribuia al compilador una garantia que bajo tres islas no existe. Ambos corregidos en `bed5d10`.

## Alcance verificado

- Archivos tocados: `CLAUDE.md` y `docs/adr/ca-adr-0029-ensamblados-de-eventos-por-rol.md`. Ninguna
  ruta prohibida (`commands/`, `skills/`, `agents/`, `hooks/`, `.claude-plugin/`, `docs/adr/mef-adr-*`,
  `src/`). `CLAUDE.md` no figura en la lista de rutas permitidas pero tampoco en la de prohibidas, y
  su edicion es exactamente lo que exige CA-6: se deja.
- `git diff --stat` confirma que no se toco ningun `.cs` ni `.csproj` -- la enmienda es puramente
  doctrinal, como declara el issue.
- `dotnet build ControlAsistencias.slnx`: **0 errores**, 5 advertencias preexistentes (NU1902 de
  `OpenTelemetry.Api` 1.14.0 y CS0414 en `CatalogoTurnos._estaActivo`), ninguna introducida aqui.
- Sin caracteres decorativos Unicode (U+2500-U+257F) en el ADR. Ancho de linea consistente con el
  estilo del archivo (~100 columnas).

## Evidencia del ADR reverificada contra el repo (no se tomo del issue)

Todas las afirmaciones factuales del writer resultaron correctas:

| Afirmacion | Verificacion |
|---|---|
| `PrivateEvents.csproj -> PublicEvents.csproj` | confirmado |
| Ambos `{Dominio}.DomainEvents.csproj` -> los dos buses | confirmado |
| `TurnoDiarioAsignado` embebe `InformacionEmpleado` + `DetalleTurno` | `TurnoDiarioAsignado.cs:18,20` |
| `ProgramacionTurnoSolicitada` hace lo mismo | `ProgramacionTurnoSolicitada.cs:13,15` |
| `ProgramacionTurnoDiarioSolicitada` usa `InformacionEmpleado` | `PrivateEvents/Programacion/...cs:16` |
| `FranjaOrdinaria.ToDetalle()` / `SubFranja.ToDetalle()` retornan tipos de `PrivateEvents` | `FranjaOrdinaria.cs:72`, `SubFranja.cs:34` |
| `PublicEvents.Tests -> PublicEvents` unica; `PrivateEvents.Tests -> PrivateEvents` unica | confirmado |

Tambien se leyo MEF-ADR-0039 del harness via `gh api` (no esta en el plugin 0.20.0 instalado): la
numeracion que el writer cita es correcta -- #2 tres islas, #4 el worker nunca referencia un Function
App, #6 payload por rol, #7 tests de referencia unica, #9 greenfield-only, #10 enforcement.

## Correcciones aplicadas (commit `bed5d10`)

1. **Rompia CA-4: el ADR afirmaba un cumplimiento inexistente del lado del worker.** El texto decia
   que el worker referencia `{Dominio}.DomainEvents` + `ReadModels` "nunca `PublicEvents`/
   `PrivateEvents`". Pero `ReadModels.csproj` referencia **ambos buses** desde el issue #289 CA-1
   (`TurnoDiarioView` reusa `InformacionEmpleado` y `DetalleTurno` en vez de redeclararlos), asi que
   el worker los alcanza **transitivamente** -- justo lo que MEF-ADR-0039 decision #2 dice que el
   grafo evita ("sin arrastrar transitivamente `PrivateEvents`/`PublicEvents` a un proceso que no los
   necesita"). Se acoto la prohibicion a la referencia **directa**, se explico por que no viola las
   tres islas (`ReadModels` no es un ensamblado de eventos, la regla no lo alcanza) y se registro como
   **deuda abierta propia, sin issue asignado**, senalando que **no la paga ninguno de #318/#319/#320**
   y que resolverla exigiria revisar una decision vigente (#289 CA-1), no solo pagar deuda. Motivo de
   registrarla: que #320 no escriba su suite de tests de arquitectura asumiendo un worker limpio.
   El diagrama ASCII quedo alineado con esa precision.
2. **La cuarta regla de la decision #3 atribuia al compilador una garantia que no tiene.** Decia que
   si un test de `PublicEvents.Tests` necesitara otro ensamblado "el compilador delata". Bajo tres
   islas eso es falso: el grafo solo cierra la via **accidental**; la deliberada sigue abierta porque
   la decision #2 restringe los `.csproj` de los tres ensamblados de eventos, no los de sus proyectos
   de test (MEF-ADR-0039 decision #7 lo dice explicitamente). Se reescribio como guardrail de diseno
   cuyo enforcement mecanico es el issue #320 (MEF-ADR-0039 decision #10), y se cambio la procedencia
   del dato de "verificado en el analisis del issue #318" a inspeccion directa hecha en esta revision.
3. **Precision de conteo y de alcance en la decision #2.** "La composicion ocurre exclusivamente en
   los dos **proyectos** que la necesitan" eran en realidad tres proyectos (dos Function Apps + el
   worker): pasa a "los dos **puntos**", nombrandolos. Se agrego que los `PackageReference` no quedan
   restringidos por la regla (los dos buses llevan el paquete de markers), fiel al canon.
4. **Decision #7, matiz doctrinal.** "Gana el marco" quedaba como si el marco impusiera la migracion;
   MEF-ADR-0039 decision #9 declara su alcance greenfield-only y la migracion de consumidores
   existentes **no-objetivo explicito**. Se aclaro que la adopcion es decision local de este repo
   --esta enmienda y #318/#319/#320 **son** esa decision-- y que la regla anti-divergencia fija la
   direccion, no una obligacion externa. CA-3 sigue cumplido: "gana el marco" queda escrito.
5. Control de cambios ampliado con las tres precisiones anteriores.

## Criterios de aceptacion

- **CA-1** cumplido: decision #2 reescrita in situ a tres islas con cero `<ProjectReference>`, diagrama
  ASCII actualizado, Function App referencia los tres, worker solo `{Dominio}.DomainEvents` +
  `ReadModels`. Precisado por la correccion 1 (referencia directa vs transitiva).
- **CA-2** cumplido: payload por rol como generalizacion de la decision #5, con record plano propio por
  ensamblado, mapeo concentrado en el Function App y la motivacion citada (velocidades de evolucion +
  modo de fallo silencioso de STJ, issue #270).
- **CA-3** cumplido: decision #7 nueva declara MEF-ADR-0039 canon y este ADR aplicacion local, con la
  regla anti-divergencia. Matizado por la correccion 4.
- **CA-4** cumplido tras la correccion 1: la brecha queda como deuda **abierta** con la evidencia
  concreta completa y punteros a #318/#319 (pagan) y #320 (congela), mas la deuda del worker via
  `ReadModels` que el writer habia omitido.
- **CA-5** cumplido: entrada nueva en "Control de cambios" (2026-08-05, issue #317) y MEF-ADR-0039
  sumado a "Referencias" como canon.
- **CA-6** cumplido: fila del indice tematico de `CLAUDE.md` cita ahora las tres islas y payload por
  rol, con `CA-ADR-0029 (aplicacion local)` + `MEF-ADR-0039 (canon del marco)`.

## Observacion no corregida (fuera de alcance del issue)

En "Consecuencias -> Positivas" sigue el texto preexistente "el worker alcanza los 5 eventos y ambas
listas de serializacion con solo dos `ProjectReference`". Hoy el worker declara tres
(`ReadModels` + los dos `DomainEvents`), aunque la frase es defendible leida como "los dos que le dan
los eventos y las listas". Es prosa anterior a esta enmienda y tocarla ampliaria el alcance de un
issue declarado puramente doctrinal: se deja como esta, anotada aqui.

## Comandos ejecutados

```
dotnet build ControlAsistencias.slnx   # 0 errores, 5 advertencias preexistentes
```

</details>

## Commits

bed5d10 refactor(issue-317): registrar la transitividad del worker via ReadModels y precisar la cuarta regla
92f54e9 docs(issue-317): enmendar CA-ADR-0029 a tres islas de ensamblados de eventos

Closes #317