### PR TITLE
Retirar las referencias de ControlHoras.DomainEvents a los buses y poseer sus payloads

### DIFF
--- a/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/Bitakora.ControlAsistencia.ControlHoras.DomainEvents.csproj
+++ b/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/Bitakora.ControlAsistencia.ControlHoras.DomainEvents.csproj
@@ -6,17 +6,12 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <!-- Issue #270: MarcacionRegistrada ya no implementa IPrivateEvent: es el evento de dominio
-       persistido en el stream, no cruza el bus. El contrato de bus es RegistroDeMarcacionCreado
-       en PrivateEvents.ControlHoras. -->
-  <ItemGroup>
-    <PackageReference Include="Cosmos.EventDriven.Abstractions" Version="2.3.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\Bitakora.ControlAsistencia.PublicEvents\Bitakora.ControlAsistencia.PublicEvents.csproj" />
-    <ProjectReference Include="..\Bitakora.ControlAsistencia.PrivateEvents\Bitakora.ControlAsistencia.PrivateEvents.csproj" />
-  </ItemGroup>
+  <!-- Isla de eventos (CA-ADR-0029 decision #2, canon MEF-ADR-0039): ninguna dependencia de
+       proyecto, tampoco hacia los otros ensamblados de eventos, y ningun paquete que retirar.
+       Issue #322: retirado Cosmos.EventDriven.Abstractions (ya no aparecia mas que en comentarios,
+       desde #270) y los ProjectReference a PublicEvents/PrivateEvents. Los payloads del evento
+       persistido (Empleado, TurnoDiario, FranjaProgramada, SubFranjaProgramada) son propios de
+       este ensamblado (payload por rol, decision #5), no tipos importados. -->
 
   <!-- Issue #275: MarcacionRegistrada.Mensajes es internal y los tests lo usan en sus asserts
        (MEF-ADR-0009, patron TurnoCreado.Mensajes). -->

--- a/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/Empleado.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/Empleado.cs
@@ -1,0 +1,18 @@
+namespace Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
+
+/// <summary>
+/// Datos de identificacion del empleado, propios de este ensamblado (issue #322, payload por rol
+/// -- CA-ADR-0029 decision #5 / MEF-ADR-0039 decision #6). Duplica con paridad exacta de campos a
+/// InformacionEmpleado (PublicEvents.Empleados) y a DetalleEmpleado (PrivateEvents.Programacion)
+/// en vez de importarlos: los tres ensamblados de eventos son tres islas sin referencias entre si
+/// (CA-ADR-0029 decision #2). El mapeo entre estos tipos vive en el Function App, el unico
+/// ensamblado que ve los tres (ProgramacionTurnoDiarioSolicitadaEventHandler.MapearEmpleado).
+/// Sin Equals custom: todos los campos son string, asi que la igualdad por valor del record por
+/// defecto ya es correcta (mismo criterio que DetalleEmpleado).
+/// </summary>
+public record Empleado(
+    string EmpleadoId,
+    string TipoIdentificacion,
+    string NumeroIdentificacion,
+    string Nombres,
+    string Apellidos);

--- a/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/FranjaProgramada.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/FranjaProgramada.cs
@@ -7,11 +7,10 @@ namespace Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 /// ensamblados de eventos son tres islas sin referencias entre si.
 /// </summary>
 /// <remarks>
-/// STUB de la fase roja (test-writer): declara la forma exacta de DetalleFranjaOrdinaria pero SIN
-/// el override de Equals/GetHashCode que compara Descansos/Extras por valor (SequenceEqual). El
-/// record por defecto compara esas IReadOnlyList por referencia (MEF-ADR-0012) -- replicar la
-/// semantica correcta (CA-1 del issue #322) es responsabilidad del implementer, ver
-/// FranjaProgramadaIgualdadTests.
+/// Equals/GetHashCode propios comparan Descansos/Extras POR VALOR (SequenceEqual, el record por
+/// defecto compararia por referencia -- ADR-0015) y EXCLUYEN Descripcion (dato derivado, no
+/// identidad de la franja) -- mismo criterio que DetalleFranjaOrdinaria (issues #129 y #288) y
+/// que FranjaProgramada (Programacion.DomainEvents, issue #319).
 /// </remarks>
 public record FranjaProgramada(
     TimeOnly HoraInicio,
@@ -19,4 +18,34 @@ public record FranjaProgramada(
     int DiaOffsetFin,
     IReadOnlyList<SubFranjaProgramada> Descansos,
     IReadOnlyList<SubFranjaProgramada> Extras,
-    string Descripcion);
+    string Descripcion)
+{
+    /// <summary>
+    /// Los eventos anteriores a este record no llevan el campo: STJ deja null en el parametro
+    /// posicional y la propiedad declarada como string no anulable mentiria. Se normaliza a
+    /// cadena vacia -- mismo criterio que DetalleFranjaOrdinaria (issue #288).
+    /// </summary>
+    public string Descripcion { get; init; } = Descripcion ?? string.Empty;
+
+    public virtual bool Equals(FranjaProgramada? other)
+    {
+        if (other is null) return false;
+        if (ReferenceEquals(this, other)) return true;
+        return HoraInicio == other.HoraInicio
+            && HoraFin == other.HoraFin
+            && DiaOffsetFin == other.DiaOffsetFin
+            && Descansos.SequenceEqual(other.Descansos)
+            && Extras.SequenceEqual(other.Extras);
+    }
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(HoraInicio);
+        hash.Add(HoraFin);
+        hash.Add(DiaOffsetFin);
+        foreach (var d in Descansos) hash.Add(d);
+        foreach (var e in Extras) hash.Add(e);
+        return hash.ToHashCode();
+    }
+}

--- a/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/FranjaProgramada.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/FranjaProgramada.cs
@@ -1,0 +1,22 @@
+namespace Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
+
+/// <summary>
+/// Representacion plana de una franja ordinaria propia de este ensamblado (issue #322, payload
+/// por rol -- CA-ADR-0029 decision #5 / MEF-ADR-0039 decision #6). Duplica con paridad exacta de
+/// campos a DetalleFranjaOrdinaria (PrivateEvents.Programacion) en vez de importarlo: los tres
+/// ensamblados de eventos son tres islas sin referencias entre si.
+/// </summary>
+/// <remarks>
+/// STUB de la fase roja (test-writer): declara la forma exacta de DetalleFranjaOrdinaria pero SIN
+/// el override de Equals/GetHashCode que compara Descansos/Extras por valor (SequenceEqual). El
+/// record por defecto compara esas IReadOnlyList por referencia (MEF-ADR-0012) -- replicar la
+/// semantica correcta (CA-1 del issue #322) es responsabilidad del implementer, ver
+/// FranjaProgramadaIgualdadTests.
+/// </remarks>
+public record FranjaProgramada(
+    TimeOnly HoraInicio,
+    TimeOnly HoraFin,
+    int DiaOffsetFin,
+    IReadOnlyList<SubFranjaProgramada> Descansos,
+    IReadOnlyList<SubFranjaProgramada> Extras,
+    string Descripcion);

--- a/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/SubFranjaProgramada.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/SubFranjaProgramada.cs
@@ -1,0 +1,19 @@
+namespace Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
+
+/// <summary>
+/// Representacion plana de una sub-franja (descanso o extra) propia de este ensamblado
+/// (issue #322, payload por rol -- CA-ADR-0029 decision #5 / MEF-ADR-0039 decision #6). Duplica
+/// con paridad exacta de campos a DetalleSubFranja (PrivateEvents.Programacion) en vez de
+/// importarlo: los tres ensamblados de eventos son tres islas sin referencias entre si.
+/// </summary>
+/// <remarks>
+/// STUB de la fase roja (test-writer): declara la forma exacta de DetalleSubFranja pero SIN el
+/// override de Equals/GetHashCode que excluye Descripcion de la identidad. Replicar esa semantica
+/// (CA-1 del issue #322) es responsabilidad del implementer -- ver SubFranjaProgramadaIgualdadTests.
+/// </remarks>
+public record SubFranjaProgramada(
+    TimeOnly HoraInicio,
+    TimeOnly HoraFin,
+    int DiaOffsetInicio,
+    int DiaOffsetFin,
+    string Descripcion);

--- a/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/SubFranjaProgramada.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/SubFranjaProgramada.cs
@@ -7,13 +7,31 @@ namespace Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 /// importarlo: los tres ensamblados de eventos son tres islas sin referencias entre si.
 /// </summary>
 /// <remarks>
-/// STUB de la fase roja (test-writer): declara la forma exacta de DetalleSubFranja pero SIN el
-/// override de Equals/GetHashCode que excluye Descripcion de la identidad. Replicar esa semantica
-/// (CA-1 del issue #322) es responsabilidad del implementer -- ver SubFranjaProgramadaIgualdadTests.
+/// Equals/GetHashCode propios EXCLUYEN Descripcion (dato derivado, no identidad de la
+/// sub-franja) -- mismo criterio que DetalleSubFranja (issue #288) y SubFranjaProgramada
+/// (Programacion.DomainEvents, issue #319).
 /// </remarks>
 public record SubFranjaProgramada(
     TimeOnly HoraInicio,
     TimeOnly HoraFin,
     int DiaOffsetInicio,
     int DiaOffsetFin,
-    string Descripcion);
+    string Descripcion)
+{
+    /// <summary>
+    /// Los eventos anteriores a este record no llevan el campo: STJ deja null en el parametro
+    /// posicional y la propiedad declarada como string no anulable mentiria. Se normaliza a
+    /// cadena vacia -- mismo criterio que DetalleSubFranja (issue #288).
+    /// </summary>
+    public string Descripcion { get; init; } = Descripcion ?? string.Empty;
+
+    public virtual bool Equals(SubFranjaProgramada? other) =>
+        other is not null
+        && HoraInicio == other.HoraInicio
+        && HoraFin == other.HoraFin
+        && DiaOffsetInicio == other.DiaOffsetInicio
+        && DiaOffsetFin == other.DiaOffsetFin;
+
+    public override int GetHashCode() =>
+        HashCode.Combine(HoraInicio, HoraFin, DiaOffsetInicio, DiaOffsetFin);
+}

--- a/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/TurnoDiario.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/TurnoDiario.cs
@@ -9,12 +9,35 @@ namespace Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 /// "TurnoDiario" es el termino exacto del glosario para este concepto.
 /// </summary>
 /// <remarks>
-/// STUB de la fase roja (test-writer): declara la forma exacta de DetalleTurno pero SIN el
-/// override de Equals/GetHashCode que compara FranjasOrdinarias por valor (SequenceEqual) y
-/// excluye Descripcion de la identidad del turno. Replicar esa semantica (CA-1 del issue #322) es
-/// responsabilidad del implementer -- ver TurnoDiarioIgualdadTests.
+/// Equals/GetHashCode propios comparan FranjasOrdinarias POR VALOR (SequenceEqual) y EXCLUYEN
+/// Descripcion (dato derivado, no identidad del turno) -- mismo criterio que DetalleTurno
+/// (issue #288) y TurnoProgramado (Programacion.DomainEvents, issue #319).
 /// </remarks>
 public record TurnoDiario(
     string Nombre,
     IReadOnlyList<FranjaProgramada> FranjasOrdinarias,
-    string Descripcion);
+    string Descripcion)
+{
+    /// <summary>
+    /// Los eventos anteriores a este record no llevan el campo: STJ deja null en el parametro
+    /// posicional y la propiedad declarada como string no anulable mentiria. Se normaliza a
+    /// cadena vacia -- mismo criterio que DetalleTurno (issue #288).
+    /// </summary>
+    public string Descripcion { get; init; } = Descripcion ?? string.Empty;
+
+    public virtual bool Equals(TurnoDiario? other)
+    {
+        if (other is null) return false;
+        if (ReferenceEquals(this, other)) return true;
+        return Nombre == other.Nombre
+            && FranjasOrdinarias.SequenceEqual(other.FranjasOrdinarias);
+    }
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(Nombre);
+        foreach (var franja in FranjasOrdinarias) hash.Add(franja);
+        return hash.ToHashCode();
+    }
+}

--- a/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/TurnoDiario.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/TurnoDiario.cs
@@ -1,0 +1,20 @@
+namespace Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
+
+/// <summary>
+/// Representacion plana del turno que rige efectivamente a un empleado en una fecha concreta,
+/// propia de este ensamblado (issue #322, payload por rol -- CA-ADR-0029 decision #5 /
+/// MEF-ADR-0039 decision #6). Duplica con paridad exacta de campos a DetalleTurno
+/// (PrivateEvents.Programacion) en vez de importarlo: los tres ensamblados de eventos son tres
+/// islas sin referencias entre si. Nombre acordado con el usuario (docs/eda/ubiquitous-language.yaml):
+/// "TurnoDiario" es el termino exacto del glosario para este concepto.
+/// </summary>
+/// <remarks>
+/// STUB de la fase roja (test-writer): declara la forma exacta de DetalleTurno pero SIN el
+/// override de Equals/GetHashCode que compara FranjasOrdinarias por valor (SequenceEqual) y
+/// excluye Descripcion de la identidad del turno. Replicar esa semantica (CA-1 del issue #322) es
+/// responsabilidad del implementer -- ver TurnoDiarioIgualdadTests.
+/// </remarks>
+public record TurnoDiario(
+    string Nombre,
+    IReadOnlyList<FranjaProgramada> FranjasOrdinarias,
+    string Descripcion);

--- a/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/TurnoDiarioAsignado.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/TurnoDiarioAsignado.cs
@@ -1,7 +1,5 @@
 using System.Reflection;
 using System.Text.Json.Serialization.Metadata;
-using Bitakora.ControlAsistencia.PrivateEvents.Programacion;
-using Bitakora.ControlAsistencia.PublicEvents.Empleados;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 
@@ -12,19 +10,23 @@ namespace Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 /// </summary>
 // HU-12: evento de event sourcing del aggregate ControlDiario
 // CA-5: contiene InformacionEmpleado, Fecha, DetalleTurno y SolicitudId (trazabilidad)
+// Issue #322: InformacionEmpleado y DetalleTurno dejan de ser tipos de PublicEvents/PrivateEvents
+// -- ahora son Empleado y TurnoDiario, propios de este ensamblado (payload por rol, CA-ADR-0029
+// decision #5). Los NOMBRES de estas propiedades NO cambian (son las claves JSON persistidas en
+// mt_events); solo cambian los TIPOS. MEF-ADR-0036: el alias del evento no se toca.
 public sealed class TurnoDiarioAsignado
 {
     public string Id { get; private set; } = null!;
-    public InformacionEmpleado InformacionEmpleado { get; private set; } = null!;
+    public Empleado InformacionEmpleado { get; private set; } = null!;
     public DateOnly Fecha { get; private set; }
-    public DetalleTurno DetalleTurno { get; private set; } = null!;
+    public TurnoDiario DetalleTurno { get; private set; } = null!;
     public Guid SolicitudId { get; private set; }
 
     public TurnoDiarioAsignado(
         string id,
-        InformacionEmpleado informacionEmpleado,
+        Empleado informacionEmpleado,
         DateOnly fecha,
-        DetalleTurno detalleTurno,
+        TurnoDiario detalleTurno,
         Guid solicitudId)
     {
         Id = id;

--- a/src/Bitakora.ControlAsistencia.ControlHoras/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/EventHandler/ProgramacionTurnoDiarioSolicitadaEventHandler.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/EventHandler/ProgramacionTurnoDiarioSolicitadaEventHandler.cs
@@ -1,7 +1,6 @@
 using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 using Bitakora.ControlAsistencia.ControlHoras.Entities;
 using Bitakora.ControlAsistencia.PrivateEvents.Programacion;
-using Bitakora.ControlAsistencia.PublicEvents.Empleados;
 using Cosmos.EventDriven.Abstractions;
 using Cosmos.EventSourcing.Abstractions.Commands;
 
@@ -37,11 +36,13 @@ public partial class ProgramacionTurnoDiarioSolicitadaEventHandler
         var streamId = ControlDiarioAggregateRoot.ComputarStreamId(
             @event.Empleado.EmpleadoId, @event.Fecha);
 
-        // CA-ADR-0029 decision #5 (payload por rol): el evento llega con DetalleEmpleado
-        // (PrivateEvents) y TurnoDiarioAsignado persiste InformacionEmpleado (PublicEvents), asi
-        // que el mapeo vive aqui -- la Function App es el unico proyecto que ve ambos ensamblados.
+        // CA-ADR-0029 decision #5 (payload por rol): el evento llega con DetalleEmpleado/DetalleTurno
+        // (PrivateEvents) y TurnoDiarioAsignado persiste Empleado/TurnoDiario (ControlHoras.DomainEvents,
+        // propios de este ensamblado desde el issue #322), asi que el mapeo vive aqui -- la Function
+        // App es el unico proyecto que ve los tres ensamblados de eventos.
         var evento = new TurnoDiarioAsignado(
-            streamId, MapearEmpleado(@event.Empleado), @event.Fecha, @event.DetalleTurno, @event.SolicitudId);
+            streamId, MapearEmpleado(@event.Empleado), @event.Fecha,
+            MapearTurnoDiario(@event.DetalleTurno), @event.SolicitudId);
 
         var existe = await _eventStore.ExistsAsync<ControlDiarioAggregateRoot>(streamId, ct);
 
@@ -65,7 +66,21 @@ public partial class ProgramacionTurnoDiarioSolicitadaEventHandler
         await _publicEventSender.PublishAsync(control.CrearDiaCalculado());
     }
 
-    private static InformacionEmpleado MapearEmpleado(DetalleEmpleado empleado) =>
+    private static Empleado MapearEmpleado(DetalleEmpleado empleado) =>
         new(empleado.EmpleadoId, empleado.TipoIdentificacion, empleado.NumeroIdentificacion,
             empleado.Nombres, empleado.Apellidos);
+
+    // Issue #322: mapeo mecanico DetalleTurno (PrivateEvents) -> TurnoDiario (ControlHoras.DomainEvents),
+    // recursivo sobre las franjas y sub-franjas anidadas. Payload por rol (CA-ADR-0029 decision #5).
+    private static TurnoDiario MapearTurnoDiario(DetalleTurno turno) =>
+        new(turno.Nombre, turno.FranjasOrdinarias.Select(MapearFranja).ToList(), turno.Descripcion);
+
+    private static FranjaProgramada MapearFranja(DetalleFranjaOrdinaria franja) =>
+        new(franja.HoraInicio, franja.HoraFin, franja.DiaOffsetFin,
+            franja.Descansos.Select(MapearSubFranja).ToList(),
+            franja.Extras.Select(MapearSubFranja).ToList(),
+            franja.Descripcion);
+
+    private static SubFranjaProgramada MapearSubFranja(DetalleSubFranja sub) =>
+        new(sub.HoraInicio, sub.HoraFin, sub.DiaOffsetInicio, sub.DiaOffsetFin, sub.Descripcion);
 }

--- a/src/Bitakora.ControlAsistencia.ControlHoras/Entities/ClasificadorTrabajo.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Entities/ClasificadorTrabajo.cs
@@ -4,7 +4,7 @@
 // descansos, extras programadas y excedente (salida mas alla del fin programado).
 // Trabaja siempre en MomentoDelDia - no construye ningun DateTime en este nivel.
 using Bitakora.ControlAsistencia.ControlHoras.ValueObjects;
-using Bitakora.ControlAsistencia.PrivateEvents.Programacion;
+using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.Entities;
 
@@ -41,7 +41,7 @@ public static class ClasificadorTrabajo
     /// Precondicion: trabajado es un intervalo valido (no vacio); la franja anomala se maneja en #136.
     /// </summary>
     public static IReadOnlyList<IntervaloClasificado> Clasificar(
-        DetalleFranjaOrdinaria programada,
+        FranjaProgramada programada,
         IntervaloTemporal trabajado,
         DateOnly fechaAncla,
         Func<DateOnly, bool> esFestivo)
@@ -175,7 +175,7 @@ public static class ClasificadorTrabajo
     }
 
     // Convierte una sub-franja (descanso o extra) a su par de minutos absolutos [Inicio, Fin).
-    private static (int Inicio, int Fin) AMinutos(DetalleSubFranja sub) =>
+    private static (int Inicio, int Fin) AMinutos(SubFranjaProgramada sub) =>
         (new MomentoDelDia(sub.HoraInicio, sub.DiaOffsetInicio).MinutosAbsolutos,
          new MomentoDelDia(sub.HoraFin, sub.DiaOffsetFin).MinutosAbsolutos);
 

--- a/src/Bitakora.ControlAsistencia.ControlHoras/Entities/ControlDiarioAggregateRoot.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Entities/ControlDiarioAggregateRoot.cs
@@ -1,6 +1,5 @@
 using Bitakora.ControlAsistencia.ControlHoras.ValueObjects;
 using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
-using Bitakora.ControlAsistencia.PrivateEvents.Programacion;
 using Bitakora.ControlAsistencia.PublicEvents.ControlHoras;
 using Bitakora.ControlAsistencia.PublicEvents.Empleados;
 using Cosmos.EventSourcing.Abstractions;
@@ -10,12 +9,14 @@ namespace Bitakora.ControlAsistencia.ControlHoras.Entities;
 // HU-12: Aggregate root del dia de trabajo de un empleado
 // Identidad: EmpleadoId + Fecha como stream ID determinista (CA-7)
 // ADR-0015: partial class para soportar clase Mensajes en archivo separado si se requiere
+// Issue #322: InformacionEmpleado y DetalleTurno cambian de tipo (Empleado/TurnoDiario, propios de
+// ControlHoras.DomainEvents) -- los NOMBRES de las propiedades no cambian.
 public partial class ControlDiarioAggregateRoot : AggregateRoot
 {
     // CA-6: estado que actualiza al aplicar TurnoDiarioAsignado
-    public InformacionEmpleado? InformacionEmpleado { get; private set; }
+    public Empleado? InformacionEmpleado { get; private set; }
     public DateOnly Fecha { get; private set; }
-    public DetalleTurno? DetalleTurno { get; private set; }
+    public TurnoDiario? DetalleTurno { get; private set; }
 
     // Trazabilidad: id de la ultima solicitud que asigno un turno (CA-5)
     public Guid UltimaSolicitudId { get; private set; }
@@ -157,5 +158,16 @@ public partial class ControlDiarioAggregateRoot : AggregateRoot
     //         Discriminar(). Ya no se mapean los ControlFranja a un DTO rico: el contrato pierde la
     //         senal de anomalia a proposito (riesgo aceptado, diferido al flujo de aprobacion).
     public DiaCalculado CrearDiaCalculado() =>
-        new(InformacionEmpleado, Fecha, _desgloseHoras.Discriminar());
+        new(MapearInformacionEmpleado(InformacionEmpleado), Fecha, _desgloseHoras.Discriminar());
+
+    // Issue #322: InformacionEmpleado del aggregate ahora es Empleado (ControlHoras.DomainEvents);
+    // DiaCalculado (PublicEvents) sigue esperando InformacionEmpleado (PublicEvents.Empleados) -- el
+    // aggregate vive en el Function App, el unico ensamblado que ve los tres ensamblados de eventos,
+    // asi que el mapeo vive aqui (CA-ADR-0029 decision #5).
+    private static InformacionEmpleado? MapearInformacionEmpleado(Empleado? empleado) =>
+        empleado is null
+            ? null
+            : new InformacionEmpleado(
+                empleado.EmpleadoId, empleado.TipoIdentificacion, empleado.NumeroIdentificacion,
+                empleado.Nombres, empleado.Apellidos);
 }

--- a/src/Bitakora.ControlAsistencia.ControlHoras/Entities/ControlFranja.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Entities/ControlFranja.cs
@@ -1,5 +1,5 @@
 using Bitakora.ControlAsistencia.ControlHoras.ValueObjects;
-using Bitakora.ControlAsistencia.PrivateEvents.Programacion;
+using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.Entities;
 
@@ -7,7 +7,8 @@ namespace Bitakora.ControlAsistencia.ControlHoras.Entities;
 // No viaja entre dominios - vive en ControlHoras junto al aggregate que lo usa.
 // Issue #183: ya no se mapea a un DTO publico; el payload de DiaCalculado viaja plano
 // (HorasDiscriminadas). ControlFranja queda como estado interno del aggregate.
-public record ControlFranja(DetalleFranjaOrdinaria Programada, DateTime? Entrada, DateTime? Salida)
+// Issue #322: DetalleFranjaOrdinaria (PrivateEvents) -> FranjaProgramada (ControlHoras.DomainEvents).
+public record ControlFranja(FranjaProgramada Programada, DateTime? Entrada, DateTime? Salida)
 {
     // CA-9: propiedad calculada; anomala cuando falta Entrada o Salida
     public bool EsAnomala => Entrada is null || Salida is null;

--- a/src/Bitakora.ControlAsistencia.ControlHoras/Entities/DepuradorDeMarcaciones.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Entities/DepuradorDeMarcaciones.cs
@@ -1,4 +1,4 @@
-using Bitakora.ControlAsistencia.PrivateEvents.Programacion;
+using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.Entities;
 
@@ -6,10 +6,12 @@ namespace Bitakora.ControlAsistencia.ControlHoras.Entities;
 // marcaciones normalizadas a franjas ordinarias del turno.
 // Sin estado propio - no necesita inyeccion ni ser instanciada.
 // Funciones auxiliares (resolver franjas a DateTime, calcular cortes) son internal/private.
+// Issue #322: DetalleTurno/DetalleFranjaOrdinaria (PrivateEvents) -> TurnoDiario/FranjaProgramada
+// (ControlHoras.DomainEvents, payload por rol).
 public static class DepuradorDeMarcaciones
 {
     public static IReadOnlyList<ControlFranja> Depurar(
-        DetalleTurno? turno,
+        TurnoDiario? turno,
         DateOnly fecha,
         IReadOnlyList<MarcacionNormalizada> marcaciones)
     {
@@ -37,7 +39,7 @@ public static class DepuradorDeMarcaciones
 
     // Convierte una franja (TimeOnly + DiaOffsetFin) a un rango DateTime relativo a la fecha ancla.
     // Para franjas nocturnas con DiaOffsetFin=1 el fin cae en el dia siguiente.
-    private static (DateTime Inicio, DateTime Fin) ResolverRango(DetalleFranjaOrdinaria franja, DateOnly fecha)
+    private static (DateTime Inicio, DateTime Fin) ResolverRango(FranjaProgramada franja, DateOnly fecha)
     {
         var inicio = fecha.ToDateTime(franja.HoraInicio);
         var fin = fecha.AddDays(franja.DiaOffsetFin).ToDateTime(franja.HoraFin);
@@ -65,7 +67,7 @@ public static class DepuradorDeMarcaciones
     // Construye el ControlFranja asignando primera=Entrada y ultima=Salida dentro del rango.
     // Con cero marcaciones: ambas null. Con una: Entrada poblada, Salida null. Intermedias se descartan.
     private static ControlFranja ConstruirControlFranja(
-        DetalleFranjaOrdinaria franja,
+        FranjaProgramada franja,
         (DateTime Inicio, DateTime Fin) rango,
         IReadOnlyList<MarcacionNormalizada> marcacionesOrdenadas)
     {

--- a/src/Bitakora.ControlAsistencia.ControlHoras/ValueObjects/DesgloseFranja.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ValueObjects/DesgloseFranja.cs
@@ -1,12 +1,13 @@
-using Bitakora.ControlAsistencia.PrivateEvents.Programacion;
+using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.ValueObjects;
 
 // Issue #129: Estructura agregada del desglose de una sola franja.
 // Record con constructor primario publico - STJ lo serializa nativamente sin ConfigurarSerializacion (ADR-0015).
 // Las propiedades calculadas se recalculan en cada acceso desde los parametros del ctor.
+// Issue #322: DetalleFranjaOrdinaria (PrivateEvents) -> FranjaProgramada (ControlHoras.DomainEvents).
 public record DesgloseFranja(
-    DetalleFranjaOrdinaria Programada,
+    FranjaProgramada Programada,
     IReadOnlyList<IntervaloClasificado> Intervalos,
     Retardo Retardo)
 {

--- a/src/Bitakora.ControlAsistencia.Projections/ControlHoras/TurnoDiarioProjection.cs
+++ b/src/Bitakora.ControlAsistencia.Projections/ControlHoras/TurnoDiarioProjection.cs
@@ -1,4 +1,6 @@
 using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
+using Bitakora.ControlAsistencia.PrivateEvents.Programacion;
+using Bitakora.ControlAsistencia.PublicEvents.Empleados;
 using Bitakora.ControlAsistencia.ReadModels.ControlHoras;
 using Marten.Events.Aggregation; // SingleStreamProjection<,> vive aqui, NO en Marten.Events.Projections
 
@@ -22,19 +24,41 @@ namespace Bitakora.ControlAsistencia.Projections.ControlHoras;
 /// stream de ControlDiarioAggregateRoot pero esta proyeccion la ignora a proposito (CA-2). Sin
 /// ShouldDelete: el turno diario nunca se borra, solo se reasigna (CA-3, "el ultimo gana").
 /// </summary>
+// Issue #322: TurnoDiarioAsignado ahora persiste Empleado/TurnoDiario (ControlHoras.DomainEvents,
+// payload por rol) en vez de InformacionEmpleado/DetalleTurno (PublicEvents/PrivateEvents).
+// TurnoDiarioView NO cambia en este issue (estado intermedio deliberado, ver issue #322 "Notas
+// tecnicas"): sigue usando los tipos de bus, asi que Create/Apply mapean los records del evento a
+// esos tipos -- mapeo mecanico dirigido por el compilador, no una vista nueva.
 public sealed partial class TurnoDiarioProjection : SingleStreamProjection<TurnoDiarioView, string>
 {
     public static TurnoDiarioView Create(TurnoDiarioAsignado evento) =>
-        new(evento.Id, evento.InformacionEmpleado, evento.Fecha, evento.DetalleTurno, evento.SolicitudId);
+        new(evento.Id, MapearEmpleado(evento.InformacionEmpleado), evento.Fecha,
+            MapearDetalleTurno(evento.DetalleTurno), evento.SolicitudId);
 
     // CA-3: "el ultimo gana" -- una reasignacion sobre el mismo (empleado, fecha) sobrescribe el
     // documento completo con lo que trae el nuevo evento. El Id no cambia (mismo stream key).
     public static TurnoDiarioView Apply(TurnoDiarioAsignado evento, TurnoDiarioView vista) =>
         vista with
         {
-            Empleado = evento.InformacionEmpleado,
+            Empleado = MapearEmpleado(evento.InformacionEmpleado),
             Fecha = evento.Fecha,
-            DetalleTurno = evento.DetalleTurno,
+            DetalleTurno = MapearDetalleTurno(evento.DetalleTurno),
             UltimaSolicitudId = evento.SolicitudId
         };
+
+    private static InformacionEmpleado MapearEmpleado(Empleado empleado) =>
+        new(empleado.EmpleadoId, empleado.TipoIdentificacion, empleado.NumeroIdentificacion,
+            empleado.Nombres, empleado.Apellidos);
+
+    private static DetalleTurno MapearDetalleTurno(TurnoDiario turno) =>
+        new(turno.Nombre, turno.FranjasOrdinarias.Select(MapearFranja).ToList(), turno.Descripcion);
+
+    private static DetalleFranjaOrdinaria MapearFranja(FranjaProgramada franja) =>
+        new(franja.HoraInicio, franja.HoraFin, franja.DiaOffsetFin,
+            franja.Descansos.Select(MapearSubFranja).ToList(),
+            franja.Extras.Select(MapearSubFranja).ToList(),
+            franja.Descripcion);
+
+    private static DetalleSubFranja MapearSubFranja(SubFranjaProgramada sub) =>
+        new(sub.HoraInicio, sub.HoraFin, sub.DiaOffsetInicio, sub.DiaOffsetFin, sub.Descripcion);
 }

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/AsignarTurnoViaSbSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/AsignarTurnoViaSbSmokeTests.cs
@@ -1,9 +1,8 @@
 using System.Text.Json;
 using AwesomeAssertions;
+using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 using Bitakora.ControlAsistencia.ControlHoras.SmokeTests.Fixtures;
-using Bitakora.ControlAsistencia.PrivateEvents.Programacion;
 using Bitakora.ControlAsistencia.PublicEvents.ControlHoras;
-using Bitakora.ControlAsistencia.PublicEvents.Empleados;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.SmokeTests.AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction;
 
@@ -78,30 +77,35 @@ public class AsignarTurnoViaSbSmokeTests(ServiceBusFixture serviceBus, PostgresF
         existe.Should().BeTrue(
             $"el evento {tipoEvento} con SolicitudId {solicitudId} deberia existir en el stream {streamId}");
 
-        // Assert detallado: obtener el evento especifico y comparar value objects
+        // Assert detallado: obtener el evento especifico y comparar value objects.
+        // Issue #322: InformacionEmpleado/DetalleTurno son las CLAVES JSON persistidas (no cambian,
+        // MEF-ADR-0036), pero el evento persistido ya no tipa esos campos con InformacionEmpleado
+        // (PublicEvents) ni DetalleTurno (PrivateEvents) -- ahora son Empleado y TurnoDiario, propios
+        // de ControlHoras.DomainEvents (payload por rol). El smoke test deserializa con el tipo que
+        // realmente posee el payload persistido.
         var eventoPersistido = await postgres.ObtenerEventoAsync<JsonElement>(
             SchemaControlHoras, streamId, tipoEvento,
             "SolicitudId", solicitudId.ToString(), TimeSpan.FromSeconds(5));
 
-        var infoEmpleadoEsperada = new InformacionEmpleado(
+        var empleadoEsperado = new Empleado(
             empleadoId, "CC", "999888777", "[TEST] Smoke ServiceBus", "[TEST] Verificacion");
-        var infoEmpleadoPersistida = eventoPersistido
-            .GetProperty("InformacionEmpleado").Deserialize<InformacionEmpleado>();
-        infoEmpleadoPersistida.Should().Be(infoEmpleadoEsperada);
+        var empleadoPersistido = eventoPersistido
+            .GetProperty("InformacionEmpleado").Deserialize<Empleado>();
+        empleadoPersistido.Should().Be(empleadoEsperado);
 
         // Issue #288: el mensaje crudo publicado arriba (objeto anonimo) no lleva "Descripcion" -- el
         // dato derivado solo lo asigna Programacion en produccion (CatalogoTurnos/FranjaOrdinaria/
         // SubFranja), no este payload sintetico. Los DTOs lo normalizan a cadena vacia; el campo se
         // excluye de la comparacion estructural porque aqui no hay texto real que verificar (esa
         // normalizacion la cubre ProgramacionTurnoDiarioSolicitadaPortabilidadTests).
-        var detalleTurnoEsperado = new DetalleTurno("[TEST] Turno Smoke SB", [
-            new DetalleFranjaOrdinaria(
+        var turnoDiarioEsperado = new TurnoDiario("[TEST] Turno Smoke SB", [
+            new FranjaProgramada(
                 new TimeOnly(8, 0), new TimeOnly(16, 0), 0,
-                Array.Empty<DetalleSubFranja>(), Array.Empty<DetalleSubFranja>(), "")
+                Array.Empty<SubFranjaProgramada>(), Array.Empty<SubFranjaProgramada>(), "")
         ], "");
-        var detalleTurnoPersistido = eventoPersistido
-            .GetProperty("DetalleTurno").Deserialize<DetalleTurno>();
-        detalleTurnoPersistido.Should().BeEquivalentTo(detalleTurnoEsperado,
+        var turnoDiarioPersistido = eventoPersistido
+            .GetProperty("DetalleTurno").Deserialize<TurnoDiario>();
+        turnoDiarioPersistido.Should().BeEquivalentTo(turnoDiarioEsperado,
             opciones => opciones.ExcludingMembersNamed("Descripcion"));
 
         // Assert HU-131 CA-1/CA-2: DiaCalculado publicado al topic dia-calculado.
@@ -213,27 +217,30 @@ public class AsignarTurnoViaSbSmokeTests(ServiceBusFixture serviceBus, PostgresF
             $"el evento {tipoEvento} con SolicitudId {solicitudId} deberia existir. " +
             $"Si falla, ServiceBusDeserializador no esta usando PropertyNameCaseInsensitive=true.");
 
-        // Assert detallado: verificar que los datos se mapearon correctamente
+        // Assert detallado: verificar que los datos se mapearon correctamente.
+        // Issue #322: el evento persistido tipa InformacionEmpleado/DetalleTurno con Empleado/
+        // TurnoDiario (ControlHoras.DomainEvents), no con los tipos de bus -- ver comentario del
+        // primer test de esta clase.
         var eventoPersistido = await postgres.ObtenerEventoAsync<JsonElement>(
             SchemaControlHoras, streamId, tipoEvento,
             "SolicitudId", solicitudId.ToString(), TimeSpan.FromSeconds(5));
 
-        var infoEmpleadoEsperada = new InformacionEmpleado(
+        var empleadoEsperado = new Empleado(
             empleadoId, "CC", "111222333", "[TEST] Smoke Wolverine", "[TEST] CamelCase Fix");
-        var infoEmpleadoPersistida = eventoPersistido
-            .GetProperty("InformacionEmpleado").Deserialize<InformacionEmpleado>();
-        infoEmpleadoPersistida.Should().Be(infoEmpleadoEsperada);
+        var empleadoPersistido = eventoPersistido
+            .GetProperty("InformacionEmpleado").Deserialize<Empleado>();
+        empleadoPersistido.Should().Be(empleadoEsperado);
 
         // Issue #288: mismo motivo que el test anterior -- el mensaje crudo en camelCase no lleva
         // "descripcion", asi que se excluye de la comparacion estructural.
-        var detalleTurnoEsperado = new DetalleTurno("[TEST] Turno Wolverine CamelCase", [
-            new DetalleFranjaOrdinaria(
+        var turnoDiarioEsperado = new TurnoDiario("[TEST] Turno Wolverine CamelCase", [
+            new FranjaProgramada(
                 new TimeOnly(7, 0), new TimeOnly(15, 0), 0,
-                Array.Empty<DetalleSubFranja>(), Array.Empty<DetalleSubFranja>(), "")
+                Array.Empty<SubFranjaProgramada>(), Array.Empty<SubFranjaProgramada>(), "")
         ], "");
-        var detalleTurnoPersistido = eventoPersistido
-            .GetProperty("DetalleTurno").Deserialize<DetalleTurno>();
-        detalleTurnoPersistido.Should().BeEquivalentTo(detalleTurnoEsperado,
+        var turnoDiarioPersistido = eventoPersistido
+            .GetProperty("DetalleTurno").Deserialize<TurnoDiario>();
+        turnoDiarioPersistido.Should().BeEquivalentTo(turnoDiarioEsperado,
             opciones => opciones.ExcludingMembersNamed("Descripcion"));
 
         // Assert HU-131: DiaCalculado publicado incluso cuando el mensaje llega en camelCase.

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests.csproj
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests.csproj
@@ -20,6 +20,10 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Bitakora.ControlAsistencia.PublicEvents\Bitakora.ControlAsistencia.PublicEvents.csproj" />
     <ProjectReference Include="..\..\src\Bitakora.ControlAsistencia.PrivateEvents\Bitakora.ControlAsistencia.PrivateEvents.csproj" />
+    <!-- Issue #322: TurnoDiarioAsignado persiste Empleado/TurnoDiario propios de este ensamblado
+         (payload por rol, CA-ADR-0029 decision #5). El smoke test verifica el evento realmente
+         persistido con su tipo dueno, no con un tipo de bus que ya no describe ese payload. -->
+    <ProjectReference Include="..\..\src\Bitakora.ControlAsistencia.ControlHoras.DomainEvents\Bitakora.ControlAsistencia.ControlHoras.DomainEvents.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoRegistroDeMarcacionCreado/DepurarAlAdicionarMarcacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoRegistroDeMarcacionCreado/DepurarAlAdicionarMarcacionTests.cs
@@ -10,7 +10,6 @@ using Bitakora.ControlAsistencia.ControlHoras.AdicionarMarcacionCuandoRegistroDe
 using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 using Bitakora.ControlAsistencia.ControlHoras.Entities;
 using Bitakora.ControlAsistencia.PrivateEvents.ControlHoras;
-using Bitakora.ControlAsistencia.PrivateEvents.Programacion;
 using Bitakora.ControlAsistencia.PublicEvents.ControlHoras;
 using Bitakora.ControlAsistencia.PublicEvents.Empleados;
 using Cosmos.EventDriven.Abstractions;
@@ -26,20 +25,24 @@ public class DepurarAlAdicionarMarcacionTests : PrivateEventHandlerAsyncTest<Reg
     private static readonly string StreamId = $"{EmpleadoId}:{Fecha:yyyy-MM-dd}";
     private static readonly string StreamIdDiaAnterior = $"{EmpleadoId}:2026-03-14";
 
-    // Empleado para construir TurnoDiarioAsignado en Given
-    private static readonly InformacionEmpleado Empleado = new(
+    // Issue #322: Empleado (ControlHoras.DomainEvents) para construir TurnoDiarioAsignado en Given.
+    private static readonly Empleado EmpleadoPersistido = new(
+        EmpleadoId, "CC", "1234567890", "Luis Augusto", "Barreto");
+
+    // InformacionEmpleado (PublicEvents) -- lo que espera DiaCalculado, evento publico sin cambios.
+    private static readonly InformacionEmpleado EmpleadoPublico = new(
         EmpleadoId, "CC", "1234567890", "Luis Augusto", "Barreto");
     private static readonly Guid SolicitudId = Guid.Parse("019600c0-0000-7000-8000-000000000001");
 
     // CA-1: franja unica 06:00-14:00
     // Issue #288: Descripcion (dato derivado) es irrelevante para estos tests -> placeholder "".
-    private static readonly DetalleFranjaOrdinaria Franja06_14 =
+    private static readonly FranjaProgramada Franja06_14 =
         new(new TimeOnly(6, 0), new TimeOnly(14, 0), 0, [], [], "");
 
     // CA-3: turno partido con dos franjas
-    private static readonly DetalleFranjaOrdinaria Franja06_12 =
+    private static readonly FranjaProgramada Franja06_12 =
         new(new TimeOnly(6, 0), new TimeOnly(12, 0), 0, [], [], "");
-    private static readonly DetalleFranjaOrdinaria Franja14_18 =
+    private static readonly FranjaProgramada Franja14_18 =
         new(new TimeOnly(14, 0), new TimeOnly(18, 0), 0, [], [], "");
 
     // Timestamps de marcaciones (fuera de ventana nocturna: >= 04:00)
@@ -58,8 +61,8 @@ public class DepurarAlAdicionarMarcacionTests : PrivateEventHandlerAsyncTest<Reg
     private static MarcacionAdicionada CrearMarcacionAdicionada(DateTime timestamp) =>
         new(StreamId, EmpleadoId, timestamp, "ENTRADA", "DEV-001");
 
-    private static TurnoDiarioAsignado CrearTurnoDiarioAsignado(DetalleTurno detalleTurno) =>
-        new(StreamId, Empleado, Fecha, detalleTurno, SolicitudId);
+    private static TurnoDiarioAsignado CrearTurnoDiarioAsignado(TurnoDiario detalleTurno) =>
+        new(StreamId, EmpleadoPersistido, Fecha, detalleTurno, SolicitudId);
 
     // Issue #184: oraculo independiente de una linea de trazabilidad (memoria de calculo). Se arma a
     // mano desde IntervaloTemporal.ToString() (primitiva ya probada) y la etiqueta traducida del recurso
@@ -75,7 +78,7 @@ public class DepurarAlAdicionarMarcacionTests : PrivateEventHandlerAsyncTest<Reg
     [Fact]
     public async Task RegistroDeMarcacionCreado_CalculaControlFranja_CuandoHayTurnoYLlegaMarcacion()
     {
-        var turnoUnico = new DetalleTurno("Turno Manana", [Franja06_14], "");
+        var turnoUnico = new TurnoDiario("Turno Manana", [Franja06_14], "");
         Given(StreamId, CrearTurnoDiarioAsignado(turnoUnico));
 
         await WhenAsync(CrearRegistroDeMarcacionCreado(Timestamp07_00));
@@ -92,12 +95,12 @@ public class DepurarAlAdicionarMarcacionTests : PrivateEventHandlerAsyncTest<Reg
         // que MinutosPorConcepto viaja vacio. Nota del issue (riesgo aceptado): el contrato plano ya no
         // distingue "franja anomala" de "dia sin horas"; ambos publican el mismo diccionario vacio.
         ThenIsPublishedPublicly(new DiaCalculado(
-            Empleado,
+            EmpleadoPublico,
             Fecha,
             new HorasDiscriminadas(new Dictionary<string, int>(), [])));
     }
 
-    // CA-2 (HU-123): sin turno previo, la marcacion crea el aggregate sin DetalleTurno.
+    // CA-2 (HU-123): sin turno previo, la marcacion crea el aggregate sin TurnoDiario.
     //        Depurar() retorna lista vacia porque DepuradorDeMarcaciones.Depurar(null,...) -> [].
     //        Verifica el caso "marcacion llega antes del turno" donde el aggregate
     //        se inicia solo con marcacion y no hay nada que depurar.
@@ -105,7 +108,7 @@ public class DepurarAlAdicionarMarcacionTests : PrivateEventHandlerAsyncTest<Reg
     [Fact]
     public async Task RegistroDeMarcacionCreado_DejaControlesDeFranjaVacios_CuandoNoHayTurnoPrevio()
     {
-        // Sin Given - el aggregate se crea solo con la marcacion (DetalleTurno queda null)
+        // Sin Given - el aggregate se crea solo con la marcacion (TurnoDiario queda null)
         await WhenAsync(CrearRegistroDeMarcacionCreado(Timestamp07_00));
 
         Then(StreamId, CrearMarcacionAdicionada(Timestamp07_00));
@@ -129,7 +132,7 @@ public class DepurarAlAdicionarMarcacionTests : PrivateEventHandlerAsyncTest<Reg
     [Fact]
     public async Task RegistroDeMarcacionCreado_RecalculaControlesDeFranjaCompletos_CuandoHayTurnoPartidoYMarcacionesAcumuladas()
     {
-        var turnoPartido = new DetalleTurno("Turno Partido", [Franja06_12, Franja14_18], "");
+        var turnoPartido = new TurnoDiario("Turno Partido", [Franja06_12, Franja14_18], "");
         Given(StreamId,
             CrearTurnoDiarioAsignado(turnoPartido),
             CrearMarcacionAdicionada(Timestamp05_50),
@@ -161,7 +164,7 @@ public class DepurarAlAdicionarMarcacionTests : PrivateEventHandlerAsyncTest<Reg
         // con LineaConcepto desde su intervalo y la etiqueta traducida. F2 es anomala (Salida null): no
         // aporta intervalos ni lineas.
         ThenIsPublishedPublicly(new DiaCalculado(
-            Empleado,
+            EmpleadoPublico,
             Fecha,
             new HorasDiscriminadas(
                 new Dictionary<string, int>

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoRegistroDeMarcacionCreado/DesgloseHorasTrasAdicionarMarcacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoRegistroDeMarcacionCreado/DesgloseHorasTrasAdicionarMarcacionTests.cs
@@ -17,8 +17,6 @@ using Bitakora.ControlAsistencia.ControlHoras.AdicionarMarcacionCuandoRegistroDe
 using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 using Bitakora.ControlAsistencia.ControlHoras.Entities;
 using Bitakora.ControlAsistencia.PrivateEvents.ControlHoras;
-using Bitakora.ControlAsistencia.PrivateEvents.Programacion;
-using Bitakora.ControlAsistencia.PublicEvents.Empleados;
 using Cosmos.EventDriven.Abstractions;
 using Cosmos.EventSourcing.Testing.Utilities;
 
@@ -31,15 +29,16 @@ public class DesgloseHorasTrasAdicionarMarcacionTests : PrivateEventHandlerAsync
     private static readonly DateOnly Fecha = new(2026, 3, 15);
     private static readonly string StreamId = $"{EmpleadoId}:{Fecha:yyyy-MM-dd}";
 
-    private static readonly InformacionEmpleado Empleado = new(
+    // Issue #322: Empleado (ControlHoras.DomainEvents) -- el tipo que persiste TurnoDiarioAsignado.
+    private static readonly Empleado Empleado = new(
         EmpleadoId, "CC", "1234567890", "Luis Augusto", "Barreto");
     private static readonly Guid SolicitudId = Guid.Parse("019600c0-0000-7000-8000-000000000003");
 
     // CA-1: turno partido con dos franjas ordinarias 08:00-12:00 y 14:00-18:00
     // Issue #288: Descripcion (dato derivado) es irrelevante para estos tests -> placeholder "".
-    private static readonly DetalleFranjaOrdinaria Franja08_12 =
+    private static readonly FranjaProgramada Franja08_12 =
         new(new TimeOnly(8, 0), new TimeOnly(12, 0), 0, [], [], "");
-    private static readonly DetalleFranjaOrdinaria Franja14_18 =
+    private static readonly FranjaProgramada Franja14_18 =
         new(new TimeOnly(14, 0), new TimeOnly(18, 0), 0, [], [], "");
 
     // Timestamps de marcaciones (fuera de ventana nocturna: >= 04:00)
@@ -58,7 +57,7 @@ public class DesgloseHorasTrasAdicionarMarcacionTests : PrivateEventHandlerAsync
     private static MarcacionAdicionada CrearMarcacionAdicionada(DateTime timestamp) =>
         new(StreamId, EmpleadoId, timestamp, "ENTRADA", "DEV-001");
 
-    private static TurnoDiarioAsignado CrearTurnoDiarioAsignado(DetalleTurno detalleTurno) =>
+    private static TurnoDiarioAsignado CrearTurnoDiarioAsignado(TurnoDiario detalleTurno) =>
         new(StreamId, Empleado, Fecha, detalleTurno, SolicitudId);
 
     // CA-1: con TurnoDiarioAsignado (turno partido 08:00-12:00 y 14:00-18:00) previo y
@@ -68,7 +67,7 @@ public class DesgloseHorasTrasAdicionarMarcacionTests : PrivateEventHandlerAsync
     [Fact]
     public async Task RegistroDeMarcacionCreado_RecalculaDesgloseHoras_CuandoMarcacionCompletaUltimaFranja()
     {
-        var turnoPartido = new DetalleTurno("Turno Partido", [Franja08_12, Franja14_18], "");
+        var turnoPartido = new TurnoDiario("Turno Partido", [Franja08_12, Franja14_18], "");
         Given(StreamId,
             CrearTurnoDiarioAsignado(turnoPartido),
             CrearMarcacionAdicionada(Timestamp08_00),

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoRegistroDeMarcacionCreado/RegistroDeMarcacionCreadoEventHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoRegistroDeMarcacionCreado/RegistroDeMarcacionCreadoEventHandlerTests.cs
@@ -6,8 +6,6 @@ using Bitakora.ControlAsistencia.ControlHoras.AdicionarMarcacionCuandoRegistroDe
 using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 using Bitakora.ControlAsistencia.ControlHoras.Entities;
 using Bitakora.ControlAsistencia.PrivateEvents.ControlHoras;
-using Bitakora.ControlAsistencia.PrivateEvents.Programacion;
-using Bitakora.ControlAsistencia.PublicEvents.Empleados;
 using Cosmos.EventDriven.Abstractions;
 using Cosmos.EventSourcing.Testing.Utilities;
 
@@ -59,9 +57,9 @@ public class RegistroDeMarcacionCreadoEventHandlerTests
         await WhenAsync(CrearRegistroDeMarcacionCreado(TimestampFueraDeVentana));
 
         Then(StreamIdDia15, CrearMarcacionAdicionada(StreamIdDia15, TimestampFueraDeVentana));
-        And<ControlDiarioAggregateRoot, InformacionEmpleado?>(
+        And<ControlDiarioAggregateRoot, Empleado?>(
             StreamIdDia15, c => c.InformacionEmpleado, null);
-        And<ControlDiarioAggregateRoot, DetalleTurno?>(
+        And<ControlDiarioAggregateRoot, TurnoDiario?>(
             StreamIdDia15, c => c.DetalleTurno, null);
         And<ControlDiarioAggregateRoot, int>(
             StreamIdDia15, c => c.Marcaciones.Count, 1);

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/DepurarAlAsignarTurnoTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/DepurarAlAsignarTurnoTests.cs
@@ -22,20 +22,28 @@ public class DepurarAlAsignarTurnoTests
     private static readonly Guid SolicitudId =
         Guid.Parse("019600c0-0000-7000-8000-000000000002");
 
-    private static readonly InformacionEmpleado Empleado = new(
+    // Issue #322: Empleado (ControlHoras.DomainEvents) -- el tipo que persiste TurnoDiarioAsignado.
+    private static readonly Empleado Empleado = new(
+        "EMP-001", "CC", "1234567890", "Luis Augusto", "Barreto");
+
+    // InformacionEmpleado (PublicEvents) -- lo que espera DiaCalculado, evento publico sin cambios.
+    private static readonly InformacionEmpleado EmpleadoPublico = new(
         "EMP-001", "CC", "1234567890", "Luis Augusto", "Barreto");
 
     // Mismo empleado, en la forma con que llega dentro del evento privado; el handler lo mapea
-    // a InformacionEmpleado para TurnoDiarioAsignado (CA-ADR-0029 decision #5).
+    // a Empleado para TurnoDiarioAsignado (CA-ADR-0029 decision #5).
     private static readonly DetalleEmpleado EmpleadoDetalle = new(
         "EMP-001", "CC", "1234567890", "Luis Augusto", "Barreto");
 
     private static readonly DateOnly Fecha = new(2026, 3, 15);
     private static readonly string StreamId = $"{Empleado.EmpleadoId}:{Fecha:yyyy-MM-dd}";
 
-    // CA-4: franja unica 06:00-14:00 para el turno asignado
-    // Issue #288: Descripcion (dato derivado) es irrelevante para estos tests -> placeholder "".
-    private static readonly DetalleFranjaOrdinaria Franja06_14 =
+    // CA-4: franja unica 06:00-14:00 para el turno asignado -- FranjaProgramada (ControlHoras.DomainEvents)
+    // es lo que el ControlDiario persiste; DetalleFranjaOrdinaria (PrivateEvents) es lo que trae el
+    // evento privado entrante. Issue #288: Descripcion (dato derivado) irrelevante -> placeholder "".
+    private static readonly FranjaProgramada Franja06_14 =
+        new(new TimeOnly(6, 0), new TimeOnly(14, 0), 0, [], [], "");
+    private static readonly DetalleFranjaOrdinaria Franja06_14Detalle =
         new(new TimeOnly(6, 0), new TimeOnly(14, 0), 0, [], [], "");
 
     // Timestamps de las marcaciones que llegan antes que el turno
@@ -49,8 +57,8 @@ public class DepurarAlAsignarTurnoTests
     private static ProgramacionTurnoDiarioSolicitada CrearEvento(DetalleTurno detalleTurno) =>
         new(SolicitudId, EmpleadoDetalle, Fecha, detalleTurno);
 
-    private static TurnoDiarioAsignado CrearTurnoDiarioAsignado(DetalleTurno detalleTurno) =>
-        new(StreamId, Empleado, Fecha, detalleTurno, SolicitudId);
+    private static TurnoDiarioAsignado CrearTurnoDiarioAsignado(TurnoDiario turnoDiario) =>
+        new(StreamId, Empleado, Fecha, turnoDiario, SolicitudId);
 
     private static MarcacionAdicionada CrearMarcacionAdicionada(DateTime timestamp) =>
         new(StreamId, Empleado.EmpleadoId, timestamp, "ENTRADA", "DEV-001");
@@ -72,13 +80,14 @@ public class DepurarAlAsignarTurnoTests
     [Fact]
     public async Task ProgramacionTurnoDiarioSolicitada_CalculaControlFranja_CuandoMarcacionesLlegaronAntesQueTurno()
     {
-        var turnoConFranjaUnica = new DetalleTurno("Turno Manana", [Franja06_14], "");
+        var turnoConFranjaUnicaDetalle = new DetalleTurno("Turno Manana", [Franja06_14Detalle], "");
         Given(StreamId,
             CrearMarcacionAdicionada(Timestamp07_00),
             CrearMarcacionAdicionada(Timestamp15_00));
 
-        await WhenAsync(CrearEvento(turnoConFranjaUnica));
+        await WhenAsync(CrearEvento(turnoConFranjaUnicaDetalle));
 
+        var turnoConFranjaUnica = new TurnoDiario("Turno Manana", [Franja06_14], "");
         Then(StreamId, CrearTurnoDiarioAsignado(turnoConFranjaUnica));
         And<ControlDiarioAggregateRoot, IReadOnlyList<ControlFranja>>(
             StreamId,
@@ -97,7 +106,7 @@ public class DepurarAlAsignarTurnoTests
         // unico concepto del dia (ordinaria 07:00-14:00, DominicalFestivaDiurna) genera una sola linea,
         // construida con LineaConcepto desde el intervalo 07:00-14:00 y la etiqueta traducida del recurso.
         ThenIsPublishedPublicly(new DiaCalculado(
-            Empleado,
+            EmpleadoPublico,
             Fecha,
             new HorasDiscriminadas(
                 new Dictionary<string, int> { ["DominicalFestivaDiurna"] = 420 },
@@ -111,10 +120,11 @@ public class DepurarAlAsignarTurnoTests
     public async Task ProgramacionTurnoDiarioSolicitada_PublicaDiaCalculado_CuandoNoHayMarcacionesPrevias()
     {
         // Sin Given - stream nuevo, sin marcaciones previas
-        var turnoConFranjaUnica = new DetalleTurno("Turno Manana", [Franja06_14], "");
+        var turnoConFranjaUnicaDetalle = new DetalleTurno("Turno Manana", [Franja06_14Detalle], "");
 
-        await WhenAsync(CrearEvento(turnoConFranjaUnica));
+        await WhenAsync(CrearEvento(turnoConFranjaUnicaDetalle));
 
+        var turnoConFranjaUnica = new TurnoDiario("Turno Manana", [Franja06_14], "");
         Then(StreamId, CrearTurnoDiarioAsignado(turnoConFranjaUnica));
         And<ControlDiarioAggregateRoot, IReadOnlyList<ControlFranja>>(
             StreamId,
@@ -125,7 +135,7 @@ public class DepurarAlAsignarTurnoTests
         // Issue #183 CA-6: la franja anomala no aporta minutos calculables y no hay retardo, asi que
         // MinutosPorConcepto viaja vacio. El contrato plano no lleva senal de anomalia (riesgo aceptado).
         ThenIsPublishedPublicly(new DiaCalculado(
-            Empleado,
+            EmpleadoPublico,
             Fecha,
             new HorasDiscriminadas(new Dictionary<string, int>(), [])));
     }
@@ -136,10 +146,11 @@ public class DepurarAlAsignarTurnoTests
     public async Task ProgramacionTurnoDiarioSolicitada_PublicaDiaCalculado_CuandoTurnoNoTieneFranjas()
     {
         // Sin Given - stream nuevo, turno sin franjas ordinarias
-        var turnoSinFranjas = new DetalleTurno("Turno Sin Franjas", [], "");
+        var turnoSinFranjasDetalle = new DetalleTurno("Turno Sin Franjas", [], "");
 
-        await WhenAsync(CrearEvento(turnoSinFranjas));
+        await WhenAsync(CrearEvento(turnoSinFranjasDetalle));
 
+        var turnoSinFranjas = new TurnoDiario("Turno Sin Franjas", [], "");
         Then(StreamId, CrearTurnoDiarioAsignado(turnoSinFranjas));
         And<ControlDiarioAggregateRoot, int>(
             StreamId,
@@ -148,7 +159,7 @@ public class DepurarAlAsignarTurnoTests
         // HU-131 CA-2: DiaCalculado se publica aunque el turno no tenga franjas.
         // Issue #183 CA-6: sin franjas que consolidar ni retardo, MinutosPorConcepto viaja vacio.
         ThenIsPublishedPublicly(new DiaCalculado(
-            Empleado,
+            EmpleadoPublico,
             Fecha,
             new HorasDiscriminadas(new Dictionary<string, int>(), [])));
     }

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/DesgloseHorasTrasAsignarTurnoTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/DesgloseHorasTrasAsignarTurnoTests.cs
@@ -13,7 +13,6 @@ using Bitakora.ControlAsistencia.ControlHoras.AsignarTurnoCuandoProgramacionTurn
 using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 using Bitakora.ControlAsistencia.ControlHoras.Entities;
 using Bitakora.ControlAsistencia.PrivateEvents.Programacion;
-using Bitakora.ControlAsistencia.PublicEvents.Empleados;
 using Cosmos.EventDriven.Abstractions;
 using Cosmos.EventSourcing.Testing.Utilities;
 
@@ -26,26 +25,34 @@ public class DesgloseHorasTrasAsignarTurnoTests
     private static readonly Guid SolicitudId =
         Guid.Parse("019600c0-0000-7000-8000-000000000004");
 
-    private static readonly InformacionEmpleado Empleado = new(
+    // Issue #322: Empleado (ControlHoras.DomainEvents) -- el tipo que persiste TurnoDiarioAsignado.
+    private static readonly Empleado Empleado = new(
         "EMP-001", "CC", "1234567890", "Luis Augusto", "Barreto");
 
     // Mismo empleado, en la forma con que llega dentro del evento privado; el handler lo mapea
-    // a InformacionEmpleado para TurnoDiarioAsignado (CA-ADR-0029 decision #5).
+    // a Empleado para TurnoDiarioAsignado (CA-ADR-0029 decision #5).
     private static readonly DetalleEmpleado EmpleadoDetalle = new(
         "EMP-001", "CC", "1234567890", "Luis Augusto", "Barreto");
 
     private static readonly DateOnly Fecha = new(2026, 3, 15);
     private static readonly string StreamId = $"{Empleado.EmpleadoId}:{Fecha:yyyy-MM-dd}";
 
-    // CA-3: franja unica 06:00-14:00 para el turno asignado
-    // Issue #288: Descripcion (dato derivado) es irrelevante para estos tests -> placeholder "".
-    private static readonly DetalleFranjaOrdinaria Franja06_14 =
+    // CA-3: franja unica 06:00-14:00 para el turno asignado -- FranjaProgramada (ControlHoras.DomainEvents)
+    // es lo que el ControlDiario persiste; DetalleFranjaOrdinaria (PrivateEvents) es lo que trae el
+    // evento privado entrante. Issue #288: Descripcion (dato derivado) irrelevante -> placeholder "".
+    private static readonly FranjaProgramada Franja06_14 =
+        new(new TimeOnly(6, 0), new TimeOnly(14, 0), 0, [], [], "");
+    private static readonly DetalleFranjaOrdinaria Franja06_14Detalle =
         new(new TimeOnly(6, 0), new TimeOnly(14, 0), 0, [], [], "");
 
     // CA-4: turno partido con dos franjas ordinarias (ambas quedaran anomalas sin marcaciones)
-    private static readonly DetalleFranjaOrdinaria Franja06_12 =
+    private static readonly FranjaProgramada Franja06_12 =
         new(new TimeOnly(6, 0), new TimeOnly(12, 0), 0, [], [], "");
-    private static readonly DetalleFranjaOrdinaria Franja14_18 =
+    private static readonly DetalleFranjaOrdinaria Franja06_12Detalle =
+        new(new TimeOnly(6, 0), new TimeOnly(12, 0), 0, [], [], "");
+    private static readonly FranjaProgramada Franja14_18 =
+        new(new TimeOnly(14, 0), new TimeOnly(18, 0), 0, [], [], "");
+    private static readonly DetalleFranjaOrdinaria Franja14_18Detalle =
         new(new TimeOnly(14, 0), new TimeOnly(18, 0), 0, [], [], "");
 
     // Timestamps de las marcaciones que llegan antes que el turno (CA-3)
@@ -58,8 +65,8 @@ public class DesgloseHorasTrasAsignarTurnoTests
     private static ProgramacionTurnoDiarioSolicitada CrearEvento(DetalleTurno detalleTurno) =>
         new(SolicitudId, EmpleadoDetalle, Fecha, detalleTurno);
 
-    private static TurnoDiarioAsignado CrearTurnoDiarioAsignado(DetalleTurno detalleTurno) =>
-        new(StreamId, Empleado, Fecha, detalleTurno, SolicitudId);
+    private static TurnoDiarioAsignado CrearTurnoDiarioAsignado(TurnoDiario turnoDiario) =>
+        new(StreamId, Empleado, Fecha, turnoDiario, SolicitudId);
 
     private static MarcacionAdicionada CrearMarcacionAdicionada(DateTime timestamp) =>
         new(StreamId, Empleado.EmpleadoId, timestamp, "ENTRADA", "DEV-001");
@@ -75,9 +82,10 @@ public class DesgloseHorasTrasAsignarTurnoTests
             CrearMarcacionAdicionada(Timestamp07_00),
             CrearMarcacionAdicionada(Timestamp15_00));
 
-        var turnoFranjaUnica = new DetalleTurno("Turno Manana", [Franja06_14], "");
-        await WhenAsync(CrearEvento(turnoFranjaUnica));
+        var turnoFranjaUnicaDetalle = new DetalleTurno("Turno Manana", [Franja06_14Detalle], "");
+        await WhenAsync(CrearEvento(turnoFranjaUnicaDetalle));
 
+        var turnoFranjaUnica = new TurnoDiario("Turno Manana", [Franja06_14], "");
         Then(StreamId, CrearTurnoDiarioAsignado(turnoFranjaUnica));
 
         // Depuracion esperada: una franja con Entrada=07:00 y Salida=15:00 (no anomala).
@@ -120,10 +128,11 @@ public class DesgloseHorasTrasAsignarTurnoTests
     public async Task ProgramacionTurnoDiarioSolicitada_DejaDesgloseHorasConFranjasAnomalas_CuandoTurnoSinMarcaciones()
     {
         // Sin Given - stream nuevo, turno partido sin marcaciones previas
-        var turnoPartido = new DetalleTurno("Turno Partido", [Franja06_12, Franja14_18], "");
+        var turnoPartidoDetalle = new DetalleTurno("Turno Partido", [Franja06_12Detalle, Franja14_18Detalle], "");
 
-        await WhenAsync(CrearEvento(turnoPartido));
+        await WhenAsync(CrearEvento(turnoPartidoDetalle));
 
+        var turnoPartido = new TurnoDiario("Turno Partido", [Franja06_12, Franja14_18], "");
         Then(StreamId, CrearTurnoDiarioAsignado(turnoPartido));
 
         // FranjasAnomalas = 2 (las dos franjas ordinarias del turno, ambas sin entrada ni salida).

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/EmpleadoIgualdadTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/EmpleadoIgualdadTests.cs
@@ -1,0 +1,35 @@
+// Issue #322: paridad de campos e igualdad de Empleado (ControlHoras.DomainEvents) con
+// InformacionEmpleado (PublicEvents.Empleados) y DetalleEmpleado (PrivateEvents.Programacion)
+// -- payload por rol, CA-ADR-0029 decision #5.
+// CA-1: todos los campos son string, asi que la igualdad por valor del record por defecto ya es
+// correcta y no lleva Equals/GetHashCode custom. Este test congela ese contrato: el dia que alguien
+// agregue una coleccion al record (o un Equals custom incompleto), la igualdad deja de cumplirse
+// aqui. Espejo de EmpleadoIgualdadTests (Programacion.Tests, issue #319).
+
+using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
+using Bitakora.ControlAsistencia.ControlHoras.Tests.ValueObjects;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Tests.AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction.Eventos;
+
+public class EmpleadoIgualdadTests : IgualdadTestBase<Empleado>
+{
+    protected override Empleado CrearInstancia() =>
+        new("EMP-001", "CC", "1234567890", "Luis Augusto", "Barreto");
+
+    protected override Empleado CrearInstanciaCopia() =>
+        new("EMP-001", "CC", "1234567890", "Luis Augusto", "Barreto");
+
+    protected override IEnumerable<(string, Empleado)> CrearInstanciasDiferentes()
+    {
+        yield return ("EmpleadoId",
+            new Empleado("EMP-002", "CC", "1234567890", "Luis Augusto", "Barreto"));
+        yield return ("TipoIdentificacion",
+            new Empleado("EMP-001", "CE", "1234567890", "Luis Augusto", "Barreto"));
+        yield return ("NumeroIdentificacion",
+            new Empleado("EMP-001", "CC", "9999999999", "Luis Augusto", "Barreto"));
+        yield return ("Nombres",
+            new Empleado("EMP-001", "CC", "1234567890", "Otro Nombre", "Barreto"));
+        yield return ("Apellidos",
+            new Empleado("EMP-001", "CC", "1234567890", "Luis Augusto", "Otro Apellido"));
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/FranjaProgramadaIgualdadTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/FranjaProgramadaIgualdadTests.cs
@@ -1,0 +1,69 @@
+// Issue #322: paridad de campos e igualdad de FranjaProgramada (ControlHoras.DomainEvents) con
+// DetalleFranjaOrdinaria (PrivateEvents.Programacion) -- payload por rol, CA-ADR-0029 decision #5.
+// CA-1: FranjaProgramada replica la semantica de igualdad del original: Descansos/Extras
+// (IReadOnlyList) se comparan POR VALOR (SequenceEqual), no por referencia (MEF-ADR-0012). Mismo
+// patron que DetalleFranjaOrdinariaIgualdadTests (PrivateEvents.Tests), del cual este archivo es
+// espejo deliberado.
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
+using Bitakora.ControlAsistencia.ControlHoras.Tests.ValueObjects;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Tests.AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction.Eventos;
+
+public class FranjaProgramadaIgualdadTests : IgualdadTestBase<FranjaProgramada>
+{
+    private static SubFranjaProgramada Descanso() =>
+        new(new TimeOnly(12, 0), new TimeOnly(13, 0), 0, 0, "");
+
+    private static SubFranjaProgramada Extra() =>
+        new(new TimeOnly(17, 0), new TimeOnly(19, 0), 0, 0, "");
+
+    protected override FranjaProgramada CrearInstancia() =>
+        new(new TimeOnly(8, 0), new TimeOnly(17, 0), 0, [Descanso()], [Extra()], "");
+
+    protected override FranjaProgramada CrearInstanciaCopia() =>
+        new(new TimeOnly(8, 0), new TimeOnly(17, 0), 0, [Descanso()], [Extra()], "");
+
+    protected override IEnumerable<(string, FranjaProgramada)> CrearInstanciasDiferentes()
+    {
+        yield return ("HoraInicio",
+            new FranjaProgramada(new TimeOnly(7, 0), new TimeOnly(17, 0), 0, [Descanso()], [Extra()], ""));
+        yield return ("HoraFin",
+            new FranjaProgramada(new TimeOnly(8, 0), new TimeOnly(18, 0), 0, [Descanso()], [Extra()], ""));
+        yield return ("DiaOffsetFin",
+            new FranjaProgramada(new TimeOnly(8, 0), new TimeOnly(17, 0), 1, [Descanso()], [Extra()], ""));
+        yield return ("Descansos",
+            new FranjaProgramada(new TimeOnly(8, 0), new TimeOnly(17, 0), 0, [], [Extra()], ""));
+        yield return ("Extras",
+            new FranjaProgramada(new TimeOnly(8, 0), new TimeOnly(17, 0), 0, [Descanso()], [], ""));
+    }
+
+    // Cobertura especifica del override: las listas se comparan por valor, no por referencia.
+
+    [Fact]
+    public void Equals_RetornaTrue_CuandoListasSonInstanciasDiferentesConMismoContenido()
+    {
+        var a = new FranjaProgramada(new TimeOnly(8, 0), new TimeOnly(17, 0), 0,
+            [new SubFranjaProgramada(new TimeOnly(12, 0), new TimeOnly(13, 0), 0, 0, "")],
+            [new SubFranjaProgramada(new TimeOnly(17, 0), new TimeOnly(19, 0), 0, 0, "")], "");
+        var b = new FranjaProgramada(new TimeOnly(8, 0), new TimeOnly(17, 0), 0,
+            [new SubFranjaProgramada(new TimeOnly(12, 0), new TimeOnly(13, 0), 0, 0, "")],
+            [new SubFranjaProgramada(new TimeOnly(17, 0), new TimeOnly(19, 0), 0, 0, "")], "");
+
+        a.Equals(b).Should().BeTrue();
+    }
+
+    [Fact]
+    public void GetHashCode_RetornaMismoHash_CuandoListasSonInstanciasDiferentesConMismoContenido()
+    {
+        var a = new FranjaProgramada(new TimeOnly(8, 0), new TimeOnly(17, 0), 0,
+            [new SubFranjaProgramada(new TimeOnly(12, 0), new TimeOnly(13, 0), 0, 0, "")],
+            [], "");
+        var b = new FranjaProgramada(new TimeOnly(8, 0), new TimeOnly(17, 0), 0,
+            [new SubFranjaProgramada(new TimeOnly(12, 0), new TimeOnly(13, 0), 0, 0, "")],
+            [], "");
+
+        a.GetHashCode().Should().Be(b.GetHashCode());
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/SubFranjaProgramadaIgualdadTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/SubFranjaProgramadaIgualdadTests.cs
@@ -1,0 +1,52 @@
+// Issue #322: paridad de campos e igualdad de SubFranjaProgramada (ControlHoras.DomainEvents) con
+// DetalleSubFranja (PrivateEvents.Programacion) -- payload por rol, CA-ADR-0029 decision #5.
+// CA-1: SubFranjaProgramada replica la semantica de igualdad del original: Descripcion (dato
+// derivado, texto del formato tecnico) EXCLUIDA de Equals/GetHashCode. Mismo patron que
+// DetalleSubFranjaIgualdadTests (PrivateEvents.Tests), del cual este archivo es espejo deliberado.
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
+using Bitakora.ControlAsistencia.ControlHoras.Tests.ValueObjects;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Tests.AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction.Eventos;
+
+public class SubFranjaProgramadaIgualdadTests : IgualdadTestBase<SubFranjaProgramada>
+{
+    protected override SubFranjaProgramada CrearInstancia() =>
+        new(new TimeOnly(10, 0), new TimeOnly(10, 15), 0, 0, "(10:00-10:15)");
+
+    protected override SubFranjaProgramada CrearInstanciaCopia() =>
+        new(new TimeOnly(10, 0), new TimeOnly(10, 15), 0, 0, "(10:00-10:15)");
+
+    protected override IEnumerable<(string, SubFranjaProgramada)> CrearInstanciasDiferentes()
+    {
+        yield return ("HoraInicio",
+            new SubFranjaProgramada(new TimeOnly(10, 5), new TimeOnly(10, 15), 0, 0, "(10:05-10:15)"));
+        yield return ("HoraFin",
+            new SubFranjaProgramada(new TimeOnly(10, 0), new TimeOnly(10, 30), 0, 0, "(10:00-10:30)"));
+        yield return ("DiaOffsetInicio",
+            new SubFranjaProgramada(new TimeOnly(1, 0), new TimeOnly(1, 15), 1, 0, "(01:00+1-01:15)"));
+        yield return ("DiaOffsetFin",
+            new SubFranjaProgramada(new TimeOnly(23, 50), new TimeOnly(0, 10), 0, 1, "(23:50-00:10+1)"));
+    }
+
+    // CA-1: dos instancias que difieren SOLO en Descripcion son iguales (dato derivado, no identidad).
+
+    [Fact]
+    public void Equals_RetornaTrue_CuandoSoloDescripcionEsDiferente()
+    {
+        var a = new SubFranjaProgramada(new TimeOnly(10, 0), new TimeOnly(10, 15), 0, 0, "(10:00-10:15)");
+        var b = new SubFranjaProgramada(new TimeOnly(10, 0), new TimeOnly(10, 15), 0, 0, "otro texto distinto");
+
+        a.Equals(b).Should().BeTrue();
+    }
+
+    [Fact]
+    public void GetHashCode_RetornaMismoHash_CuandoSoloDescripcionEsDiferente()
+    {
+        var a = new SubFranjaProgramada(new TimeOnly(10, 0), new TimeOnly(10, 15), 0, 0, "(10:00-10:15)");
+        var b = new SubFranjaProgramada(new TimeOnly(10, 0), new TimeOnly(10, 15), 0, 0, "otro texto distinto");
+
+        a.GetHashCode().Should().Be(b.GetHashCode());
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/TurnoDiarioAsignadoSerializacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/TurnoDiarioAsignadoSerializacionTests.cs
@@ -3,7 +3,6 @@
 using System.Text.Json;
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
-using Bitakora.ControlAsistencia.ControlHoras.Infraestructura;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.Tests.AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction.Eventos;
 
@@ -123,5 +122,145 @@ public class TurnoDiarioAsignadoSerializacionTests
         deserializado.Fecha.Should().Be(new DateOnly(2026, 3, 15));
         deserializado.InformacionEmpleado.Should().Be(empleadoEsperado);
         deserializado.DetalleTurno.Should().Be(turnoEsperado);
+    }
+
+    // Issue #322 CA-2 (agregado en revision): el JSON de arriba lleva "Descansos": [] y
+    // "Extras": [], asi que SubFranjaProgramada no participaba de ningun round-trip contra la forma
+    // persistida. Los streams reales de dev si tienen turnos con sub-franjas: este test las incluye,
+    // con offsets distintos entre inicio y fin, para que un cruce de campos al releer el JSON
+    // ya escrito no pase inadvertido.
+    [Fact]
+    public void Deserializar_ReconstruyeLasSubFranjasAnidadas_ConLaFormaPersistidaQueLlevaDescansosYExtras()
+    {
+        const string jsonPersistidoConSubFranjas = """
+            {
+              "Id": "EMP-001:2026-03-15",
+              "InformacionEmpleado": {
+                "EmpleadoId": "EMP-001",
+                "TipoIdentificacion": "CC",
+                "NumeroIdentificacion": "1234567890",
+                "Nombres": "Luis Augusto",
+                "Apellidos": "Barreto"
+              },
+              "Fecha": "2026-03-15",
+              "DetalleTurno": {
+                "Nombre": "Turno Nocturno",
+                "FranjasOrdinarias": [
+                  {
+                    "HoraInicio": "22:00:00",
+                    "HoraFin": "06:00:00",
+                    "DiaOffsetFin": 1,
+                    "Descansos": [
+                      {
+                        "HoraInicio": "23:50:00",
+                        "HoraFin": "00:10:00",
+                        "DiaOffsetInicio": 0,
+                        "DiaOffsetFin": 1,
+                        "Descripcion": "(23:50-00:10+1)"
+                      }
+                    ],
+                    "Extras": [
+                      {
+                        "HoraInicio": "06:00:00",
+                        "HoraFin": "08:00:00",
+                        "DiaOffsetInicio": 1,
+                        "DiaOffsetFin": 1,
+                        "Descripcion": "(06:00+1-08:00+1)"
+                      }
+                    ],
+                    "Descripcion": "(22:00-06:00+1)"
+                  }
+                ],
+                "Descripcion": "Turno Nocturno (22:00-06:00+1)"
+              },
+              "SolicitudId": "019600b0-0000-7000-8000-000000000001"
+            }
+            """;
+        var opciones = ConfiguracionSerializacionControlHoras.CrearOpcionesMarten();
+
+        var deserializado = JsonSerializer.Deserialize<TurnoDiarioAsignado>(
+            jsonPersistidoConSubFranjas, opciones);
+
+        var descansoEsperado = new SubFranjaProgramada(
+            new TimeOnly(23, 50), new TimeOnly(0, 10), 0, 1, "(23:50-00:10+1)");
+        var extraEsperada = new SubFranjaProgramada(
+            new TimeOnly(6, 0), new TimeOnly(8, 0), 1, 1, "(06:00+1-08:00+1)");
+
+        deserializado.Should().NotBeNull();
+        var franja = deserializado!.DetalleTurno.FranjasOrdinarias.Should().ContainSingle().Subject;
+        franja.Descansos.Should().ContainSingle().Which.Should().Be(descansoEsperado);
+        franja.Extras.Should().ContainSingle().Which.Should().Be(extraEsperada);
+
+        // Igualdad de SubFranjaProgramada excluye Descripcion (CA-1), asi que el assert de arriba
+        // no la cubre: se verifica aparte para que una perdida del dato derivado se vea.
+        franja.Descansos[0].Descripcion.Should().Be("(23:50-00:10+1)");
+        franja.Extras[0].Descripcion.Should().Be("(06:00+1-08:00+1)");
+    }
+
+    // Issue #322 CA-2 / Nota de seguridad de datos (agregado en revision): los eventos escritos
+    // ANTES del issue #288 no llevan "Descripcion" en ningun nivel. STJ deja null en el parametro
+    // posicional y los tres records lo normalizan a cadena vacia -- rama que ningun round-trip
+    // ejercitaba sobre el evento persistido. Espejo de
+    // ProgramacionTurnoSolicitadaSerializacionTests.Deserializar_NormalizaDescripcionACadenaVacia_*
+    // (Programacion.Tests, issue #319).
+    [Fact]
+    public void Deserializar_NormalizaDescripcionACadenaVaciaEnLosTresNiveles_CuandoElJsonPersistidoNoLlevaEseCampo()
+    {
+        const string jsonPersistidoAntesDeDescripcion = """
+            {
+              "Id": "EMP-001:2026-03-15",
+              "InformacionEmpleado": {
+                "EmpleadoId": "EMP-001",
+                "TipoIdentificacion": "CC",
+                "NumeroIdentificacion": "1234567890",
+                "Nombres": "Luis Augusto",
+                "Apellidos": "Barreto"
+              },
+              "Fecha": "2026-03-15",
+              "DetalleTurno": {
+                "Nombre": "Turno Manana",
+                "FranjasOrdinarias": [
+                  {
+                    "HoraInicio": "08:00:00",
+                    "HoraFin": "16:00:00",
+                    "DiaOffsetFin": 0,
+                    "Descansos": [
+                      {
+                        "HoraInicio": "12:00:00",
+                        "HoraFin": "13:00:00",
+                        "DiaOffsetInicio": 0,
+                        "DiaOffsetFin": 0
+                      }
+                    ],
+                    "Extras": []
+                  }
+                ]
+              },
+              "SolicitudId": "019600b0-0000-7000-8000-000000000001"
+            }
+            """;
+        var opciones = ConfiguracionSerializacionControlHoras.CrearOpcionesMarten();
+
+        var deserializado = JsonSerializer.Deserialize<TurnoDiarioAsignado>(
+            jsonPersistidoAntesDeDescripcion, opciones);
+
+        deserializado.Should().NotBeNull();
+        deserializado!.DetalleTurno.Descripcion.Should().BeEmpty();
+
+        var franja = deserializado.DetalleTurno.FranjasOrdinarias.Should().ContainSingle().Subject;
+        franja.Descripcion.Should().BeEmpty();
+        franja.Descansos.Should().ContainSingle().Which.Descripcion.Should().BeEmpty();
+
+        // El resto del payload se relee intacto: la ausencia del campo derivado no degrada la
+        // identidad del turno (que lo excluye por diseno, CA-1).
+        deserializado.DetalleTurno.Should().Be(new TurnoDiario(
+            "Turno Manana",
+            [
+                new FranjaProgramada(
+                    new TimeOnly(8, 0), new TimeOnly(16, 0), 0,
+                    [new SubFranjaProgramada(new TimeOnly(12, 0), new TimeOnly(13, 0), 0, 0, "")],
+                    [], "")
+            ],
+            ""));
     }
 }

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/TurnoDiarioAsignadoSerializacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/TurnoDiarioAsignadoSerializacionTests.cs
@@ -4,8 +4,6 @@ using System.Text.Json;
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 using Bitakora.ControlAsistencia.ControlHoras.Infraestructura;
-using Bitakora.ControlAsistencia.PrivateEvents.Programacion;
-using Bitakora.ControlAsistencia.PublicEvents.Empleados;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.Tests.AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction.Eventos;
 
@@ -14,32 +12,36 @@ namespace Bitakora.ControlAsistencia.ControlHoras.Tests.AsignarTurnoCuandoProgra
 /// Requerido porque Marten usa STJ con PropertyNamingPolicy=null (PascalCase)
 /// y el evento tiene constructor privado y propiedades con private set.
 /// Ver ADR-0013 y feedback de memoria: ConfigurarSerializacion es obligatorio.
+///
+/// Issue #322: InformacionEmpleado y DetalleTurno cambian de tipo (Empleado/TurnoDiario, propios
+/// de ControlHoras.DomainEvents) pero NO de nombre de propiedad -- son las claves JSON que ya
+/// estan persistidas en mt_events.
 /// </summary>
 public class TurnoDiarioAsignadoSerializacionTests
 {
     private static readonly Guid SolicitudId =
         Guid.Parse("019600b0-0000-7000-8000-000000000001");
 
-    private static readonly InformacionEmpleado Empleado = new(
+    private static readonly Empleado EmpleadoDePrueba = new(
         "EMP-001", "CC", "1234567890", "Luis Augusto", "Barreto");
 
     private static readonly DateOnly Fecha = new DateOnly(2026, 3, 15);
 
     // Issue #288: Descripcion (dato derivado, texto del formato tecnico) es irrelevante para este
     // round-trip -> placeholder no vacio para verificar tambien que sobrevive la serializacion.
-    private static readonly DetalleTurno DetalleTurnoTest = new(
+    private static readonly TurnoDiario TurnoDiarioDePrueba = new(
         "Turno Manana",
-        [new DetalleFranjaOrdinaria(new TimeOnly(8, 0), new TimeOnly(16, 0), 0, [], [], "(08:00-16:00)")],
+        [new FranjaProgramada(new TimeOnly(8, 0), new TimeOnly(16, 0), 0, [], [], "(08:00-16:00)")],
         "Turno Manana (08:00-16:00)");
 
-    private static readonly string StreamId = $"{Empleado.EmpleadoId}:{Fecha:yyyy-MM-dd}";
+    private static readonly string StreamId = $"{EmpleadoDePrueba.EmpleadoId}:{Fecha:yyyy-MM-dd}";
 
     // Regla 16: todo evento persistido en Marten debe tener test de serializacion roundtrip
     // Verifica con datos reales y completos (no listas vacias para VOs anidados)
     [Fact]
     public void Deserializar_ReconstruyeEvento_ConTodosLosCampos()
     {
-        var evento = new TurnoDiarioAsignado(StreamId, Empleado, Fecha, DetalleTurnoTest, SolicitudId);
+        var evento = new TurnoDiarioAsignado(StreamId, EmpleadoDePrueba, Fecha, TurnoDiarioDePrueba, SolicitudId);
         var opciones = ConfiguracionSerializacionControlHoras.CrearOpcionesMarten();
 
         var json = JsonSerializer.Serialize(evento, opciones);
@@ -49,17 +51,77 @@ public class TurnoDiarioAsignadoSerializacionTests
         deserializado!.Id.Should().Be(StreamId);
         deserializado.SolicitudId.Should().Be(SolicitudId);
         deserializado.Fecha.Should().Be(Fecha);
-        deserializado.InformacionEmpleado.EmpleadoId.Should().Be(Empleado.EmpleadoId);
-        deserializado.InformacionEmpleado.Nombres.Should().Be(Empleado.Nombres);
-        deserializado.DetalleTurno.Nombre.Should().Be(DetalleTurnoTest.Nombre);
+        deserializado.InformacionEmpleado.EmpleadoId.Should().Be(EmpleadoDePrueba.EmpleadoId);
+        deserializado.InformacionEmpleado.Nombres.Should().Be(EmpleadoDePrueba.Nombres);
+        deserializado.DetalleTurno.Nombre.Should().Be(TurnoDiarioDePrueba.Nombre);
         deserializado.DetalleTurno.FranjasOrdinarias.Should().HaveCount(1);
         deserializado.DetalleTurno.FranjasOrdinarias[0].HoraInicio
             .Should().Be(new TimeOnly(8, 0));
 
         // Issue #288 CA-7: Descripcion (dato derivado persistido) sobrevive el round-trip,
         // tanto a nivel turno como a nivel de cada franja ordinaria.
-        deserializado.DetalleTurno.Descripcion.Should().Be(DetalleTurnoTest.Descripcion);
+        deserializado.DetalleTurno.Descripcion.Should().Be(TurnoDiarioDePrueba.Descripcion);
         deserializado.DetalleTurno.FranjasOrdinarias[0].Descripcion
-            .Should().Be(DetalleTurnoTest.FranjasOrdinarias[0].Descripcion);
+            .Should().Be(TurnoDiarioDePrueba.FranjasOrdinarias[0].Descripcion);
+    }
+
+    // Issue #322 CA-2 / Nota de seguridad de datos (critica): JSON con la FORMA EXACTA que Marten
+    // ya escribio en mt_events ANTES de este issue (PascalCase, PropertyNamingPolicy=null). Los
+    // nombres de propiedad (InformacionEmpleado, Fecha, DetalleTurno, SolicitudId) no cambian --
+    // solo los tipos anidados (Empleado/TurnoDiario en vez de InformacionEmpleado/DetalleTurno de
+    // PublicEvents/PrivateEvents). Este round-trip demuestra que un evento ya persistido se relee
+    // identico, sin ninguna migracion de datos (MEF-ADR-0036: el alias del evento no se toca).
+    //
+    // La comparacion es por igualdad estructural completa (.Should().Be() sobre el objeto
+    // compuesto, no solo sus campos escalares): asi el test tambien exige que TurnoDiario/
+    // FranjaProgramada repliquen la semantica de igualdad de los originales (CA-1), no solo su
+    // forma de campos.
+    [Fact]
+    public void Deserializar_ReconstruyeIdentico_DesdeElJsonConLaFormaYaPersistida()
+    {
+        const string jsonPersistidoHoy = """
+            {
+              "Id": "EMP-001:2026-03-15",
+              "InformacionEmpleado": {
+                "EmpleadoId": "EMP-001",
+                "TipoIdentificacion": "CC",
+                "NumeroIdentificacion": "1234567890",
+                "Nombres": "Luis Augusto",
+                "Apellidos": "Barreto"
+              },
+              "Fecha": "2026-03-15",
+              "DetalleTurno": {
+                "Nombre": "Turno Manana",
+                "FranjasOrdinarias": [
+                  {
+                    "HoraInicio": "08:00:00",
+                    "HoraFin": "16:00:00",
+                    "DiaOffsetFin": 0,
+                    "Descansos": [],
+                    "Extras": [],
+                    "Descripcion": "(08:00-16:00)"
+                  }
+                ],
+                "Descripcion": "Turno Manana (08:00-16:00)"
+              },
+              "SolicitudId": "019600b0-0000-7000-8000-000000000001"
+            }
+            """;
+        var opciones = ConfiguracionSerializacionControlHoras.CrearOpcionesMarten();
+
+        var deserializado = JsonSerializer.Deserialize<TurnoDiarioAsignado>(jsonPersistidoHoy, opciones);
+
+        var empleadoEsperado = new Empleado("EMP-001", "CC", "1234567890", "Luis Augusto", "Barreto");
+        var turnoEsperado = new TurnoDiario(
+            "Turno Manana",
+            [new FranjaProgramada(new TimeOnly(8, 0), new TimeOnly(16, 0), 0, [], [], "(08:00-16:00)")],
+            "Turno Manana (08:00-16:00)");
+
+        deserializado.Should().NotBeNull();
+        deserializado!.Id.Should().Be("EMP-001:2026-03-15");
+        deserializado.SolicitudId.Should().Be(Guid.Parse("019600b0-0000-7000-8000-000000000001"));
+        deserializado.Fecha.Should().Be(new DateOnly(2026, 3, 15));
+        deserializado.InformacionEmpleado.Should().Be(empleadoEsperado);
+        deserializado.DetalleTurno.Should().Be(turnoEsperado);
     }
 }

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/TurnoDiarioIgualdadTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/TurnoDiarioIgualdadTests.cs
@@ -1,0 +1,81 @@
+// Issue #322: paridad de campos e igualdad de TurnoDiario (ControlHoras.DomainEvents) con
+// DetalleTurno (PrivateEvents.Programacion) -- payload por rol, CA-ADR-0029 decision #5.
+// CA-1: TurnoDiario replica la semantica de igualdad del original: FranjasOrdinarias
+// (IReadOnlyList) se compara POR VALOR (SequenceEqual), no por referencia (MEF-ADR-0012), y
+// Descripcion (dato derivado) queda EXCLUIDA de la identidad del turno. Mismo patron que
+// DetalleTurnoIgualdadTests (PrivateEvents.Tests), del cual este archivo es espejo deliberado.
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
+using Bitakora.ControlAsistencia.ControlHoras.Tests.ValueObjects;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Tests.AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction.Eventos;
+
+public class TurnoDiarioIgualdadTests : IgualdadTestBase<TurnoDiario>
+{
+    private static FranjaProgramada FranjaOrdinaria() =>
+        new(new TimeOnly(6, 0), new TimeOnly(14, 0), 0, [], [], "(06:00-14:00)");
+
+    protected override TurnoDiario CrearInstancia() =>
+        new("Turno Manana", [FranjaOrdinaria()], "Turno Manana (06:00-14:00)");
+
+    protected override TurnoDiario CrearInstanciaCopia() =>
+        new("Turno Manana", [FranjaOrdinaria()], "Turno Manana (06:00-14:00)");
+
+    protected override IEnumerable<(string, TurnoDiario)> CrearInstanciasDiferentes()
+    {
+        yield return ("Nombre",
+            new TurnoDiario("Turno Tarde", [FranjaOrdinaria()], "Turno Tarde (06:00-14:00)"));
+        yield return ("FranjasOrdinarias",
+            new TurnoDiario("Turno Manana", [], "Turno Manana"));
+    }
+
+    // CA-1: dos instancias que difieren SOLO en Descripcion son iguales (dato derivado, no identidad).
+
+    [Fact]
+    public void Equals_RetornaTrue_CuandoSoloDescripcionEsDiferente()
+    {
+        var a = new TurnoDiario("Turno Manana", [FranjaOrdinaria()], "Turno Manana (06:00-14:00)");
+        var b = new TurnoDiario("Turno Manana", [FranjaOrdinaria()], "otro texto distinto");
+
+        a.Equals(b).Should().BeTrue();
+    }
+
+    [Fact]
+    public void GetHashCode_RetornaMismoHash_CuandoSoloDescripcionEsDiferente()
+    {
+        var a = new TurnoDiario("Turno Manana", [FranjaOrdinaria()], "Turno Manana (06:00-14:00)");
+        var b = new TurnoDiario("Turno Manana", [FranjaOrdinaria()], "otro texto distinto");
+
+        a.GetHashCode().Should().Be(b.GetHashCode());
+    }
+
+    // CA-1: bug latente evitado - dos TurnoDiario con franjas EQUIVALENTES en listas DISTINTAS
+    // son iguales (el record por defecto compararia FranjasOrdinarias por referencia).
+
+    [Fact]
+    public void Equals_RetornaTrue_CuandoFranjasSonInstanciasDeListaDiferentesConMismoContenido()
+    {
+        var a = new TurnoDiario("Turno Manana",
+            new List<FranjaProgramada> { FranjaOrdinaria() }.AsReadOnly(),
+            "Turno Manana (06:00-14:00)");
+        var b = new TurnoDiario("Turno Manana",
+            new List<FranjaProgramada> { FranjaOrdinaria() }.AsReadOnly(),
+            "Turno Manana (06:00-14:00)");
+
+        a.Equals(b).Should().BeTrue();
+    }
+
+    [Fact]
+    public void GetHashCode_RetornaMismoHash_CuandoFranjasSonInstanciasDeListaDiferentesConMismoContenido()
+    {
+        var a = new TurnoDiario("Turno Manana",
+            new List<FranjaProgramada> { FranjaOrdinaria() }.AsReadOnly(),
+            "Turno Manana (06:00-14:00)");
+        var b = new TurnoDiario("Turno Manana",
+            new List<FranjaProgramada> { FranjaOrdinaria() }.AsReadOnly(),
+            "Turno Manana (06:00-14:00)");
+
+        a.GetHashCode().Should().Be(b.GetHashCode());
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/ProgramacionTurnoDiarioSolicitadaEventHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/ProgramacionTurnoDiarioSolicitadaEventHandlerTests.cs
@@ -88,4 +88,45 @@ public class ProgramacionTurnoDiarioSolicitadaEventHandlerTests
         And<ControlDiarioAggregateRoot, Guid>(StreamId, c => c.UltimaSolicitudId, SolicitudId);
         And<ControlDiarioAggregateRoot, string?>(StreamId, c => c.DetalleTurno!.Nombre, TurnoDiarioTest.Nombre);
     }
+
+    // CA-4 (agregado en revision): el mapeo del Function App es recursivo hasta las sub-franjas,
+    // pero los dos tests anteriores solo pasan franjas con Descansos/Extras vacios, asi que
+    // MapearFranja/MapearSubFranja quedaban sin ejercitar. Aqui el evento privado entrante trae un
+    // descanso y una extra con offsets distintos y Descripcion no vacia en los tres niveles: si el
+    // mapeo perdiera un campo o cruzara DiaOffsetInicio/DiaOffsetFin, la comparacion
+    // member-by-member de Then/And lo delata.
+    [Fact]
+    public async Task ProgramacionTurnoDiarioSolicitada_MapeaDescansosYExtrasConSusOffsets_CuandoLaFranjaTraeSubFranjas()
+    {
+        var turnoEntrante = new DetalleTurno(
+            "Turno Nocturno",
+            [
+                new DetalleFranjaOrdinaria(
+                    new TimeOnly(22, 0), new TimeOnly(6, 0), 1,
+                    [new DetalleSubFranja(new TimeOnly(23, 50), new TimeOnly(0, 10), 0, 1, "(23:50-00:10+1)")],
+                    [new DetalleSubFranja(new TimeOnly(6, 0), new TimeOnly(8, 0), 1, 1, "(06:00+1-08:00+1)")],
+                    "(22:00-06:00+1)")
+            ],
+            "Turno Nocturno (22:00-06:00+1)");
+
+        await WhenAsync(new ProgramacionTurnoDiarioSolicitada(
+            SolicitudId, EmpleadoDetalle, Fecha, turnoEntrante));
+
+        // Oraculo construido a mano, no derivado del mapeo bajo prueba (MEF-ADR-0002).
+        var turnoPersistidoEsperado = new TurnoDiario(
+            "Turno Nocturno",
+            [
+                new FranjaProgramada(
+                    new TimeOnly(22, 0), new TimeOnly(6, 0), 1,
+                    [new SubFranjaProgramada(new TimeOnly(23, 50), new TimeOnly(0, 10), 0, 1, "(23:50-00:10+1)")],
+                    [new SubFranjaProgramada(new TimeOnly(6, 0), new TimeOnly(8, 0), 1, 1, "(06:00+1-08:00+1)")],
+                    "(22:00-06:00+1)")
+            ],
+            "Turno Nocturno (22:00-06:00+1)");
+
+        Then(StreamId, new TurnoDiarioAsignado(
+            StreamId, Empleado, Fecha, turnoPersistidoEsperado, SolicitudId));
+        And<ControlDiarioAggregateRoot, TurnoDiario?>(
+            StreamId, c => c.DetalleTurno, turnoPersistidoEsperado);
+    }
 }

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/ProgramacionTurnoDiarioSolicitadaEventHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/ProgramacionTurnoDiarioSolicitadaEventHandlerTests.cs
@@ -5,7 +5,6 @@ using Bitakora.ControlAsistencia.ControlHoras.AsignarTurnoCuandoProgramacionTurn
 using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 using Bitakora.ControlAsistencia.ControlHoras.Entities;
 using Bitakora.ControlAsistencia.PrivateEvents.Programacion;
-using Bitakora.ControlAsistencia.PublicEvents.Empleados;
 using Cosmos.EventDriven.Abstractions;
 using Cosmos.EventSourcing.Testing.Utilities;
 
@@ -18,11 +17,12 @@ public class ProgramacionTurnoDiarioSolicitadaEventHandlerTests
     private static readonly Guid SolicitudId =
         Guid.Parse("019600b0-0000-7000-8000-000000000001");
 
-    private static readonly InformacionEmpleado Empleado = new(
+    // Issue #322: Empleado (ControlHoras.DomainEvents) -- el tipo que persiste TurnoDiarioAsignado.
+    private static readonly Empleado Empleado = new(
         "EMP-001", "CC", "1234567890", "Luis Augusto", "Barreto");
 
     // Mismo empleado, en la forma con que llega dentro del evento privado; el handler lo mapea
-    // a InformacionEmpleado para TurnoDiarioAsignado (CA-ADR-0029 decision #5).
+    // a Empleado para TurnoDiarioAsignado (CA-ADR-0029 decision #5).
     private static readonly DetalleEmpleado EmpleadoDetalle = new(
         "EMP-001", "CC", "1234567890", "Luis Augusto", "Barreto");
 
@@ -31,10 +31,18 @@ public class ProgramacionTurnoDiarioSolicitadaEventHandlerTests
     // CA-7: stream ID determinista que el handler debe computar internamente
     private static readonly string StreamId = $"{Empleado.EmpleadoId}:{Fecha:yyyy-MM-dd}";
 
+    // El evento privado sigue trayendo DetalleTurno (PrivateEvents) sin cambios.
     // Issue #288: Descripcion (dato derivado) es irrelevante para este test -> placeholder "".
     private static readonly DetalleTurno DetalleTurnoTest = new(
         "Turno Manana",
         [new DetalleFranjaOrdinaria(new TimeOnly(8, 0), new TimeOnly(16, 0), 0, [], [], "")],
+        "");
+
+    // Issue #322: TurnoDiario (ControlHoras.DomainEvents) -- lo que el handler persiste, mapeado
+    // desde DetalleTurnoTest (mismos valores, tipo nuevo).
+    private static readonly TurnoDiario TurnoDiarioTest = new(
+        "Turno Manana",
+        [new FranjaProgramada(new TimeOnly(8, 0), new TimeOnly(16, 0), 0, [], [], "")],
         "");
 
     protected override IPrivateEventHandlerAsync<ProgramacionTurnoDiarioSolicitada> Handler =>
@@ -44,7 +52,7 @@ public class ProgramacionTurnoDiarioSolicitadaEventHandlerTests
         new(SolicitudId, EmpleadoDetalle, Fecha, DetalleTurnoTest);
 
     private static TurnoDiarioAsignado CrearTurnoDiarioAsignado() =>
-        new(StreamId, Empleado, Fecha, DetalleTurnoTest, SolicitudId);
+        new(StreamId, Empleado, Fecha, TurnoDiarioTest, SolicitudId);
 
     // CA-3: NO existe ControlDiario para EmpleadoId+Fecha - el handler inicia el stream
     // CA-5: el evento incluye InformacionEmpleado, Fecha, DetalleTurno y SolicitudId
@@ -58,9 +66,9 @@ public class ProgramacionTurnoDiarioSolicitadaEventHandlerTests
 
         Then(StreamId, CrearTurnoDiarioAsignado());
         And<ControlDiarioAggregateRoot, string>(StreamId, c => c.Id, StreamId);
-        And<ControlDiarioAggregateRoot, InformacionEmpleado?>(StreamId, c => c.InformacionEmpleado, Empleado);
+        And<ControlDiarioAggregateRoot, Empleado?>(StreamId, c => c.InformacionEmpleado, Empleado);
         And<ControlDiarioAggregateRoot, DateOnly>(StreamId, c => c.Fecha, Fecha);
-        And<ControlDiarioAggregateRoot, string?>(StreamId, c => c.DetalleTurno!.Nombre, DetalleTurnoTest.Nombre);
+        And<ControlDiarioAggregateRoot, string?>(StreamId, c => c.DetalleTurno!.Nombre, TurnoDiarioTest.Nombre);
     }
 
     // CA-4: YA existe ControlDiario para EmpleadoId+Fecha - el handler agrega al stream existente
@@ -70,7 +78,7 @@ public class ProgramacionTurnoDiarioSolicitadaEventHandlerTests
     public async Task ProgramacionTurnoDiarioSolicitada_EmiteTurnoDiarioAsignado_CuandoYaExisteControlDiario()
     {
         var solicitudAnteriorId = Guid.Parse("019600b0-0000-7000-8000-000000000002");
-        var turnoAnterior = new TurnoDiarioAsignado(StreamId, Empleado, Fecha, DetalleTurnoTest, solicitudAnteriorId);
+        var turnoAnterior = new TurnoDiarioAsignado(StreamId, Empleado, Fecha, TurnoDiarioTest, solicitudAnteriorId);
 
         // Pre-carga el stream con el mismo StreamId que usara el handler (CA-8)
         Given(StreamId, turnoAnterior);
@@ -78,6 +86,6 @@ public class ProgramacionTurnoDiarioSolicitadaEventHandlerTests
 
         Then(StreamId, CrearTurnoDiarioAsignado());
         And<ControlDiarioAggregateRoot, Guid>(StreamId, c => c.UltimaSolicitudId, SolicitudId);
-        And<ControlDiarioAggregateRoot, string?>(StreamId, c => c.DetalleTurno!.Nombre, DetalleTurnoTest.Nombre);
+        And<ControlDiarioAggregateRoot, string?>(StreamId, c => c.DetalleTurno!.Nombre, TurnoDiarioTest.Nombre);
     }
 }

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/CalcularDesgloseFranjaTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/CalcularDesgloseFranjaTests.cs
@@ -15,7 +15,7 @@
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.ControlHoras.ValueObjects;
 using Bitakora.ControlAsistencia.ControlHoras.Entities;
-using Bitakora.ControlAsistencia.PrivateEvents.Programacion;
+using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.Tests.Entities;
 
@@ -36,7 +36,7 @@ public class CalcularDesgloseFranjaTests
     // Construccion de la entrada del metodo: ControlFranja recibe DateTime? (frontera del dominio).
     private static DateTime Dt(int hora, int minuto = 0) => new(2026, 3, 16, hora, minuto, 0);
 
-    private static ControlFranja Control(DetalleFranjaOrdinaria programada, DateTime? entrada, DateTime? salida) =>
+    private static ControlFranja Control(FranjaProgramada programada, DateTime? entrada, DateTime? salida) =>
         new(programada, entrada, salida);
 
     // Helpers de asercion: siempre en MomentoDelDia / IntervaloTemporal, nunca DateTime.
@@ -50,15 +50,15 @@ public class CalcularDesgloseFranjaTests
         new(IntervaloTemporal.Crear(inicio, fin), concepto);
 
     // Issue #288: Descripcion (dato derivado) es irrelevante para estos tests -> placeholder "".
-    private static DetalleSubFranja Sub(int horaInicio, int horaFin, int diaOffsetInicio = 0, int diaOffsetFin = 0) =>
+    private static SubFranjaProgramada Sub(int horaInicio, int horaFin, int diaOffsetInicio = 0, int diaOffsetFin = 0) =>
         new(new TimeOnly(horaInicio, 0), new TimeOnly(horaFin, 0), diaOffsetInicio, diaOffsetFin, "");
 
-    private static DetalleFranjaOrdinaria Franja(
+    private static FranjaProgramada Franja(
         int horaInicio,
         int horaFin,
         int diaOffsetFin = 0,
-        IReadOnlyList<DetalleSubFranja>? descansos = null,
-        IReadOnlyList<DetalleSubFranja>? extras = null) =>
+        IReadOnlyList<SubFranjaProgramada>? descansos = null,
+        IReadOnlyList<SubFranjaProgramada>? extras = null) =>
         new(new TimeOnly(horaInicio, 0), new TimeOnly(horaFin, 0), diaOffsetFin,
             descansos ?? [], extras ?? [], "");
 

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/ClasificadorTrabajoTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/ClasificadorTrabajoTests.cs
@@ -7,7 +7,7 @@
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.ControlHoras.ValueObjects;
 using Bitakora.ControlAsistencia.ControlHoras.Entities;
-using Bitakora.ControlAsistencia.PrivateEvents.Programacion;
+using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.Tests.Entities;
 
@@ -41,15 +41,15 @@ public class ClasificadorTrabajoTests
         new(IntervaloTemporal.Crear(inicio, fin), concepto);
 
     // Issue #288: Descripcion (dato derivado) es irrelevante para estos tests -> placeholder "".
-    private static DetalleSubFranja Sub(int horaInicio, int horaFin, int diaOffsetInicio = 0, int diaOffsetFin = 0) =>
+    private static SubFranjaProgramada Sub(int horaInicio, int horaFin, int diaOffsetInicio = 0, int diaOffsetFin = 0) =>
         new(new TimeOnly(horaInicio, 0), new TimeOnly(horaFin, 0), diaOffsetInicio, diaOffsetFin, "");
 
-    private static DetalleFranjaOrdinaria Franja(
+    private static FranjaProgramada Franja(
         int horaInicio,
         int horaFin,
         int diaOffsetFin = 0,
-        IReadOnlyList<DetalleSubFranja>? descansos = null,
-        IReadOnlyList<DetalleSubFranja>? extras = null) =>
+        IReadOnlyList<SubFranjaProgramada>? descansos = null,
+        IReadOnlyList<SubFranjaProgramada>? extras = null) =>
         new(new TimeOnly(horaInicio, 0), new TimeOnly(horaFin, 0), diaOffsetFin,
             descansos ?? [], extras ?? [], "");
 

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/ConsolidadorDesgloseHorasTestData.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/ConsolidadorDesgloseHorasTestData.cs
@@ -15,7 +15,7 @@
 // e intervalos), mas RetardoNeto.
 
 using Bitakora.ControlAsistencia.ControlHoras.ValueObjects;
-using Bitakora.ControlAsistencia.PrivateEvents.Programacion;
+using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.Tests.Entities;
 
@@ -37,7 +37,7 @@ internal static class ConsolidadorDesgloseHorasTestData
     // viaja en el DesgloseFranja para que el consolidador la preserve en DesglosePorFranja.
     // El detalle real de lo trabajado vive en los IntervaloClasificado de cada franja.
     // Issue #288: Descripcion (dato derivado) es irrelevante para estos tests -> placeholder "".
-    public static DetalleFranjaOrdinaria Programada(int horaInicio, int horaFin, int diaOffsetFin = 0) =>
+    public static FranjaProgramada Programada(int horaInicio, int horaFin, int diaOffsetFin = 0) =>
         new(new TimeOnly(horaInicio, 0), new TimeOnly(horaFin, 0), diaOffsetFin, [], [], "");
 
     // Retardo de una franja, a partir de sus intervalos retardados y compensados.
@@ -48,7 +48,7 @@ internal static class ConsolidadorDesgloseHorasTestData
 
     // DesgloseFranja sintetico: programada + intervalos clasificados + detalle de retardo.
     public static DesgloseFranja Desglose(
-        DetalleFranjaOrdinaria programada,
+        FranjaProgramada programada,
         IReadOnlyList<IntervaloClasificado> intervalos,
         Retardo retardo) =>
         new(programada, intervalos, retardo);

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/ControlFranjaTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/ControlFranjaTests.cs
@@ -2,7 +2,7 @@
 
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.ControlHoras.Entities;
-using Bitakora.ControlAsistencia.PrivateEvents.Programacion;
+using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.Tests.Entities;
 
@@ -13,7 +13,7 @@ namespace Bitakora.ControlAsistencia.ControlHoras.Tests.Entities;
 public class ControlFranjaTests
 {
     // Issue #288: Descripcion (dato derivado) es irrelevante para estos tests -> placeholder "".
-    private static readonly DetalleFranjaOrdinaria Franja06_14 = new(
+    private static readonly FranjaProgramada Franja06_14 = new(
         new TimeOnly(6, 0), new TimeOnly(14, 0), 0, [], [], "");
 
     private static readonly DateTime T07 = new(2026, 3, 15, 7, 0, 0);

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/CrearDiaCalculadoConHorasDiscriminadasTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/CrearDiaCalculadoConHorasDiscriminadasTests.cs
@@ -27,7 +27,6 @@ using Bitakora.ControlAsistencia.ControlHoras.Entities;
 using Bitakora.ControlAsistencia.PrivateEvents.ControlHoras;
 using Bitakora.ControlAsistencia.PrivateEvents.Programacion;
 using Bitakora.ControlAsistencia.PublicEvents.ControlHoras;
-using Bitakora.ControlAsistencia.PublicEvents.Empleados;
 using Cosmos.EventDriven.Abstractions;
 using Cosmos.EventSourcing.Testing.Utilities;
 
@@ -37,11 +36,12 @@ public class CrearDiaCalculadoConHorasDiscriminadasTests
 {
     // Datos compartidos - el stream ID es determinista a partir de EmpleadoId+Fecha.
     // private static: las nested classes acceden a los miembros privados de la clase contenedora.
-    private static readonly InformacionEmpleado Empleado = new(
+    // Issue #322: Empleado (ControlHoras.DomainEvents) -- el tipo que persiste TurnoDiarioAsignado.
+    private static readonly Empleado Empleado = new(
         "EMP-001", "CC", "1234567890", "Luis Augusto", "Barreto");
 
     // Mismo empleado, en la forma con que llega dentro del evento privado; el handler lo mapea
-    // a InformacionEmpleado para TurnoDiarioAsignado (CA-ADR-0029 decision #5).
+    // a Empleado para TurnoDiarioAsignado (CA-ADR-0029 decision #5).
     private static readonly DetalleEmpleado EmpleadoDetalle = new(
         "EMP-001", "CC", "1234567890", "Luis Augusto", "Barreto");
 
@@ -49,9 +49,13 @@ public class CrearDiaCalculadoConHorasDiscriminadasTests
     private static readonly string StreamId = $"{Empleado.EmpleadoId}:{Fecha:yyyy-MM-dd}";
     private static readonly Guid SolicitudId = Guid.Parse("019600d0-0000-7000-8000-000000000001");
 
-    // Franja unica 06:00-14:00 usada por los escenarios de turno.
+    // Franja unica 06:00-14:00 usada por los escenarios de turno. FranjaProgramada
+    // (ControlHoras.DomainEvents) es lo que el ControlDiario persiste; DetalleFranjaOrdinaria
+    // (PrivateEvents) es lo que trae el evento privado entrante.
     // Issue #288: Descripcion (dato derivado) es irrelevante para estos tests -> placeholder "".
-    private static readonly DetalleFranjaOrdinaria Franja06_14 =
+    private static readonly FranjaProgramada Franja06_14 =
+        new(new TimeOnly(6, 0), new TimeOnly(14, 0), 0, [], [], "");
+    private static readonly DetalleFranjaOrdinaria Franja06_14Detalle =
         new(new TimeOnly(6, 0), new TimeOnly(14, 0), 0, [], [], "");
 
     // Marcaciones que completan la franja (entrada+salida) -> franja NO anomala (CA-4).
@@ -61,8 +65,8 @@ public class CrearDiaCalculadoConHorasDiscriminadasTests
     private static MarcacionAdicionada CrearMarcacionAdicionada(DateTime timestamp) =>
         new(StreamId, Empleado.EmpleadoId, timestamp, "ENTRADA", "DEV-001");
 
-    private static TurnoDiarioAsignado CrearTurnoDiarioAsignado(DetalleTurno detalleTurno) =>
-        new(StreamId, Empleado, Fecha, detalleTurno, SolicitudId);
+    private static TurnoDiarioAsignado CrearTurnoDiarioAsignado(TurnoDiario turnoDiario) =>
+        new(StreamId, Empleado, Fecha, turnoDiario, SolicitudId);
 
     // Oraculo independiente: dia con franja 06:00-14:00 trabajada 07:00-15:00 (domingo 2026-03-15,
     // no anomala). El retardo 60min (06:00-07:00) se compensa con el excedente 60min (14:00-15:00) ->
@@ -96,9 +100,10 @@ public class CrearDiaCalculadoConHorasDiscriminadasTests
                 CrearMarcacionAdicionada(Timestamp07_00),
                 CrearMarcacionAdicionada(Timestamp15_00));
 
-            var turnoFranjaUnica = new DetalleTurno("Turno Manana", [Franja06_14], "");
-            await WhenAsync(CrearEvento(turnoFranjaUnica));
+            var turnoFranjaUnicaDetalle = new DetalleTurno("Turno Manana", [Franja06_14Detalle], "");
+            await WhenAsync(CrearEvento(turnoFranjaUnicaDetalle));
 
+            var turnoFranjaUnica = new TurnoDiario("Turno Manana", [Franja06_14], "");
             Then(StreamId, CrearTurnoDiarioAsignado(turnoFranjaUnica));
 
             And<ControlDiarioAggregateRoot, IReadOnlyDictionary<string, int>>(
@@ -120,9 +125,10 @@ public class CrearDiaCalculadoConHorasDiscriminadasTests
         public async Task CrearDiaCalculado_LlevaMinutosPorConceptoVacio_CuandoTurnoSinMarcaciones()
         {
             // Sin Given - stream nuevo, turno sin marcaciones previas.
-            var turnoFranjaUnica = new DetalleTurno("Turno Manana", [Franja06_14], "");
-            await WhenAsync(CrearEvento(turnoFranjaUnica));
+            var turnoFranjaUnicaDetalle = new DetalleTurno("Turno Manana", [Franja06_14Detalle], "");
+            await WhenAsync(CrearEvento(turnoFranjaUnicaDetalle));
 
+            var turnoFranjaUnica = new TurnoDiario("Turno Manana", [Franja06_14], "");
             Then(StreamId, CrearTurnoDiarioAsignado(turnoFranjaUnica));
 
             And<ControlDiarioAggregateRoot, HorasDiscriminadas>(

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/DepuradorDeMarcacionesTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/DepuradorDeMarcacionesTests.cs
@@ -2,7 +2,7 @@
 
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.ControlHoras.Entities;
-using Bitakora.ControlAsistencia.PrivateEvents.Programacion;
+using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.Tests.Entities;
 
@@ -14,17 +14,17 @@ public class DepuradorDeMarcacionesTests
 {
     // Franjas nombradas semanticamente
     // Issue #288: Descripcion (dato derivado) es irrelevante para estos tests -> placeholder "".
-    private static readonly DetalleFranjaOrdinaria Franja06_14 = new(
+    private static readonly FranjaProgramada Franja06_14 = new(
         new TimeOnly(6, 0), new TimeOnly(14, 0), 0, [], [], "");
 
-    private static readonly DetalleFranjaOrdinaria Franja06_12 = new(
+    private static readonly FranjaProgramada Franja06_12 = new(
         new TimeOnly(6, 0), new TimeOnly(12, 0), 0, [], [], "");
 
-    private static readonly DetalleFranjaOrdinaria Franja14_18 = new(
+    private static readonly FranjaProgramada Franja14_18 = new(
         new TimeOnly(14, 0), new TimeOnly(18, 0), 0, [], [], "");
 
     // DiaOffsetFin=1 porque 22:00 > 06:00 (fin al dia siguiente)
-    private static readonly DetalleFranjaOrdinaria Franja22_06_Nocturna = new(
+    private static readonly FranjaProgramada Franja22_06_Nocturna = new(
         new TimeOnly(22, 0), new TimeOnly(6, 0), 1, [], [], "");
 
     // Fecha de referencia para todos los tests
@@ -49,7 +49,7 @@ public class DepuradorDeMarcacionesTests
     {
         // CA-1: Una franja (06:00-14:00) con dos marcaciones (07:00, 15:00)
         // Con franja unica el rango es (-inf, +inf) -> primera=Entrada, ultima=Salida
-        var turno = new DetalleTurno("Diurno", [Franja06_14], "");
+        var turno = new TurnoDiario("Diurno", [Franja06_14], "");
 
         var resultado = DepuradorDeMarcaciones.Depurar(turno, FechaBase, [M(7, 0), M(15, 0)]);
 
@@ -65,7 +65,7 @@ public class DepuradorDeMarcacionesTests
         // Gap 12:00-14:00 -> punto de corte = 13:00 (punto medio del gap)
         // F1 captura marcaciones antes de 13:00: 05:50 y 12:05
         // F2 captura marcaciones desde 13:00: 14:10 y 18:15
-        var turno = new DetalleTurno("Partido", [Franja06_12, Franja14_18], "");
+        var turno = new TurnoDiario("Partido", [Franja06_12, Franja14_18], "");
 
         var resultado = DepuradorDeMarcaciones.Depurar(turno, FechaBase,
             [Marcacion05_50, Marcacion12_05, M(14, 10), M(18, 15)]);
@@ -81,7 +81,7 @@ public class DepuradorDeMarcacionesTests
     public void Depurar_ProduceEntradaConSalidaNull_CuandoFranjaTieneUnaSolaMarcacion()
     {
         // CA-3: Franja con una sola marcacion -> Entrada poblada, Salida null, EsAnomala true
-        var turno = new DetalleTurno("Diurno", [Franja06_14], "");
+        var turno = new TurnoDiario("Diurno", [Franja06_14], "");
 
         var resultado = DepuradorDeMarcaciones.Depurar(turno, FechaBase, [M(7, 0)]);
 
@@ -95,7 +95,7 @@ public class DepuradorDeMarcacionesTests
     public void Depurar_ProduceEntradaYSalidaNull_CuandoFranjaSinMarcaciones()
     {
         // CA-4: Franja sin marcaciones -> Entrada null, Salida null, EsAnomala true
-        var turno = new DetalleTurno("Diurno", [Franja06_14], "");
+        var turno = new TurnoDiario("Diurno", [Franja06_14], "");
 
         var resultado = DepuradorDeMarcaciones.Depurar(turno, FechaBase, []);
 
@@ -110,7 +110,7 @@ public class DepuradorDeMarcacionesTests
     {
         // CA-5: Franja unica con marcaciones 07:00, 10:00, 12:00, 15:00
         // -> Entrada=07:00, Salida=15:00; las de 10:00 y 12:00 se descartan
-        var turno = new DetalleTurno("Diurno", [Franja06_14], "");
+        var turno = new TurnoDiario("Diurno", [Franja06_14], "");
 
         var resultado = DepuradorDeMarcaciones.Depurar(turno, FechaBase,
             [M(7, 0), M(10, 0), M(12, 0), M(15, 0)]);
@@ -135,7 +135,7 @@ public class DepuradorDeMarcacionesTests
         // CA-7: Franja nocturna 22:00-06:00 con DiaOffsetFin=1, fecha ancla 2026-03-15
         // Rango resuelto: 2026-03-15 22:00 -> 2026-03-16 06:00
         // Marcacion 22:30 del 15 y 05:30 del 16 quedan en la misma franja
-        var turno = new DetalleTurno("Nocturno", [Franja22_06_Nocturna], "");
+        var turno = new TurnoDiario("Nocturno", [Franja22_06_Nocturna], "");
 
         var resultado = DepuradorDeMarcaciones.Depurar(turno, FechaBase, [M(22, 30), MSig(5, 30)]);
 
@@ -149,7 +149,7 @@ public class DepuradorDeMarcacionesTests
     {
         // CA-8: Con una sola franja, el rango es (-inf, +inf) -> todas las marcaciones le pertenecen.
         // Timestamps fuera del horario nominal de la franja para verificar que no se filtra por hora.
-        var turno = new DetalleTurno("Diurno", [Franja06_14], "");
+        var turno = new TurnoDiario("Diurno", [Franja06_14], "");
 
         var resultado = DepuradorDeMarcaciones.Depurar(turno, FechaBase, [M(3, 0), M(20, 0)]);
 
@@ -164,7 +164,7 @@ public class DepuradorDeMarcacionesTests
         // CA-10: Turno partido donde solo la primera franja tiene marcaciones
         // F1 (06:00-12:00): Entrada=05:50, Salida=12:05 -> EsAnomala false
         // F2 (14:00-18:00): Entrada=null, Salida=null -> EsAnomala true
-        var turno = new DetalleTurno("Partido", [Franja06_12, Franja14_18], "");
+        var turno = new TurnoDiario("Partido", [Franja06_12, Franja14_18], "");
 
         var resultado = DepuradorDeMarcaciones.Depurar(turno, FechaBase,
             [Marcacion05_50, Marcacion12_05]);

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/ControlHorasDomainEventsAislamientoTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/ControlHorasDomainEventsAislamientoTests.cs
@@ -1,0 +1,44 @@
+// Issue #322: CA-3. ControlHoras.DomainEvents es una de las "tres islas" de ensamblados de
+// eventos (CA-ADR-0029 decision #2 / MEF-ADR-0039 decision #2): cero <ProjectReference> (ni hacia
+// PublicEvents/PrivateEvents ni hacia ningun otro proyecto del repo) y cero <PackageReference> --
+// el retiro de Cosmos.EventDriven.Abstractions cierra la posibilidad de reintroducir un marker de
+// bus (IPublicEvent/IPrivateEvent) en un evento persistido por compilacion.
+//
+// Verificado por lectura directa del .csproj (no por reflexion del assembly compilado): esta es
+// la unica forma de detectar una referencia declarada pero no usada por ningun tipo, que el
+// compilador no delataria.
+
+using System.Runtime.CompilerServices;
+using AwesomeAssertions;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Tests.Infraestructura;
+
+public class ControlHorasDomainEventsAislamientoTests
+{
+    private static string RutaCsproj([CallerFilePath] string? archivoDeEsteTest = null)
+    {
+        var directorioDeEsteTest = Path.GetDirectoryName(archivoDeEsteTest)!;
+        var raizRepo = Path.GetFullPath(Path.Combine(directorioDeEsteTest, "..", "..", ".."));
+        return Path.Combine(
+            raizRepo,
+            "src",
+            "Bitakora.ControlAsistencia.ControlHoras.DomainEvents",
+            "Bitakora.ControlAsistencia.ControlHoras.DomainEvents.csproj");
+    }
+
+    [Fact]
+    public void Csproj_NoTieneProjectReference()
+    {
+        var contenido = File.ReadAllText(RutaCsproj());
+
+        contenido.Should().NotContain("<ProjectReference");
+    }
+
+    [Fact]
+    public void Csproj_NoTienePackageReference()
+    {
+        var contenido = File.ReadAllText(RutaCsproj());
+
+        contenido.Should().NotContain("<PackageReference");
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/DesgloseFranjaSerializacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/DesgloseFranjaSerializacionTests.cs
@@ -8,7 +8,6 @@ using AwesomeAssertions;
 using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 using Bitakora.ControlAsistencia.ControlHoras.ValueObjects;
 using Bitakora.ControlAsistencia.ControlHoras.Infraestructura;
-using Bitakora.ControlAsistencia.PrivateEvents.Programacion;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.Tests.Infraestructura;
 
@@ -21,14 +20,14 @@ public class DesgloseFranjaSerializacionTests
         IntervaloTemporal.Crear(new MomentoDelDia(inicio), new MomentoDelDia(fin));
 
     // Issue #288: Descripcion (dato derivado) es irrelevante para estos tests -> placeholder "".
-    private static DetalleFranjaOrdinaria CrearFranjaProgramadaConDescanso() =>
-        new DetalleFranjaOrdinaria(
+    private static FranjaProgramada CrearFranjaProgramadaConDescanso() =>
+        new FranjaProgramada(
             new TimeOnly(8, 0), new TimeOnly(17, 0), 0,
-            [new DetalleSubFranja(new TimeOnly(12, 0), new TimeOnly(13, 0), 0, 0, "")],
+            [new SubFranjaProgramada(new TimeOnly(12, 0), new TimeOnly(13, 0), 0, 0, "")],
             [], "");
 
-    private static DetalleFranjaOrdinaria CrearFranjaProgramadaSimple() =>
-        new DetalleFranjaOrdinaria(new TimeOnly(8, 0), new TimeOnly(17, 0), 0, [], [], "");
+    private static FranjaProgramada CrearFranjaProgramadaSimple() =>
+        new FranjaProgramada(new TimeOnly(8, 0), new TimeOnly(17, 0), 0, [], [], "");
 
     [Fact]
     public void RoundTrip_PreservaProgramada_CuandoFranjaConDescanso()

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/DesgloseHorasSerializacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/DesgloseHorasSerializacionTests.cs
@@ -8,7 +8,6 @@ using AwesomeAssertions;
 using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 using Bitakora.ControlAsistencia.ControlHoras.ValueObjects;
 using Bitakora.ControlAsistencia.ControlHoras.Infraestructura;
-using Bitakora.ControlAsistencia.PrivateEvents.Programacion;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.Tests.Infraestructura;
 
@@ -21,8 +20,8 @@ public class DesgloseHorasSerializacionTests
         IntervaloTemporal.Crear(new MomentoDelDia(inicio), new MomentoDelDia(fin));
 
     // Issue #288: Descripcion (dato derivado) es irrelevante para estos tests -> placeholder "".
-    private static DetalleFranjaOrdinaria CrearFranjaProgramadaSimple() =>
-        new DetalleFranjaOrdinaria(new TimeOnly(8, 0), new TimeOnly(17, 0), 0, [], [], "");
+    private static FranjaProgramada CrearFranjaProgramadaSimple() =>
+        new FranjaProgramada(new TimeOnly(8, 0), new TimeOnly(17, 0), 0, [], [], "");
 
     private static DesgloseFranja CrearFranjaDiurna() =>
         new DesgloseFranja(

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ValueObjects/DesgloseFranjaTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ValueObjects/DesgloseFranjaTests.cs
@@ -3,7 +3,7 @@
 // CA-2: MinutosPorConcepto omite los conceptos que no aparecen en Intervalos
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.ControlHoras.ValueObjects;
-using Bitakora.ControlAsistencia.PrivateEvents.Programacion;
+using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.Tests.ValueObjects;
 
@@ -17,8 +17,8 @@ public class DesgloseFranjaTests
         IntervaloTemporal.Crear(new MomentoDelDia(inicio), new MomentoDelDia(fin));
 
     // Issue #288: Descripcion (dato derivado) es irrelevante para estos tests -> placeholder "".
-    private static DetalleFranjaOrdinaria CrearFranjaProgramada() =>
-        new DetalleFranjaOrdinaria(new TimeOnly(8, 0), new TimeOnly(17, 0), 0, [], [], "");
+    private static FranjaProgramada CrearFranjaProgramada() =>
+        new FranjaProgramada(new TimeOnly(8, 0), new TimeOnly(17, 0), 0, [], [], "");
 
     // ---------- CA-1: agrupa por concepto y suma duraciones ----------
 

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ValueObjects/DesgloseHorasDiscriminarTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ValueObjects/DesgloseHorasDiscriminarTests.cs
@@ -21,7 +21,7 @@
 
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.ControlHoras.ValueObjects;
-using Bitakora.ControlAsistencia.PrivateEvents.Programacion;
+using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.Tests.ValueObjects;
 
@@ -31,7 +31,7 @@ public class DesgloseHorasDiscriminarTests
         IntervaloTemporal.Crear(new MomentoDelDia(inicio), new MomentoDelDia(fin));
 
     // Issue #288: Descripcion (dato derivado) es irrelevante para estos tests -> placeholder "".
-    private static DetalleFranjaOrdinaria FranjaProgramada() =>
+    private static FranjaProgramada FranjaProgramada() =>
         new(new TimeOnly(8, 0), new TimeOnly(17, 0), 0, [], [], "");
 
     // El retardo de la franja no influye en Discriminar (solo lo hace DesgloseHoras.RetardoTotal):

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ValueObjects/DesgloseHorasTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ValueObjects/DesgloseHorasTests.cs
@@ -4,7 +4,7 @@
 //       y TotalMinutosPorConcepto vacio
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.ControlHoras.ValueObjects;
-using Bitakora.ControlAsistencia.PrivateEvents.Programacion;
+using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.Tests.ValueObjects;
 
@@ -19,8 +19,8 @@ public class DesgloseHorasTests
         IntervaloTemporal.Crear(new MomentoDelDia(inicio), new MomentoDelDia(fin));
 
     // Issue #288: Descripcion (dato derivado) es irrelevante para estos tests -> placeholder "".
-    private static DetalleFranjaOrdinaria CrearFranjaProgramada() =>
-        new DetalleFranjaOrdinaria(new TimeOnly(8, 0), new TimeOnly(17, 0), 0, [], [], "");
+    private static FranjaProgramada CrearFranjaProgramada() =>
+        new FranjaProgramada(new TimeOnly(8, 0), new TimeOnly(17, 0), 0, [], [], "");
 
     private static DesgloseFranja CrearFranjaConIntervalos(
         params (TimeOnly inicio, TimeOnly fin, Concepto concepto)[] datos)

--- a/tests/Bitakora.ControlAsistencia.Projections.Tests/ControlHoras/TurnoDiarioProjectionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Projections.Tests/ControlHoras/TurnoDiarioProjectionTests.cs
@@ -5,6 +5,12 @@
 //
 // Cada assert compara contra un oraculo armado a mano (MEF-ADR-0002, no-tautologia): nunca se
 // reusa la logica de Create/Apply bajo prueba para construir el valor esperado.
+//
+// Issue #322: TurnoDiarioAsignado ahora persiste Empleado/TurnoDiario (ControlHoras.DomainEvents,
+// payload por rol) en vez de InformacionEmpleado/DetalleTurno (PublicEvents/PrivateEvents).
+// TurnoDiarioView NO cambia en este issue (estado intermedio deliberado): sigue usando los tipos
+// de bus, asi que estos tests construyen el evento con los tipos nuevos y esperan la vista con los
+// tipos de bus -- Create/Apply son responsables del mapeo mecanico entre ambos.
 
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
@@ -17,10 +23,32 @@ namespace Bitakora.ControlAsistencia.Projections.Tests.ControlHoras;
 
 public class TurnoDiarioProjectionTests
 {
-    private static InformacionEmpleado EmpleadoDePrueba() =>
+    // Empleado (ControlHoras.DomainEvents) -- lo que trae el evento persistido.
+    private static Empleado EmpleadoDePrueba() =>
         new("EMP-001", "CC", "1098765432", "Ana", "Ramirez");
 
-    private static DetalleTurno DetalleTurnoDePrueba(string nombre) =>
+    // InformacionEmpleado (PublicEvents) -- lo que espera TurnoDiarioView, sin cambios en este issue.
+    private static InformacionEmpleado EmpleadoEsperadoEnVista() =>
+        new("EMP-001", "CC", "1098765432", "Ana", "Ramirez");
+
+    private static TurnoDiario TurnoDiarioDePrueba(string nombre) =>
+        new(
+            nombre,
+            [
+                new FranjaProgramada(
+                    new TimeOnly(6, 0),
+                    new TimeOnly(14, 0),
+                    DiaOffsetFin: 0,
+                    Descansos: [new SubFranjaProgramada(
+                        new TimeOnly(10, 0), new TimeOnly(10, 15), 0, 0, "(10:00-10:15)")],
+                    Extras: [],
+                    Descripcion: "(06:00-14:00)[Descansos:(10:00-10:15)]")
+            ],
+            $"{nombre}: (06:00-14:00)[Descansos:(10:00-10:15)]");
+
+    // DetalleTurno (PrivateEvents) -- lo que espera TurnoDiarioView, con la misma forma de datos
+    // que TurnoDiarioDePrueba pero en el tipo de bus (mapeo mecanico que Create/Apply deben hacer).
+    private static DetalleTurno DetalleTurnoEsperadoEnVista(string nombre) =>
         new(
             nombre,
             [
@@ -36,20 +64,24 @@ public class TurnoDiarioProjectionTests
             $"{nombre}: (06:00-14:00)[Descansos:(10:00-10:15)]");
 
     // CA-2/CA-5: Create mapea los cinco campos de la vista desde el evento fundacional, incluida
-    // la estructura completa de franjas anidadas (descansos/extras) que trae DetalleTurno.
+    // la estructura completa de franjas anidadas (descansos/extras) que trae TurnoDiario.
     [Fact]
     public void Create_ProyectaElTurnoDiarioVigente_DesdeTurnoDiarioAsignado()
     {
         var empleado = EmpleadoDePrueba();
-        var detalleTurno = DetalleTurnoDePrueba("Turno Manana");
+        var turnoDiario = TurnoDiarioDePrueba("Turno Manana");
         var fecha = new DateOnly(2026, 8, 3);
         var solicitudId = Guid.NewGuid();
-        var evento = new TurnoDiarioAsignado("EMP-001:2026-08-03", empleado, fecha, detalleTurno, solicitudId);
+        var evento = new TurnoDiarioAsignado("EMP-001:2026-08-03", empleado, fecha, turnoDiario, solicitudId);
 
         var vista = TurnoDiarioProjection.Create(evento);
 
         vista.Should().Be(new TurnoDiarioView(
-            "EMP-001:2026-08-03", empleado, fecha, detalleTurno, solicitudId));
+            "EMP-001:2026-08-03",
+            EmpleadoEsperadoEnVista(),
+            fecha,
+            DetalleTurnoEsperadoEnVista("Turno Manana"),
+            solicitudId));
     }
 
     // CA-3: la reasignacion sobrescribe -- dos TurnoDiarioAsignado consecutivos sobre el mismo
@@ -61,15 +93,17 @@ public class TurnoDiarioProjectionTests
         var empleado = EmpleadoDePrueba();
         var fecha = new DateOnly(2026, 8, 3);
         var vistaPrevia = new TurnoDiarioView(
-            "EMP-001:2026-08-03", empleado, fecha, DetalleTurnoDePrueba("Turno Manana"), Guid.NewGuid());
-        var nuevoDetalleTurno = DetalleTurnoDePrueba("Turno Tarde");
+            "EMP-001:2026-08-03", EmpleadoEsperadoEnVista(), fecha,
+            DetalleTurnoEsperadoEnVista("Turno Manana"), Guid.NewGuid());
+        var nuevoTurnoDiario = TurnoDiarioDePrueba("Turno Tarde");
         var nuevaSolicitudId = Guid.NewGuid();
         var segundoEvento = new TurnoDiarioAsignado(
-            vistaPrevia.Id, empleado, fecha, nuevoDetalleTurno, nuevaSolicitudId);
+            vistaPrevia.Id, empleado, fecha, nuevoTurnoDiario, nuevaSolicitudId);
 
         var vista = TurnoDiarioProjection.Apply(segundoEvento, vistaPrevia);
 
         vista.Should().Be(new TurnoDiarioView(
-            vistaPrevia.Id, empleado, fecha, nuevoDetalleTurno, nuevaSolicitudId));
+            vistaPrevia.Id, EmpleadoEsperadoEnVista(), fecha,
+            DetalleTurnoEsperadoEnVista("Turno Tarde"), nuevaSolicitudId));
     }
 }

--- a/tests/Bitakora.ControlAsistencia.Projections.Tests/ControlHoras/TurnoDiarioProjectionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Projections.Tests/ControlHoras/TurnoDiarioProjectionTests.cs
@@ -31,20 +31,24 @@ public class TurnoDiarioProjectionTests
     private static InformacionEmpleado EmpleadoEsperadoEnVista() =>
         new("EMP-001", "CC", "1098765432", "Ana", "Ramirez");
 
+    // Issue #322 (revision): la franja lleva un descanso que cruza medianoche (offsets 0 -> 1) y una
+    // extra al dia siguiente (1 -> 1). Con los offsets todos en cero, un mapeo que cruzara
+    // DiaOffsetInicio con DiaOffsetFin producia el mismo resultado y ningun test lo veia.
     private static TurnoDiario TurnoDiarioDePrueba(string nombre) =>
         new(
             nombre,
             [
                 new FranjaProgramada(
+                    new TimeOnly(22, 0),
                     new TimeOnly(6, 0),
-                    new TimeOnly(14, 0),
-                    DiaOffsetFin: 0,
+                    DiaOffsetFin: 1,
                     Descansos: [new SubFranjaProgramada(
-                        new TimeOnly(10, 0), new TimeOnly(10, 15), 0, 0, "(10:00-10:15)")],
-                    Extras: [],
-                    Descripcion: "(06:00-14:00)[Descansos:(10:00-10:15)]")
+                        new TimeOnly(23, 50), new TimeOnly(0, 10), 0, 1, "(23:50-00:10+1)")],
+                    Extras: [new SubFranjaProgramada(
+                        new TimeOnly(6, 0), new TimeOnly(8, 0), 1, 1, "(06:00+1-08:00+1)")],
+                    Descripcion: "(22:00-06:00+1)[Descansos:(23:50-00:10+1)]")
             ],
-            $"{nombre}: (06:00-14:00)[Descansos:(10:00-10:15)]");
+            $"{nombre}: (22:00-06:00+1)[Descansos:(23:50-00:10+1)]");
 
     // DetalleTurno (PrivateEvents) -- lo que espera TurnoDiarioView, con la misma forma de datos
     // que TurnoDiarioDePrueba pero en el tipo de bus (mapeo mecanico que Create/Apply deben hacer).
@@ -53,15 +57,16 @@ public class TurnoDiarioProjectionTests
             nombre,
             [
                 new DetalleFranjaOrdinaria(
+                    new TimeOnly(22, 0),
                     new TimeOnly(6, 0),
-                    new TimeOnly(14, 0),
-                    DiaOffsetFin: 0,
+                    DiaOffsetFin: 1,
                     Descansos: [new DetalleSubFranja(
-                        new TimeOnly(10, 0), new TimeOnly(10, 15), 0, 0, "(10:00-10:15)")],
-                    Extras: [],
-                    Descripcion: "(06:00-14:00)[Descansos:(10:00-10:15)]")
+                        new TimeOnly(23, 50), new TimeOnly(0, 10), 0, 1, "(23:50-00:10+1)")],
+                    Extras: [new DetalleSubFranja(
+                        new TimeOnly(6, 0), new TimeOnly(8, 0), 1, 1, "(06:00+1-08:00+1)")],
+                    Descripcion: "(22:00-06:00+1)[Descansos:(23:50-00:10+1)]")
             ],
-            $"{nombre}: (06:00-14:00)[Descansos:(10:00-10:15)]");
+            $"{nombre}: (22:00-06:00+1)[Descansos:(23:50-00:10+1)]");
 
     // CA-2/CA-5: Create mapea los cinco campos de la vista desde el evento fundacional, incluida
     // la estructura completa de franjas anidadas (descansos/extras) que trae TurnoDiario.
@@ -82,6 +87,19 @@ public class TurnoDiarioProjectionTests
             fecha,
             DetalleTurnoEsperadoEnVista("Turno Manana"),
             solicitudId));
+
+        // Issue #322 (revision): la igualdad de DetalleTurno/DetalleFranjaOrdinaria/DetalleSubFranja
+        // EXCLUYE Descripcion por diseno (dato derivado, no identidad), asi que el assert de arriba
+        // no cubre ese campo: si el mapeo del worker lo dejara caer, la vista quedaria sin la
+        // memoria de calculo y ningun test lo veria. Se verifica en los tres niveles.
+        var franjaProyectada = vista.DetalleTurno.FranjasOrdinarias.Should().ContainSingle().Subject;
+        vista.DetalleTurno.Descripcion
+            .Should().Be("Turno Manana: (22:00-06:00+1)[Descansos:(23:50-00:10+1)]");
+        franjaProyectada.Descripcion.Should().Be("(22:00-06:00+1)[Descansos:(23:50-00:10+1)]");
+        franjaProyectada.Descansos.Should().ContainSingle()
+            .Which.Descripcion.Should().Be("(23:50-00:10+1)");
+        franjaProyectada.Extras.Should().ContainSingle()
+            .Which.Descripcion.Should().Be("(06:00+1-08:00+1)");
     }
 
     // CA-3: la reasignacion sobrescribe -- dos TurnoDiarioAsignado consecutivos sobre el mismo


### PR DESCRIPTION
## Resumen

Pipeline TDD completado:
- Fase roja: tests escritos con stubs
- Fase verde: implementación completa
- Smoke tests: escritos para endpoints detectados
- Fase refactor: revisión de calidad

## Decisiones del pipeline

<details>
<summary>Test Writer (fase roja) — 32m 33s</summary>

## ES Test Writer - Decisiones (issue #322)

### Por que este flujo NO uso el carril de senal de refactor puro (pipeline-state/refactor-signal.md)

El issue mismo lo indica explicitamente: "Tipo `refactor`: cero comportamiento nuevo. No es
refactor puro (tests cambian) -- no aplica MEF-ADR-0017." Aunque el nucleo del cambio es mover
tipos entre ensamblados (candidato tipico al "caso mandatorio" de refactor de firma), el issue
exige verificar comportamiento real y nuevo:
- CA-1: `TurnoDiario`/`FranjaProgramada`/`SubFranjaProgramada` deben replicar la semantica de
  igualdad de los originales (Equals con SequenceEqual, exclusion de Descripcion).
- CA-2: un round-trip contra el JSON con la forma YA persistida hoy debe demostrar que la
  deserializacion es identica (guardrail de seguridad de datos, MEF-ADR-0036).
- CA-3: el csproj debe quedar en cero referencias -- verificable solo leyendo el archivo, no algo
  que el compilador imponga.

Estas tres verificaciones SI tienen un estado rojo compilable y significativo (no solo "no
compila"), asi que el carril TDD normal aplica.

### Tests creados

- `AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/TurnoDiarioIgualdadTests.cs`
  (8 tests, espejo de `DetalleTurnoIgualdadTests` en `PrivateEvents.Tests`): paridad de campos +
  Equals/GetHashCode con SequenceEqual + exclusion de Descripcion. **Rojo real**: `TurnoDiario` es
  un stub sin el override, el record por defecto compara `FranjasOrdinarias` por referencia.
- `.../Eventos/FranjaProgramadaIgualdadTests.cs` (7 tests, espejo de
  `DetalleFranjaOrdinariaIgualdadTests`): idem para `Descansos`/`Extras`. Rojo por el mismo motivo.
- `.../Eventos/SubFranjaProgramadaIgualdadTests.cs` (6 tests, espejo de
  `DetalleSubFranjaIgualdadTests`): paridad + exclusion de Descripcion (sin listas, pero el stub
  tampoco excluye Descripcion de la igualdad -> rojo).
- `.../Eventos/TurnoDiarioAsignadoSerializacionTests.cs`: agrega
  `Deserializar_ReconstruyeIdentico_DesdeElJsonConLaFormaYaPersistida` -- CA-2 critica. JSON
  literal con la forma EXACTA que Marten ya escribe hoy (PascalCase, mismos nombres de propiedad),
  deserializado contra `TurnoDiarioAsignado` (con los tipos nuevos) y comparado por igualdad
  estructural completa (`.Should().Be()`, no solo campos escalares) contra un oraculo construido a
  mano. Rojo por la misma razon: sin el Equals/GetHashCode del implementer, dos `TurnoDiario` con
  la misma franja no programada como lista vacia (real, con un elemento) no son iguales.
- `Infraestructura/ControlHorasDomainEventsAislamientoTests.cs` (2 tests, CA-3): lee el `.csproj`
  de `ControlHoras.DomainEvents` por texto (via `[CallerFilePath]` para ubicar la raiz del repo sin
  depender del working directory) y verifica ausencia de `<ProjectReference` y `<PackageReference`.
  Rojo: el csproj todavia tiene ambas referencias (las dejo intactas a proposito, ver mas abajo).

### Stubs creados (sin logica real pendiente)

- `Empleado.cs`: record plano, paridad con `InformacionEmpleado` (PublicEvents). Sin Equals custom
  -- todos los campos son string, la igualdad por valor del record por defecto ya es correcta
  (mismo criterio documentado en `DetalleEmpleado.cs`). Por eso NO hay
  `EmpleadoIgualdadTests.cs` (no hay nada que testear que no sea trivial).
- `TurnoDiario.cs`, `FranjaProgramada.cs`, `SubFranjaProgramada.cs`: records con la forma exacta de
  `DetalleTurno`/`DetalleFranjaOrdinaria`/`DetalleSubFranja` pero **sin** el override de
  Equals/GetHashCode que excluye Descripcion y compara listas por valor. Es la pieza de
  comportamiento pendiente que le corresponde al implementer (replicar la semantica de CA-1).

### Cambios de produccion que SI hice (mapeo mecanico, no logica de negocio nueva)

Justificacion: sin propagar el cambio de tipo en cascada, el codigo no compila y se pierde TODA la
suite existente de `ControlHoras.Tests`/`Projections.Tests` como colateral no deseado. Estos
cambios son renombres de tipo dirigidos por el compilador (mismos nombres de campo, paridad
exacta) mas mapeos 1:1 sin ninguna decision de negocio -- analogos al `MapearEmpleado` que ya
existia en el handler antes de este issue.

- `TurnoDiarioAsignado.cs`: `InformacionEmpleado`/`DetalleTurno` (tipos) -> `Empleado`/`TurnoDiario`
  (mismos NOMBRES de propiedad -- son las claves JSON persistidas). `ConfigurarSerializacion` no
  cambia (generico via reflection, agnostico al tipo anidado).
- `ControlDiarioAggregateRoot.cs`: propiedades `InformacionEmpleado`/`DetalleTurno` cambian de TIPO
  (mismo nombre). `CrearDiaCalculado()` agrega el mapeo `Empleado -> InformacionEmpleado`
  (PublicEvents) requerido por CA-4 -- el aggregate vive en el FA, el unico que ve los tres
  ensamblados.
- `DepuradorDeMarcaciones.cs`, `ControlFranja.cs`, `ClasificadorTrabajo.cs`, `DesgloseFranja.cs`:
  cambio de tipo de parametro/propiedad (`DetalleFranjaOrdinaria`/`DetalleSubFranja` ->
  `FranjaProgramada`/`SubFranjaProgramada`), logica interna intacta.
- `ProgramacionTurnoDiarioSolicitadaEventHandler.cs`: `MapearEmpleado` ahora retorna `Empleado`
  (antes `InformacionEmpleado`); se agrega `MapearTurnoDiario`/`MapearFranja`/`MapearSubFranja`
  (recursivo, 1:1) -- CA-4 explicito.
- `TurnoDiarioProjection.cs` (worker): `Create`/`Apply` ahora mapean `Empleado`/`TurnoDiario` (del
  evento) a `InformacionEmpleado`/`DetalleTurno` (lo que sigue esperando `TurnoDiarioView`, que NO
  cambia en este issue -- CA-5). El worker alcanza `PublicEvents`/`PrivateEvents` transitivamente
  via `ReadModels` (deuda ya documentada en CA-ADR-0029), asi que los `using` nuevos compilan sin
  tocar el `.csproj` del worker.

**Deliberadamente NO toque** `ControlHoras.DomainEvents.csproj` (las referencias siguen ahi): es
exactamente lo que CA-3 pide verificar como rojo. Removerlas es tarea del implementer.

### Tests existentes actualizados (rename mecanico de tipo, explicitamente listados en el issue)

`DepuradorDeMarcacionesTests`, `ControlFranjaTests`, `ClasificadorTrabajoTests`,
`CalcularDesgloseFranjaTests`, `ConsolidadorDesgloseHorasTestData`, `DesgloseFranjaTests`,
`DesgloseHorasTests`, `DesgloseHorasDiscriminarTests`, `DesgloseFranjaSerializacionTests`,
`DesgloseHorasSerializacionTests`, `DesgloseHorasTrasAdicionarMarcacionTests`,
`DepurarAlAdicionarMarcacionTests`, `RegistroDeMarcacionCreadoEventHandlerTests`,
`DesgloseHorasTrasAsignarTurnoTests`, `DepurarAlAsignarTurnoTests`,
`ProgramacionTurnoDiarioSolicitadaEventHandlerTests`, `CrearDiaCalculadoConHorasDiscriminadasTests`,
`TurnoDiarioProjectionTests` (Projections.Tests).

En los archivos que consumen simultaneamente el evento entrante (`ProgramacionTurnoDiarioSolicitada`,
que sigue usando `DetalleTurno`/`DetalleEmpleado` de PrivateEvents, sin cambios) y el evento
persistido (`TurnoDiarioAsignado`, que ahora usa `TurnoDiario`/`Empleado`), duplique las constantes
de franja/empleado con sufijo `Detalle` (p.ej. `Franja06_14` de tipo `FranjaProgramada` +
`Franja06_14Detalle` de tipo `DetalleFranjaOrdinaria`, mismos valores) para evitar construir el
tipo equivocado. Donde solo se necesitaba el tipo persistido, reutilice el nombre `Empleado`
directamente como campo estatico de tipo `Empleado` (legal en C#: la posicion de tipo y la posicion
de miembro se resuelven en contextos distintos; verificado por compilacion exitosa).

En archivos que ademas necesitaban `InformacionEmpleado` (PublicEvents) para construir el
`DiaCalculado` esperado (`DepurarAlAdicionarMarcacionTests`, `DepurarAlAsignarTurnoTests`), agregue
un campo separado `EmpleadoPublico` con los mismos valores.

### Verificacion del estado rojo (corrido real, no solo lectura de codigo)

`dotnet test` sobre `ControlHoras.Tests`: 395 tests, 18 en rojo -- exactamente los 17 tests nuevos
(Igualdad x3 + round-trip persistido + csproj x2) mas UN test existente que colapsa como
consecuencia directa y esperada (`DesgloseFranjaSerializacionTests.RoundTrip_PreservaProgramada_CuandoFranjaConDescanso`,
que compara `FranjaProgramada` completa por `.Should().Be()` con una lista de descansos NO vacia,
asi que no se beneficia de la optimizacion del compilador que cachea `[]` como `Array.Empty<T>()`
compartido). El resto de la suite (377 tests) permanece verde porque `And<>()`/`Then()` del harness
y la mayoria de comparaciones estructurales usan `BeEquivalentTo` (member-by-member), indiferente a
que falte el Equals custom.

`Projections.Tests`: 53/53 verdes -- el mapeo de `TurnoDiarioProjection` es completo y correcto
(mecanico, sin ambiguedad), y `TurnoDiarioView`/sus tipos anidados no cambian.

Build de la solucion completa: 0 errores.

### Cobertura de criterios

| Criterio de aceptacion | Test(s) |
|---|---|
| CA-1: paridad de campos + igualdad replicada | `TurnoDiarioIgualdadTests`, `FranjaProgramadaIgualdadTests`, `SubFranjaProgramadaIgualdadTests` |
| CA-2: TurnoDiarioAsignado usa records propios, mismos nombres JSON, round-trip identico | `TurnoDiarioAsignadoSerializacionTests.Deserializar_ReconstruyeIdentico_DesdeElJsonConLaFormaYaPersistida` |
| CA-3: cero ProjectReference/PackageReference | `ControlHorasDomainEventsAislamientoTests` |
| CA-4: mapeo en el FA (handler + aggregate) | Cambios de produccion en `ProgramacionTurnoDiarioSolicitadaEventHandler.cs` y `ControlDiarioAggregateRoot.cs`, ejercitados por `ProgramacionTurnoDiarioSolicitadaEventHandlerTests`, `DepurarAlAsignarTurnoTests`, `DesgloseHorasTrasAsignarTurnoTests`, `CrearDiaCalculadoConHorasDiscriminadasTests` |
| CA-5: TurnoDiarioProjection mapea a tipos actuales de la vista | `TurnoDiarioProjectionTests` (Projections.Tests, verde -- mapeo mecanico completo) |
| CA-6: suite en verde (objetivo final del implementer) | Ver seccion "Verificacion del estado rojo": 18 tests en rojo hoy, a resolver por el implementer agregando Equals/GetHashCode a los 3 records y removiendo las referencias del csproj |

### Desviaciones del plan del planner

| Sugerencia del issue | Desviacion aplicada | Razon tecnica | Consecuencia |
|---|---|---|---|
| "Impacto/Modifica" no menciona explicitamente `ControlFranja.cs`, `ClasificadorTrabajo.cs`, `DesgloseFranja.cs`, `ConsolidadorDesgloseHorasTestData.cs`, ni los tests de `ValueObjects/Desglose*` | Se tocaron igual (rename mecanico de tipo) | El propio issue ya anticipaba esto: "+ la familia de calculo que consuma los tipos: DepuradorDeMarcaciones, ControlFranja, DesgloseHoras -- segun dicte el compilador". El compilador efectivamente lo exigio: `ControlFranja.Programada`, `ClasificadorTrabajo.Clasificar`, `DesgloseFranja.Programada` son consumidores directos de `DetalleFranjaOrdinaria`/`DetalleSubFranja` | Ningun CA nuevo; cambio de tipo sin alterar comportamiento. Documentado explicitamente como previsto por el propio issue |
| El issue no detalla como resolver el doble tipo (persistido vs. evento entrante) en los tests de handler | Se duplicaron constantes con sufijo `Detalle` para el tipo PrivateEvents y sin sufijo para el tipo DomainEvents | Necesario para que las pruebas construyan ambos tipos con los mismos valores sin violar CA-1 (usar el tipo correcto en cada posicion) | Mas verboso pero explicito; ningun CA afectado |
| CA-5 podria leerse como exigiendo un ciclo rojo/verde para `TurnoDiarioProjectionTests` | Se implemento el mapeo completo y correcto en `TurnoDiarioProjection.cs`, dejando el test en verde | El propio issue lo caracteriza como "mapeo mecanico dirigido por el compilador, no una vista nueva ni un cambio de doctrina read-side" -- sin ambiguedad de negocio que amerite TDD real. El comportamiento verdaderamente nuevo de este issue (CA-1/CA-2/CA-3) ya queda en rojo por otra via | `TurnoDiarioProjectionTests` queda verde tras mi fase; no viola el principio fundamental porque los 17 tests que SI prueban comportamiento nuevo estan en rojo |

Ninguna otra desviacion relevante.

</details>

<details>
<summary>Implementer (fase verde) — 5m 52s</summary>

## ES Implementer - Decisiones

### Enfoque de implementacion

El test-writer dejo la fase roja con 18 tests fallando, todos concentrados en dos piezas
faltantes:

1. `FranjaProgramada`, `SubFranjaProgramada` y `TurnoDiario` (`ControlHoras.DomainEvents`)
   declaradas como stubs: la forma de campos ya era correcta (paridad con `DetalleFranjaOrdinaria`
   / `DetalleSubFranja` / `DetalleTurno` de `PrivateEvents`), pero sin el override de
   `Equals`/`GetHashCode` que compara colecciones por valor (`SequenceEqual`) y excluye
   `Descripcion` de la identidad. Repliqué exactamente el mismo patron ya usado por el issue
   paralelo #319 en `Programacion.DomainEvents` (mismo criterio, mismo codigo, distinto
   namespace).
2. `Bitakora.ControlAsistencia.ControlHoras.DomainEvents.csproj` seguia declarando
   `PackageReference Cosmos.EventDriven.Abstractions` y `ProjectReference` hacia `PublicEvents`
   y `PrivateEvents`. Los retire, dejando unicamente el `InternalsVisibleTo` hacia
   `ControlHoras.Tests` que sigue siendo necesario para `MarcacionRegistrada.Mensajes` (issue
   #275, evento no relacionado con este issue que vive en el mismo ensamblado).

El resto del trabajo (mapeo mecanico en `ProgramacionTurnoDiarioSolicitadaEventHandler`,
`ControlDiarioAggregateRoot`, `DepuradorDeMarcaciones`, `ControlFranja`, `ClasificadorTrabajo`,
`DesgloseFranja`, `TurnoDiarioProjection`) ya venia resuelto en la fase roja como "cambios de
produccion necesarios para no perder la suite existente como colateral" (segun el propio mensaje
de commit del test-writer) -- lo verifique leyendo cada archivo y confirmando que sigue el
mapeo campo a campo esperado por el issue (CA-4, CA-5), sin necesidad de tocarlo.

### Decisiones de diseno

- Equals/GetHashCode de `FranjaProgramada`/`SubFranjaProgramada`/`TurnoDiario`: copia literal del
  patron de `DetalleFranjaOrdinaria`/`DetalleSubFranja`/`DetalleTurno` (PrivateEvents) y de
  `FranjaProgramada`/`SubFranjaProgramada`/`TurnoProgramado` (Programacion.DomainEvents, issue
  #319) -- mismo criterio de paridad de comportamiento exigido por CA-1, sin inventar una
  variante nueva.
- `Descripcion { get; init; } = Descripcion ?? string.Empty` se mantiene en los tres records: es
  el mismo mecanismo de normalizacion de compatibilidad retroactiva que ya usan sus contrapartes
  de bus (issue #288), necesario porque STJ deja `null` en el parametro posicional cuando el JSON
  persistido no trae el campo.
- csproj: solo se retiraron las dos referencias senaladas por CA-3 (`ProjectReference` x2,
  `PackageReference` x1). El `InternalsVisibleTo` no es parte del alcance de este issue (protege
  el acceso a `MarcacionRegistrada.Mensajes`, evento no tocado aqui) y se dejo intacto.

### ADRs consultados

- MEF-ADR-0039 (decisiones 2 y 6): tres islas, payload por rol -- aplicado al retirar referencias
  del csproj y al mantener los records propios del ensamblado.
- CA-ADR-0029 (enmendado por #317): misma doctrina de tres islas a nivel local del repo.
- MEF-ADR-0036: identidad del evento intacta -- no se toco el alias `turno_diario_asignado` ni el
  nombre/ubicacion de la clase `TurnoDiarioAsignado`; solo cambiaron tipos de payload anidado.
  Verificado por el test de round-trip `TurnoDiarioAsignadoSerializacionTests` (ya en verde desde
  antes de mi intervencion, no lo toque).
- MEF-ADR-0034/0035: el mapeo en `TurnoDiarioProjection` es mecanico, dirigido por el compilador
  (records del evento -> tipos de bus que `TurnoDiarioView` sigue esperando), consistente con
  el estado intermedio deliberado que el issue documenta.
- MEF-ADR-0016: naming de metodos de test -- no aplica, no cree tests nuevos.

### Desviaciones de ADRs

Ninguna desviacion -- todos los ADRs aplicados al pie de la letra.

### Desviaciones del plan del planner

Ninguna desviacion -- el plan de archivos ("Impacto esperado en archivos") coincidio exactamente
con lo que quedo pendiente tras la fase roja.

### Precedentes consultados

- `src/Bitakora.ControlAsistencia.Programacion.DomainEvents/{FranjaProgramada,
  SubFranjaProgramada,TurnoProgramado}.cs` (issue #319, paralelo-seguro con este issue): alineado
  con MEF-ADR-0039/CA-ADR-0029, replicado tal cual para ControlHoras.
- `src/Bitakora.ControlAsistencia.PrivateEvents/Programacion/{DetalleFranjaOrdinaria,
  DetalleSubFranja,DetalleTurno}.cs`: fuente original de la semantica de igualdad que CA-1 exige
  preservar; alineado con MEF-ADR-0012 (records con `IReadOnlyList` necesitan Equals/GetHashCode
  propios para no comparar por referencia).

### Infraestructura modificada

Ninguna. Este issue no introduce ni modifica eventos de bus (`IPublicEvent`/`IPrivateEvent`) --
solo tipos de payload propios del ensamblado de dominio persistido. No aplica ningun cambio a
`infra/environments/dev/main.tf`.

### Complejidad encontrada

- Un intento fallido menor: al escribir el comentario del csproj use "--" dentro de un comentario
  XML/MSBuild, lo que rompe el parser de MSBuild (`MSB4025`, "An XML comment cannot contain '--'
  ..."). Lo corregi cambiando a texto sin doble guion. No cuenta como intento sobre un test (fue
  un error de build detectado y corregido de inmediato, ver regla de "Que es un intento").

### Resultado

- Tests pasando: 713/713 (12 omitidos por servicios externos no configurados localmente:
  Postgres/ServiceBus en SmokeTests, comportamiento esperado y preexistente).
- `ControlHoras.Tests`: 395/395.
- `Projections.Tests`: 53/53.
- Build de la solucion completa: 0 errores.

</details>
<details>
<summary>Smoke Test Writer — 6m 46s</summary>

_(El agente no generó resumen)_

</details>
<details>
<summary>Reviewer (fase refactor) — 15m 15s</summary>

## ES Reviewer - Revision (issue #322)

### Evaluacion general
- Calidad: **buena**. El refactor cumple los 6 CAs, la suite quedo en verde en todo momento y las
  decisiones de forma replican con fidelidad el precedente del issue hermano #319.
- Cambios realizados: **si** (solo tests: 4 casos nuevos + 1 oraculo reforzado + 1 using huerfano).
  Cero cambios en `src/` -- el codigo de produccion no requirio correccion.
- Suite: 736 tests, 0 errores, 724 correctos, 12 omitidos (smoke sin Postgres/ServiceBus local,
  preexistente). Baseline al iniciar: 725 / 0 errores.

### Cumplimiento de ADRs aplicables

| ADR | Cumplimiento | Observacion |
|---|---|---|
| MEF-ADR-0039 (tres islas, payload por rol) | **no verificable en este entorno** | El ADR **no existe** en el plugin instalado (`mefisto/0.20.0` llega hasta MEF-ADR-0038; tampoco esta en `0.10.0`). Verifique contra su aplicacion local, CA-ADR-0029 (decisiones #2, #5 y #7), que lo parafrasea con precision y declara "gana el marco". Escalado al planner mas abajo. |
| CA-ADR-0029 dec. #2 (tres islas) | ok | `ControlHoras.DomainEvents.csproj` queda con cero `<ProjectReference>` y cero `<PackageReference>`; verificado por lectura directa del archivo y congelado por `ControlHorasDomainEventsAislamientoTests`. |
| CA-ADR-0029 dec. #5 (payload por rol) | ok | Los cuatro records (`Empleado`, `TurnoDiario`, `FranjaProgramada`, `SubFranjaProgramada`) son propios del ensamblado, con paridad exacta de campos verificada contra `InformacionEmpleado`, `DetalleTurno`, `DetalleFranjaOrdinaria` y `DetalleSubFranja`. Todo el mapeo vive en el Function App (`ProgramacionTurnoDiarioSolicitadaEventHandler`, `ControlDiarioAggregateRoot`) o en el worker (`TurnoDiarioProjection`), nunca dentro de un ensamblado de eventos. |
| CA-ADR-0029 dec. #4 y #6 (listas de serializacion e identidad) | ok | `ConfiguracionSerializacionControlHoras` e `IdentidadEventosControlHoras` intactos; `TurnoDiarioAsignado` sigue en `TiposPersistidos` con el mismo nombre simple. |
| MEF-ADR-0036 (identidad del evento persistido) | ok | La clase `TurnoDiarioAsignado` no se renombro ni se movio de ensamblado -> el alias `turno_diario_asignado` no cambia. Solo cambian tipos de payload anidado, cuyo nombre CLR **no** se persiste en el JSON de `mt_events`. Los nombres de propiedad (`InformacionEmpleado`, `Fecha`, `DetalleTurno`, `SolicitudId`), que si son claves JSON, se conservan. No aplica el protocolo de dos despliegues. Guardas de alias (`ComposicionContenedorTests`, `IdentidadEventosControlHorasTests`) en verde, con sus literales sin tocar. |
| MEF-ADR-0012 (encapsulamiento y serializacion) | ok con una desviacion de forma (ver abajo) | `ConfigurarSerializacion` con resolver + backing fields via reflection intacto; sin `[JsonConstructor]`; sin `InternalsVisibleTo` nuevo; ningun evento lleva marker de bus (el paquete de markers fue retirado, asi que reintroducirlo ya no compila). |
| MEF-ADR-0034 / 0035 (read-side) | ok | `TurnoDiarioProjection` sigue `sealed partial`, con `Create`/`Apply` **estaticos** que retornan copia (`vista with { ... }`); `TurnoDiarioView` sigue siendo un `record` plano sin `partial`. El mapeo agregado es mecanico y no cambia lifecycle ni registro. |
| MEF-ADR-0016 (naming de tests) | ok | Los tests nuevos siguen `<Sujeto>_<LoQuePasa>[_Complemento]`, alineados con el precedente del hermano #319 (`Deserializar_..._ConLaFormaPersistidaAntesDelCambioDeTipos`). |

**Escalamiento al planner**: el issue lista `MEF-ADR-0039` como ADR aplicable, pero ese ADR **no
esta publicado en el plugin instalado** (`mefisto@0.20.0`, ultimo ADR: MEF-ADR-0038). O falta
`/plugin update mefisto`, o el ADR aun no se publico en el harness. La revision se sostuvo sobre
CA-ADR-0029, que es su aplicacion local declarada, pero conviene cerrarlo antes de #320 (que
escribira los tests de arquitectura contra ese canon).

### Desviaciones de ADRs

**Desviaciones declaradas por el implementer**: ninguna ("todos los ADRs aplicados al pie de la
letra", `stage-2-implementer.md`).

**Desviaciones detectadas por el reviewer (NO declaradas)**:

#### Desviacion: MEF-ADR-0012 (forma del tipo con coleccion)
- **Regla del ADR**: "Usar `record` para eventos con colecciones (ej: `IReadOnlyList<T>`) promete
  igualdad por valor que no cumple -- `sealed class` no hace esa promesa" (linea 44).
- **Desviacion encontrada en el diff**: `TurnoDiario` y `FranjaProgramada`
  (`ControlHoras.DomainEvents/*.cs`) son `record` con `IReadOnlyList<T>`.
- **Evaluacion**: **aceptable**. La promesa **si** se cumple: ambos declaran `Equals`/`GetHashCode`
  propios con `SequenceEqual`, y ese comportamiento queda congelado por
  `TurnoDiarioIgualdadTests` / `FranjaProgramadaIgualdadTests` (incluidos los casos "listas
  distintas con mismo contenido"). Ademas CA-1 exige **paridad exacta con los originales**, que son
  `record` con el mismo override desde #129/#288; convertirlos a `sealed class` habria roto esa
  paridad y divergido del hermano #319 sin ganancia.
- **Accion tomada**: no corregida (desviacion de forma con el proposito del ADR satisfecho).
- **Status**: pendiente de evaluacion del usuario.

#### Desviacion: CA-ADR-0029 dec. #2 (proposito del canon, no su letra)
- **Regla**: el worker no debe arrastrar `PublicEvents`/`PrivateEvents` "ni transitivamente".
- **Desviacion encontrada**: `TurnoDiarioProjection.cs` (worker) ahora **nombra explicitamente**
  tipos de bus (`using ...PrivateEvents.Programacion`, `using ...PublicEvents.Empleados`), que
  alcanza solo por transitividad via `ReadModels`. Antes del diff el pass-through no requeria esos
  `using`.
- **Evaluacion**: **aceptable y previsto**. El issue lo declara "estado intermedio deliberado"
  (CA-5: la vista no cambia aqui) y CA-ADR-0029 ya registra esa transitividad como deuda abierta
  sin issue asignado. La letra de la decision #2 se cumple: el `.csproj` del worker no gano ninguna
  referencia directa (verificado).
- **Accion tomada**: no corregida (fuera del alcance declarado del issue). **Escalada**: el issue
  de `ReadModels` pendiente debe crearse antes de #320, porque hoy la deuda es mas visible que
  antes del PR.
- **Status**: pendiente de evaluacion del usuario.

### Precedentes consultados por el implementer

| Precedente | ADR aplicable | Veredicto |
|---|---|---|
| `Programacion.DomainEvents/{FranjaProgramada,SubFranjaProgramada,TurnoProgramado,Empleado}.cs` (#319) | CA-ADR-0029 #2/#5 | **alineado**. Verificado archivo por archivo: mismo criterio de igualdad, mismo comentario de normalizacion de `Descripcion`, misma ausencia de `Equals` custom en `Empleado`. |
| `PrivateEvents/Programacion/{DetalleTurno,DetalleFranjaOrdinaria,DetalleSubFranja}.cs` | MEF-ADR-0012 | **alineado** en la semantica (override con `SequenceEqual`, exclusion de `Descripcion`); el matiz de `record` vs `sealed class` se trata como desviacion de forma arriba. Paridad de campos verificada uno a uno. |

### Convenciones del pipeline (no ADRs)

| Convencion | Estado | Observacion |
|---|---|---|
| Cada test con `Then()` + `And<>()` | ok | El test de handler que agregue lleva `Then(streamId, ...)` + `And<ControlDiarioAggregateRoot, TurnoDiario?>(...)`. Los tests de igualdad/serializacion/csproj no usan el DSL (no aplica). |
| Overloads correctos para stream IDs compuestos | ok | `ControlDiarioAggregateRoot` tiene `ComputarStreamId` (clave compuesta): todos los tests usan `Given(streamId, ...)`, `Then(streamId, ...)` y `And<T,P>(streamId, ...)`. |
| Fakes manuales (no NSubstitute) | n/a | El handler solo depende de `IEventStore` e `IPublicEventSender`, provistos por el harness. |
| Feature folders (produccion y tests) | ok | Records nuevos en la raiz del ensamblado de eventos (patron de #319); tests nuevos en `AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/`, espejo del feature que los consume. |
| Smoke tests: SkipWhen, secrets, cobertura | ok | `Assert.SkipWhen` (xUnit v3) en ambos tests, filtro por `SolicitudId` (no por posicion), cobertura de los dos efectos del handler (persistencia en Postgres + publicacion de `DiaCalculado`) y del dead letter acotado. La nueva `<ProjectReference>` a `ControlHoras.DomainEvents` es correcta: el smoke test debe deserializar el payload persistido con su tipo dueno. |
| Proyecciones read-side: partial, inmutabilidad, read APIs, naming | ok | `sealed partial`, `Create`/`Apply` estaticos, `vista with { ... }`, read model plano sin `partial`. Sin Function GET tocada. |
| Compatibilidad Marten write-side/read-side (#447) | n/a | El diff no toca la version de `Cosmos.EventSourcing.*` ni `ComposicionServicios*`, `ConfiguracionMartenProjections*`, `ConfiguracionSerializacion*`, `IdentidadEventos*`, ni ninguna linea con `AddEventTypes`/`opts.Events.`/`Policies.`/`TypeInfoResolver`. Gate no disparado. |
| Identidad de stream (MEF-ADR-0037) | ok | El handler tocado sigue derivando la clave por `ControlDiarioAggregateRoot.ComputarStreamId(empleadoId, fecha)` -- punto unico de conversion, sin reconstruccion paralela. Sin `ToString("N"/"B"/...)`, sin `GroupId`, sin GET de consulta en el diff. Los componentes son `string` + `DateOnly` (formato explicito de fecha: lo que el ADR exige). |
| Control de volumen de telemetria (MEF-ADR-0038) | n/a | El diff no toca `ComposicionServicios*`, `ConfiguracionObservabilidad*`, `AddOpenTelemetry`, `SetSampler` ni el callback de Wolverine. |
| Tests via ToString/comportamiento | ok | Ningun getter nuevo expuesto para tests; los records son payload plano por contrato del ADR. |
| Sin numeros magicos | ok | Horas/offsets viven en constantes o literales de escenario nombrados en cada test. |
| Condiciones en positivo | ok | `if (existe) ... else ...` en el handler. El unico ternario negativo (`empleado is null ? null : ...`) es la forma idiomatica de "caso vacio primero"; no amerita churn. |

### Elegancia del codigo
- Los cuatro records nuevos son compactos, con XML doc que explica **por que** duplican en vez de
  importar (la pregunta que un lector se hace primero). Sin codigo muerto.
- El comentario del `.csproj` esta escrito sin `--` (evita `MSB4025`) y explica la ausencia de
  referencias, que es informacion que de otro modo se pierde al borrar lineas.
- Los mapeos del handler y de la proyeccion son expresiones de una linea con `Select(...).ToList()`,
  recursivas por composicion de metodos -- idiomatico y sin ceremonia.
- `ControlDiarioAggregateRoot.CrearDiaCalculado()` mantiene Tell-don't-Ask: el aggregate sigue
  entregando el evento ya empaquetado; el mapeo hacia `InformacionEmpleado` (PublicEvents) queda
  privado dentro del aggregate.
- **Sobre el antipatron #2 de MEF-ADR-0012** (clase/metodo estatico que opera sobre datos crudos):
  los mapeos `Mapear*` no lo son. La alternativa Tell-don't-Ask (`DetalleTurno.ToTurnoDiario()`)
  es **imposible por construccion**: exigiria que un ensamblado de eventos referencie a otro,
  justo lo que las tres islas prohiben. CA-ADR-0029 dec. #5 manda explicitamente que ese mapeo
  viva en el Function App. Sin hallazgo.
- Compilacion limpia: los unicos warnings son `NU1902` preexistentes de `OpenTelemetry.Api` en el
  dominio Programacion, ajenos a este diff.

### Criticas y hallazgos

1. **[Mayor - corregido] Los mapeos recursivos del Function App no estaban ejercitados.**
   `MapearFranja`/`MapearSubFranja` del handler solo veian franjas con `Descansos`/`Extras` vacios.
   Verificado con mutacion deliberada (cruzar `DiaOffsetInicio` con `DiaOffsetFin` en
   `MapearSubFranja`): **toda la suite pasaba en verde**. Corregido agregando un test con turno
   nocturno, un descanso que cruza medianoche y una extra al dia siguiente; con el test nuevo, la
   misma mutacion falla (1 test rojo) y sin el, ninguno.

2. **[Mayor - corregido] El oraculo de `TurnoDiarioProjectionTests` era mas debil de lo que
   aparentaba (CA-5).** Usaba un descanso con ambos offsets en `0` y sin extras, y comparaba con
   `Should().Be()` -- pero la igualdad de `DetalleTurno`/`DetalleFranjaOrdinaria`/`DetalleSubFranja`
   **excluye `Descripcion` por diseno**. Resultado: ni un cruce de offsets ni la perdida completa de
   `Descripcion` en el mapeo del worker rompian ningun test (verificado con dos mutaciones: 53/53
   verdes en ambos casos). Reforzado el oraculo (offsets distintos, extra presente) y agregados
   asserts explicitos de `Descripcion` en los tres niveles; ahora las dos mutaciones fallan.

3. **[Menor - corregido] El round-trip contra la forma persistida no cubria sub-franjas ni la
   forma anterior al issue #288.** El JSON del test llevaba `"Descansos": []` y `"Extras": []`, asi
   que `SubFranjaProgramada` nunca se releia desde JSON persistido; y la rama
   `Descripcion ?? string.Empty` de los tres records -- la que protege a los eventos ya escritos en
   dev antes de #288 -- no se ejercitaba sobre el evento persistido. Ambos huecos cerrados con dos
   tests nuevos (el segundo, espejo del que #319 ya tiene en `Programacion.Tests`).

4. **[Menor - corregido] Faltaba el contrato de igualdad de `Empleado`** (cuarto record de CA-1),
   pese a que el hermano #319 si lo tiene (`Programacion.Tests/ValueObjects/EmpleadoIgualdadTests`).
   Agregado como espejo.

5. **[Cosmetico - corregido] `using` huerfano** en `TurnoDiarioAsignadoSerializacionTests.cs`
   (`ControlHoras.Infraestructura`: `ConfiguracionSerializacionControlHoras` vive en
   `ControlHoras.DomainEvents` desde #237). Removido por ser archivo del diff.

6. **[Observacion, no corregido] `dotnet format --verify-no-changes` sigue en exit 2** por 5
   `IDE0005` en archivos **que este diff no toca** (`IntervaloTemporalSerializacionMartenTests`,
   `MarcacionAdicionadaSerializacionTests`, `IntervaloClasificadoSerializacionTests`,
   `RetardoSerializacionTests`, `TurnoCreadoSerializacionTests` -- el mismo `using` huerfano
   heredado de #237). Deuda preexistente, no regresion de este PR; corregirla habria violado la
   regla de no refactorizar codigo ajeno a la HU. Candidata a issue de limpieza.

7. **[Observacion, no corregido] Tres nombres simples homonimos entre los dos `DomainEvents`.**
   `Empleado`, `FranjaProgramada` y `SubFranjaProgramada` existen ahora en
   `Programacion.DomainEvents` (#319) y en `ControlHoras.DomainEvents` (#322), y el **worker
   referencia ambos ensamblados**. Ya hay un archivo que importa los dos namespaces
   (`Projections.Tests/ConfiguracionMartenProjectionsTests.cs`), hoy sin conflicto porque no usa
   esos tipos. A diferencia del caso que motivo la regla de "nombres simples distintos por rol"
   (deuda de #270 en CA-ADR-0029, donde un `using` equivocado publicaba el evento rico al bus **en
   silencio**), aqui el modo de fallo es **error de compilacion** (`CS0104` por ambiguedad, o tipo
   incompatible): detectable, no silencioso. Riesgo bajo; se registra para que #320 lo considere al
   escribir los tests de arquitectura.

### Refactorings aplicados
- Ninguno sobre `src/`. El codigo de produccion no requirio correccion: el mapeo campo a campo es
  correcto en los tres puntos (handler, aggregate, proyeccion), verificado por lectura y por
  mutacion.
- Sobre tests: refuerzo del oraculo de `TurnoDiarioProjectionTests` (hallazgo 2) y retiro de un
  `using` huerfano (hallazgo 5).

### Cobertura de criterios de aceptacion

| Criterio | Estado | Test(s) |
|---|---|---|
| CA-1: records propios con paridad exacta de campos e igualdad replicada | cubierto (reforzado) | `TurnoDiarioIgualdadTests`, `FranjaProgramadaIgualdadTests`, `SubFranjaProgramadaIgualdadTests`, **`EmpleadoIgualdadTests`** (agregado) |
| CA-2: `TurnoDiarioAsignado` usa los records propios sin cambiar nombres de propiedad; round-trip identico contra la forma persistida | cubierto (reforzado) | `Deserializar_ReconstruyeEvento_ConTodosLosCampos`, `Deserializar_ReconstruyeIdentico_DesdeElJsonConLaFormaYaPersistida`, **`Deserializar_ReconstruyeLasSubFranjasAnidadas_ConLaFormaPersistidaQueLlevaDescansosYExtras`**, **`Deserializar_NormalizaDescripcionACadenaVaciaEnLosTresNiveles_CuandoElJsonPersistidoNoLlevaEseCampo`** (agregados) |
| CA-3: cero `<ProjectReference>` y cero `<PackageReference>` | cubierto | `ControlHorasDomainEventsAislamientoTests.Csproj_NoTieneProjectReference` / `Csproj_NoTienePackageReference` |
| CA-4: el FA es el punto de mapeo (handler + aggregate + `CrearDiaCalculado`) | cubierto (reforzado) | `ProgramacionTurnoDiarioSolicitada_EmiteTurnoDiarioAsignado_Cuando{No,Ya}ExisteControlDiario`, **`ProgramacionTurnoDiarioSolicitada_MapeaDescansosYExtrasConSusOffsets_CuandoLaFranjaTraeSubFranjas`** (agregado), `DepurarAlAsignarTurnoTests`, `DesgloseHorasTrasAsignarTurnoTests`, `CrearDiaCalculadoConHorasDiscriminadasTests` (verifican que `DiaCalculado` sigue llevando `InformacionEmpleado` de PublicEvents: contrato publico intacto) |
| CA-5: `TurnoDiarioProjection.Create/Apply` mapean a los tipos actuales de la vista; config-test y guardas de alias en verde | cubierto (reforzado) | `TurnoDiarioProjectionTests` (oraculo reforzado), `ConfiguracionMartenProjectionsTests`, `ComposicionContenedorTests`, `IdentidadEventosControlHorasTests` |
| CA-6: suite completa en verde | cubierto | 736 tests, 0 errores (12 omitidos por servicios externos no configurados en local) |

### Tests agregados
- `EmpleadoIgualdadTests` (8 tests heredados de `IgualdadTestBase<Empleado>`) -- contrato de
  igualdad del cuarto record, CA-1.
- `ProgramacionTurnoDiarioSolicitada_MapeaDescansosYExtrasConSusOffsets_CuandoLaFranjaTraeSubFranjas`
  -- cubre `MapearFranja`/`MapearSubFranja` del Function App, CA-4. Con `Then(...)` + `And<>()`.
- `Deserializar_ReconstruyeLasSubFranjasAnidadas_ConLaFormaPersistidaQueLlevaDescansosYExtras`
  -- round-trip de sub-franjas anidadas desde la forma JSON de `mt_events`, CA-2.
- `Deserializar_NormalizaDescripcionACadenaVaciaEnLosTresNiveles_CuandoElJsonPersistidoNoLlevaEseCampo`
  -- compatibilidad retroactiva con eventos escritos antes de #288, CA-2 / nota de seguridad de datos.
- Oraculo reforzado en `TurnoDiarioProjectionTests` (no es test nuevo, es el existente endurecido).

</details>

## Cobertura

| Archivo | Cobertura | Umbral | Estado |
|---|---|---|---|
| TurnoDiarioProjection.cs | 100.0% | 95% | ok |
| ControlDiarioAggregateRoot.cs | 100.0% | 95% | ok |
| Empleado.cs | - | excluido | - |
| FranjaProgramada.cs | - | no evaluado | - |
| SubFranjaProgramada.cs | - | no evaluado | - |
| TurnoDiario.cs | - | no evaluado | - |
| TurnoDiarioAsignado.cs | - | no evaluado | - |
| ProgramacionTurnoDiarioSolicitadaEventHandler.cs | - | no evaluado | - |
| ClasificadorTrabajo.cs | - | no evaluado | - |
| ControlFranja.cs | - | no evaluado | - |
| DepuradorDeMarcaciones.cs | - | no evaluado | - |
| DesgloseFranja.cs | - | no evaluado | - |
## Commits

5aacc6b refactor(issue-322): reforzar los guardrails de paridad del payload por rol
985e6c3 test(issue-322): smoke test verifica el evento persistido con su tipo dueno
37dd7ae feat(issue-322): completar Equals/GetHashCode e islas de ControlHoras.DomainEvents (fase verde)
1832963 test(issue-322): tests para Empleado/TurnoDiario/FranjaProgramada/SubFranjaProgramada y stubs de mapeo (fase roja)

Closes #322