### PR TITLE
Retirar la referencia PrivateEvents -> PublicEvents y duplicar los payloads compartidos

### DIFF
--- a/src/Bitakora.ControlAsistencia.ControlHoras/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/EventHandler/ProgramacionTurnoDiarioSolicitadaEventHandler.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/EventHandler/ProgramacionTurnoDiarioSolicitadaEventHandler.cs
@@ -1,6 +1,7 @@
 using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 using Bitakora.ControlAsistencia.ControlHoras.Entities;
 using Bitakora.ControlAsistencia.PrivateEvents.Programacion;
+using Bitakora.ControlAsistencia.PublicEvents.Empleados;
 using Cosmos.EventDriven.Abstractions;
 using Cosmos.EventSourcing.Abstractions.Commands;
 
@@ -36,8 +37,12 @@ public partial class ProgramacionTurnoDiarioSolicitadaEventHandler
         var streamId = ControlDiarioAggregateRoot.ComputarStreamId(
             @event.Empleado.EmpleadoId, @event.Fecha);
 
+        // Issue #318 CA-4: @event.Empleado es DetalleEmpleado (payload propio de PrivateEvents,
+        // tres islas). TurnoDiarioAsignado sigue tipando InformacionEmpleado (PublicEvents) hasta
+        // que #319 le de a ControlHoras.DomainEvents su propio record -- el mapeo inverso vive
+        // aqui, el unico proyecto que ve PrivateEvents y PublicEvents a la vez.
         var evento = new TurnoDiarioAsignado(
-            streamId, @event.Empleado, @event.Fecha, @event.DetalleTurno, @event.SolicitudId);
+            streamId, MapearEmpleado(@event.Empleado), @event.Fecha, @event.DetalleTurno, @event.SolicitudId);
 
         var existe = await _eventStore.ExistsAsync<ControlDiarioAggregateRoot>(streamId, ct);
 
@@ -60,4 +65,8 @@ public partial class ProgramacionTurnoDiarioSolicitadaEventHandler
         // todos son anomalos (CA-2): AsignarTurno/Iniciar siempre agregan el evento al stream.
         await _publicEventSender.PublishAsync(control.CrearDiaCalculado());
     }
+
+    // Stub de fase roja (issue #318 CA-4) -- el implementer completa el mapeo campo a campo.
+    private static InformacionEmpleado MapearEmpleado(DetalleEmpleado empleado) =>
+        throw new NotImplementedException();
 }

--- a/src/Bitakora.ControlAsistencia.ControlHoras/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/EventHandler/ProgramacionTurnoDiarioSolicitadaEventHandler.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/EventHandler/ProgramacionTurnoDiarioSolicitadaEventHandler.cs
@@ -66,7 +66,7 @@ public partial class ProgramacionTurnoDiarioSolicitadaEventHandler
         await _publicEventSender.PublishAsync(control.CrearDiaCalculado());
     }
 
-    // Stub de fase roja (issue #318 CA-4) -- el implementer completa el mapeo campo a campo.
     private static InformacionEmpleado MapearEmpleado(DetalleEmpleado empleado) =>
-        throw new NotImplementedException();
+        new(empleado.EmpleadoId, empleado.TipoIdentificacion, empleado.NumeroIdentificacion,
+            empleado.Nombres, empleado.Apellidos);
 }

--- a/src/Bitakora.ControlAsistencia.ControlHoras/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/EventHandler/ProgramacionTurnoDiarioSolicitadaEventHandler.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/EventHandler/ProgramacionTurnoDiarioSolicitadaEventHandler.cs
@@ -37,10 +37,9 @@ public partial class ProgramacionTurnoDiarioSolicitadaEventHandler
         var streamId = ControlDiarioAggregateRoot.ComputarStreamId(
             @event.Empleado.EmpleadoId, @event.Fecha);
 
-        // Issue #318 CA-4: @event.Empleado es DetalleEmpleado (payload propio de PrivateEvents,
-        // tres islas). TurnoDiarioAsignado sigue tipando InformacionEmpleado (PublicEvents) hasta
-        // que #319 le de a ControlHoras.DomainEvents su propio record -- el mapeo inverso vive
-        // aqui, el unico proyecto que ve PrivateEvents y PublicEvents a la vez.
+        // CA-ADR-0029 decision #5 (payload por rol): el evento llega con DetalleEmpleado
+        // (PrivateEvents) y TurnoDiarioAsignado persiste InformacionEmpleado (PublicEvents), asi
+        // que el mapeo vive aqui -- la Function App es el unico proyecto que ve ambos ensamblados.
         var evento = new TurnoDiarioAsignado(
             streamId, MapearEmpleado(@event.Empleado), @event.Fecha, @event.DetalleTurno, @event.SolicitudId);
 

--- a/src/Bitakora.ControlAsistencia.PrivateEvents/Bitakora.ControlAsistencia.PrivateEvents.csproj
+++ b/src/Bitakora.ControlAsistencia.PrivateEvents/Bitakora.ControlAsistencia.PrivateEvents.csproj
@@ -10,8 +10,8 @@
     <PackageReference Include="Cosmos.EventDriven.Abstractions" Version="2.3.1" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Bitakora.ControlAsistencia.PublicEvents\Bitakora.ControlAsistencia.PublicEvents.csproj" />
-  </ItemGroup>
+  <!-- Issue #318 (tres islas, MEF-ADR-0039 decision 2): cero ProjectReference entre ensamblados
+       de eventos. PrivateEvents ya no depende de PublicEvents: DetalleEmpleado sustituye el
+       unico uso de InformacionEmpleado que quedaba (ProgramacionTurnoDiarioSolicitada). -->
 
 </Project>

--- a/src/Bitakora.ControlAsistencia.PrivateEvents/Bitakora.ControlAsistencia.PrivateEvents.csproj
+++ b/src/Bitakora.ControlAsistencia.PrivateEvents/Bitakora.ControlAsistencia.PrivateEvents.csproj
@@ -6,12 +6,10 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <!-- Isla de eventos (CA-ADR-0029 decision #2): solo el paquete de markers IPrivateEvent.
+       Ninguna dependencia de proyecto, tampoco hacia los otros ensamblados de eventos. -->
   <ItemGroup>
     <PackageReference Include="Cosmos.EventDriven.Abstractions" Version="2.3.1" />
   </ItemGroup>
-
-  <!-- Issue #318 (tres islas, MEF-ADR-0039 decision 2): cero ProjectReference entre ensamblados
-       de eventos. PrivateEvents ya no depende de PublicEvents: DetalleEmpleado sustituye el
-       unico uso de InformacionEmpleado que quedaba (ProgramacionTurnoDiarioSolicitada). -->
 
 </Project>

--- a/src/Bitakora.ControlAsistencia.PrivateEvents/Programacion/DetalleEmpleado.cs
+++ b/src/Bitakora.ControlAsistencia.PrivateEvents/Programacion/DetalleEmpleado.cs
@@ -1,0 +1,22 @@
+namespace Bitakora.ControlAsistencia.PrivateEvents.Programacion;
+
+/// <summary>
+/// Representacion plana del empleado que viaja en eventos privados intra-BC.
+/// </summary>
+/// <remarks>
+/// Issue #318 (tres islas, MEF-ADR-0039 decision 2 y 6): payload propio de PrivateEvents con
+/// paridad exacta de campos con InformacionEmpleado (PublicEvents/Empleados). No referencia ese
+/// tipo -- PrivateEvents queda sin ProjectReference a PublicEvents (CA-ADR-0029 enmendado por
+/// #317). El nombre difiere a proposito de "InformacionEmpleado" para que un using equivocado
+/// no resuelva en silencio en los ~20 archivos que importan ambos namespaces (MEF-ADR-0039
+/// decision 6).
+/// Sin comportamiento, sin Equals custom: todos los campos son string, la igualdad por valor
+/// del record por defecto es correcta (a diferencia de DetalleTurno/DetalleFranjaOrdinaria/
+/// DetalleSubFranja, que tienen IReadOnlyList y necesitan Equals propio, ADR-0015).
+/// </remarks>
+public record DetalleEmpleado(
+    string EmpleadoId,
+    string TipoIdentificacion,
+    string NumeroIdentificacion,
+    string Nombres,
+    string Apellidos);

--- a/src/Bitakora.ControlAsistencia.PrivateEvents/Programacion/DetalleEmpleado.cs
+++ b/src/Bitakora.ControlAsistencia.PrivateEvents/Programacion/DetalleEmpleado.cs
@@ -4,15 +4,14 @@ namespace Bitakora.ControlAsistencia.PrivateEvents.Programacion;
 /// Representacion plana del empleado que viaja en eventos privados intra-BC.
 /// </summary>
 /// <remarks>
-/// Issue #318 (tres islas, MEF-ADR-0039 decision 2 y 6): payload propio de PrivateEvents con
-/// paridad exacta de campos con InformacionEmpleado (PublicEvents/Empleados). No referencia ese
-/// tipo -- PrivateEvents queda sin ProjectReference a PublicEvents (CA-ADR-0029 enmendado por
-/// #317). El nombre difiere a proposito de "InformacionEmpleado" para que un using equivocado
-/// no resuelva en silencio en los ~20 archivos que importan ambos namespaces (MEF-ADR-0039
-/// decision 6).
-/// Sin comportamiento, sin Equals custom: todos los campos son string, la igualdad por valor
-/// del record por defecto es correcta (a diferencia de DetalleTurno/DetalleFranjaOrdinaria/
-/// DetalleSubFranja, que tienen IReadOnlyList y necesitan Equals propio, ADR-0015).
+/// Payload por rol (CA-ADR-0029 decision #5): duplica con paridad exacta de campos a
+/// InformacionEmpleado (PublicEvents/Empleados) en vez de importarlo, porque los ensamblados de
+/// eventos son tres islas sin referencias entre si (decision #2). El nombre simple es
+/// deliberadamente distinto para que un using equivocado no compile en los proyectos que ven
+/// ambos namespaces -- mismo criterio que RegistroDeMarcacionCreado frente a MarcacionRegistrada.
+/// Sin Equals custom: todos los campos son string, asi que la igualdad por valor del record por
+/// defecto ya es correcta (a diferencia de DetalleTurno/DetalleFranjaOrdinaria/DetalleSubFranja,
+/// cuyas IReadOnlyList el record compararia por referencia -- MEF-ADR-0012).
 /// </remarks>
 public record DetalleEmpleado(
     string EmpleadoId,

--- a/src/Bitakora.ControlAsistencia.PrivateEvents/Programacion/ProgramacionTurnoDiarioSolicitada.cs
+++ b/src/Bitakora.ControlAsistencia.PrivateEvents/Programacion/ProgramacionTurnoDiarioSolicitada.cs
@@ -1,4 +1,3 @@
-using Bitakora.ControlAsistencia.PublicEvents.Empleados;
 using Cosmos.EventDriven.Abstractions;
 
 namespace Bitakora.ControlAsistencia.PrivateEvents.Programacion;
@@ -9,17 +8,20 @@ namespace Bitakora.ControlAsistencia.PrivateEvents.Programacion;
 /// Se emite uno por cada fecha del arreglo del comando.
 /// Consumidor: ControlHoras (mismo Bounded Context "Control de Asistencia") -> es intra-BC,
 /// por eso es IPrivateEvent y no IPublicEvent (ADR-0024 decision #2).
+/// Issue #318: Empleado tipa con DetalleEmpleado (payload propio de PrivateEvents, MEF-ADR-0039
+/// decision 6) en vez de InformacionEmpleado (PublicEvents) -- PrivateEvents queda sin
+/// ProjectReference a PublicEvents (tres islas, CA-ADR-0029 enmendado por #317).
 /// </summary>
 public sealed class ProgramacionTurnoDiarioSolicitada : IPrivateEvent
 {
     public Guid SolicitudId { get; private set; }
-    public InformacionEmpleado Empleado { get; private set; } = null!;
+    public DetalleEmpleado Empleado { get; private set; } = null!;
     public DateOnly Fecha { get; private set; }
     public DetalleTurno DetalleTurno { get; private set; } = null!;
 
     public ProgramacionTurnoDiarioSolicitada(
         Guid solicitudId,
-        InformacionEmpleado empleado,
+        DetalleEmpleado empleado,
         DateOnly fecha,
         DetalleTurno detalleTurno)
     {

--- a/src/Bitakora.ControlAsistencia.PrivateEvents/Programacion/ProgramacionTurnoDiarioSolicitada.cs
+++ b/src/Bitakora.ControlAsistencia.PrivateEvents/Programacion/ProgramacionTurnoDiarioSolicitada.cs
@@ -8,9 +8,8 @@ namespace Bitakora.ControlAsistencia.PrivateEvents.Programacion;
 /// Se emite uno por cada fecha del arreglo del comando.
 /// Consumidor: ControlHoras (mismo Bounded Context "Control de Asistencia") -> es intra-BC,
 /// por eso es IPrivateEvent y no IPublicEvent (ADR-0024 decision #2).
-/// Issue #318: Empleado tipa con DetalleEmpleado (payload propio de PrivateEvents, MEF-ADR-0039
-/// decision 6) en vez de InformacionEmpleado (PublicEvents) -- PrivateEvents queda sin
-/// ProjectReference a PublicEvents (tres islas, CA-ADR-0029 enmendado por #317).
+/// Todo su payload es propio de este ensamblado -- DetalleEmpleado incluido, que duplica a
+/// InformacionEmpleado (PublicEvents) en vez de importarlo (CA-ADR-0029 decisiones #2 y #5).
 /// </summary>
 public sealed class ProgramacionTurnoDiarioSolicitada : IPrivateEvent
 {

--- a/src/Bitakora.ControlAsistencia.Programacion/SolicitarProgramacionTurnoFunction/CommandHandler/SolicitarProgramacionTurnoCommandHandler.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/SolicitarProgramacionTurnoFunction/CommandHandler/SolicitarProgramacionTurnoCommandHandler.cs
@@ -1,6 +1,7 @@
 using Bitakora.ControlAsistencia.PrivateEvents.Programacion;
 using Bitakora.ControlAsistencia.Programacion.DomainEvents;
 using Bitakora.ControlAsistencia.Programacion.Entities;
+using Bitakora.ControlAsistencia.PublicEvents.Empleados;
 using Cosmos.EventDriven.Abstractions;
 using Cosmos.EventSourcing.Abstractions.Commands;
 
@@ -41,11 +42,19 @@ public partial class SolicitarProgramacionTurnoCommandHandler
 
         // ADR-0024 decision #2/#3: ProgramacionTurnoDiarioSolicitada es intra-BC (lo consume
         // ControlHoras, mismo BC) -> IPrivateEvent publicado al ASB interno via IPrivateEventSender.
+        // Issue #318 CA-4: DetalleEmpleado es el payload propio de PrivateEvents (tres islas);
+        // el mapeo desde InformacionEmpleado (tipo del comando HTTP, sin cambios) vive aqui,
+        // el unico proyecto que ve PublicEvents y PrivateEvents a la vez.
+        var empleado = MapearEmpleado(command.Empleado);
         var eventosPrivados = command.Fechas
             .Select(fecha => new ProgramacionTurnoDiarioSolicitada(
-                command.Id, command.Empleado, fecha, detalleTurno))
+                command.Id, empleado, fecha, detalleTurno))
             .ToArray();
 
         await _privateEventSender.PublishAsync(eventosPrivados);
     }
+
+    // Stub de fase roja (issue #318 CA-4) -- el implementer completa el mapeo campo a campo.
+    private static DetalleEmpleado MapearEmpleado(InformacionEmpleado empleado) =>
+        throw new NotImplementedException();
 }

--- a/src/Bitakora.ControlAsistencia.Programacion/SolicitarProgramacionTurnoFunction/CommandHandler/SolicitarProgramacionTurnoCommandHandler.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/SolicitarProgramacionTurnoFunction/CommandHandler/SolicitarProgramacionTurnoCommandHandler.cs
@@ -54,7 +54,7 @@ public partial class SolicitarProgramacionTurnoCommandHandler
         await _privateEventSender.PublishAsync(eventosPrivados);
     }
 
-    // Stub de fase roja (issue #318 CA-4) -- el implementer completa el mapeo campo a campo.
     private static DetalleEmpleado MapearEmpleado(InformacionEmpleado empleado) =>
-        throw new NotImplementedException();
+        new(empleado.EmpleadoId, empleado.TipoIdentificacion, empleado.NumeroIdentificacion,
+            empleado.Nombres, empleado.Apellidos);
 }

--- a/src/Bitakora.ControlAsistencia.Programacion/SolicitarProgramacionTurnoFunction/CommandHandler/SolicitarProgramacionTurnoCommandHandler.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/SolicitarProgramacionTurnoFunction/CommandHandler/SolicitarProgramacionTurnoCommandHandler.cs
@@ -42,9 +42,9 @@ public partial class SolicitarProgramacionTurnoCommandHandler
 
         // ADR-0024 decision #2/#3: ProgramacionTurnoDiarioSolicitada es intra-BC (lo consume
         // ControlHoras, mismo BC) -> IPrivateEvent publicado al ASB interno via IPrivateEventSender.
-        // Issue #318 CA-4: DetalleEmpleado es el payload propio de PrivateEvents (tres islas);
-        // el mapeo desde InformacionEmpleado (tipo del comando HTTP, sin cambios) vive aqui,
-        // el unico proyecto que ve PublicEvents y PrivateEvents a la vez.
+        // CA-ADR-0029 decision #5 (payload por rol): el comando HTTP trae InformacionEmpleado
+        // (PublicEvents) y el evento privado lleva DetalleEmpleado, asi que el mapeo vive aqui --
+        // la Function App es el unico proyecto que ve ambos ensamblados.
         var empleado = MapearEmpleado(command.Empleado);
         var eventosPrivados = command.Fechas
             .Select(fecha => new ProgramacionTurnoDiarioSolicitada(

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/DepurarAlAsignarTurnoTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/DepurarAlAsignarTurnoTests.cs
@@ -25,6 +25,11 @@ public class DepurarAlAsignarTurnoTests
     private static readonly InformacionEmpleado Empleado = new(
         "EMP-001", "CC", "1234567890", "Luis Augusto", "Barreto");
 
+    // Issue #318 CA-4: payload propio de PrivateEvents que llega en el evento bajo prueba;
+    // el handler lo mapea a InformacionEmpleado. Paridad de campos con Empleado.
+    private static readonly DetalleEmpleado EmpleadoDetalle = new(
+        "EMP-001", "CC", "1234567890", "Luis Augusto", "Barreto");
+
     private static readonly DateOnly Fecha = new(2026, 3, 15);
     private static readonly string StreamId = $"{Empleado.EmpleadoId}:{Fecha:yyyy-MM-dd}";
 
@@ -42,7 +47,7 @@ public class DepurarAlAsignarTurnoTests
         new ProgramacionTurnoDiarioSolicitadaEventHandler(EventStore, PublicEventSender);
 
     private static ProgramacionTurnoDiarioSolicitada CrearEvento(DetalleTurno detalleTurno) =>
-        new(SolicitudId, Empleado, Fecha, detalleTurno);
+        new(SolicitudId, EmpleadoDetalle, Fecha, detalleTurno);
 
     private static TurnoDiarioAsignado CrearTurnoDiarioAsignado(DetalleTurno detalleTurno) =>
         new(StreamId, Empleado, Fecha, detalleTurno, SolicitudId);

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/DepurarAlAsignarTurnoTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/DepurarAlAsignarTurnoTests.cs
@@ -25,8 +25,8 @@ public class DepurarAlAsignarTurnoTests
     private static readonly InformacionEmpleado Empleado = new(
         "EMP-001", "CC", "1234567890", "Luis Augusto", "Barreto");
 
-    // Issue #318 CA-4: payload propio de PrivateEvents que llega en el evento bajo prueba;
-    // el handler lo mapea a InformacionEmpleado. Paridad de campos con Empleado.
+    // Mismo empleado, en la forma con que llega dentro del evento privado; el handler lo mapea
+    // a InformacionEmpleado para TurnoDiarioAsignado (CA-ADR-0029 decision #5).
     private static readonly DetalleEmpleado EmpleadoDetalle = new(
         "EMP-001", "CC", "1234567890", "Luis Augusto", "Barreto");
 

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/DesgloseHorasTrasAsignarTurnoTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/DesgloseHorasTrasAsignarTurnoTests.cs
@@ -29,8 +29,8 @@ public class DesgloseHorasTrasAsignarTurnoTests
     private static readonly InformacionEmpleado Empleado = new(
         "EMP-001", "CC", "1234567890", "Luis Augusto", "Barreto");
 
-    // Issue #318 CA-4: payload propio de PrivateEvents que llega en el evento bajo prueba;
-    // el handler lo mapea a InformacionEmpleado. Paridad de campos con Empleado.
+    // Mismo empleado, en la forma con que llega dentro del evento privado; el handler lo mapea
+    // a InformacionEmpleado para TurnoDiarioAsignado (CA-ADR-0029 decision #5).
     private static readonly DetalleEmpleado EmpleadoDetalle = new(
         "EMP-001", "CC", "1234567890", "Luis Augusto", "Barreto");
 

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/DesgloseHorasTrasAsignarTurnoTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/DesgloseHorasTrasAsignarTurnoTests.cs
@@ -29,6 +29,11 @@ public class DesgloseHorasTrasAsignarTurnoTests
     private static readonly InformacionEmpleado Empleado = new(
         "EMP-001", "CC", "1234567890", "Luis Augusto", "Barreto");
 
+    // Issue #318 CA-4: payload propio de PrivateEvents que llega en el evento bajo prueba;
+    // el handler lo mapea a InformacionEmpleado. Paridad de campos con Empleado.
+    private static readonly DetalleEmpleado EmpleadoDetalle = new(
+        "EMP-001", "CC", "1234567890", "Luis Augusto", "Barreto");
+
     private static readonly DateOnly Fecha = new(2026, 3, 15);
     private static readonly string StreamId = $"{Empleado.EmpleadoId}:{Fecha:yyyy-MM-dd}";
 
@@ -51,7 +56,7 @@ public class DesgloseHorasTrasAsignarTurnoTests
         new ProgramacionTurnoDiarioSolicitadaEventHandler(EventStore, PublicEventSender);
 
     private static ProgramacionTurnoDiarioSolicitada CrearEvento(DetalleTurno detalleTurno) =>
-        new(SolicitudId, Empleado, Fecha, detalleTurno);
+        new(SolicitudId, EmpleadoDetalle, Fecha, detalleTurno);
 
     private static TurnoDiarioAsignado CrearTurnoDiarioAsignado(DetalleTurno detalleTurno) =>
         new(StreamId, Empleado, Fecha, detalleTurno, SolicitudId);

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/ProgramacionTurnoDiarioSolicitadaPortabilidadTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/ProgramacionTurnoDiarioSolicitadaPortabilidadTests.cs
@@ -11,7 +11,6 @@ using System.Text.Json;
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.ControlHoras.Infraestructura;
 using Bitakora.ControlAsistencia.PrivateEvents.Programacion;
-using Bitakora.ControlAsistencia.PublicEvents.Empleados;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.Tests.AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction.Eventos;
 
@@ -20,7 +19,8 @@ public class ProgramacionTurnoDiarioSolicitadaPortabilidadTests
     private static readonly Guid SolicitudId =
         Guid.Parse("019600b0-0000-7000-8000-000000000009");
 
-    private static readonly InformacionEmpleado Empleado = new(
+    // Issue #318 CA-2: Empleado ahora tipa con DetalleEmpleado (payload propio de PrivateEvents).
+    private static readonly DetalleEmpleado Empleado = new(
         "EMP-001", "CC", "1234567890", "Luis Augusto", "Barreto");
 
     private static readonly DateOnly Fecha = new(2026, 3, 15);

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/ProgramacionTurnoDiarioSolicitadaEventHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/ProgramacionTurnoDiarioSolicitadaEventHandlerTests.cs
@@ -21,9 +21,8 @@ public class ProgramacionTurnoDiarioSolicitadaEventHandlerTests
     private static readonly InformacionEmpleado Empleado = new(
         "EMP-001", "CC", "1234567890", "Luis Augusto", "Barreto");
 
-    // Issue #318 CA-4: DetalleEmpleado es el payload propio de PrivateEvents (tres islas) que
-    // llega en el evento bajo prueba; el handler lo mapea a InformacionEmpleado para
-    // TurnoDiarioAsignado. Misma persona, paridad de campos con Empleado.
+    // Mismo empleado, en la forma con que llega dentro del evento privado; el handler lo mapea
+    // a InformacionEmpleado para TurnoDiarioAsignado (CA-ADR-0029 decision #5).
     private static readonly DetalleEmpleado EmpleadoDetalle = new(
         "EMP-001", "CC", "1234567890", "Luis Augusto", "Barreto");
 

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/ProgramacionTurnoDiarioSolicitadaEventHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/ProgramacionTurnoDiarioSolicitadaEventHandlerTests.cs
@@ -21,6 +21,12 @@ public class ProgramacionTurnoDiarioSolicitadaEventHandlerTests
     private static readonly InformacionEmpleado Empleado = new(
         "EMP-001", "CC", "1234567890", "Luis Augusto", "Barreto");
 
+    // Issue #318 CA-4: DetalleEmpleado es el payload propio de PrivateEvents (tres islas) que
+    // llega en el evento bajo prueba; el handler lo mapea a InformacionEmpleado para
+    // TurnoDiarioAsignado. Misma persona, paridad de campos con Empleado.
+    private static readonly DetalleEmpleado EmpleadoDetalle = new(
+        "EMP-001", "CC", "1234567890", "Luis Augusto", "Barreto");
+
     private static readonly DateOnly Fecha = new DateOnly(2026, 3, 15);
 
     // CA-7: stream ID determinista que el handler debe computar internamente
@@ -36,7 +42,7 @@ public class ProgramacionTurnoDiarioSolicitadaEventHandlerTests
         new ProgramacionTurnoDiarioSolicitadaEventHandler(EventStore, PublicEventSender);
 
     private static ProgramacionTurnoDiarioSolicitada CrearEvento() =>
-        new(SolicitudId, Empleado, Fecha, DetalleTurnoTest);
+        new(SolicitudId, EmpleadoDetalle, Fecha, DetalleTurnoTest);
 
     private static TurnoDiarioAsignado CrearTurnoDiarioAsignado() =>
         new(StreamId, Empleado, Fecha, DetalleTurnoTest, SolicitudId);

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/CrearDiaCalculadoConHorasDiscriminadasTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/CrearDiaCalculadoConHorasDiscriminadasTests.cs
@@ -40,9 +40,8 @@ public class CrearDiaCalculadoConHorasDiscriminadasTests
     private static readonly InformacionEmpleado Empleado = new(
         "EMP-001", "CC", "1234567890", "Luis Augusto", "Barreto");
 
-    // Issue #318 CA-4: payload propio de PrivateEvents que llega en el evento
-    // ProgramacionTurnoDiarioSolicitada; el handler lo mapea a InformacionEmpleado. Paridad de
-    // campos con Empleado.
+    // Mismo empleado, en la forma con que llega dentro del evento privado; el handler lo mapea
+    // a InformacionEmpleado para TurnoDiarioAsignado (CA-ADR-0029 decision #5).
     private static readonly DetalleEmpleado EmpleadoDetalle = new(
         "EMP-001", "CC", "1234567890", "Luis Augusto", "Barreto");
 

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/CrearDiaCalculadoConHorasDiscriminadasTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/CrearDiaCalculadoConHorasDiscriminadasTests.cs
@@ -40,6 +40,12 @@ public class CrearDiaCalculadoConHorasDiscriminadasTests
     private static readonly InformacionEmpleado Empleado = new(
         "EMP-001", "CC", "1234567890", "Luis Augusto", "Barreto");
 
+    // Issue #318 CA-4: payload propio de PrivateEvents que llega en el evento
+    // ProgramacionTurnoDiarioSolicitada; el handler lo mapea a InformacionEmpleado. Paridad de
+    // campos con Empleado.
+    private static readonly DetalleEmpleado EmpleadoDetalle = new(
+        "EMP-001", "CC", "1234567890", "Luis Augusto", "Barreto");
+
     private static readonly DateOnly Fecha = new(2026, 3, 15);
     private static readonly string StreamId = $"{Empleado.EmpleadoId}:{Fecha:yyyy-MM-dd}";
     private static readonly Guid SolicitudId = Guid.Parse("019600d0-0000-7000-8000-000000000001");
@@ -74,7 +80,7 @@ public class CrearDiaCalculadoConHorasDiscriminadasTests
                 EventStore, PublicEventSender);
 
         private static ProgramacionTurnoDiarioSolicitada CrearEvento(DetalleTurno detalleTurno) =>
-            new(SolicitudId, Empleado, Fecha, detalleTurno);
+            new(SolicitudId, EmpleadoDetalle, Fecha, detalleTurno);
 
         // CA-4: con turno (franja 06:00-14:00) y marcaciones previas que la completan (07:00, 15:00),
         //       la franja queda NO anomala. CrearDiaCalculado() debe empaquetar el payload plano

--- a/tests/Bitakora.ControlAsistencia.PrivateEvents.Tests/Programacion/DetalleEmpleadoIgualdadTests.cs
+++ b/tests/Bitakora.ControlAsistencia.PrivateEvents.Tests/Programacion/DetalleEmpleadoIgualdadTests.cs
@@ -1,0 +1,32 @@
+// Issue #318: DetalleEmpleado es el payload propio de PrivateEvents (tres islas, MEF-ADR-0039
+// decision 6) que sustituye a InformacionEmpleado (PublicEvents) en ProgramacionTurnoDiarioSolicitada.
+// A diferencia de DetalleTurno/DetalleFranjaOrdinaria/DetalleSubFranja, todos sus campos son
+// string: la igualdad por valor del record por defecto es correcta, sin Equals/GetHashCode custom
+// (no hay IReadOnlyList que el record compare por referencia, ADR-0015).
+
+using Bitakora.ControlAsistencia.PrivateEvents.Programacion;
+
+namespace Bitakora.ControlAsistencia.PrivateEvents.Tests.Programacion;
+
+public class DetalleEmpleadoIgualdadTests : IgualdadTestBase<DetalleEmpleado>
+{
+    protected override DetalleEmpleado CrearInstancia() =>
+        new("EMP-001", "CC", "1234567890", "Luis Augusto", "Barreto");
+
+    protected override DetalleEmpleado CrearInstanciaCopia() =>
+        new("EMP-001", "CC", "1234567890", "Luis Augusto", "Barreto");
+
+    protected override IEnumerable<(string, DetalleEmpleado)> CrearInstanciasDiferentes()
+    {
+        yield return ("EmpleadoId",
+            new DetalleEmpleado("EMP-002", "CC", "1234567890", "Luis Augusto", "Barreto"));
+        yield return ("TipoIdentificacion",
+            new DetalleEmpleado("EMP-001", "CE", "1234567890", "Luis Augusto", "Barreto"));
+        yield return ("NumeroIdentificacion",
+            new DetalleEmpleado("EMP-001", "CC", "9999999999", "Luis Augusto", "Barreto"));
+        yield return ("Nombres",
+            new DetalleEmpleado("EMP-001", "CC", "1234567890", "Otro Nombre", "Barreto"));
+        yield return ("Apellidos",
+            new DetalleEmpleado("EMP-001", "CC", "1234567890", "Luis Augusto", "Otro Apellido"));
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.PrivateEvents.Tests/Programacion/DetalleEmpleadoIgualdadTests.cs
+++ b/tests/Bitakora.ControlAsistencia.PrivateEvents.Tests/Programacion/DetalleEmpleadoIgualdadTests.cs
@@ -1,8 +1,8 @@
-// Issue #318: DetalleEmpleado es el payload propio de PrivateEvents (tres islas, MEF-ADR-0039
-// decision 6) que sustituye a InformacionEmpleado (PublicEvents) en ProgramacionTurnoDiarioSolicitada.
-// A diferencia de DetalleTurno/DetalleFranjaOrdinaria/DetalleSubFranja, todos sus campos son
-// string: la igualdad por valor del record por defecto es correcta, sin Equals/GetHashCode custom
-// (no hay IReadOnlyList que el record compare por referencia, ADR-0015).
+// Contrato de igualdad de DetalleEmpleado, por simetria con la familia Detalle*IgualdadTests.
+// A diferencia de sus hermanos, todos sus campos son string: la igualdad por valor del record por
+// defecto ya es correcta y no necesita Equals/GetHashCode propios (MEF-ADR-0012). Estos tests
+// congelan esa premisa: si el record gana una coleccion, el record la compararia por referencia
+// y el test rojo lo delata.
 
 using Bitakora.ControlAsistencia.PrivateEvents.Programacion;
 

--- a/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/Bitakora.ControlAsistencia.Programacion.SmokeTests.csproj
+++ b/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/Bitakora.ControlAsistencia.Programacion.SmokeTests.csproj
@@ -16,8 +16,10 @@
     <PackageReference Include="xunit.v3.mtp-v2" Version="3.*" />
   </ItemGroup>
 
+  <!-- Programacion no publica eventos publicos: sus smoke tests solo consumen el bus interno.
+       Sin referencia a PublicEvents, un smoke test no puede volver a tipar el payload del evento
+       privado con InformacionEmpleado sin que el compilador lo delate (CA-ADR-0029 decision #5). -->
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Bitakora.ControlAsistencia.PublicEvents\Bitakora.ControlAsistencia.PublicEvents.csproj" />
     <ProjectReference Include="..\..\src\Bitakora.ControlAsistencia.PrivateEvents\Bitakora.ControlAsistencia.PrivateEvents.csproj" />
   </ItemGroup>
 

--- a/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoSmokeTests.cs
@@ -3,7 +3,6 @@ using System.Net.Http.Json;
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.PrivateEvents.Programacion;
 using Bitakora.ControlAsistencia.Programacion.SmokeTests.Fixtures;
-using Bitakora.ControlAsistencia.PublicEvents.Empleados;
 
 namespace Bitakora.ControlAsistencia.Programacion.SmokeTests.SolicitarProgramacionTurnoFunction;
 
@@ -97,8 +96,11 @@ public class SolicitarProgramacionTurnoSmokeTests(ApiFixture api, ServiceBusFixt
         new[] { evento1.Fecha, evento2.Fecha }.Should()
             .BeEquivalentTo(new[] { DateOnly.Parse(fecha1), DateOnly.Parse(fecha2) });
 
-        // Verificar datos del empleado y turno en uno de los eventos
-        var empleadoEsperado = new InformacionEmpleado(
+        // Verificar datos del empleado y turno en uno de los eventos.
+        // Issue #318 CA-2: evento1.Empleado tipa con DetalleEmpleado (payload propio de
+        // PrivateEvents), no InformacionEmpleado (PublicEvents) -- el JSON en el cable es
+        // identico por la paridad de campos.
+        var empleadoEsperado = new DetalleEmpleado(
             empleadoId, "CC", "555666777", "[TEST] Smoke ServiceBus", "[TEST] Publicacion");
         evento1.Empleado.Should().Be(empleadoEsperado);
 

--- a/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoSmokeTests.cs
@@ -96,10 +96,9 @@ public class SolicitarProgramacionTurnoSmokeTests(ApiFixture api, ServiceBusFixt
         new[] { evento1.Fecha, evento2.Fecha }.Should()
             .BeEquivalentTo(new[] { DateOnly.Parse(fecha1), DateOnly.Parse(fecha2) });
 
-        // Verificar datos del empleado y turno en uno de los eventos.
-        // Issue #318 CA-2: evento1.Empleado tipa con DetalleEmpleado (payload propio de
-        // PrivateEvents), no InformacionEmpleado (PublicEvents) -- el JSON en el cable es
-        // identico por la paridad de campos.
+        // Verificar datos del empleado y turno en uno de los eventos. El payload del empleado es
+        // DetalleEmpleado (PrivateEvents): con la paridad de campos el JSON del cable no cambia,
+        // asi que este smoke test tambien evidencia la compatibilidad del despliegue rolling.
         var empleadoEsperado = new DetalleEmpleado(
             empleadoId, "CC", "555666777", "[TEST] Smoke ServiceBus", "[TEST] Publicacion");
         evento1.Empleado.Should().Be(empleadoEsperado);

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/DetalleEmpleadoParidadConInformacionEmpleadoTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/DetalleEmpleadoParidadConInformacionEmpleadoTests.cs
@@ -1,0 +1,30 @@
+// Guardrail de la duplicacion deliberada de payload por rol (CA-ADR-0029 decision #5):
+// DetalleEmpleado (PrivateEvents) e InformacionEmpleado (PublicEvents) declaran el mismo dato en
+// dos ensamblados que no se referencian, y solo esta Function App ve ambos.
+// Sin este test, agregar un campo a uno de los dos no rompe nada: MapearEmpleado sigue
+// compilando, el campo nuevo nunca cruza el bus y el consumidor lo recibe en su valor default --
+// perdida silenciosa, sin excepcion, que es el modo de fallo que ese ADR documenta.
+// El JSON del cable tampoco cambia mientras la paridad se mantenga (compatibilidad del despliegue
+// rolling entre productor y consumidor).
+
+using System.Reflection;
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.PrivateEvents.Programacion;
+using Bitakora.ControlAsistencia.PublicEvents.Empleados;
+
+namespace Bitakora.ControlAsistencia.Programacion.Tests.SolicitarProgramacionTurnoFunction;
+
+public class DetalleEmpleadoParidadConInformacionEmpleadoTests
+{
+    private static IEnumerable<(string Nombre, Type Tipo)> Campos<T>() =>
+        typeof(T).GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Select(p => (p.Name, p.PropertyType));
+
+    [Fact]
+    public void DetalleEmpleado_DeclaraLosMismosCamposQueInformacionEmpleado()
+    {
+        var campos = Campos<DetalleEmpleado>();
+
+        campos.Should().Equal(Campos<InformacionEmpleado>());
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoCommandHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoCommandHandlerTests.cs
@@ -25,8 +25,8 @@ public class SolicitarProgramacionTurnoCommandHandlerTests
     private static readonly InformacionEmpleado Empleado =
         new("E001", "CC", "12345678", "Juan", "Perez");
 
-    // Issue #318 CA-4: payload propio de PrivateEvents (DetalleEmpleado) con paridad de campos
-    // con Empleado (InformacionEmpleado) -- el mapeo lo hace el handler bajo prueba.
+    // Mismo empleado, en la forma que el handler debe producir para el evento privado
+    // (CA-ADR-0029 decision #5): si el mapeo pierde o permuta un campo, estos tests lo delatan.
     private static readonly DetalleEmpleado EmpleadoDetalle =
         new("E001", "CC", "12345678", "Juan", "Perez");
 

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoCommandHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoCommandHandlerTests.cs
@@ -25,6 +25,11 @@ public class SolicitarProgramacionTurnoCommandHandlerTests
     private static readonly InformacionEmpleado Empleado =
         new("E001", "CC", "12345678", "Juan", "Perez");
 
+    // Issue #318 CA-4: payload propio de PrivateEvents (DetalleEmpleado) con paridad de campos
+    // con Empleado (InformacionEmpleado) -- el mapeo lo hace el handler bajo prueba.
+    private static readonly DetalleEmpleado EmpleadoDetalle =
+        new("E001", "CC", "12345678", "Juan", "Perez");
+
     // El DetalleTurno esperado corresponde al catalogo creado en CrearEventoTurno()
     // Issue #288 CA-2: Descripcion lleva el texto real que produce el ToString() del tipo rico
     // (CatalogoTurnos a nivel turno, FranjaOrdinaria a nivel franja). La coherencia entre ambos
@@ -64,7 +69,7 @@ public class SolicitarProgramacionTurnoCommandHandlerTests
         Then(new ProgramacionTurnoSolicitada(
             GuidAggregateId, Empleado, [Fecha1], DetalleEsperado));
         ThenIsPublishedPrivately(new ProgramacionTurnoDiarioSolicitada(
-            GuidAggregateId, Empleado, Fecha1, DetalleEsperado));
+            GuidAggregateId, EmpleadoDetalle, Fecha1, DetalleEsperado));
         And<SolicitudProgramacionAggregateRoot, int>(s => s.Fechas.Count, 1);
     }
 
@@ -80,9 +85,9 @@ public class SolicitarProgramacionTurnoCommandHandlerTests
             GuidAggregateId, Empleado, [Fecha1, Fecha2], DetalleEsperado));
         ThenIsPublishedPrivately(
             new ProgramacionTurnoDiarioSolicitada(
-                GuidAggregateId, Empleado, Fecha1, DetalleEsperado),
+                GuidAggregateId, EmpleadoDetalle, Fecha1, DetalleEsperado),
             new ProgramacionTurnoDiarioSolicitada(
-                GuidAggregateId, Empleado, Fecha2, DetalleEsperado));
+                GuidAggregateId, EmpleadoDetalle, Fecha2, DetalleEsperado));
         And<SolicitudProgramacionAggregateRoot, int>(s => s.Fechas.Count, 2);
     }
 


### PR DESCRIPTION
## Resumen

Pipeline TDD completado:
- Fase roja: tests escritos con stubs
- Fase verde: implementación completa
- Smoke tests: escritos para endpoints detectados
- Fase refactor: revisión de calidad

## Decisiones del pipeline

<details>
<summary>Test Writer (fase roja) — 16m 47s</summary>

## ES Test Writer - Decisiones

### Tipo de tarea
No es refactoring puro (el issue lo dice explícitamente en "Notas técnicas": "No es refactor puro
(los tests cambian de tipos), asi que no aplica el archivo señal de MEF-ADR-0017"). Se siguió el
flujo normal de test-writer: tests modificados/nuevos + stubs mínimos de compilación.

### Tests modificados/creados
- `SolicitarProgramacionTurnoCommandHandlerTests.cs` (Programacion.Tests): 2 tests existentes
  modificados para usar `EmpleadoDetalle` (DetalleEmpleado) en `ThenIsPublishedPrivately`
  - `DebeEmitirProgramacionSolicitadaYPublicarEvento_CuandoDatosValidos` - CA-2/CA-4
  - `DebePublicarUnEventoPorCadaFecha_CuandoHayMultiplesFechas` - CA-2/CA-4
- `ProgramacionTurnoDiarioSolicitadaEventHandlerTests.cs` (ControlHoras.Tests): 2 tests
  modificados para construir el evento con `EmpleadoDetalle` (DetalleEmpleado) - CA-2/CA-4
- `DepurarAlAsignarTurnoTests.cs` (ControlHoras.Tests): 1 factory method modificado
  (`CrearEvento`), afecta a sus 3 `[Fact]` - CA-2/CA-4
- `DesgloseHorasTrasAsignarTurnoTests.cs` (ControlHoras.Tests): 1 factory method modificado
  (`CrearEvento`), afecta a sus 2 `[Fact]` - CA-2/CA-4
- `CrearDiaCalculadoConHorasDiscriminadasTests.cs` (ControlHoras.Tests, nested
  `ViaAsignarTurnoTests`): 1 factory method modificado (`CrearEvento`), afecta a sus 2 `[Fact]`
  - CA-2/CA-4 (archivo no listado en el issue, ver "Desviaciones")
- `ProgramacionTurnoDiarioSolicitadaPortabilidadTests.cs` (ControlHoras.Tests): tipo de `Empleado`
  cambiado a `DetalleEmpleado` - CA-2, CA-5 (round-trip por el bus sigue en verde sin cambios de
  comportamiento, paridad de campos)
- `SolicitarProgramacionTurnoSmokeTests.cs` (Programacion.SmokeTests): `empleadoEsperado` cambiado
  de `InformacionEmpleado` a `DetalleEmpleado` - CA-2 (archivo no listado en el issue, ver
  "Desviaciones"; bug real de compilación detectado, no solo deseable)
- `DetalleEmpleadoIgualdadTests.cs` (PrivateEvents.Tests, NUEVO): 8 tests heredados de
  `IgualdadTestBase<DetalleEmpleado>` - CA-1 (por simetría con la familia `Detalle*IgualdadTests`,
  sugerido como opcional en el issue). Estos tests PASAN de inmediato: `DetalleEmpleado` es un
  record con todos los campos string, sin lista que el record compare por referencia (a
  diferencia de `DetalleTurno`/`DetalleFranjaOrdinaria`/`DetalleSubFranja`), así que la igualdad
  por defecto ya es correcta y no requiere implementación adicional.

`ProgramacionTurnoDiarioSolicitadaDeserializacionTests.cs` NO se modificó: solo accede a
`evento.Empleado.EmpleadoId` etc. (paridad de campos con `DetalleEmpleado`), sin importar el tipo
`InformacionEmpleado` -- compila y sigue en verde sin cambios, cubriendo CA-5 (JSON idéntico en el
cable) sin tocarlo.

### Estructura elegida
- No se creó una clase base intermedia: cada archivo de test ya tenía su propio patrón de
  `Empleado`/`EmpleadoDetalle` como constante estática, consistente con el resto del dominio.
- `EmpleadoDetalle` (DetalleEmpleado) se agregó como constante hermana de `Empleado`
  (InformacionEmpleado) en cada archivo, en vez de reemplazar `Empleado`: ambos tipos coexisten en
  el mismo test porque el comando HTTP/aggregate siguen usando `InformacionEmpleado` mientras que
  solo el evento de bus `ProgramacionTurnoDiarioSolicitada` usa `DetalleEmpleado` (CA-4).

### Stubs creados
- `DetalleEmpleado.cs` (PrivateEvents/Programacion): record plano completo (CA-1) -- no es un stub
  con `NotImplementedException`, es la implementación real y completa porque es un DTO sin
  comportamiento (mismo patrón que otros records del proyecto: la implementación completa de un
  tipo de datos puro no tiene lógica que estabar).
- `SolicitarProgramacionTurnoCommandHandler.MapearEmpleado(InformacionEmpleado)` ->
  `throw new NotImplementedException()`: aísla el único punto de comportamiento nuevo (CA-4,
  mapeo `InformacionEmpleado -> DetalleEmpleado`) sin romper el resto del handler (las
  precondiciones de "solicitud ya existe" / "turno no encontrado" siguen pasando).
- `ProgramacionTurnoDiarioSolicitadaEventHandler.MapearEmpleado(DetalleEmpleado)` ->
  `throw new NotImplementedException()`: mapeo inverso (CA-4, `DetalleEmpleado ->
  InformacionEmpleado`) para construir `TurnoDiarioAsignado`. Como este mapeo ocurre antes del
  `if (existe)`, TODOS los tests de este handler (y de sus 2 archivos hermanos que comparten el
  mismo Handler) quedan en rojo -- correcto, porque todos ejercitan la ruta que necesita el mapeo.

Se optó por extraer un método `MapearEmpleado` en vez de un `throw` inline porque `throw` como
expresión de C# solo es válido en contextos específicos (operador condicional, `??`, cuerpo de
lambda/método) y no como argumento de una llamada a constructor.

### Decisiones de diseño
- El swap de tipo en `ProgramacionTurnoDiarioSolicitada.Empleado` (InformacionEmpleado ->
  DetalleEmpleado) y la eliminación del `<ProjectReference>` en `PrivateEvents.csproj` se hicieron
  en esta fase (no son "implementación real" en el sentido de lógica de negocio -- son cambios de
  forma del tipo, mecánicos, indispensables para que las nuevas aserciones de los tests compilen).
  El comportamiento real (los dos mapeos) se dejó como stub para el implementer.
- Verificado con `dotnet build` (0 errores) y `dotnet test --solution` (11 tests en rojo, todos
  por `NotImplementedException` en `MapearEmpleado`; 613 en verde; 12 omitidos por falta de infra
  de smoke tests). Los 11 tests en rojo son exactamente los que ejercitan CA-4 (el mapeo). Ningún
  test no relacionado con este issue se rompió.

### Cobertura de criterios
| Criterio de aceptación | Test(s) |
|---|---|
| CA-1: DetalleEmpleado con paridad de campos | `DetalleEmpleadoIgualdadTests` (8 tests) |
| CA-2: Empleado tipa DetalleEmpleado, sin using PublicEvents | `SolicitarProgramacionTurnoCommandHandlerTests` (2), `ProgramacionTurnoDiarioSolicitadaEventHandlerTests` (2), `DepurarAlAsignarTurnoTests` (3), `DesgloseHorasTrasAsignarTurnoTests` (2), `CrearDiaCalculadoConHorasDiscriminadasTests.ViaAsignarTurnoTests` (2), `ProgramacionTurnoDiarioSolicitadaPortabilidadTests` (verificado vía build, sin nuevo Fact) |
| CA-3: PrivateEvents.csproj sin ProjectReference | verificado por `grep` manual + build exitoso (no hay test de arquitectura hasta #320) |
| CA-4: mapeos viven en los Function Apps | Todos los tests de handlers arriba fallan por `NotImplementedException` en `MapearEmpleado`, marcando el hueco que el implementer debe llenar |
| CA-5: suite completa en verde tras la implementación | `ProgramacionTurnoDiarioSolicitadaDeserializacionTests` (sin cambios, ya en verde), `ProgramacionTurnoDiarioSolicitadaPortabilidadTests` (sin cambios de comportamiento, ya en verde) |

### Desviaciones del plan del planner

| Sugerencia del issue | Desviación aplicada | Razón técnica | Consecuencia |
|---|---|---|---|
| Impacto/Modifica lista `AsignarTurnoViaSbSmokeTests` y `DeadLetterMinimos` (ControlHoras.SmokeTests) como afectados | NO se modificaron | Inspección directa: ninguno construye `ProgramacionTurnoDiarioSolicitada` ni usa `InformacionEmpleado`/`DetalleEmpleado` para ese evento -- publican JSON crudo (objetos anónimos) al bus y verifican `TurnoDiarioAsignado`/`DiaCalculado` (que conservan `InformacionEmpleado`, sin cambios) o usan su propio record minimal `InformacionEmpleadoMinimo` | Ningún cambio necesario; confirmado con `dotnet build` (0 errores) sin tocarlos |
| Impacto/Modifica NO lista `SolicitarProgramacionTurnoSmokeTests.cs` (Programacion.SmokeTests) | SE modificó | Este archivo SÍ construye/consume `ProgramacionTurnoDiarioSolicitada` vía `WaitForMessageAsync<ProgramacionTurnoDiarioSolicitada>` y comparaba `evento1.Empleado` (ahora `DetalleEmpleado`) contra una instancia de `InformacionEmpleado` -- error de compilación real (CS1503), no solo deseable | Cambiado `empleadoEsperado` a `DetalleEmpleado`; sin este cambio el build completo no compila |
| Impacto/Modifica NO lista `CrearDiaCalculadoConHorasDiscriminadasTests.cs` | SE modificó | Construye `ProgramacionTurnoDiarioSolicitada` con `Empleado` (InformacionEmpleado) en la nested class `ViaAsignarTurnoTests` -- mismo error de compilación (CS1503) que el caso anterior | Agregada constante `EmpleadoDetalle` y usada en el factory `CrearEvento`; sin este cambio el build no compila |
| Issue sugiere posible nombre "InformacionEmpleadoInterna", resuelto por el planner a "DetalleEmpleado" | Aplicado sin cambios | La justificación del planner (consistencia con la familia `Detalle*` de `PrivateEvents/Programacion`, y nombre distinto para que un `using` equivocado no compile) es sólida y verificable en el propio ADR (CA-ADR-0029 decisión #5, caso `RegistroDeMarcacionCreado`) | Ninguna -- se usó `DetalleEmpleado` tal cual |

### Notas para el implementer
- Completar `SolicitarProgramacionTurnoCommandHandler.MapearEmpleado`: mapeo campo a campo
  `InformacionEmpleado -> DetalleEmpleado` (mismos 5 campos, mismo orden).
- Completar `ProgramacionTurnoDiarioSolicitadaEventHandler.MapearEmpleado`: mapeo inverso
  `DetalleEmpleado -> InformacionEmpleado` (mismos 5 campos, mismo orden).
- No se requiere `ConfigurarSerializacion` para `DetalleEmpleado` (todos los campos son
  primitivos, sin ctor privado ni propiedades `private set`).

</details>

<details>
<summary>Implementer (fase verde) — 2m 53s</summary>

## ES Implementer - Decisiones

### Enfoque de implementacion

El test-writer ya dejo resuelto todo lo estructural de este issue (tres islas): el record
`DetalleEmpleado` (PrivateEvents/Programacion), el swap de tipo en
`ProgramacionTurnoDiarioSolicitada.Empleado`, la retirada de la `<ProjectReference>` en
`PrivateEvents.csproj`, y los dos sitios de mapeo (productor/consumidor) con stubs
`MapearEmpleado(...) => throw new NotImplementedException()`. Mi trabajo se redujo a CA-4:
completar el mapeo campo a campo en los dos Function Apps, que es el unico comportamiento
nuevo real de este refactor.

- **Productor** (`SolicitarProgramacionTurnoCommandHandler`, Programacion):
  `MapearEmpleado(InformacionEmpleado) : DetalleEmpleado` -- construye el record propio de
  PrivateEvents a partir del tipo del comando HTTP (PublicEvents, sin cambios).
- **Consumidor** (`ProgramacionTurnoDiarioSolicitadaEventHandler`, ControlHoras):
  `MapearEmpleado(DetalleEmpleado) : InformacionEmpleado` -- mapeo inverso, porque
  `TurnoDiarioAsignado` sigue tipando `InformacionEmpleado` (PublicEvents) hasta que el
  issue #319 le de a `ControlHoras.DomainEvents` su propio record.

Ambos mapeos son construcciones directas campo a campo (misma paridad de nombres y tipos
entre `InformacionEmpleado` y `DetalleEmpleado`, verificada por inspeccion de
`PublicEvents/Empleados/InformacionEmpleado.cs`), sin logica condicional ni transformacion.

### Decisiones de diseno

- No agregue ningun archivo nuevo ni toque la forma de `DetalleEmpleado` ni de
  `ProgramacionTurnoDiarioSolicitada`: ya estaban completos y correctos segun CA-1/CA-2.
- No toque `PrivateEvents.csproj`: ya estaba sin `ProjectReference` (CA-3), verificado con
  `grep -n "<ProjectReference"` (vacio).
- Mantuve el mapeo como metodo privado estatico `MapearEmpleado` en cada handler (nombre y
  ubicacion que ya proponia el stub del test-writer) -- es la forma minima y coherente con
  "el mapeo vive en el Function App, unico proyecto que ve los tres [ensamblados]" (contexto
  del issue).

### ADRs consultados

- MEF-ADR-0039 (decision 2: tres islas / cero ProjectReference; decision 6: payload por rol)
- CA-ADR-0029 enmendado por #317 (doctrina local de tres islas)
- CA-ADR-0025 / MEF-ADR-0023 (payload plano y portable en eventos que cruzan el bus)
- MEF-ADR-0036 (no aplica: confirmado que `ProgramacionTurnoDiarioSolicitada` es evento de
  bus exclusivamente, no persistido -- ver comentario en `IdentidadEventosControlHoras.cs`)
- MEF-ADR-0016 (naming de tests -- no agregue tests, no aplico cambio)

### Desviaciones de ADRs

Ninguna desviacion -- todos los ADRs aplicados al pie de la letra.

### Desviaciones del plan del planner

Ninguna desviacion -- la implementacion siguio exactamente el "Impacto esperado en archivos"
del issue: solo se tocaron los dos Function Apps para completar CA-4, todo lo demas ya lo
habia resuelto el test-writer.

### Precedentes consultados

- `InformacionEmpleado` (PublicEvents/Empleados) como fuente de la paridad de campos exigida
  por CA-1: verificado alineado, record positional plano sin comportamiento.

### Infraestructura modificada

Ninguna. Este issue no toca topics/subscriptions de Service Bus (es un refactor de tipos de
payload dentro del mismo evento, no cambia el productor/consumidor ni el naming del evento).

### Complejidad encontrada

Ninguna significativa. El test-writer dejo el trabajo estructural completo y bien acotado;
solo quedaban dos metodos de mapeo triviales con paridad exacta de campos. Verifique con
`dotnet build` y `dotnet test` que no quedaban referencias residuales a
`InformacionEmpleado` en codigo real dentro de `PrivateEvents` (solo en comentarios
explicativos de los propios archivos, que documentan la razon del cambio).

### Resultado

- Tests pasando: 624/624 ejecutados (12 omitidos por falta de infraestructura local
  ServiceBus/Postgres, esperado en smoke tests). 0 errores.

</details>
<details>
<summary>Smoke Test Writer — 4m 5s</summary>

_(El agente no generó resumen)_

</details>
<details>
<summary>Reviewer (fase refactor) — 13m 15s</summary>

## ES Reviewer - Revision

### Evaluacion general
- Calidad: **buena**
- Cambios realizados: **si** (1 commit: `refactor(issue-318): dejar el csproj de PrivateEvents verificable y congelar la paridad del payload`)
- Baseline al iniciar: verde (624 correctos, 12 omitidos por infra de smoke tests, 0 errores). No hubo `blockage-report.md`.
- Estado final: **625 correctos, 12 omitidos, 0 errores** (+1 test de contrato agregado en la revision).

### Cumplimiento de ADRs aplicables

| ADR | Cumplimiento | Observacion |
|---|---|---|
| **MEF-ADR-0039** (canon del marco: tres islas / payload por rol) | verificado **indirectamente** | **El ADR no existe en el plugin instalado**: `mefisto/0.20.0/docs/adr/` llega hasta `mef-adr-0038`, y `grep -rl "MEF-ADR-0039"` sobre todo el cache del marketplace no devuelve nada (vive solo en el harness `main`, sin publicar). Verifique el diff contra **CA-ADR-0029 enmendado por #317**, que es la aplicacion local literal de sus decisiones #2 y #6 (ver decision #7 del ADR local). Ver "Criticas y hallazgos" -> H0. |
| **CA-ADR-0029** dec. #2 (tres islas, cero `ProjectReference`) | ok (tras correccion) | `PrivateEvents.csproj` queda con cero referencias de proyecto y solo el `PackageReference` de markers. El comentario que dejo el implementer **contenia** la palabra `ProjectReference` y rompia la verificacion literal de CA-3; corregido (H1). |
| **CA-ADR-0029** dec. #5 (payload por rol; nombre simple distinto) | ok | `DetalleEmpleado` es record propio de `PrivateEvents` con paridad exacta de 5 campos `string`; nombre deliberadamente distinto de `InformacionEmpleado`, coherente con el precedente `RegistroDeMarcacionCreado` vs `MarcacionRegistrada` (#270). Los dos mapeos viven en los Function Apps, unicos proyectos que ven ambos ensamblados. Agregue el guardrail que faltaba para que la paridad no se rompa en silencio (H3). |
| **CA-ADR-0029** dec. #3 regla 4 (tests de un ensamblado de bus referencian solo su ensamblado) | ok | `PrivateEvents.Tests -> PrivateEvents` unicamente; el test nuevo de igualdad no importa PublicEvents. |
| **CA-ADR-0029** dec. #6 / **MEF-ADR-0036** (identidad del evento persistido) | **no aplica**, confirmado | `IdentidadEventosControlHoras.TiposPersistidos` = `[MarcacionRegistrada, MarcacionAdicionada, TurnoDiarioAsignado]`; el comentario del archivo excluye explicitamente a `ProgramacionTurnoDiarioSolicitada` ("solo cruzan el bus"). Ningun alias del event store cambia; cero streams afectados. No hace falta protocolo de dos despliegues. |
| **CA-ADR-0025 / MEF-ADR-0023** (lo que cruza el bus es plano y portable) | ok | `DetalleEmpleado` es `record` positional de solo `string`: STJ lo serializa sin resolver custom. No requiere `ConfigurarSerializacion`. |
| **MEF-ADR-0012** (encapsulamiento, serializacion, records vs sealed class) | ok | Recorrido explicito de los 7 antipatrones abajo. |
| **MEF-ADR-0016** (naming de tests) | ok en lo nuevo | El test que agregue: `DetalleEmpleado_DeclaraLosMismosCamposQueInformacionEmpleado`. Los tests preexistentes con prefijo `Debe...` no los toque (ver H6). |

**Recorrido de antipatrones de MEF-ADR-0012** (ninguno presente):
1. Propiedad publica nueva en VO consumida solo por servicio externo: no hay -- `DetalleEmpleado` es DTO de transporte, no VO con invariantes.
2. Clase estatica operando sobre datos crudos de un VO: no hay; los mapeos son metodos privados del handler que los usa.
3. Getter expuesto solo para tests: no hay.
4. `InternalsVisibleTo` de un ensamblado de eventos hacia un dominio: no hay.
5. `[JsonConstructor]` en ctor privado: no hay.
6. `record` con `IReadOnlyList<T>` en la igualdad: **no aplica a `DetalleEmpleado`** (5 campos `string`), y esa premisa quedo congelada por `DetalleEmpleadoIgualdadTests`. Sus hermanos `DetalleTurno`/`DetalleFranjaOrdinaria`/`DetalleSubFranja` ya tienen `Equals`/`GetHashCode` propios, sin cambios en este diff.
7. Evento con marker de bus cargando modelo rico: **verificado explicitamente**. `ProgramacionTurnoDiarioSolicitada` (`IPrivateEvent`) ahora tiene payload 100% propio y plano. El guardrail de round-trip **con serializador por defecto** existe y sigue verde: `ProgramacionTurnoDiarioSolicitadaPortabilidadTests` (productor con `JsonSerializerDefaults.Web`, consumidor via `ServiceBusDeserializador`) y `ProgramacionTurnoDiarioSolicitadaDeserializacionTests` (JSON camelCase literal, verifica los 5 campos del empleado uno por uno). Este ultimo es ademas el guardrail real de CA-5: si alguien renombra un campo de `DetalleEmpleado`, el JSON congelado lo delata.

### Desviaciones de ADRs

**Desviaciones declaradas por el implementer**: ninguna. Su resumen dice "Ninguna desviacion -- todos los ADRs aplicados al pie de la letra", y la verificacion lo confirma en lo sustantivo.

**Desviaciones detectadas por el reviewer (NO declaradas)**:

#### Desviacion menor: CA-ADR-0029 dec. #2 -- verificabilidad de CA-3
- **Regla**: `PrivateEvents.csproj` con cero `<ProjectReference>`, verificable con `grep ProjectReference src/Bitakora.ControlAsistencia.PrivateEvents/*.csproj` **vacio** (CA-3 del issue).
- **Desviacion encontrada**: `PrivateEvents.csproj:13-15` -- el comentario explicativo contenia literalmente la palabra `ProjectReference`, asi que el `grep` del CA devolvia una linea y el criterio no se podia dar por cumplido con su propia forma de verificacion. Riesgo real hacia adelante: el issue #320 (tests de arquitectura) puede implementar el enforcement por texto.
- **Accion tomada**: corregida en refactor -- comentario reescrito sin esa palabra y reubicado sobre el `ItemGroup` de paquetes. `grep` ahora sale vacio (exit 1).
- **Status**: resuelta en este PR.

Ninguna otra desviacion. El resto del diff cumple los ADRs aplicables.

### Precedentes consultados por el implementer

| Precedente | ADR aplicable | Veredicto |
|---|---|---|
| `PublicEvents/Empleados/InformacionEmpleado.cs` (fuente de la paridad de campos) | CA-ADR-0029 dec. #5 | **alineado** -- record positional plano, sin comportamiento. La paridad es exacta (mismos 5 nombres, mismos tipos, mismo orden), verificado por reflection en el test nuevo. |
| `RegistroDeMarcacionCreado` vs `MarcacionRegistrada` (#270), citado en el ADR como resolucion estandar del doble rol | CA-ADR-0029 dec. #5 | **alineado** -- mismo criterio de nombre simple distinto aplicado aqui. |

### Convenciones del pipeline (no ADRs)

| Convencion | Estado | Observacion |
|---|---|---|
| Cada test con `Then()` + `And<>()` | ok | `SolicitarProgramacionTurnoCommandHandlerTests`: ambos tests conservan `Then(...)` + `ThenIsPublishedPrivately(...)` + `And<SolicitudProgramacionAggregateRoot,int>(...)`. Los tests de contrato (igualdad, paridad) no usan el DSL por diseno. |
| Overloads correctos para stream IDs compuestos | ok | `ProgramacionTurnoDiarioSolicitadaEventHandlerTests` y hermanos usan `StreamId` compuesto (`{EmpleadoId}:{Fecha}`) computado con `ComputarStreamId`; el diff no cambio esos overloads. |
| Fakes manuales (no NSubstitute) | ok | `EventStore`/`PublicEventSender` de los tests siguen siendo fakes concretos; el diff no introdujo mocks. |
| Feature folders (produccion y tests) | ok | El test nuevo quedo en `Programacion.Tests/SolicitarProgramacionTurnoFunction/`, espejo del feature folder del productor (donde vive el mapeo). |
| Smoke tests: SkipWhen, secrets, cobertura | ok | `Assert.SkipWhen(!serviceBus.IsConfigured, ...)` presente; filtrado por `SolicitudId` (no por posicion); cubre camino feliz + 409 duplicado + 404 + cuatro 400 de validacion; verifica el efecto secundario real (los 2 eventos publicados) y la ausencia de dead letter de la corrida. La suscripcion `smoke-tests` del topic `programacion-turno-diario-solicitada` existe en `infra/environments/dev/main.tf`. Sin archivos duplicados por comando. Sin cambios de infra requeridos por este issue. |
| Proyecciones read-side | n/a | El diff no toca `ReadModels`/`Projections` ni Functions GET. |
| Compatibilidad Marten write-side/read-side | n/a | El gate no aplica: el diff no toca la version de `Cosmos.EventSourcing.*` ni ninguna configuracion de Marten (`ComposicionServicios*`, `ConfiguracionMartenProjections*`, `ConfiguracionSerializacion*`, `IdentidadEventos*`, `opts.Events.*`, `AddEventTypes`, ...). No decompile nada. |
| Identidad de stream (MEF-ADR-0037) | ok | El diff toca un sitio de lectura de identidad: `ControlDiarioAggregateRoot.ComputarStreamId(@event.Empleado.EmpleadoId, @event.Fecha)` en el EventHandler. Sigue siendo el punto unico de conversion (sin concatenacion paralela), el `EmpleadoId` es `string` de dominio (no `Guid` formateado) y no hay `ToString("N"/"B"/...)` ni `ToUpper/ToLower` en ninguna linea nueva. Ningun GET de read-side en el diff. |
| Control de volumen de telemetria (MEF-ADR-0038) | n/a | El gate no aplica: el diff no toca `ComposicionServicios*`, `ConfiguracionObservabilidad*`, `AddOpenTelemetry`, `SetSampler`, `UseAzureMonitorExporter` ni el callback de `AgregarWolverineParaComandosServerless`. |
| Tests via ToString/comportamiento | ok | Las aserciones son sobre el evento producido y el estado del aggregate, no sobre getters expuestos para test. |
| Sin numeros magicos | ok | Sin constantes nuevas; los literales del empleado son datos de prueba, no reglas de negocio. |
| Condiciones en positivo (guardas if/else afirmativas) | ok | El `if (existe) ... else ...` del EventHandler ya estaba en positivo y no se toco. |
| Sin caracter U+2500 en `.cs` | ok | `grep` sobre el diff: 0 ocurrencias. |

### Elegancia del codigo

- **Compacto**: los dos `MapearEmpleado` son expression-bodied, campo a campo, sin logica condicional -- la forma minima posible para el mapeo. No hay duplicacion evitable: los dos mapeos son inversos entre si y viven en Function Apps distintos que **no pueden** compartir codigo sin reintroducir una dependencia (extraer un mapper comun exigiria un ensamblado que vea ambos buses, justo lo que el issue elimina).
- **Legible**: `DetalleEmpleado` / `InformacionEmpleado` se distinguen a simple vista en los archivos que usan ambos; la constante de test `EmpleadoDetalle` junto a `Empleado` deja explicito que son la misma persona en dos formas.
- **Idiomatico**: `record` positional para el DTO, herencia de `IgualdadTestBase<T>` para el contrato de igualdad, LINQ en el productor. El `var empleado = MapearEmpleado(command.Empleado)` fuera del `Select` evita mapear N veces dentro del loop -- correcto y deliberado.
- **Robusto**: la conversion no puede fallar (5 strings, sin parseo). Ningun `catch` nuevo, ningun swallowing.
- **Eficiente**: sin loops anidados; el mapeo se calcula una vez para las N fechas.
- **Limpio (tras la revision)**: los comentarios de proceso ("Issue #318 CA-4: ...", 3-4 lineas repetidas en 7 archivos) se compactaron a la razon arquitectonica citando el ADR vigente. Motivo: un comentario que dice "hasta que #319 le de su propio record" caduca en el proximo PR; la decision del ADR no.

### Criticas y hallazgos

- **H0 (mayor, no bloqueante -- escalado al planner)**: el issue lista **MEF-ADR-0039** como ADR aplicable y el implementer declaro haberlo consultado, pero **ese ADR no existe en el plugin instalado**: `mefisto/0.20.0/docs/adr/` llega hasta `mef-adr-0038` y el `grep` sobre todo el cache del marketplace no lo encuentra. Vive en el harness `main`, sin publicar. Consecuencia: ni el implementer ni yo pudimos leer el canon citado; la verificacion se hizo contra **CA-ADR-0029 enmendado por #317**, que transcribe sus decisiones #2 y #6 y declara "gana el marco" (dec. #7). Riesgo residual bajo (el ADR local es literal y exhaustivo), pero **el issue deberia citar CA-ADR-0029 como fuente verificable** o el harness publicar 0.21.0 antes de #319/#320, que dependen del mismo canon.
- **H1 (menor, corregido)**: comentario en `PrivateEvents.csproj` que contenia la palabra `ProjectReference` y rompia la verificacion literal de CA-3. Ver "Desviaciones detectadas".
- **H2 (menor, corregido)**: `Programacion.SmokeTests.csproj` conservaba `<ProjectReference>` a `PublicEvents` que quedo **huerfana** con este cambio -- `grep` confirmo que ningun `.cs` del proyecto usa ya un tipo de ese ensamblado, y `Programacion` no publica ningun `IPublicEvent` (los unicos son `DiaCalculado`/`HorasDiscriminadas`, de ControlHoras). Dejarla mantenia abierta la via por la que un smoke test futuro volveria a tipar el payload del evento privado con `InformacionEmpleado` sin que el compilador lo delate -- exactamente el riesgo que motiva el nombre distinto (CA-ADR-0029 dec. #5). Retirada; suite verde.
- **H3 (mayor, corregido con test)**: **faltaba el guardrail de la duplicacion deliberada**. Con la paridad de campos como unica garantia y ningun test que la congele, agregar un campo a `InformacionEmpleado` seguiria compilando (`MapearEmpleado` lee 5 propiedades), el campo nuevo nunca cruzaria el bus y el consumidor lo recibiria en su valor default: perdida silenciosa, sin excepcion -- el modo de fallo que CA-ADR-0029 dec. #5 documenta empiricamente (#270). Agregue `DetalleEmpleadoParidadConInformacionEmpleadoTests` y **verifique que no es vacuo**: mutando `InformacionEmpleado` con un campo `Cargo` el test falla; revertida la mutacion, verde.
- **H4 (menor, no corregido -- deuda preexistente, fuera de alcance)**: `dotnet format --verify-no-changes` sale con codigo 2 por **9 warnings IDE0005** (usings innecesarios). Conteo identico antes y despues de mis cambios (9 = 9), y ninguno esta en una linea que este PR toque: 7 en `ControlHoras.Tests/**/*SerializacionTests.cs` y 2 en `Programacion.Tests` (uno de ellos, `SolicitarProgramacionTurnoCommandHandlerTests.cs:5`, es `using ...Programacion.CrearTurnoFunction`, preexistente). Corregirlos tocaria 9 archivos ajenos al issue. **Candidato a issue de limpieza propio.**
- **H5 (cosmetico, no corregido -- deuda documental generalizada)**: ~20 comentarios en `src/` citan **"ADR-0015"** con el sentido del ADR de estilo de modelado, que hoy es **MEF-ADR-0012** (en el marco, `mef-adr-0015` es "Snapshots de Marten como excepcion", tema distinto; localmente no existe `ca-adr-0015`). El codigo nuevo replicaba la cita rota; en los dos archivos nuevos la corregi a MEF-ADR-0012, pero no toque los ~20 sitios preexistentes. **Candidato a issue de limpieza documental.**
- **H6 (cosmetico, no corregido)**: los dos tests del productor conservan el prefijo `Debe...` (`DebeEmitirProgramacionSolicitadaYPublicarEvento_CuandoDatosValidos`, `DebePublicarUnEventoPorCadaFecha_CuandoHayMultiplesFechas`), que MEF-ADR-0016 proscribe a favor de `<Sujeto>_<LoQuePasa>_Cuando<Condicion>` con el nombre del comando como sujeto. Son preexistentes: el diff cambio su cuerpo, no su nombre. Renombrarlos aqui agregaria ruido sin relacion con la HU.

### Refactorings aplicados

1. `PrivateEvents.csproj`: comentario reescrito sin la palabra `ProjectReference` y movido sobre el `ItemGroup` de paquetes -- CA-3 pasa a ser verificable con su propio `grep` (H1).
2. `Programacion.SmokeTests.csproj`: retirada la `ProjectReference` huerfana a `PublicEvents`, con el motivo documentado en el archivo (H2).
3. Comentarios de proceso compactados en 7 archivos (`ProgramacionTurnoDiarioSolicitada`, ambos handlers, 4 archivos de test y el smoke test): de 3-4 lineas con numero de issue a 2 lineas citando la decision del ADR vigente. Se elimino la referencia a trabajo futuro (#319) que caduca en el proximo PR.
4. `DetalleEmpleado`: `<remarks>` reescrito -- explica la duplicacion por rol y el motivo del nombre distinto citando CA-ADR-0029 dec. #2/#5 y MEF-ADR-0012 (en vez de "ADR-0015", ver H5).

Cada cambio se verifico con `dotnet test` inmediatamente despues; ninguno rompio la suite y no hubo que revertir nada.

### Cobertura de criterios de aceptacion

| Criterio | Estado | Test(s) / evidencia |
|---|---|---|
| CA-1: `DetalleEmpleado` record plano positional con paridad exacta de 5 campos `string`, sin comportamiento ni Equals custom | cubierto | `DetalleEmpleadoIgualdadTests` (8 tests heredados de `IgualdadTestBase<DetalleEmpleado>`) + **`DetalleEmpleado_DeclaraLosMismosCamposQueInformacionEmpleado`** (nuevo: congela la paridad por reflection) |
| CA-2: `ProgramacionTurnoDiarioSolicitada.Empleado` tipa `DetalleEmpleado`, sin `using` de PublicEvents | cubierto | Compilacion + `ProgramacionTurnoDiarioSolicitadaPortabilidadTests`, `...EventHandlerTests` (2), `DepurarAlAsignarTurnoTests` (3), `DesgloseHorasTrasAsignarTurnoTests` (2), `CrearDiaCalculadoConHorasDiscriminadasTests.ViaAsignarTurnoTests` (2) |
| CA-3: `PrivateEvents.csproj` con cero `<ProjectReference>`, conservando el `PackageReference` de markers | cubierto | `grep ProjectReference src/Bitakora.ControlAsistencia.PrivateEvents/*.csproj` -> **vacio (exit 1)** tras H1. `PackageReference Cosmos.EventDriven.Abstractions 2.3.1` intacto |
| CA-4: los dos mapeos viven en los Function Apps; comando HTTP y aggregates sin cambio de tipo | cubierto | `SolicitarProgramacionTurnoCommandHandlerTests` (2, valores distintos entre campos -> detectan permutacion o perdida) y `ProgramacionTurnoDiarioSolicitadaEventHandlerTests` (2) + los 7 tests de handler hermanos. `SolicitarProgramacionTurno` y `TurnoDiarioAsignado` conservan `InformacionEmpleado` |
| CA-5: suite verde; JSON del cable identico (compatibilidad rolling) | cubierto | Suite: **625/625 ejecutados, 0 errores**. `ProgramacionTurnoDiarioSolicitadaDeserializacionTests` (JSON camelCase literal, 5 campos del empleado verificados uno a uno) y `...PortabilidadTests` (round-trip con serializador **por defecto**, sin resolver) siguen verdes sin cambios de comportamiento; el test de paridad nuevo cierra el flanco de la divergencia futura |

### Tests agregados

- `tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/DetalleEmpleadoParidadConInformacionEmpleadoTests.cs` -- **1 test de contrato** (`DetalleEmpleado_DeclaraLosMismosCamposQueInformacionEmpleado`): compara por reflection la secuencia de `(nombre, tipo)` de las propiedades publicas de ambos records. Vive en `Programacion.Tests` porque es el unico proyecto de test que ve los dos ensamblados sin violar las tres islas (`PrivateEvents.Tests` solo puede referenciar su propio ensamblado, CA-ADR-0029 dec. #3 regla 4). Verificado como no vacuo por mutacion.
- No hicieron falta tests de igualdad ni de serializacion adicionales: el test-writer ya cubrio `IgualdadTestBase<DetalleEmpleado>` y los dos guardrails de cable preexistentes cubren el round-trip con serializador por defecto (`IPrivateEvent`, MEF-ADR-0012 "frontera de serializacion: event store vs bus").

</details>

## Cobertura

| Archivo | Cobertura | Umbral | Estado |
|---|---|---|---|
| SolicitarProgramacionTurnoCommandHandler.cs | 100.0% | 95% | ok |
| DetalleEmpleado.cs | - | excluido | - |
| ProgramacionTurnoDiarioSolicitadaEventHandler.cs | - | no evaluado | - |
| ProgramacionTurnoDiarioSolicitada.cs | - | no evaluado | - |
## Commits

2c8ab23 refactor(issue-318): dejar el csproj de PrivateEvents verificable y congelar la paridad del payload
cdf3a20 feat(issue-318): completar el mapeo campo a campo DetalleEmpleado<->InformacionEmpleado (fase verde)
c7c6273 test(issue-318): tests para DetalleEmpleado y stubs de mapeo (fase roja)

Closes #318