### PR TITLE
Segmentar el turno asignado en bloques absolutos de tiempo

### DIFF
--- a/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/BloqueTurno.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/BloqueTurno.cs
@@ -1,0 +1,14 @@
+namespace Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
+
+/// <summary>
+/// Bloque de tiempo absoluto (hora local del tenant) que resulta de segmentar un turno diario
+/// (<see cref="TurnoDiario.Segmentar"/>, issue #327). Forma plana pensada para consumo directo de
+/// clientes de calendario (FullCalendar, Syncfusion Scheduler): sin solape, roto en cada medianoche
+/// que cruce.
+/// </summary>
+/// <remarks>
+/// No se persiste en <c>mt_events</c> ni requiere <c>ConfigurarSerializacion</c>: es el resultado de
+/// un metodo de lectura pura, no el payload de un evento. Su serializacion como parte del documento
+/// del read model es alcance del issue sucesor (TurnoVigente).
+/// </remarks>
+public record BloqueTurno(TipoBloque Tipo, DateTime Inicio, DateTime Fin);

--- a/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/FranjaProgramada.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/FranjaProgramada.cs
@@ -48,4 +48,37 @@ public record FranjaProgramada(
         foreach (var e in Extras) hash.Add(e);
         return hash.ToHashCode();
     }
+
+    /// <summary>
+    /// Recorta la franja por sus descansos y extras y devuelve los tramos resultantes en orden
+    /// cronologico (issue #327): un tramo tipado por cada sub-franja y un tramo Ordinaria en cada
+    /// hueco entre ellas. El glosario define descansos y extras como contenidos en la ordinaria, y
+    /// el algoritmo los trata igual -- por eso se fusionan en una sola secuencia ordenada, que
+    /// admite ademas que se intercalen entre si.
+    /// </summary>
+    /// <remarks>
+    /// La hora de inicio de la franja pertenece siempre al dia de asignacion (offset 0); solo su
+    /// hora de fin lleva <see cref="DiaOffsetFin"/>. Cada sub-franja resuelve sus dos offsets
+    /// propios (<see cref="SubFranjaProgramada.ATramo"/>).
+    /// </remarks>
+    internal IEnumerable<Tramo> Segmentar()
+    {
+        var subFranjas = Descansos
+            .Select(descanso => descanso.ATramo(TipoBloque.Descanso))
+            .Concat(Extras.Select(extra => extra.ATramo(TipoBloque.Extra)))
+            .OrderBy(sub => sub.Inicio);
+
+        var finFranja = Tramo.MinutosAbsolutos(HoraFin, DiaOffsetFin);
+        var cursor = Tramo.MinutosAbsolutos(HoraInicio, 0);
+        foreach (var sub in subFranjas)
+        {
+            if (sub.Inicio > cursor)
+                yield return new Tramo(TipoBloque.Ordinaria, cursor, sub.Inicio);
+            yield return sub;
+            cursor = sub.Fin;
+        }
+
+        if (cursor < finFranja)
+            yield return new Tramo(TipoBloque.Ordinaria, cursor, finFranja);
+    }
 }

--- a/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/SubFranjaProgramada.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/SubFranjaProgramada.cs
@@ -34,4 +34,14 @@ public record SubFranjaProgramada(
 
     public override int GetHashCode() =>
         HashCode.Combine(HoraInicio, HoraFin, DiaOffsetInicio, DiaOffsetFin);
+
+    /// <summary>
+    /// Traduce la sub-franja al tramo en minutos absolutos que le corresponde dentro de la
+    /// segmentacion del turno (issue #327). Cada extremo resuelve su propio offset de dia contra la
+    /// fecha de asignacion -- no contra el inicio de la franja que la contiene.
+    /// </summary>
+    internal Tramo ATramo(TipoBloque tipo) => new(
+        tipo,
+        Tramo.MinutosAbsolutos(HoraInicio, DiaOffsetInicio),
+        Tramo.MinutosAbsolutos(HoraFin, DiaOffsetFin));
 }

--- a/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/TipoBloque.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/TipoBloque.cs
@@ -1,0 +1,19 @@
+namespace Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
+
+/// <summary>
+/// Tipo de bloque resultante de segmentar un turno diario (<see cref="TurnoDiario.Segmentar"/>,
+/// issue #327). El glosario define los descansos y las extras como sub-franjas contenidas en la
+/// franja ordinaria; el algoritmo de segmentacion las trata igual: ambas recortan la ordinaria en
+/// bloques tipados.
+/// </summary>
+public enum TipoBloque
+{
+    /// <summary>Tramo de trabajo ordinario, fuera de descansos y extras.</summary>
+    Ordinaria,
+
+    /// <summary>Tramo de descanso contenido dentro de la franja ordinaria.</summary>
+    Descanso,
+
+    /// <summary>Tramo de trabajo extra contenido dentro de la franja ordinaria.</summary>
+    Extra
+}

--- a/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/Tramo.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/Tramo.cs
@@ -1,0 +1,51 @@
+namespace Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
+
+/// <summary>
+/// Tramo de turno expresado en minutos absolutos desde la medianoche de la fecha de asignacion.
+/// Representacion intermedia de <see cref="TurnoDiario.Segmentar"/> (issue #327): la aritmetica de
+/// offsets de dia se resuelve en enteros y solo al final se traduce a instantes
+/// (<see cref="ResolverA"/>).
+/// </summary>
+/// <remarks>
+/// <c>internal</c> a proposito: no es payload de ningun evento persistido -- el criterio de
+/// inclusion de este ensamblado (CA-ADR-0029 decision #1) no lo alcanza, es detalle del algoritmo.
+/// La aritmetica replica la de <c>MomentoDelDia</c> (ControlHoras/ValueObjects) en vez de reusarla:
+/// aquel vive en el Function App, que referencia este ensamblado y no al reves (isla de eventos,
+/// CA-ADR-0029 decision #2 / MEF-ADR-0039 decisiones 2 y 4).
+/// </remarks>
+internal readonly record struct Tramo(TipoBloque Tipo, int Inicio, int Fin)
+{
+    private const int MinutosPorHora = 60;
+    private const int MinutosPorDia = 1440;
+
+    internal static int MinutosAbsolutos(TimeOnly hora, int diaOffset) =>
+        hora.Hour * MinutosPorHora + hora.Minute + diaOffset * MinutosPorDia;
+
+    /// <summary>
+    /// Rompe el tramo en cada medianoche que cruce (CA-4): ningun tramo resultante abarca mas de un
+    /// dia calendario. Un tramo que arranca exactamente a medianoche no se parte en su propio
+    /// inicio.
+    /// </summary>
+    internal IEnumerable<Tramo> RomperEnMedianoche()
+    {
+        var cursor = Inicio;
+        var primerLimite = (Inicio / MinutosPorDia + 1) * MinutosPorDia;
+        for (var limite = primerLimite; limite < Fin; limite += MinutosPorDia)
+        {
+            yield return this with { Inicio = cursor, Fin = limite };
+            cursor = limite;
+        }
+
+        yield return this with { Inicio = cursor };
+    }
+
+    /// <summary>
+    /// Resuelve el tramo a un <see cref="BloqueTurno"/> con instantes absolutos, contra
+    /// <paramref name="fecha"/> (el dia de asignacion del turno).
+    /// </summary>
+    internal BloqueTurno ResolverA(DateOnly fecha)
+    {
+        var medianoche = fecha.ToDateTime(TimeOnly.MinValue);
+        return new BloqueTurno(Tipo, medianoche.AddMinutes(Inicio), medianoche.AddMinutes(Fin));
+    }
+}

--- a/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/TurnoDiario.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/TurnoDiario.cs
@@ -40,4 +40,13 @@ public record TurnoDiario(
         foreach (var franja in FranjasOrdinarias) hash.Add(franja);
         return hash.ToHashCode();
     }
+
+    /// <summary>
+    /// Segmenta el turno en bloques absolutos de tiempo (issue #327): resuelve los offsets de dia de
+    /// cada franja/descanso/extra contra <paramref name="fecha"/> (el dia de asignacion del turno) y
+    /// rompe en la medianoche cualquier bloque que cruce el limite del dia. Lectura pura -- no muta
+    /// el turno ni persiste el resultado (MEF-ADR-0012, Tell-don't-Ask: la aritmetica vive junto al
+    /// dato, no como calculo externo sobre TimeOnly/DiaOffset crudos).
+    /// </summary>
+    public IReadOnlyList<BloqueTurno> Segmentar(DateOnly fecha) => throw new NotImplementedException();
 }

--- a/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/TurnoDiario.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/TurnoDiario.cs
@@ -48,5 +48,81 @@ public record TurnoDiario(
     /// el turno ni persiste el resultado (MEF-ADR-0012, Tell-don't-Ask: la aritmetica vive junto al
     /// dato, no como calculo externo sobre TimeOnly/DiaOffset crudos).
     /// </summary>
-    public IReadOnlyList<BloqueTurno> Segmentar(DateOnly fecha) => throw new NotImplementedException();
+    public IReadOnlyList<BloqueTurno> Segmentar(DateOnly fecha) =>
+        FranjasOrdinarias
+            .SelectMany(SegmentarFranja)
+            .SelectMany(RomperEnMedianoche)
+            .Select(tramo => new BloqueTurno(
+                tramo.Tipo, ResolverMomento(fecha, tramo.Inicio), ResolverMomento(fecha, tramo.Fin)))
+            .ToList();
+
+    private const int MinutosPorHora = 60;
+    private const int MinutosPorDia = 1440;
+
+    /// <summary>
+    /// Tramo intermedio en minutos absolutos desde la medianoche de la fecha ancla -- misma
+    /// aritmetica que <c>MomentoDelDia.MinutosAbsolutos</c> (ControlHoras/ValueObjects), pero
+    /// autonoma: este ensamblado no puede referenciar el Function App que lo consume
+    /// (MEF-ADR-0039 decisiones 2/4, isla de eventos).
+    /// </summary>
+    private readonly record struct Tramo(TipoBloque Tipo, int Inicio, int Fin);
+
+    private static int MinutosAbsolutos(TimeOnly hora, int diaOffset) =>
+        hora.Hour * MinutosPorHora + hora.Minute + diaOffset * MinutosPorDia;
+
+    /// <summary>
+    /// Recorta la franja ordinaria por sus descansos y extras (glosario: ambos contenidos en la
+    /// ordinaria, tratados igual -- issue #327 notas tecnicas): produce tramos Ordinaria en los
+    /// huecos y tramos Descanso/Extra en cada sub-franja, en orden cronologico.
+    /// </summary>
+    private static IEnumerable<Tramo> SegmentarFranja(FranjaProgramada franja)
+    {
+        var inicioFranja = MinutosAbsolutos(franja.HoraInicio, 0);
+        var finFranja = MinutosAbsolutos(franja.HoraFin, franja.DiaOffsetFin);
+
+        var subFranjas = franja.Descansos
+            .Select(d => new Tramo(TipoBloque.Descanso,
+                MinutosAbsolutos(d.HoraInicio, d.DiaOffsetInicio), MinutosAbsolutos(d.HoraFin, d.DiaOffsetFin)))
+            .Concat(franja.Extras
+                .Select(e => new Tramo(TipoBloque.Extra,
+                    MinutosAbsolutos(e.HoraInicio, e.DiaOffsetInicio), MinutosAbsolutos(e.HoraFin, e.DiaOffsetFin))))
+            .OrderBy(sub => sub.Inicio)
+            .ToList();
+
+        var cursor = inicioFranja;
+        foreach (var sub in subFranjas)
+        {
+            if (sub.Inicio > cursor)
+                yield return new Tramo(TipoBloque.Ordinaria, cursor, sub.Inicio);
+            yield return sub;
+            cursor = sub.Fin;
+        }
+
+        if (cursor < finFranja)
+            yield return new Tramo(TipoBloque.Ordinaria, cursor, finFranja);
+    }
+
+    /// <summary>
+    /// Rompe un tramo en cada medianoche que cruce (CA-4): ningun bloque resultante abarca mas
+    /// de un dia calendario.
+    /// </summary>
+    private static IEnumerable<Tramo> RomperEnMedianoche(Tramo tramo)
+    {
+        var cursor = tramo.Inicio;
+        var primerLimite = (cursor / MinutosPorDia + 1) * MinutosPorDia;
+        for (var limite = primerLimite; limite < tramo.Fin; limite += MinutosPorDia)
+        {
+            yield return new Tramo(tramo.Tipo, cursor, limite);
+            cursor = limite;
+        }
+
+        yield return new Tramo(tramo.Tipo, cursor, tramo.Fin);
+    }
+
+    private static DateTime ResolverMomento(DateOnly fecha, int minutosAbsolutos)
+    {
+        var dias = minutosAbsolutos / MinutosPorDia;
+        var minutosDelDia = minutosAbsolutos % MinutosPorDia;
+        return fecha.AddDays(dias).ToDateTime(TimeOnly.MinValue).AddMinutes(minutosDelDia);
+    }
 }

--- a/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/TurnoDiario.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/TurnoDiario.cs
@@ -42,87 +42,16 @@ public record TurnoDiario(
     }
 
     /// <summary>
-    /// Segmenta el turno en bloques absolutos de tiempo (issue #327): resuelve los offsets de dia de
-    /// cada franja/descanso/extra contra <paramref name="fecha"/> (el dia de asignacion del turno) y
-    /// rompe en la medianoche cualquier bloque que cruce el limite del dia. Lectura pura -- no muta
-    /// el turno ni persiste el resultado (MEF-ADR-0012, Tell-don't-Ask: la aritmetica vive junto al
-    /// dato, no como calculo externo sobre TimeOnly/DiaOffset crudos).
+    /// Segmenta el turno en bloques absolutos de tiempo (issue #327): cada franja se recorta por sus
+    /// descansos y extras, cada tramo resultante se rompe en la medianoche que cruce y se resuelve
+    /// contra <paramref name="fecha"/> (el dia de asignacion del turno). Lectura pura -- no muta el
+    /// turno ni persiste el resultado (MEF-ADR-0012, Tell-don't-Ask: cada paso lo ejecuta el objeto
+    /// dueno del dato, no un calculo externo sobre TimeOnly/DiaOffset crudos).
     /// </summary>
     public IReadOnlyList<BloqueTurno> Segmentar(DateOnly fecha) =>
         FranjasOrdinarias
-            .SelectMany(SegmentarFranja)
-            .SelectMany(RomperEnMedianoche)
-            .Select(tramo => new BloqueTurno(
-                tramo.Tipo, ResolverMomento(fecha, tramo.Inicio), ResolverMomento(fecha, tramo.Fin)))
+            .SelectMany(franja => franja.Segmentar())
+            .SelectMany(tramo => tramo.RomperEnMedianoche())
+            .Select(tramo => tramo.ResolverA(fecha))
             .ToList();
-
-    private const int MinutosPorHora = 60;
-    private const int MinutosPorDia = 1440;
-
-    /// <summary>
-    /// Tramo intermedio en minutos absolutos desde la medianoche de la fecha ancla -- misma
-    /// aritmetica que <c>MomentoDelDia.MinutosAbsolutos</c> (ControlHoras/ValueObjects), pero
-    /// autonoma: este ensamblado no puede referenciar el Function App que lo consume
-    /// (MEF-ADR-0039 decisiones 2/4, isla de eventos).
-    /// </summary>
-    private readonly record struct Tramo(TipoBloque Tipo, int Inicio, int Fin);
-
-    private static int MinutosAbsolutos(TimeOnly hora, int diaOffset) =>
-        hora.Hour * MinutosPorHora + hora.Minute + diaOffset * MinutosPorDia;
-
-    /// <summary>
-    /// Recorta la franja ordinaria por sus descansos y extras (glosario: ambos contenidos en la
-    /// ordinaria, tratados igual -- issue #327 notas tecnicas): produce tramos Ordinaria en los
-    /// huecos y tramos Descanso/Extra en cada sub-franja, en orden cronologico.
-    /// </summary>
-    private static IEnumerable<Tramo> SegmentarFranja(FranjaProgramada franja)
-    {
-        var inicioFranja = MinutosAbsolutos(franja.HoraInicio, 0);
-        var finFranja = MinutosAbsolutos(franja.HoraFin, franja.DiaOffsetFin);
-
-        var subFranjas = franja.Descansos
-            .Select(d => new Tramo(TipoBloque.Descanso,
-                MinutosAbsolutos(d.HoraInicio, d.DiaOffsetInicio), MinutosAbsolutos(d.HoraFin, d.DiaOffsetFin)))
-            .Concat(franja.Extras
-                .Select(e => new Tramo(TipoBloque.Extra,
-                    MinutosAbsolutos(e.HoraInicio, e.DiaOffsetInicio), MinutosAbsolutos(e.HoraFin, e.DiaOffsetFin))))
-            .OrderBy(sub => sub.Inicio)
-            .ToList();
-
-        var cursor = inicioFranja;
-        foreach (var sub in subFranjas)
-        {
-            if (sub.Inicio > cursor)
-                yield return new Tramo(TipoBloque.Ordinaria, cursor, sub.Inicio);
-            yield return sub;
-            cursor = sub.Fin;
-        }
-
-        if (cursor < finFranja)
-            yield return new Tramo(TipoBloque.Ordinaria, cursor, finFranja);
-    }
-
-    /// <summary>
-    /// Rompe un tramo en cada medianoche que cruce (CA-4): ningun bloque resultante abarca mas
-    /// de un dia calendario.
-    /// </summary>
-    private static IEnumerable<Tramo> RomperEnMedianoche(Tramo tramo)
-    {
-        var cursor = tramo.Inicio;
-        var primerLimite = (cursor / MinutosPorDia + 1) * MinutosPorDia;
-        for (var limite = primerLimite; limite < tramo.Fin; limite += MinutosPorDia)
-        {
-            yield return new Tramo(tramo.Tipo, cursor, limite);
-            cursor = limite;
-        }
-
-        yield return new Tramo(tramo.Tipo, cursor, tramo.Fin);
-    }
-
-    private static DateTime ResolverMomento(DateOnly fecha, int minutosAbsolutos)
-    {
-        var dias = minutosAbsolutos / MinutosPorDia;
-        var minutosDelDia = minutosAbsolutos % MinutosPorDia;
-        return fecha.AddDays(dias).ToDateTime(TimeOnly.MinValue).AddMinutes(minutosDelDia);
-    }
 }

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/TurnoDiarioSegmentarTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/TurnoDiarioSegmentarTests.cs
@@ -122,6 +122,64 @@ public class TurnoDiarioSegmentarTests
     }
 
     [Fact]
+    public void Segmentar_IntercalaDescansoYExtraEnOrdenCronologico_CuandoLaFranjaTieneAmbos()
+    {
+        // CA-2 + CA-3 combinados: descansos y extras conviven en la misma franja y el recorte los
+        // intercala por hora de inicio, no por la coleccion en que fueron declarados. Los datos
+        // declaran la extra (13:00) ANTES que el descanso (10:00) a proposito: el orden del
+        // resultado depende del reloj, no del orden de llegada.
+        var extra = SubFranja(13, 0, 14, 0);
+        var descanso = SubFranja(10, 0, 11, 0);
+        var franja = Franja(6, 0, 16, 0, descansos: [descanso], extras: [extra]);
+        var turno = Turno(franja);
+
+        var resultado = turno.Segmentar(Fecha);
+
+        var esperado = new[]
+        {
+            new BloqueTurno(TipoBloque.Ordinaria,
+                new DateTime(2026, 8, 10, 6, 0, 0), new DateTime(2026, 8, 10, 10, 0, 0)),
+            new BloqueTurno(TipoBloque.Descanso,
+                new DateTime(2026, 8, 10, 10, 0, 0), new DateTime(2026, 8, 10, 11, 0, 0)),
+            new BloqueTurno(TipoBloque.Ordinaria,
+                new DateTime(2026, 8, 10, 11, 0, 0), new DateTime(2026, 8, 10, 13, 0, 0)),
+            new BloqueTurno(TipoBloque.Extra,
+                new DateTime(2026, 8, 10, 13, 0, 0), new DateTime(2026, 8, 10, 14, 0, 0)),
+            new BloqueTurno(TipoBloque.Ordinaria,
+                new DateTime(2026, 8, 10, 14, 0, 0), new DateTime(2026, 8, 10, 16, 0, 0)),
+        };
+        resultado.Should().Equal(esperado);
+        AsegurarCobertura(resultado, new DateTime(2026, 8, 10, 6, 0, 0), new DateTime(2026, 8, 10, 16, 0, 0));
+    }
+
+    [Fact]
+    public void Segmentar_NoEmiteBloquesOrdinariosDeDuracionCero_CuandoLasSubFranjasTocanLosExtremosDeLaFranja()
+    {
+        // CA-5 en su borde degenerado: cuando una sub-franja arranca exactamente donde arranca la
+        // franja (06:00) y otra termina exactamente donde termina (14:00), no debe aparecer un
+        // bloque Ordinaria de duracion cero en ninguno de los dos extremos.
+        var descanso = SubFranja(6, 0, 7, 0);
+        var extra = SubFranja(13, 0, 14, 0);
+        var franja = Franja(6, 0, 14, 0, descansos: [descanso], extras: [extra]);
+        var turno = Turno(franja);
+
+        var resultado = turno.Segmentar(Fecha);
+
+        var esperado = new[]
+        {
+            new BloqueTurno(TipoBloque.Descanso,
+                new DateTime(2026, 8, 10, 6, 0, 0), new DateTime(2026, 8, 10, 7, 0, 0)),
+            new BloqueTurno(TipoBloque.Ordinaria,
+                new DateTime(2026, 8, 10, 7, 0, 0), new DateTime(2026, 8, 10, 13, 0, 0)),
+            new BloqueTurno(TipoBloque.Extra,
+                new DateTime(2026, 8, 10, 13, 0, 0), new DateTime(2026, 8, 10, 14, 0, 0)),
+        };
+        resultado.Should().Equal(esperado);
+        resultado.Should().OnlyContain(b => b.Fin > b.Inicio);
+        AsegurarCobertura(resultado, new DateTime(2026, 8, 10, 6, 0, 0), new DateTime(2026, 8, 10, 14, 0, 0));
+    }
+
+    [Fact]
     public void Segmentar_RompeEnMedianoche_CuandoLaFranjaCruzaElLimiteDelDia()
     {
         // CA-4: franja nocturna 22:00-06:00+1 (DiaOffsetFin=1) sin descansos ni extras -> se rompe

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/TurnoDiarioSegmentarTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/TurnoDiarioSegmentarTests.cs
@@ -1,0 +1,196 @@
+// Issue #327: Segmentar el turno asignado en bloques absolutos de tiempo.
+// TurnoDiario.Segmentar(DateOnly) es comportamiento de lectura pura sobre el payload de
+// TurnoDiarioAsignado -- no hay comando ni evento nuevo (MEF-ADR-0012 Tell-don't-Ask: la
+// aritmetica de resolucion de offsets de dia y ruptura en medianoche vive en el objeto que
+// posee los datos, no como calculo externo). Estilo de test: Arrange/Act/Assert plano sobre un
+// metodo puro -- no aplica el harness Given/When/Then de command handlers (mismo patron que
+// IntervaloTemporalSegmentacionTests.cs).
+//
+// Semantica de los offsets confirmada contra el uso real en produccion (ClasificadorTrabajo,
+// DepuradorDeMarcaciones): HoraInicio de la franja es siempre offset 0 (el dia de fecha); HoraFin
+// usa DiaOffsetFin; cada SubFranjaProgramada (descanso/extra) usa su propio DiaOffsetInicio/Fin.
+// Todos los offsets son relativos a la MISMA fecha ancla (la fecha de asignacion del turno), no al
+// inicio de la franja individual.
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Tests.AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction.Eventos;
+
+public class TurnoDiarioSegmentarTests
+{
+    private static readonly DateOnly Fecha = new(2026, 8, 10);
+
+    private static SubFranjaProgramada SubFranja(
+        int horaInicio, int minutoInicio, int horaFin, int minutoFin,
+        int diaOffsetInicio = 0, int diaOffsetFin = 0) =>
+        new(new TimeOnly(horaInicio, minutoInicio), new TimeOnly(horaFin, minutoFin),
+            diaOffsetInicio, diaOffsetFin, "");
+
+    private static FranjaProgramada Franja(
+        int horaInicio, int minutoInicio, int horaFin, int minutoFin, int diaOffsetFin = 0,
+        IReadOnlyList<SubFranjaProgramada>? descansos = null,
+        IReadOnlyList<SubFranjaProgramada>? extras = null) =>
+        new(new TimeOnly(horaInicio, minutoInicio), new TimeOnly(horaFin, minutoFin), diaOffsetFin,
+            descansos ?? [], extras ?? [], "");
+
+    private static TurnoDiario Turno(params FranjaProgramada[] franjas) =>
+        new("Turno", franjas, "");
+
+    // CA-5: la union de los bloques cubre exactamente [inicioEsperado, finEsperado] -- el primer
+    // bloque arranca donde arranca la franja, el ultimo termina donde termina, y cada bloque
+    // intermedio termina exactamente donde empieza el siguiente (sin huecos, sin solapes).
+    private static void AsegurarCobertura(
+        IReadOnlyList<BloqueTurno> bloques, DateTime inicioEsperado, DateTime finEsperado)
+    {
+        bloques.Should().NotBeEmpty();
+        bloques[0].Inicio.Should().Be(inicioEsperado);
+        bloques[^1].Fin.Should().Be(finEsperado);
+        for (var i = 0; i < bloques.Count - 1; i++)
+            bloques[i].Fin.Should().Be(bloques[i + 1].Inicio);
+    }
+
+    // CA-4: ningun bloque cruza el limite del dia -- o queda contenido en un solo dia calendario,
+    // o termina exactamente a medianoche (limite que pertenece al dia de Inicio, no lo cruza).
+    private static void AsegurarSinCruceDeMedianoche(IReadOnlyList<BloqueTurno> bloques) =>
+        bloques.Should().OnlyContain(b => b.Inicio.Date == b.Fin.Date || b.Fin.TimeOfDay == TimeSpan.Zero);
+
+    [Fact]
+    public void Segmentar_RetornaUnBloqueOrdinaria_CuandoFranjaNoTieneDescansosNiExtras()
+    {
+        // CA-1: franja simple 06:00-14:00, sin descansos ni extras -> un unico bloque Ordinaria.
+        var franja = Franja(6, 0, 14, 0);
+        var turno = Turno(franja);
+
+        var resultado = turno.Segmentar(Fecha);
+
+        var esperado = new[]
+        {
+            new BloqueTurno(TipoBloque.Ordinaria,
+                new DateTime(2026, 8, 10, 6, 0, 0), new DateTime(2026, 8, 10, 14, 0, 0)),
+        };
+        resultado.Should().Equal(esperado);
+        AsegurarCobertura(resultado, new DateTime(2026, 8, 10, 6, 0, 0), new DateTime(2026, 8, 10, 14, 0, 0));
+    }
+
+    [Fact]
+    public void Segmentar_RecortaLaOrdinariaEnTresBloques_CuandoHayUnDescansoContenido()
+    {
+        // CA-2: franja 06:00-14:00 con descanso 10:00-11:00 contenido ->
+        // [Ordinaria 06:00-10:00, Descanso 10:00-11:00, Ordinaria 11:00-14:00], contiguos.
+        var descanso = SubFranja(10, 0, 11, 0);
+        var franja = Franja(6, 0, 14, 0, descansos: [descanso]);
+        var turno = Turno(franja);
+
+        var resultado = turno.Segmentar(Fecha);
+
+        var esperado = new[]
+        {
+            new BloqueTurno(TipoBloque.Ordinaria,
+                new DateTime(2026, 8, 10, 6, 0, 0), new DateTime(2026, 8, 10, 10, 0, 0)),
+            new BloqueTurno(TipoBloque.Descanso,
+                new DateTime(2026, 8, 10, 10, 0, 0), new DateTime(2026, 8, 10, 11, 0, 0)),
+            new BloqueTurno(TipoBloque.Ordinaria,
+                new DateTime(2026, 8, 10, 11, 0, 0), new DateTime(2026, 8, 10, 14, 0, 0)),
+        };
+        resultado.Should().Equal(esperado);
+        AsegurarCobertura(resultado, new DateTime(2026, 8, 10, 6, 0, 0), new DateTime(2026, 8, 10, 14, 0, 0));
+    }
+
+    [Fact]
+    public void Segmentar_RecortaLaOrdinariaEnTresBloques_CuandoHayUnaExtraContenida()
+    {
+        // CA-3: mismo patron de recorte que CA-2, ahora con una extra (glosario: extras contenidas
+        // en la ordinaria, igual que los descansos) 12:00-13:00 dentro de la franja 06:00-14:00.
+        var extra = SubFranja(12, 0, 13, 0);
+        var franja = Franja(6, 0, 14, 0, extras: [extra]);
+        var turno = Turno(franja);
+
+        var resultado = turno.Segmentar(Fecha);
+
+        var esperado = new[]
+        {
+            new BloqueTurno(TipoBloque.Ordinaria,
+                new DateTime(2026, 8, 10, 6, 0, 0), new DateTime(2026, 8, 10, 12, 0, 0)),
+            new BloqueTurno(TipoBloque.Extra,
+                new DateTime(2026, 8, 10, 12, 0, 0), new DateTime(2026, 8, 10, 13, 0, 0)),
+            new BloqueTurno(TipoBloque.Ordinaria,
+                new DateTime(2026, 8, 10, 13, 0, 0), new DateTime(2026, 8, 10, 14, 0, 0)),
+        };
+        resultado.Should().Equal(esperado);
+        AsegurarCobertura(resultado, new DateTime(2026, 8, 10, 6, 0, 0), new DateTime(2026, 8, 10, 14, 0, 0));
+    }
+
+    [Fact]
+    public void Segmentar_RompeEnMedianoche_CuandoLaFranjaCruzaElLimiteDelDia()
+    {
+        // CA-4: franja nocturna 22:00-06:00+1 (DiaOffsetFin=1) sin descansos ni extras -> se rompe
+        // en las 00:00; el tramo posterior lleva la fecha del dia siguiente.
+        var franja = Franja(22, 0, 6, 0, diaOffsetFin: 1);
+        var turno = Turno(franja);
+
+        var resultado = turno.Segmentar(Fecha);
+
+        var esperado = new[]
+        {
+            new BloqueTurno(TipoBloque.Ordinaria,
+                new DateTime(2026, 8, 10, 22, 0, 0), new DateTime(2026, 8, 11, 0, 0, 0)),
+            new BloqueTurno(TipoBloque.Ordinaria,
+                new DateTime(2026, 8, 11, 0, 0, 0), new DateTime(2026, 8, 11, 6, 0, 0)),
+        };
+        resultado.Should().Equal(esperado);
+        AsegurarCobertura(resultado, new DateTime(2026, 8, 10, 22, 0, 0), new DateTime(2026, 8, 11, 6, 0, 0));
+        AsegurarSinCruceDeMedianoche(resultado);
+    }
+
+    [Fact]
+    public void Segmentar_RompeElDescansoEnMedianoche_CuandoElDescansoCruzaElLimiteDelDiaDentroDeUnaFranjaNocturna()
+    {
+        // Caso borde de CA-4/CA-5 (notas tecnicas del issue): el propio descanso cruza la
+        // medianoche dentro de una franja nocturna 22:00-08:00+1. Da igual el orden en que el
+        // algoritmo aplique el recorte por descanso y la ruptura en 00:00: el resultado observable
+        // es el mismo -> ningun bloque (ni ordinario ni de descanso) cruza el limite del dia.
+        var descanso = SubFranja(23, 0, 1, 0, diaOffsetFin: 1);
+        var franja = Franja(22, 0, 8, 0, diaOffsetFin: 1, descansos: [descanso]);
+        var turno = Turno(franja);
+
+        var resultado = turno.Segmentar(Fecha);
+
+        var esperado = new[]
+        {
+            new BloqueTurno(TipoBloque.Ordinaria,
+                new DateTime(2026, 8, 10, 22, 0, 0), new DateTime(2026, 8, 10, 23, 0, 0)),
+            new BloqueTurno(TipoBloque.Descanso,
+                new DateTime(2026, 8, 10, 23, 0, 0), new DateTime(2026, 8, 11, 0, 0, 0)),
+            new BloqueTurno(TipoBloque.Descanso,
+                new DateTime(2026, 8, 11, 0, 0, 0), new DateTime(2026, 8, 11, 1, 0, 0)),
+            new BloqueTurno(TipoBloque.Ordinaria,
+                new DateTime(2026, 8, 11, 1, 0, 0), new DateTime(2026, 8, 11, 8, 0, 0)),
+        };
+        resultado.Should().Equal(esperado);
+        AsegurarCobertura(resultado, new DateTime(2026, 8, 10, 22, 0, 0), new DateTime(2026, 8, 11, 8, 0, 0));
+        AsegurarSinCruceDeMedianoche(resultado);
+    }
+
+    [Fact]
+    public void Segmentar_ConcatenaLosBloquesDeCadaFranjaEnOrden_CuandoElTurnoTieneVariasFranjasOrdinarias()
+    {
+        // Caso borde: turno partido (dos franjas independientes en el mismo dia, ej. jornada con
+        // interrupcion larga) -- Segmentar concatena los bloques de cada franja en el orden en que
+        // aparecen en FranjasOrdinarias, sin fusionarlas entre si.
+        var franjaManana = Franja(6, 0, 10, 0);
+        var franjaTarde = Franja(14, 0, 18, 0);
+        var turno = Turno(franjaManana, franjaTarde);
+
+        var resultado = turno.Segmentar(Fecha);
+
+        var esperado = new[]
+        {
+            new BloqueTurno(TipoBloque.Ordinaria,
+                new DateTime(2026, 8, 10, 6, 0, 0), new DateTime(2026, 8, 10, 10, 0, 0)),
+            new BloqueTurno(TipoBloque.Ordinaria,
+                new DateTime(2026, 8, 10, 14, 0, 0), new DateTime(2026, 8, 10, 18, 0, 0)),
+        };
+        resultado.Should().Equal(esperado);
+    }
+}


### PR DESCRIPTION
## Resumen

Pipeline TDD completado:
- Fase roja: tests escritos con stubs
- Fase verde: implementación completa
- Fase refactor: revisión de calidad

## Decisiones del pipeline

<details>
<summary>Test Writer (fase roja) — 6m 55s</summary>

## ES Test Writer - Decisiones

### Tipo de tarea

No es refactoring puro: el issue introduce comportamiento nuevo (`TurnoDiario.Segmentar`) y un
tipo nuevo (`BloqueTurno`/`TipoBloque`). Se sigue el flujo TDD normal (fase roja).

### Tests creados

- `TurnoDiarioSegmentarTests.cs` (7 tests, `tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/`):
  - `Segmentar_RetornaUnBloqueOrdinaria_CuandoFranjaNoTieneDescansosNiExtras` - CA-1
  - `Segmentar_RecortaLaOrdinariaEnTresBloques_CuandoHayUnDescansoContenido` - CA-2
  - `Segmentar_RecortaLaOrdinariaEnTresBloques_CuandoHayUnaExtraContenida` - CA-3
  - `Segmentar_RompeEnMedianoche_CuandoLaFranjaCruzaElLimiteDelDia` - CA-4
  - `Segmentar_RompeElDescansoEnMedianoche_CuandoElDescansoCruzaElLimiteDelDiaDentroDeUnaFranjaNocturna` - caso borde CA-4/CA-5 (descanso que a su vez cruza medianoche dentro de franja nocturna; el issue lo senala explicitamente en "Notas tecnicas")
  - `Segmentar_ConcatenaLosBloquesDeCadaFranjaEnOrden_CuandoElTurnoTieneVariasFranjasOrdinarias` - caso borde (turno partido, no cubierto por ningun CA explicito pero relevante dado que `FranjasOrdinarias` es una lista)
  - CA-5 (cobertura exacta, sin huecos ni solapes) esta verificado DENTRO de cada uno de los tests CA-1..CA-4 via el helper `AsegurarCobertura`, tal como pide el issue ("verificado sobre los casos concretos de CA-1..CA-4"), no como test aparte.

### Estructura elegida

- Una sola clase de test (`TurnoDiarioSegmentarTests`), sin nested classes: un unico metodo bajo
  prueba (`TurnoDiario.Segmentar`), sin multiples handlers que compartan Given.
- **No se usa el harness `CommandHandlerAsyncTest`/Given-When-Then**: no hay comando ni event
  handler involucrados (el issue lo aclara: "No aplica: no hay comando ni evento nuevo"). Es un
  metodo de lectura pura sobre un record existente. Se sigue el patron ya establecido en el
  proyecto para este tipo de pruebas: `IntervaloTemporalSegmentacionTests.cs`
  (Arrange/Act/Assert plano con AwesomeAssertions, sin DSL de event sourcing).
- Helpers factory (`SubFranja`, `Franja`, `Turno`) para reducir ruido posicional de los records
  con muchos parametros.
- Dos helpers de aserto reutilizados entre tests: `AsegurarCobertura` (CA-5: limites exactos +
  contiguidad entre bloques consecutivos) y `AsegurarSinCruceDeMedianoche` (CA-4: cada bloque
  esta contenido en un solo dia calendario o termina exactamente a medianoche). Ambos son checks
  estructurales sobre la lista YA devuelta -- no derivan el valor esperado de logica de
  produccion (MEF-ADR-0002, oraculo independiente): los limites absolutos (`inicioEsperado`,
  `finEsperado`) se pasan como literales armados a mano en cada test.

### Stubs creados

- `TipoBloque` (enum nuevo, `src/.../ControlHoras.DomainEvents/TipoBloque.cs`): `Ordinaria`,
  `Descanso`, `Extra`. Archivo propio siguiendo el precedente de otros enums del dominio
  (`BandaHoraria.cs`, `TipoDia.cs`, `Concepto.cs`), aunque el issue solo listaba `BloqueTurno.cs`
  como archivo a crear -- decision de estructura, no una desviacion de comportamiento.
- `BloqueTurno` (record nuevo, `src/.../ControlHoras.DomainEvents/BloqueTurno.cs`):
  `(TipoBloque Tipo, DateTime Inicio, DateTime Fin)`. Sin override de Equals/GetHashCode: solo
  tiene campos de valor simples (enum + 2 DateTime), el record por defecto ya compara por valor
  correctamente (no hay colecciones que disparen el bug de ADR-0015).
- `TurnoDiario.Segmentar(DateOnly fecha): IReadOnlyList<BloqueTurno>` (metodo agregado al record
  existente `TurnoDiario`): `=> throw new NotImplementedException();`.

No hizo falta crear ningun .resx/Mensajes: el metodo no reporta ninguna regla de negocio que
falle (es geometria pura sobre datos ya validados), ni el issue especifica ninguna excepcion de
dominio para este metodo.

### Decisiones de diseno

- **Semantica de los offsets confirmada contra codigo de produccion existente**, no inventada:
  `ClasificadorTrabajo.AMinutos`/`Clasificar` y `DepuradorDeMarcaciones.ResolverRango` ya resuelven
  `FranjaProgramada.HoraInicio` (offset 0 implicito) / `HoraFin+DiaOffsetFin` y
  `SubFranjaProgramada.HoraInicio+DiaOffsetInicio` / `HoraFin+DiaOffsetFin` contra la MISMA fecha
  ancla del turno (no relativa al inicio de cada franja individual). Los datos de los tests
  replican esa semantica exactamente.
- Fecha ancla fija `new DateOnly(2026, 8, 10)` en todos los tests, reutilizada como constante
  `Fecha` para evitar relojes/`DateTime.Now` (deterministico).
- Los descansos/extras de los tests CA-1..CA-3 usan offset 0/0 (no cruzan medianoche): mantiene
  cada CA enfocado en un solo comportamiento. El cruce de medianoche combinado con un descanso se
  cubre aparte en el test de caso borde dedicado, evitando que un solo test intente verificar dos
  comportamientos con datos que oscurecerian cual falla.
- No se agrego test de "aggregate/handler no encontrado" ni "ya existe" (reglas 4/5 del agente):
  no aplican, `Segmentar` no es un command handler ni orquesta el EventStore.

### Cobertura de criterios

| Criterio de aceptacion | Test(s) |
|---|---|
| CA-1: franja sin descansos/extras -> un bloque Ordinaria | `Segmentar_RetornaUnBloqueOrdinaria_CuandoFranjaNoTieneDescansosNiExtras` |
| CA-2: descanso contenido -> Ordinaria/Descanso/Ordinaria contiguos | `Segmentar_RecortaLaOrdinariaEnTresBloques_CuandoHayUnDescansoContenido` |
| CA-3: extra contenida -> mismo patron de recorte | `Segmentar_RecortaLaOrdinariaEnTresBloques_CuandoHayUnaExtraContenida` |
| CA-4: franja cruza medianoche -> rota en 00:00, tramo posterior con fecha+1 | `Segmentar_RompeEnMedianoche_CuandoLaFranjaCruzaElLimiteDelDia` (+ caso borde con descanso a medianoche) |
| CA-5: cobertura exacta sin huecos/solapes | Verificado dentro de cada test CA-1..CA-4 via `AsegurarCobertura` |

### Desviaciones del plan del planner

Ninguna - la interfaz publica propuesta (`TurnoDiario.Segmentar`, `BloqueTurno`, `TipoBloque`) se
implemento tal cual, sin ajustes. La unica decision no dictada explicitamente por el issue fue la
ubicacion de `TipoBloque` en archivo propio en vez de anidado en `BloqueTurno.cs` (ver "Stubs
creados"), que es una decision de organizacion de archivos, no de comportamiento ni de superficie
publica.

</details>

<details>
<summary>Implementer (fase verde) — 4m 10s</summary>

## ES Implementer - Decisiones

### Enfoque de implementacion

`TurnoDiario.Segmentar(DateOnly fecha)` se implemento como pipeline de tres pasos LINQ sobre
`FranjasOrdinarias`:

1. `SegmentarFranja(FranjaProgramada)`: convierte cada franja a minutos absolutos
   (`hora.Hour * 60 + hora.Minute + diaOffset * 1440`, misma formula que
   `MomentoDelDia.MinutosAbsolutos`), ordena sus descansos+extras por inicio y genera tramos
   `Ordinaria` en los huecos y tramos `Descanso`/`Extra` en cada sub-franja -- un solo barrido
   cronologico, sin asumir que descansos y extras no se intercalan entre si.
2. `RomperEnMedianoche(Tramo)`: parte cualquier tramo que cruce uno o mas limites de dia
   (multiplos de 1440) en sub-tramos que no cruzan ninguno. Aplica el orden que sugieren las
   notas tecnicas del issue: primero el recorte por descansos/extras, despues la ruptura en
   00:00 (los dos ordenes producen el mismo resultado observable segun el propio issue, pero
   este orden simplifica el algoritmo: solo hay un tipo de frontera a la vez en cada paso).
3. Resolucion final a `DateTime` absoluto: `fecha.AddDays(minutos/1440).ToDateTime(TimeOnly.MinValue).AddMinutes(minutos%1440)`.

Verificado a mano contra los 4 casos del test (franja simple, con descanso, con extra, franja
nocturna) y el caso borde (descanso que el mismo cruza medianoche dentro de una franja
nocturna) antes de correr la suite -- todos coincidieron con los bloques esperados por el
test-writer en el primer intento.

### Decisiones de diseno

- **Aritmetica autonoma, no reutilizando `MomentoDelDia`/`IntervaloTemporal`**: esos VOs viven
  en `Bitakora.ControlAsistencia.ControlHoras` (el Function App write-side), que referencia
  `ControlHoras.DomainEvents` -- no al reves. Referenciarlos desde `DomainEvents` invertiria la
  dependencia y violaria la isla de eventos (MEF-ADR-0039 decisiones 2/4: el ensamblado de
  eventos no depende de ningun proyecto). Se replico la misma formula de minutos absolutos
  (documentada en el XMLDOC del `readonly record struct Tramo` senalando el precedente) de
  forma local y privada, sin exponerla como API publica del record.
- **`readonly record struct Tramo` privado**: estructura interna (Tipo, Inicio, Fin en
  minutos absolutos) para pasar datos entre los pasos internos del pipeline sin comprometer
  la superficie publica de `TurnoDiario` -- solo `Segmentar` y `BloqueTurno` son publicos, tal
  como pide la seccion "NO es publico" del issue.
- **Constantes con nombre** (`MinutosPorHora = 60`, `MinutosPorDia = 1440`) en vez de literales
  magicos, siguiendo el patron ya usado en `MomentoDelDia`/`IntervaloTemporal`.
- **Un solo barrido cronologico para el recorte** (en vez de recortar primero por descansos y
  luego por extras en pasadas separadas): al fusionar ambas colecciones y ordenarlas por
  inicio antes de recorrer, el algoritmo soporta sin cambios adicionales el caso (no cubierto
  explicitamente por los tests pero coherente con el glosario) de una extra y un descanso no
  contiguos dentro de la misma franja.

### ADRs consultados

- MEF-ADR-0012 (Tell-don't-Ask): la aritmetica de segmentacion vive dentro de `TurnoDiario`,
  operando sobre sus propios datos (`FranjasOrdinarias`), no como calculo externo sobre
  `TimeOnly`/`DiaOffset` crudos extraidos por un caller.
- MEF-ADR-0039 decisiones 2/4 (DomainEvents como unico puente write/read, isla sin
  dependencias): confirmado leyendo el .csproj de `ControlHoras.DomainEvents` (sin
  `ProjectReference`) antes de decidir no reutilizar `MomentoDelDia`/`IntervaloTemporal`.
- CA-ADR-0029: no aplica cambio de ubicacion de ensamblados -- `BloqueTurno`/`TipoBloque` ya
  los creo el test-writer en `ControlHoras.DomainEvents`, coherente con la isla de eventos.
- MEF-ADR-0016: los nombres de metodo de test ya vienen del test-writer; no se tocaron tests.

### Desviaciones de ADRs

Ninguna desviacion -- todos los ADRs aplicados al pie de la letra.

### Desviaciones del plan del planner

Ninguna desviacion -- la interfaz publica propuesta (`TurnoDiario.Segmentar(DateOnly)`,
`BloqueTurno(TipoBloque, DateTime, DateTime)`, `TipoBloque` con 3 valores) coincide exactamente
con lo que el test-writer ya habia dejado stubbed; se implemento tal cual.

### Precedentes consultados

- `IntervaloTemporal.Segmentar` / `MomentoDelDia` (`src/Bitakora.ControlAsistencia.ControlHoras/ValueObjects/`):
  alineados con MEF-ADR-0012 (Tell-don't-Ask, aritmetica encapsulada) -- se tomo la formula de
  minutos absolutos y el patron de romper-por-fronteras como referencia conceptual, pero NO se
  referencio el codigo directamente (violaria la isla de eventos, MEF-ADR-0039). Se replico la
  logica de forma autonoma en `TurnoDiario.cs`.

### Infraestructura modificada

Ninguna. El issue es comportamiento de lectura pura sobre un payload existente -- no hay
comando, evento nuevo ni publicacion a Service Bus.

### Complejidad encontrada

- Confirmar que `DomainEvents` no podia referenciar `ControlHoras` (Function App) requirio
  revisar los `.csproj` antes de decidir la estrategia (aritmetica autonoma vs. reutilizar
  VOs existentes). Sin esa verificacion se hubiera intentado un `ProjectReference` invalido.
- El caso borde de "descanso que cruza medianoche dentro de una franja nocturna" (test
  `Segmentar_RompeElDescansoEnMedianoche_...`) se verifico a mano contra el algoritmo antes de
  ejecutar la suite para confirmar que el orden elegido (recortar por sub-franjas, luego
  romper en medianoche) produce el resultado exacto esperado por el test-writer.

### Resultado

- Tests pasando: 412/412 en `ControlHoras.Tests` (incluye los 7 tests de
  `TurnoDiarioSegmentarTests`); 730/742 en la suite completa de la solucion (12 omitidos por
  falta de infraestructura externa -- ServiceBus/Postgres locales -- no relacionados con este
  issue).

</details>
<details>
<summary>Reviewer (fase refactor) — 10m 4s</summary>

## ES Reviewer - Revision

### Evaluacion general
- Calidad: buena (algoritmo correcto al primer intento, bien documentado) con **una desviacion
  no declarada de MEF-ADR-0012** que se corrigio en refactor.
- Cambios realizados: si (commit `eeaaea5`).

Baseline al iniciar: 742 tests, 730 correctos, 12 omitidos (Postgres/ServiceBus no configurados
localmente), 0 errores. No existia `blockage-report.md` y no hizo falta crearlo.
Resultado final: 744 tests, 732 correctos, 12 omitidos, 0 errores.

### Cumplimiento de ADRs aplicables

| ADR | Cumplimiento | Observacion |
|---|---|---|
| MEF-ADR-0012: Tell-don't-Ask / estilo de modelado | **desviacion NO declarada** (corregida) | `TurnoDiario.SegmentarFranja` era un metodo estatico que leia los datos crudos de `FranjaProgramada` y `SubFranjaProgramada`. Detalle abajo. |
| MEF-ADR-0039 dec. 2/4: DomainEvents como unico puente write/read | ok | La logica vive en `ControlHoras.DomainEvents`, que sigue siendo isla (cero `ProjectReference`, cero `PackageReference` -- verificado con `ControlHorasDomainEventsAislamientoTests`, verde). |
| CA-ADR-0029: ensamblados de eventos por rol | **desviacion NO declarada** (aceptada por necesidad estructural) | Decision #1 excluye "value objects de calculo" del ensamblado, y `BloqueTurno`/`TipoBloque` no son payload de ningun evento. Detalle abajo. |
| MEF-ADR-0016: naming de tests | ok | Los 8 tests siguen `<Sujeto>_<LoQuePasa>_Cuando<Condicion>` con sujeto = metodo bajo prueba (`Segmentar`), correcto para un test que no es de command handler. |

**Nota sobre disponibilidad del ADR**: el issue lista **MEF-ADR-0039**, pero la version del plugin
instalada (`mefisto/0.20.0`) solo trae ADRs hasta MEF-ADR-0038 -- `docs/adr/mef-adr-0039-*.md` no
existe en el cache. La verificacion se hizo contra **CA-ADR-0029** (aplicacion local del canon,
que cita literalmente las decisiones #2, #4, #5 y #6 de MEF-ADR-0039) y contra el `.csproj` real.
Escalo al planner: o el issue referencia un ADR aun no publicado en el marco, o hace falta
`/plugin update mefisto`.

### Desviaciones de ADRs

**Desviaciones declaradas por el implementer** (de `stage-2-implementer.md`):

Ninguna: el implementer declaro explicitamente "Ninguna desviacion -- todos los ADRs aplicados al
pie de la letra". Esa afirmacion resulto incorrecta en dos puntos (abajo).

**Desviaciones detectadas por el reviewer (NO declaradas por el implementer)**:

#### Desviacion 1: MEF-ADR-0012 (Tell-don't-Ask)
- **Regla del ADR**: "Si un metodo de otra clase necesita datos del objeto para calcular algo, ese
  calculo debe vivir dentro del objeto. **Esta regla aplica por igual a aggregates y a value
  objects**. [...] Si una clase externa (servicio, helper, clase estatica) necesita leer estado
  interno de un VO para operar sobre el, la operacion pertenece al propio VO." Heuristica #1: "La
  operacion, ¿depende solo de datos del propio objeto? -> vive en el objeto."
- **Desviacion encontrada en el diff**: `TurnoDiario.cs:78-103` (fase verde). El metodo estatico
  `SegmentarFranja(FranjaProgramada franja)` leia `franja.HoraInicio`, `franja.HoraFin`,
  `franja.DiaOffsetFin`, `franja.Descansos` y `franja.Extras`, y ademas descendia un nivel mas para
  leer `d.HoraInicio`, `d.DiaOffsetInicio`, `d.HoraFin`, `d.DiaOffsetFin` de cada
  `SubFranjaProgramada`. Es exactamente el antipatron #2 del checklist activo del reviewer
  ("metodo/clase estatica que opera sobre datos crudos de un VO"): el calculo depende **solo** de
  datos de `FranjaProgramada`, asi que por la heuristica #1 pertenece a `FranjaProgramada`.
  Ironicamente el XMLDOC del metodo publico invocaba MEF-ADR-0012 mientras el cuerpo lo violaba.
- **Accion tomada**: **corregida en refactor** (commit `eeaaea5`). Ver "Refactorings aplicados".
- **Status**: resuelta, no requiere evaluacion del usuario.

#### Desviacion 2: CA-ADR-0029 decision #1 (criterio de inclusion del ensamblado de eventos)
- **Regla del ADR**: "Un ensamblado de eventos contiene los eventos y los tipos que los componen
  (su payload). **No contiene aggregates, ni value objects de calculo, ni comandos**."
- **Desviacion encontrada en el diff**: `BloqueTurno.cs` y `TipoBloque.cs` viven en
  `ControlHoras.DomainEvents` pero **no componen el payload de ningun evento** -- son el tipo de
  retorno de un metodo de lectura, es decir, value objects de calculo bajo la letra del ADR. Ni el
  planner (que lo propuso en la seccion "Interfaz publica") ni el implementer lo registraron como
  tension.
- **Evaluacion del reviewer**: **aceptable por necesidad estructural, no corregible dentro del
  issue**. Una vez decidido que `Segmentar` vive en `TurnoDiario` (lo cual si es Tell-don't-Ask
  correcto y lo fundamenta MEF-ADR-0039 dec. 2/4), el tipo de retorno tiene que ser visible desde
  la isla, y la isla no puede referenciar nada. No hay ubicacion alternativa. La propia
  `BloqueTurno.cs` documenta que no se persiste ni lleva `ConfigurarSerializacion`, asi que no
  contamina el contrato del event store ni `IdentidadEventosControlHoras.TiposPersistidos`
  (verificado: sin cambios).
- **Consecuencia que hay que escalar al planner antes del issue sucesor** (hallazgo propio de esta
  revision, no anticipado por el issue): `ReadModels.csproj` referencia **solo** `PublicEvents` y
  `PrivateEvents` -- **no** referencia `ControlHoras.DomainEvents`. Por lo tanto el read model
  `TurnoVigente` del issue sucesor **no puede** declarar hoy una propiedad
  `IReadOnlyList<BloqueTurno>`. Sus dos salidas son: (a) agregar
  `ReadModels -> ControlHoras.DomainEvents`, que acopla `ReadModels` a un dominio concreto y
  agrava la deuda ya registrada en CA-ADR-0029 ("el worker alcanza los buses transitivamente via
  ReadModels"); o (b) redeclarar un `BloqueTurno` plano en `ReadModels`, aplicando el patron de
  payload-por-rol de la decision #5 al read-side. La opcion debe decidirla el planner, no el
  implementer del sucesor.
- **Status**: pendiente de evaluacion del usuario.

### Precedentes consultados por el implementer

| Precedente | ADR aplicable | Veredicto |
|---|---|---|
| `IntervaloTemporal.Segmentar` / `MomentoDelDia` (`ControlHoras/ValueObjects/`) | MEF-ADR-0012 | alineado. Se cito como referencia **conceptual** sin referenciar el codigo -- correcto: `ControlHoras` (Function App) referencia `DomainEvents` y no al reves, asi que reusarlo cerraria un ciclo e invalidaria la isla. |

**Tension entre ADRs, resuelta a favor de la isla (registro explicito):** MEF-ADR-0012 tiene una
"Contrapartida activa" que proscribe reescribir a mano un calculo que el dominio ya expone
(`dia * 1440 + t.Hour * 60 + t.Minute` frente a `MomentoDelDia.MinutosAbsolutos`, caso real del
PR #155). Este diff hace literalmente eso. **No es una violacion**: la contrapartida presupone que
el objeto rico sea alcanzable, y aqui CA-ADR-0029 decision #2 (cero `ProjectReference`) lo impide
por compilacion. La duplicacion es forzada, no una omision de lectura. El implementer lo razono
bien; el refactor la deja documentada en el XMLDOC de `Tramo`, junto a la razon estructural.

### Convenciones del pipeline (no ADRs)

| Convencion | Estado | Observacion |
|---|---|---|
| Cada test con `Then()` + `And<>()` | n/a | No hay command handler ni DSL de event sourcing: `Segmentar` es un metodo puro. Estilo Arrange/Act/Assert, con el precedente `IntervaloTemporalSegmentacionTests` que el test-writer cito. Correcto. |
| Overloads correctos para stream IDs compuestos | n/a | El diff no toca ningun aggregate ni stream. |
| Fakes manuales (no NSubstitute) | n/a | Sin dependencias que doblar. |
| Feature folders (produccion y tests) | ok | Test en `AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/`, espejo del precedente del PR #326. Un archivo por responsabilidad. |
| Smoke tests: SkipWhen, secrets, cobertura | n/a | El diff no agrega endpoint ni efecto secundario observable: es comportamiento de lectura pura, sin comando, evento nuevo ni publicacion. Nada que verificar contra dev. |
| Proyecciones read-side: partial, inmutabilidad, read APIs, naming | n/a | El diff no toca `ReadModels` ni `Projections` (eso es el issue sucesor). Ver la consecuencia escalada arriba. |
| Compatibilidad Marten write-side/read-side | n/a | El diff no toca version de `Cosmos.EventSourcing.*` ni ningun archivo/linea de configuracion Marten (`ComposicionServicios*`, `ConfiguracionSerializacion*`, `IdentidadEventos*`, `AddEventTypes`, `opts.Events.*`...). Gate no disparado; no se decompilo nada. |
| Identidad de stream (MEF-ADR-0037) | n/a | El diff no toca `StartStream`/`ExistsAsync`/`GetAggregateRootAsync`/`GroupId`/`ComputarStreamId` ni ningun GET de consulta. |
| Control de volumen de telemetria (MEF-ADR-0038) | n/a | El diff no toca seams de observabilidad ni el callback de Wolverine. |
| Tests via ToString/comportamiento | ok | Los tests verifican el valor retornado por `Segmentar`; no se expuso ningun getter para satisfacerlos. |
| Sin numeros magicos | ok | `MinutosPorHora`/`MinutosPorDia` con nombre (ahora en `Tramo`, junto a la aritmetica que los usa). |
| Condiciones en positivo (guardas if/else afirmativas) | ok | `if (sub.Inicio > cursor)` y `if (cursor < finFranja)` son guardas afirmativas sin rama `else`. |
| Sin `─` (U+2500) en `.cs` | ok | Verificado por grep sobre los archivos nuevos y modificados. |

### Elegancia del codigo

**Antes del refactor**: el algoritmo era correcto y estaba bien comentado, pero `TurnoDiario`
concentraba 85 lineas de aritmetica sobre datos de **otros tres tipos**. El metodo publico
`Segmentar` leia bien como pipeline, pero cada paso del pipeline hablaba aritmetica primitiva
(`hora.Hour * 60 + ...`) en vez de lenguaje de dominio.

**Despues**: cada objeto ejecuta el paso que le corresponde y el metodo publico queda en 5 lineas
que se leen como la especificacion del issue:

```csharp
FranjasOrdinarias
    .SelectMany(franja => franja.Segmentar())      // recorte por descansos/extras (CA-2, CA-3)
    .SelectMany(tramo => tramo.RomperEnMedianoche()) // CA-4
    .Select(tramo => tramo.ResolverA(fecha))       // resolucion a instantes (CA-1)
    .ToList();
```

Otros hallazgos por atributo:

- **Compacto**: `ResolverMomento` calculaba `dias` y `minutosDelDia` por division/modulo para
  luego recomponerlos; `fecha.ToDateTime(TimeOnly.MinValue).AddMinutes(minutosAbsolutos)` es
  algebraicamente identico (la aritmetica de `DateTime` es naive, sin ajuste DST) y cabe en una
  linea. Simplificado. Tambien se retiro un `.ToList()` innecesario sobre la secuencia ordenada de
  sub-franjas, que se recorre una sola vez.
- **Idiomatico**: `RomperEnMedianoche` reconstruia el `Tramo` a mano en cada `yield`; ahora usa
  `this with { ... }`, que es lo idiomatico para un `record struct` y expresa mejor "el mismo tramo
  con otros limites".
- **Eficiente**: el algoritmo es O(n log n) por el `OrderBy` sobre las sub-franjas de cada franja,
  optimo para el problema. Sin loops anidados evitables ni trabajo repetido dentro de bucles.
- **Robusto**: `Segmentar` es lectura pura sin I/O ni excepciones esperadas, coherente con
  MEF-ADR-0004 (no hay regla de negocio que reportar). El guard `(Inicio / MinutosPorDia + 1)` no
  parte un tramo que arranca exactamente a medianoche -- correcto, y ahora con test.
- **Limpio**: cero warnings del compilador atribuibles al diff; `dotnet format` sobre el proyecto
  `ControlHoras.DomainEvents` da `exit=0`.

### Criticas y hallazgos

1. **[Mayor - corregido]** Violacion de Tell-don't-Ask en `TurnoDiario.SegmentarFranja`
   (desviacion 1). Corregida en `eeaaea5`.
2. **[Mayor - escalado, no corregible aqui]** `BloqueTurno` en un ensamblado cuyo criterio es "se
   persiste", y `ReadModels` sin acceso a el (desviacion 2). El issue sucesor arranca bloqueado si
   el planner no decide antes la via.
3. **[Menor - no corregido, fuera del diff]** `dotnet format --verify-no-changes` sobre la solucion
   completa devuelve `exit=2` por `IDE0005` (using innecesario) en 5 archivos de test:
   `IntervaloClasificadoSerializacionTests.cs`, `MarcacionAdicionadaSerializacionTests.cs`,
   `RetardoSerializacionTests.cs`, `IntervaloTemporalSerializacionMartenTests.cs`,
   `TurnoCreadoSerializacionTests.cs`. **Verificado que es heredado, no una regresion de este
   pipeline**: el mismo `exit=2` se reproduce con `git stash` de todos mis cambios. Ninguno de esos
   archivos pertenece al diff de #327 (vienen del PR #326). No los toco por la regla "solo lo que
   esta en el diff"; se reporta para que el equipo decida limpiarlos en un issue de tooling.
4. **[Menor - documental]** El resumen del test-writer dice "7 tests" y el archivo entregado tenia
   6. Con los 2 agregados en esta fase son 8.
5. **[Cosmetico - no accionable]** El algoritmo asume que descansos y extras **no se solapan entre
   si** dentro de una franja. Con datos solapados produciria bloques solapados (romperia el
   invariante de CA-5). No es un defecto de este diff: el glosario define ambas sub-franjas como
   contenidas y disjuntas, la validacion vive aguas arriba (aggregate de Programacion), y el issue
   no lo lista como CA. Se deja registrado por si el sucesor decide endurecerlo.

### Refactorings aplicados

1. **`SubFranjaProgramada.ATramo(TipoBloque)`** (`internal`): la sub-franja resuelve sus propios
   dos offsets de dia. Antes lo hacia `TurnoDiario` leyendole los 4 campos.
2. **`FranjaProgramada.Segmentar()`** (`internal`): la franja se recorta por sus descansos y
   extras, fusionados y ordenados cronologicamente. Antes era `TurnoDiario.SegmentarFranja(franja)`
   estatico. El XMLDOC documenta la asimetria de offsets (inicio siempre offset 0, fin con
   `DiaOffsetFin`), que antes solo se deducia leyendo el cuerpo.
3. **`Tramo` promovido a archivo propio** como `internal readonly record struct` con la aritmetica
   (`MinutosAbsolutos`), `RomperEnMedianoche()` y `ResolverA(fecha)`. Era un tipo anidado privado de
   `TurnoDiario`. `internal` a proposito: no es payload de ningun evento -- lo documenta su XMLDOC,
   junto con la razon por la que la aritmetica de `MomentoDelDia` se replica en vez de reusarse.
4. **`TurnoDiario.Segmentar(fecha)`** queda como pipeline de coordinacion de 5 lineas, sin leer un
   solo campo crudo de sus franjas.
5. **Simplificacion de la resolucion a instantes** (`ResolverA`) y retiro del `.ToList()`
   intermedio, descritos en "Elegancia".

Protocolo seguido: `dotnet test` despues de cada cambio. No hubo que revertir nada.

### Cobertura de criterios de aceptacion

| Criterio | Estado | Test(s) |
|---|---|---|
| CA-1: franja sin descansos ni extras -> un bloque `Ordinaria` absoluto | cubierto | `Segmentar_RetornaUnBloqueOrdinaria_CuandoFranjaNoTieneDescansosNiExtras` |
| CA-2: descanso contenido -> `Ordinaria`/`Descanso`/`Ordinaria` contiguos | cubierto | `Segmentar_RecortaLaOrdinariaEnTresBloques_CuandoHayUnDescansoContenido` |
| CA-3: extra contenida -> mismo patron de recorte | cubierto | `Segmentar_RecortaLaOrdinariaEnTresBloques_CuandoHayUnaExtraContenida` |
| CA-4: franja con `DiaOffsetFin = 1` -> rota en 00:00, tramo posterior con fecha+1 | cubierto | `Segmentar_RompeEnMedianoche_CuandoLaFranjaCruzaElLimiteDelDia` + `Segmentar_RompeElDescansoEnMedianoche_CuandoElDescansoCruzaElLimiteDelDiaDentroDeUnaFranjaNocturna` (el descanso que a su vez cruza el limite). Ambos afirman `AsegurarSinCruceDeMedianoche`. |
| CA-5: union exacta de los bloques, sin huecos ni solapes, sobre los casos de CA-1..CA-4 | cubierto | Helper `AsegurarCobertura` invocado dentro de cada test de CA-1..CA-4 y de los 2 agregados: verifica extremo inicial, extremo final y contiguidad `bloques[i].Fin == bloques[i+1].Inicio`. Es la forma que el propio issue pide ("verificado sobre los casos concretos"), no un test aparte. |

Cobertura adicional mas alla de los CAs: turno partido en dos franjas independientes
(`Segmentar_ConcatenaLosBloquesDeCadaFranjaEnOrden_...`), mas los 2 agregados abajo.

### Tests agregados

Dos tests que cubren ramas del algoritmo que ningun test ejercitaba (se habrian podido romper en un
refactor futuro sin que la suite lo delatara):

1. `Segmentar_IntercalaDescansoYExtraEnOrdenCronologico_CuandoLaFranjaTieneAmbos` -- ejercita la
   decision de diseno explicita del implementer (fusionar `Descansos` y `Extras` en **una sola**
   secuencia ordenada por hora de inicio, en vez de dos pasadas). Los datos declaran la extra
   (13:00) antes que el descanso (10:00) a proposito, para que el test falle si alguien sustituye
   el `OrderBy` por el orden de las colecciones. Resultado: 5 bloques alternados.
2. `Segmentar_NoEmiteBloquesOrdinariosDeDuracionCero_CuandoLasSubFranjasTocanLosExtremosDeLaFranja`
   -- cubre las **dos guardas de borde** (`if (sub.Inicio > cursor)` y `if (cursor < finFranja)`),
   que sin test podian degradarse a `>=`/`<=` sin consecuencia visible: un descanso que arranca
   exactamente con la franja y una extra que termina exactamente con ella no deben producir bloques
   `Ordinaria` de duracion cero. Afirma ademas `OnlyContain(b => b.Fin > b.Inicio)`.

Ambos siguen MEF-ADR-0016, son `[Fact]`, reusan los factory helpers y `AsegurarCobertura` (CA-5) ya
existentes en el archivo, y pasan contra la implementacion sin modificarla.

**Tests de contrato evaluados y descartados con justificacion** (paso 4b):

- *Igualdad*: `BloqueTurno` es un `record` de `enum` + 2 `DateTime`, sin colecciones -- la igualdad
  generada por el compilador es correcta y no cae en el antipatron #6 de MEF-ADR-0012
  (`IReadOnlyList<T>` como propiedad de igualdad). Ya queda ejercitada de forma real por los 8
  tests, que comparan con `Should().Equal(esperado)` (que usa `Equals`). Una subclase de
  `IgualdadTestBase<BloqueTurno>` seria redundante. Los tipos que si tienen igualdad manual
  (`TurnoDiario`, `FranjaProgramada`, `SubFranjaProgramada`) ya traen sus `*IgualdadTests` del
  PR #326.
- *Serializacion*: `BloqueTurno` no tiene `ConfigurarSerializacion` ni entra en
  `IdentidadEventosControlHoras.TiposPersistidos` (ambos verificados sin cambios) -- no se persiste
  ni cruza ningun bus, asi que no aplica ni el round-trip Marten (6d) ni el round-trip con
  serializador por defecto (6e). Su serializacion como parte del documento del read model es
  alcance del issue sucesor, tal como el issue lo declara.

</details>

## Cobertura

| Archivo | Cobertura | Umbral | Estado |
|---|---|---|---|
| BloqueTurno.cs | - | excluido | - |
| FranjaProgramada.cs | - | no evaluado | - |
| SubFranjaProgramada.cs | - | no evaluado | - |
| TipoBloque.cs | - | no evaluado | - |
| Tramo.cs | - | no evaluado | - |
| TurnoDiario.cs | - | no evaluado | - |
## Commits

eeaaea5 refactor(issue-327): mover la aritmetica de segmentacion al objeto dueno del dato
1e781e2 feat(issue-327): implementar TurnoDiario.Segmentar en bloques absolutos (fase verde)
4c69743 test(issue-327): tests para TurnoDiario.Segmentar y stubs BloqueTurno/TipoBloque (fase roja)

Closes #327