### PR TITLE
Crear el read model TurnoVigente con su proyeccion y consulta puntual

### DIFF
--- a/src/Bitakora.ControlAsistencia.ControlHoras/Infraestructura/ComposicionServicios.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Infraestructura/ComposicionServicios.cs
@@ -124,6 +124,13 @@ public static class ComposicionServicios
             // los mismos valores literales, que es la dimension que el par de #289 dejo abierta.
             options.Schema.For<TurnoDiarioView>().UseNumericRevisions(true);
 
+            // Issue #328, mismo par que #294 cerro para TurnoDiarioView (comentario arriba): el
+            // worker registra TurnoVigenteProjection, asi que Marten crea mt_version de TurnoVigente
+            // como bigint alla. Este Function App no puede registrar esa proyeccion (vive en el
+            // ensamblado del worker, CA-ADR-0029) asi que declara la misma forma explicitamente
+            // para no divergir sobre la MISMA tabla fisica.
+            options.Schema.For<TurnoVigente>().UseNumericRevisions(true);
+
             if (options.Serializer() is Marten.Services.SystemTextJsonSerializer stj)
             {
                 stj.Configure(jsonOptions =>

--- a/src/Bitakora.ControlAsistencia.ControlHoras/ObtenerTurnoVigente/FunctionEndpoint.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ObtenerTurnoVigente/FunctionEndpoint.cs
@@ -1,0 +1,35 @@
+using Cosmos.MultiTenancy;
+using Marten;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.ObtenerTurnoVigente;
+
+// Issue #328: Function GET del read model TurnoVigente (via (a) proyeccion materializada,
+// skills/projections/naming.md, MEF-ADR-0006 enmienda #363). Feature folder sin sufijo Function, un
+// namespace por query (skills/projections/read-apis.md): esta clase FunctionEndpoint no colisiona
+// con ObtenerTurnoDiario/ListarTurnosDiarios/RegistrarMarcacionFunction/... porque cada una vive en
+// su propio namespace.
+//
+// FASE ROJA (projection-test-writer, issue #328): Run es un stub que lanza NotImplementedException
+// a proposito -- el comportamiento real (parseo tipado de empleadoId/fecha con 400 explicito,
+// ControlDiarioAggregateRoot.ComputarStreamId, QuerySession acotada al tenant de ITenantResolver,
+// session.LoadAsync<TurnoVigente> y el 200/404, CA-4) es responsabilidad de projection-implementer.
+// El constructor SI se prueba (ComposicionServiciosTests.AgregarServiciosControlHoras_
+// ResuelveElEndpointDeObtenerTurnoVigente...): IDocumentStore e ITenantResolver ya resuelven del
+// contenedor del write-side (los usa ObtenerTurnoDiario), asi que ese test de composicion no
+// requiere implementar Run para quedar en verde -- solo prueba wiring, no comportamiento.
+public class FunctionEndpoint(IDocumentStore store, ITenantResolver tenantResolver)
+{
+    [Function("ObtenerTurnoVigente")]
+    public Task<IActionResult> Run(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "control-horas/turnos-vigentes/{empleadoId}/{fecha}")]
+        HttpRequest req,
+        string empleadoId,
+        string fecha,
+        CancellationToken ct)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/Bitakora.ControlAsistencia.ControlHoras/ObtenerTurnoVigente/FunctionEndpoint.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ObtenerTurnoVigente/FunctionEndpoint.cs
@@ -1,3 +1,6 @@
+using System.Globalization;
+using Bitakora.ControlAsistencia.ControlHoras.Entities;
+using Bitakora.ControlAsistencia.ReadModels.ControlHoras;
 using Cosmos.MultiTenancy;
 using Marten;
 using Microsoft.AspNetCore.Http;
@@ -12,24 +15,46 @@ namespace Bitakora.ControlAsistencia.ControlHoras.ObtenerTurnoVigente;
 // con ObtenerTurnoDiario/ListarTurnosDiarios/RegistrarMarcacionFunction/... porque cada una vive en
 // su propio namespace.
 //
-// FASE ROJA (projection-test-writer, issue #328): Run es un stub que lanza NotImplementedException
-// a proposito -- el comportamiento real (parseo tipado de empleadoId/fecha con 400 explicito,
-// ControlDiarioAggregateRoot.ComputarStreamId, QuerySession acotada al tenant de ITenantResolver,
-// session.LoadAsync<TurnoVigente> y el 200/404, CA-4) es responsabilidad de projection-implementer.
-// El constructor SI se prueba (ComposicionServiciosTests.AgregarServiciosControlHoras_
-// ResuelveElEndpointDeObtenerTurnoVigente...): IDocumentStore e ITenantResolver ya resuelven del
-// contenedor del write-side (los usa ObtenerTurnoDiario), asi que ese test de composicion no
-// requiere implementar Run para quedar en verde -- solo prueba wiring, no comportamiento.
+// Mismo patron que ObtenerTurnoDiario (issue #289): la ruta recibe empleadoId y fecha como los
+// componentes tipados de la clave natural compuesta -- la clave se reconstruye con
+// ControlDiarioAggregateRoot.ComputarStreamId, nunca con una concatenacion propia del endpoint
+// (MEF-ADR-0037). CA-4: fecha invalida -> 400 explicito; 200 con la vista completa (Id incluido --
+// la UI lo necesita como ancla de comandos, ver issue "Notas tecnicas") o 404 sin body cuando no
+// hay turno vigente.
 public class FunctionEndpoint(IDocumentStore store, ITenantResolver tenantResolver)
 {
+    private const string FormatoFecha = "yyyy-MM-dd";
+
     [Function("ObtenerTurnoVigente")]
-    public Task<IActionResult> Run(
+    public async Task<IActionResult> Run(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "control-horas/turnos-vigentes/{empleadoId}/{fecha}")]
         HttpRequest req,
         string empleadoId,
         string fecha,
         CancellationToken ct)
     {
-        throw new NotImplementedException();
+        // Fecha no liga directo a DateOnly en el modelo aislado de Functions: se recibe como
+        // string y se parsea con formato explicito, devolviendo 400 ante formato invalido
+        // (mismo patron de ObtenerTurnoDiario, issue #289).
+        if (!DateOnly.TryParseExact(
+                fecha, FormatoFecha, CultureInfo.InvariantCulture, DateTimeStyles.None, out var fechaParseada))
+            return new BadRequestObjectResult(
+                $"El parametro 'fecha' debe tener el formato {FormatoFecha}");
+
+        var streamKey = ControlDiarioAggregateRoot.ComputarStreamId(empleadoId, fechaParseada);
+
+        // CA-4: la QuerySession se abre SIEMPRE acotada al tenant que resuelve ITenantResolver --
+        // nunca a un tenant id que llegara por ruta o query string (mitigacion estructural contra
+        // BOLA/IDOR, MEF-ADR-0028/skills/projections/read-apis.md). empleadoId y fecha SI vienen de
+        // la ruta: son el recurso, no el tenant.
+        await using var session = store.QuerySession(tenantResolver.TenantId);
+        var vista = await session.LoadAsync<TurnoVigente>(streamKey, ct);
+
+        // CA-4: 404 sin body cuando no hay turno vigente para ese (empleado, fecha) -- no es un
+        // error, significa que ese dia no tiene turno asignado.
+        if (vista is null)
+            return new NotFoundResult();
+
+        return new OkObjectResult(vista);
     }
 }

--- a/src/Bitakora.ControlAsistencia.Projections/ControlHoras/TurnoVigenteProjection.cs
+++ b/src/Bitakora.ControlAsistencia.Projections/ControlHoras/TurnoVigenteProjection.cs
@@ -1,0 +1,39 @@
+using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
+using Bitakora.ControlAsistencia.ReadModels.ControlHoras;
+using Marten.Events.Aggregation; // SingleStreamProjection<,> vive aqui, NO en Marten.Events.Projections
+
+namespace Bitakora.ControlAsistencia.Projections.ControlHoras;
+
+/// <summary>
+/// Clase de proyeccion companion de TurnoVigente (issue #328, receta N1 -- un solo stream,
+/// (EmpleadoId, Fecha), MEF-ADR-0035). Vive en el worker (Bitakora.ControlAsistencia.Projections),
+/// el ensamblado que si referencia Marten y el analizador JasperFx.Events.SourceGenerator.
+///
+/// partial es obligatorio (skills/projections/modelos-marten.md): el source generator descubre
+/// Create/Apply por convencion y emite el dispatcher [GeneratedEvolver]. Sin partial el build
+/// queda limpio pero falla en RUNTIME al registrar la proyeccion (InvalidProjectionException) --
+/// error que el config-test detecta al resolver el named store
+/// (ConfigurarControlHoras_RegistraTurnoVigenteProjectionComoAsync).
+///
+/// FASE ROJA (projection-test-writer, issue #328): Create/Apply son stubs que lanzan
+/// NotImplementedException a proposito -- la implementacion real (invocar
+/// evento.DetalleTurno.Segmentar(evento.Fecha) y mapear cada BloqueTurno a Bloque, Tell-don't-Ask
+/// MEF-ADR-0012) es responsabilidad de projection-implementer. El registro en el named store del
+/// worker (ConfiguracionMartenProjectionsControlHoras.ConfigurarControlHoras,
+/// opts.Projections.Add&lt;TurnoVigenteProjection&gt;(ProjectionLifecycle.Async)) tampoco se toca
+/// aqui: ese seam ya existe con implementacion real (issue #289) y sumar esta proyeccion es
+/// tambien alcance de projection-implementer.
+///
+/// Solo TurnoDiarioAsignado alimenta esta vista: MarcacionAdicionada tambien vive en el mismo
+/// stream de ControlDiarioAggregateRoot pero esta proyeccion la ignora a proposito (issue #328,
+/// "Eventos que la alimentan"). Sin ShouldDelete: el turno vigente nunca se borra, solo se
+/// reasigna ("el ultimo gana", CA-2).
+/// </summary>
+public sealed partial class TurnoVigenteProjection : SingleStreamProjection<TurnoVigente, string>
+{
+    public static TurnoVigente Create(TurnoDiarioAsignado evento) =>
+        throw new NotImplementedException();
+
+    public static TurnoVigente Apply(TurnoDiarioAsignado evento, TurnoVigente vista) =>
+        throw new NotImplementedException();
+}

--- a/src/Bitakora.ControlAsistencia.Projections/ControlHoras/TurnoVigenteProjection.cs
+++ b/src/Bitakora.ControlAsistencia.Projections/ControlHoras/TurnoVigenteProjection.cs
@@ -1,7 +1,8 @@
 using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 using Bitakora.ControlAsistencia.ReadModels.ControlHoras;
 using Marten.Events.Aggregation; // SingleStreamProjection<,> vive aqui, NO en Marten.Events.Projections
-using BloqueVigente = Bitakora.ControlAsistencia.ReadModels.ControlHoras.Bloque;
+// Solo TipoBloque es ambiguo entre los dos namespaces de arriba (CS0104): Bloque existe unicamente
+// en ReadModels y BloqueTurno unicamente en DomainEvents, asi que ninguno de los dos necesita alias.
 using TipoBloqueVigente = Bitakora.ControlAsistencia.ReadModels.ControlHoras.TipoBloque;
 using TipoBloqueEvento = Bitakora.ControlAsistencia.ControlHoras.DomainEvents.TipoBloque;
 
@@ -26,8 +27,8 @@ namespace Bitakora.ControlAsistencia.Projections.ControlHoras;
 /// Create/Apply invocan evento.DetalleTurno.Segmentar(evento.Fecha) (issue #327, Tell-don't-Ask
 /// MEF-ADR-0012: la aritmetica de segmentacion vive en TurnoDiario, no se reimplementa aqui) y
 /// mapean cada BloqueTurno resultante al record Bloque propio de la vista (ReadModels, sin
-/// relacion de tipo con DomainEvents -- alias BloqueVigente/TipoBloqueVigente para desambiguar del
-/// TipoBloque homonimo de ControlHoras.DomainEvents, CS0104).
+/// relacion de tipo con DomainEvents -- alias TipoBloqueVigente/TipoBloqueEvento para desambiguar
+/// el unico nombre homonimo entre ambos ensamblados, TipoBloque, CS0104).
 ///
 /// Solo TurnoDiarioAsignado alimenta esta vista: MarcacionAdicionada tambien vive en el mismo
 /// stream de ControlDiarioAggregateRoot pero esta proyeccion la ignora a proposito (issue #328,
@@ -47,11 +48,17 @@ public sealed partial class TurnoVigenteProjection : SingleStreamProjection<Turn
             MapearBloques(evento));
 
     // CA-2: "el ultimo gana" -- una reasignacion sobre el mismo (empleado, fecha) sobrescribe
-    // turno, horario y bloques. Id, EmpleadoId, NombreCompleto y Fecha no cambian (mismo stream,
-    // mismo empleado): el evento no trae informacion distinta de empleado en una reasignacion.
+    // turno, horario y bloques. Id, EmpleadoId y Fecha no cambian: son la identidad del stream
+    // ("{EmpleadoId}:{Fecha:yyyy-MM-dd}"), invariante para todos los eventos del mismo documento.
+    //
+    // NombreCompleto SI se refresca: cada TurnoDiarioAsignado trae el payload Empleado completo, y
+    // el criterio del "ultimo gana" aplica igual a un nombre corregido aguas arriba -- dejarlo fijo
+    // congelaria para siempre el nombre de la primera asignacion. Mismo criterio que la proyeccion
+    // hermana sobre este stream (TurnoDiarioProjection.Apply refresca Empleado entero, issue #289).
     public static TurnoVigente Apply(TurnoDiarioAsignado evento, TurnoVigente vista) =>
         vista with
         {
+            NombreCompleto = NombreCompleto(evento.InformacionEmpleado),
             NombreTurno = evento.DetalleTurno.Nombre,
             HorarioResumido = evento.DetalleTurno.Descripcion,
             Bloques = MapearBloques(evento)
@@ -63,10 +70,10 @@ public sealed partial class TurnoVigenteProjection : SingleStreamProjection<Turn
     private static string NombreCompleto(Empleado empleado) =>
         $"{empleado.Nombres} {empleado.Apellidos}";
 
-    private static IReadOnlyList<BloqueVigente> MapearBloques(TurnoDiarioAsignado evento) =>
+    private static IReadOnlyList<Bloque> MapearBloques(TurnoDiarioAsignado evento) =>
         evento.DetalleTurno.Segmentar(evento.Fecha).Select(MapearBloque).ToList();
 
-    private static BloqueVigente MapearBloque(BloqueTurno bloque) =>
+    private static Bloque MapearBloque(BloqueTurno bloque) =>
         new(MapearTipo(bloque.Tipo), bloque.Inicio, bloque.Fin);
 
     private static TipoBloqueVigente MapearTipo(TipoBloqueEvento tipo) => tipo switch

--- a/src/Bitakora.ControlAsistencia.Projections/ControlHoras/TurnoVigenteProjection.cs
+++ b/src/Bitakora.ControlAsistencia.Projections/ControlHoras/TurnoVigenteProjection.cs
@@ -1,6 +1,9 @@
 using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 using Bitakora.ControlAsistencia.ReadModels.ControlHoras;
 using Marten.Events.Aggregation; // SingleStreamProjection<,> vive aqui, NO en Marten.Events.Projections
+using BloqueVigente = Bitakora.ControlAsistencia.ReadModels.ControlHoras.Bloque;
+using TipoBloqueVigente = Bitakora.ControlAsistencia.ReadModels.ControlHoras.TipoBloque;
+using TipoBloqueEvento = Bitakora.ControlAsistencia.ControlHoras.DomainEvents.TipoBloque;
 
 namespace Bitakora.ControlAsistencia.Projections.ControlHoras;
 
@@ -15,14 +18,16 @@ namespace Bitakora.ControlAsistencia.Projections.ControlHoras;
 /// error que el config-test detecta al resolver el named store
 /// (ConfigurarControlHoras_RegistraTurnoVigenteProjectionComoAsync).
 ///
-/// FASE ROJA (projection-test-writer, issue #328): Create/Apply son stubs que lanzan
-/// NotImplementedException a proposito -- la implementacion real (invocar
-/// evento.DetalleTurno.Segmentar(evento.Fecha) y mapear cada BloqueTurno a Bloque, Tell-don't-Ask
-/// MEF-ADR-0012) es responsabilidad de projection-implementer. El registro en el named store del
-/// worker (ConfiguracionMartenProjectionsControlHoras.ConfigurarControlHoras,
-/// opts.Projections.Add&lt;TurnoVigenteProjection&gt;(ProjectionLifecycle.Async)) tampoco se toca
-/// aqui: ese seam ya existe con implementacion real (issue #289) y sumar esta proyeccion es
-/// tambien alcance de projection-implementer.
+/// Se registra en ConfiguracionMartenProjectionsControlHoras.ConfigurarControlHoras con
+/// opts.Projections.Add&lt;TurnoVigenteProjection&gt;(ProjectionLifecycle.Async) -- lifecycle
+/// canonico del worker (MEF-ADR-0034 seccion 3), sumado aditivamente junto a TurnoDiarioProjection
+/// (issue #289) en el mismo AddMartenStore.
+///
+/// Create/Apply invocan evento.DetalleTurno.Segmentar(evento.Fecha) (issue #327, Tell-don't-Ask
+/// MEF-ADR-0012: la aritmetica de segmentacion vive en TurnoDiario, no se reimplementa aqui) y
+/// mapean cada BloqueTurno resultante al record Bloque propio de la vista (ReadModels, sin
+/// relacion de tipo con DomainEvents -- alias BloqueVigente/TipoBloqueVigente para desambiguar del
+/// TipoBloque homonimo de ControlHoras.DomainEvents, CS0104).
 ///
 /// Solo TurnoDiarioAsignado alimenta esta vista: MarcacionAdicionada tambien vive en el mismo
 /// stream de ControlDiarioAggregateRoot pero esta proyeccion la ignora a proposito (issue #328,
@@ -32,8 +37,43 @@ namespace Bitakora.ControlAsistencia.Projections.ControlHoras;
 public sealed partial class TurnoVigenteProjection : SingleStreamProjection<TurnoVigente, string>
 {
     public static TurnoVigente Create(TurnoDiarioAsignado evento) =>
-        throw new NotImplementedException();
+        new(
+            evento.Id,
+            evento.InformacionEmpleado.EmpleadoId,
+            NombreCompleto(evento.InformacionEmpleado),
+            evento.Fecha,
+            evento.DetalleTurno.Nombre,
+            evento.DetalleTurno.Descripcion,
+            MapearBloques(evento));
 
+    // CA-2: "el ultimo gana" -- una reasignacion sobre el mismo (empleado, fecha) sobrescribe
+    // turno, horario y bloques. Id, EmpleadoId, NombreCompleto y Fecha no cambian (mismo stream,
+    // mismo empleado): el evento no trae informacion distinta de empleado en una reasignacion.
     public static TurnoVigente Apply(TurnoDiarioAsignado evento, TurnoVigente vista) =>
-        throw new NotImplementedException();
+        vista with
+        {
+            NombreTurno = evento.DetalleTurno.Nombre,
+            HorarioResumido = evento.DetalleTurno.Descripcion,
+            Bloques = MapearBloques(evento)
+        };
+
+    // Unico lugar del sistema donde se concatena Nombres + Apellidos (issue #328, "Investigacion
+    // del planner"): el read model expone un solo campo de presentacion, no nombres/apellidos
+    // separados.
+    private static string NombreCompleto(Empleado empleado) =>
+        $"{empleado.Nombres} {empleado.Apellidos}";
+
+    private static IReadOnlyList<BloqueVigente> MapearBloques(TurnoDiarioAsignado evento) =>
+        evento.DetalleTurno.Segmentar(evento.Fecha).Select(MapearBloque).ToList();
+
+    private static BloqueVigente MapearBloque(BloqueTurno bloque) =>
+        new(MapearTipo(bloque.Tipo), bloque.Inicio, bloque.Fin);
+
+    private static TipoBloqueVigente MapearTipo(TipoBloqueEvento tipo) => tipo switch
+    {
+        TipoBloqueEvento.Ordinaria => TipoBloqueVigente.Ordinaria,
+        TipoBloqueEvento.Descanso => TipoBloqueVigente.Descanso,
+        TipoBloqueEvento.Extra => TipoBloqueVigente.Extra,
+        _ => throw new ArgumentOutOfRangeException(nameof(tipo), tipo, "TipoBloque sin mapeo a TipoBloqueVigente")
+    };
 }

--- a/src/Bitakora.ControlAsistencia.Projections/Infraestructura/ConfiguracionMartenProjectionsControlHoras.cs
+++ b/src/Bitakora.ControlAsistencia.Projections/Infraestructura/ConfiguracionMartenProjectionsControlHoras.cs
@@ -108,6 +108,11 @@ public static class ConfiguracionMartenProjectionsControlHoras
                 // seccion 3); Inline solo seria valido con justificacion explicita del issue, que
                 // este no la da.
                 opts.Projections.Add<TurnoDiarioProjection>(ProjectionLifecycle.Async);
+
+                // Issue #328 CA-3: segunda proyeccion concreta del BC, sumada aditivamente a la de
+                // arriba (mismo stream (EmpleadoId, Fecha), otra vista). N1, lifecycle Async
+                // -- mismo criterio que TurnoDiarioProjection.
+                opts.Projections.Add<TurnoVigenteProjection>(ProjectionLifecycle.Async);
             })
             // Registrar el store no basta: sin esta llamada el daemon queda apagado y ninguna
             // proyeccion se materializa. HotCold elige lider sobre advisory locks de PostgreSQL,

--- a/src/Bitakora.ControlAsistencia.ReadModels/ControlHoras/Bloque.cs
+++ b/src/Bitakora.ControlAsistencia.ReadModels/ControlHoras/Bloque.cs
@@ -1,0 +1,10 @@
+namespace Bitakora.ControlAsistencia.ReadModels.ControlHoras;
+
+/// <summary>
+/// Bloque de tiempo absoluto (hora local del tenant) que compone el turno vigente -- forma propia
+/// de ReadModels, homonima deliberada de <c>BloqueTurno</c> (ControlHoras.DomainEvents, issue #327)
+/// para que la proyeccion no cargue un alias de tipo entre ambos (issue #328, "Investigacion del
+/// planner"). Record plano, sin comportamiento: la clase de proyeccion companion es quien mapea
+/// cada <c>BloqueTurno</c> que produce <c>TurnoDiario.Segmentar</c> a este tipo.
+/// </summary>
+public sealed record Bloque(TipoBloque Tipo, DateTime Inicio, DateTime Fin);

--- a/src/Bitakora.ControlAsistencia.ReadModels/ControlHoras/TipoBloque.cs
+++ b/src/Bitakora.ControlAsistencia.ReadModels/ControlHoras/TipoBloque.cs
@@ -1,0 +1,22 @@
+namespace Bitakora.ControlAsistencia.ReadModels.ControlHoras;
+
+/// <summary>
+/// Tipo de bloque resultante de segmentar el turno vigente (issue #328, misma semantica que
+/// <c>TipoBloque</c> de ControlHoras.DomainEvents, issue #327). ReadModels es isla (cero
+/// referencias de proyecto, no conoce DomainEvents ni buses): este enum se duplica con paridad de
+/// nombre y valores en vez de importarlo, mismo criterio de "tres islas" que ya aplican Empleado,
+/// TurnoDiario, FranjaProgramada y SubFranjaProgramada entre PublicEvents/PrivateEvents/DomainEvents.
+/// La clase de proyeccion companion (TurnoVigenteProjection, en el worker) es quien mapea el
+/// TipoBloque de DomainEvents a este.
+/// </summary>
+public enum TipoBloque
+{
+    /// <summary>Tramo de trabajo ordinario, fuera de descansos y extras.</summary>
+    Ordinaria,
+
+    /// <summary>Tramo de descanso contenido dentro de la franja ordinaria.</summary>
+    Descanso,
+
+    /// <summary>Tramo de trabajo extra contenido dentro de la franja ordinaria.</summary>
+    Extra
+}

--- a/src/Bitakora.ControlAsistencia.ReadModels/ControlHoras/TurnoVigente.cs
+++ b/src/Bitakora.ControlAsistencia.ReadModels/ControlHoras/TurnoVigente.cs
@@ -1,36 +1,6 @@
 namespace Bitakora.ControlAsistencia.ReadModels.ControlHoras;
 
 /// <summary>
-/// Tipo de bloque resultante de segmentar el turno vigente (issue #328, misma semantica que
-/// <c>TipoBloque</c> de ControlHoras.DomainEvents, issue #327). ReadModels es isla (cero
-/// referencias de proyecto, no conoce DomainEvents ni buses): este enum se duplica con paridad de
-/// nombre y valores en vez de importarlo, mismo criterio de "tres islas" que ya aplican Empleado,
-/// TurnoDiario, FranjaProgramada y SubFranjaProgramada entre PublicEvents/PrivateEvents/DomainEvents.
-/// La clase de proyeccion companion (TurnoVigenteProjection, en el worker) es quien mapea el
-/// TipoBloque de DomainEvents a este.
-/// </summary>
-public enum TipoBloque
-{
-    /// <summary>Tramo de trabajo ordinario, fuera de descansos y extras.</summary>
-    Ordinaria,
-
-    /// <summary>Tramo de descanso contenido dentro de la franja ordinaria.</summary>
-    Descanso,
-
-    /// <summary>Tramo de trabajo extra contenido dentro de la franja ordinaria.</summary>
-    Extra
-}
-
-/// <summary>
-/// Bloque de tiempo absoluto (hora local del tenant) que compone el turno vigente -- forma propia
-/// de ReadModels, homonima deliberada de <c>BloqueTurno</c> (ControlHoras.DomainEvents, issue #327)
-/// para que la proyeccion no cargue un alias de tipo entre ambos (issue #328, "Investigacion del
-/// planner"). Record plano, sin comportamiento: la clase de proyeccion companion es quien mapea
-/// cada <c>BloqueTurno</c> que produce <c>TurnoDiario.Segmentar</c> a este tipo.
-/// </summary>
-public sealed record Bloque(TipoBloque Tipo, DateTime Inicio, DateTime Fin);
-
-/// <summary>
 /// Read model del turno que rige a un empleado en una fecha (issue #328) -- reemplazo de
 /// <c>TurnoDiarioView</c> (issue #289), disenado desde la necesidad de lectura (panorama del
 /// programador, consulta del trabajador, consulta puntual del aprobador) y no desde el evento

--- a/src/Bitakora.ControlAsistencia.ReadModels/ControlHoras/TurnoVigente.cs
+++ b/src/Bitakora.ControlAsistencia.ReadModels/ControlHoras/TurnoVigente.cs
@@ -1,0 +1,64 @@
+namespace Bitakora.ControlAsistencia.ReadModels.ControlHoras;
+
+/// <summary>
+/// Tipo de bloque resultante de segmentar el turno vigente (issue #328, misma semantica que
+/// <c>TipoBloque</c> de ControlHoras.DomainEvents, issue #327). ReadModels es isla (cero
+/// referencias de proyecto, no conoce DomainEvents ni buses): este enum se duplica con paridad de
+/// nombre y valores en vez de importarlo, mismo criterio de "tres islas" que ya aplican Empleado,
+/// TurnoDiario, FranjaProgramada y SubFranjaProgramada entre PublicEvents/PrivateEvents/DomainEvents.
+/// La clase de proyeccion companion (TurnoVigenteProjection, en el worker) es quien mapea el
+/// TipoBloque de DomainEvents a este.
+/// </summary>
+public enum TipoBloque
+{
+    /// <summary>Tramo de trabajo ordinario, fuera de descansos y extras.</summary>
+    Ordinaria,
+
+    /// <summary>Tramo de descanso contenido dentro de la franja ordinaria.</summary>
+    Descanso,
+
+    /// <summary>Tramo de trabajo extra contenido dentro de la franja ordinaria.</summary>
+    Extra
+}
+
+/// <summary>
+/// Bloque de tiempo absoluto (hora local del tenant) que compone el turno vigente -- forma propia
+/// de ReadModels, homonima deliberada de <c>BloqueTurno</c> (ControlHoras.DomainEvents, issue #327)
+/// para que la proyeccion no cargue un alias de tipo entre ambos (issue #328, "Investigacion del
+/// planner"). Record plano, sin comportamiento: la clase de proyeccion companion es quien mapea
+/// cada <c>BloqueTurno</c> que produce <c>TurnoDiario.Segmentar</c> a este tipo.
+/// </summary>
+public sealed record Bloque(TipoBloque Tipo, DateTime Inicio, DateTime Fin);
+
+/// <summary>
+/// Read model del turno que rige a un empleado en una fecha (issue #328) -- reemplazo de
+/// <c>TurnoDiarioView</c> (issue #289), disenado desde la necesidad de lectura (panorama del
+/// programador, consulta del trabajador, consulta puntual del aprobador) y no desde el evento
+/// disponible. Convive con TurnoDiarioView hasta que la contraccion (#323) retire el read model
+/// viejo -- nombres distintos, sin colision.
+///
+/// Record plano SIN partial (MEF-ADR-0035, skills/projections/modelos-marten.md): el comportamiento
+/// de proyeccion vive en la clase companion TurnoVigenteProjection, en el worker
+/// (Bitakora.ControlAsistencia.Projections). Este tipo vive en ReadModels (MEF-ADR-0034 seccion 5)
+/// y no gana ninguna referencia de proyecto nueva con este issue -- Bloque/TipoBloque son propios,
+/// sin relacion de tipo con ControlHoras.DomainEvents.
+///
+/// Divergencia documentada frente al naming canonico del Skill (naming.md: "{Concepto}View"): este
+/// read model NO lleva sufijo "View" -- decision del repo, extension de la proscripcion de sufijos
+/// de infraestructura del issue #317 CA-2 al read-side (ver issue #328, "ADRs aplicables").
+///
+/// Id es el stream key que compone ControlDiarioAggregateRoot.ComputarStreamId:
+/// "{EmpleadoId}:{Fecha:yyyy-MM-dd}" -- nunca un Guid (Events.StreamIdentity = AsString). Excluye
+/// deliberadamente UltimaSolicitudId (trazabilidad interna que TurnoDiarioView si expone) y la
+/// identificacion completa del empleado: solo EmpleadoId (lookup/resourceId) y NombreCompleto (un
+/// solo campo, concatenado por la proyeccion desde Empleado.Nombres + Empleado.Apellidos -- unico
+/// lugar del sistema donde se hace, issue #328 "Investigacion del planner").
+/// </summary>
+public sealed record TurnoVigente(
+    string Id,
+    string EmpleadoId,
+    string NombreCompleto,
+    DateOnly Fecha,
+    string NombreTurno,
+    string HorarioResumido,
+    IReadOnlyList<Bloque> Bloques);

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/ObtenerTurnoVigente/ObtenerTurnoVigenteSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/ObtenerTurnoVigente/ObtenerTurnoVigenteSmokeTests.cs
@@ -1,0 +1,205 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.ControlHoras.SmokeTests.Fixtures;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.SmokeTests.ObtenerTurnoVigente;
+
+// Issue #328: smoke tests de ObtenerTurnoVigente, GET control-horas/turnos-vigentes/{empleadoId}/{fecha}.
+// Function GET read-side sobre la proyeccion TurnoVigente (receta N1, MEF-ADR-0034/0035) --
+// reemplazo de TurnoDiarioView (#289) que convive con el read model viejo hasta la contraccion
+// (#323). Mismo mecanismo de siembra que ObtenerTurnoDiarioSmokeTests (#289): se publica
+// ProgramacionTurnoDiarioSolicitada al bus interno; ControlHoras persiste TurnoDiarioAsignado y el
+// worker de proyecciones materializa la vista de forma asincrona.
+//
+// Estos tests quedan ROJOS hasta que el deploy publique ObtenerTurnoVigente en dev: mientras la
+// revision anterior siga corriendo, la ruta no existe y el host responde 404 a todo -- el caso 400
+// falla y el caso 404 pasa por la razon equivocada. Mismo precedente que ObtenerTurnoDiarioSmokeTests
+// (#289) y ListarTurnosDiariosSmokeTests (#290). El CI de PR no los ejecuta (solo corre *.Tests); su
+// veredicto real se lee despues del deploy.
+//
+// Lifecycle Async (MEF-ADR-0034 seccion 3): el worker materializa TurnoVigente DESPUES de que
+// ControlHoras persiste turno_diario_asignado. El caso de exito envuelve la consulta en
+// Polling.WaitUntilAsync (timeout estandar 30s) -- unica excepcion documentada al "no usar Polling
+// directo en tests": si el timeout se agota es un fallo real (worker no desplegado o proyeccion sin
+// registrar en el named store), nunca un skip.
+//
+// Formas locales DESACOPLADAS del read model de produccion (Bitakora.ControlAsistencia.ReadModels.
+// ControlHoras.TurnoVigente/Bloque/TipoBloque): el smoke test no referencia ReadModels (isla, MEF-
+// ADR-0034 seccion 5) ni el Function App. TipoBloqueSmoke replica el orden de valores del enum de
+// produccion porque STJ lo serializa como el entero subyacente (ComposicionServicios no registra
+// JsonStringEnumConverter para las respuestas HTTP) -- si produccion reordenara TipoBloque, este
+// test detectaria el cambio de contrato al fallar la comparacion.
+//
+// No se repite aqui el CA-2 ("el ultimo gana", reasignacion sobrescribe) ni el mapeo detallado de
+// descansos/extras: esas reglas de negocio de la proyeccion ya las cubre el unit test de
+// TurnoVigenteProjection (projection-test-writer). Este smoke test es black-box: solo verifica que
+// el endpoint desplegado responde con la vista materializada.
+public class ObtenerTurnoVigenteSmokeTests(ApiFixture api, ServiceBusFixture serviceBus)
+{
+    private readonly HttpClient _client = api.Client;
+
+    private const string TopicEntrada = "programacion-turno-diario-solicitada";
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
+
+    // Case-insensitive: la respuesta viaja en camelCase (ComposicionServicios configura
+    // JsonNamingPolicy.CamelCase para las respuestas HTTP), mientras que las formas locales de este
+    // archivo son PascalCase (mismo patron que ObtenerTurnoDiarioSmokeTests).
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    private enum TipoBloqueSmoke
+    {
+        Ordinaria,
+        Descanso,
+        Extra
+    }
+
+    private sealed record BloqueSmoke(TipoBloqueSmoke Tipo, DateTime Inicio, DateTime Fin);
+
+    private sealed record TurnoVigenteRespuestaSmoke(
+        string Id,
+        string EmpleadoId,
+        string NombreCompleto,
+        DateOnly Fecha,
+        string NombreTurno,
+        string HorarioResumido,
+        IReadOnlyList<BloqueSmoke> Bloques);
+
+    private static string Ruta(string empleadoId, DateOnly fecha) =>
+        $"/api/control-horas/turnos-vigentes/{empleadoId}/{fecha:yyyy-MM-dd}";
+
+    // Mismo formato que ControlDiarioAggregateRoot.ComputarStreamId, reconstruido localmente:
+    // el smoke test no referencia el Function App (ControlHoras.Entities).
+    private static string ComputarStreamId(string empleadoId, DateOnly fecha) =>
+        $"{empleadoId}:{fecha:yyyy-MM-dd}";
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task DebeEstarDisponible_CuandoSeConsultaHealthCheck()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var response = await _client.GetAsync("/api/health", ct);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ObtenerTurnoVigente_Retorna200ConLaVistaCompleta_CuandoElBusAsignaElTurno()
+    {
+        Assert.SkipWhen(!serviceBus.IsConfigured,
+            "ServiceBus no configurado. Usa appsettings.local.json o variable ServiceBus__ConnectionString.");
+
+        var ct = TestContext.Current.CancellationToken;
+
+        // Arrange: identificadores unicos por ejecucion y fecha fija (nunca DateTime.UtcNow).
+        var solicitudId = Guid.CreateVersion7();
+        var empleadoId = Guid.CreateVersion7().ToString();
+        var fecha = new DateOnly(2026, 4, 9);
+
+        var evento = new
+        {
+            SolicitudId = solicitudId,
+            Empleado = new
+            {
+                EmpleadoId = empleadoId,
+                TipoIdentificacion = "CC",
+                NumeroIdentificacion = "111222333",
+                Nombres = "[TEST] Smoke",
+                Apellidos = "[TEST] TurnoVigente"
+            },
+            Fecha = fecha.ToString("yyyy-MM-dd"),
+            DetalleTurno = new
+            {
+                Nombre = "[TEST] Turno Vigente Query",
+                FranjasOrdinarias = new[]
+                {
+                    new
+                    {
+                        HoraInicio = "08:00:00",
+                        HoraFin = "16:00:00",
+                        DiaOffsetFin = 0,
+                        Descansos = Array.Empty<object>(),
+                        Extras = Array.Empty<object>(),
+                        Descripcion = (string?)null
+                    }
+                },
+                Descripcion = "[TEST] Turno Vigente 08:00-16:00"
+            }
+        };
+
+        // Act: publicar al bus interno -- ControlHoras persiste TurnoDiarioAsignado y el worker de
+        // proyecciones materializa TurnoVigente de forma asincrona.
+        await serviceBus.PublishAsync(TopicEntrada, evento, solicitudId.ToString());
+
+        // Act + Assert: reintentar el GET hasta que la proyeccion asincrona materialice la vista.
+        var ruta = Ruta(empleadoId, fecha);
+        var respuesta = await Polling.WaitUntilAsync(async () =>
+        {
+            var response = await _client.GetAsync(ruta, ct);
+            if (response.StatusCode == HttpStatusCode.NotFound)
+                return null;
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            return await response.Content.ReadFromJsonAsync<TurnoVigenteRespuestaSmoke>(
+                JsonOptions, cancellationToken: ct);
+        }, Timeout);
+
+        // Sin assert de NotBeNull: WaitUntilAsync devuelve un valor no nulo o lanza TimeoutException
+        // ("el worker no materializo TurnoVigente dentro del timeout"), nunca null.
+
+        // Assert: Id como stream key -- ancla para comandos/lookups de la UI, no se pinta pero SI
+        // viaja en la respuesta (decision de entrevista, "Notas tecnicas" del issue #328).
+        respuesta.Id.Should().Be(ComputarStreamId(empleadoId, fecha));
+        respuesta.EmpleadoId.Should().Be(empleadoId);
+        respuesta.NombreCompleto.Should().Be("[TEST] Smoke [TEST] TurnoVigente");
+        respuesta.Fecha.Should().Be(fecha);
+        respuesta.NombreTurno.Should().Be("[TEST] Turno Vigente Query");
+        respuesta.HorarioResumido.Should().Be("[TEST] Turno Vigente 08:00-16:00");
+
+        // Assert: Bloques -- un solo tramo Ordinaria (sin descansos/extras/cruce de medianoche),
+        // absoluto contra la fecha de asignacion (TurnoDiario.Segmentar, issue #327).
+        var bloqueEsperado = new BloqueSmoke(
+            TipoBloqueSmoke.Ordinaria,
+            fecha.ToDateTime(new TimeOnly(8, 0)),
+            fecha.ToDateTime(new TimeOnly(16, 0)));
+        respuesta.Bloques.Should().BeEquivalentTo([bloqueEsperado]);
+    }
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ObtenerTurnoVigente_Retorna404_CuandoNoHayTurnoVigenteParaEseEmpleadoYFecha()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        // Arrange: empleadoId nuevo, nunca creado por ningun test -- no puede tener turno vigente.
+        var empleadoId = Guid.CreateVersion7().ToString();
+        var fecha = new DateOnly(2026, 4, 10);
+
+        var response = await _client.GetAsync(Ruta(empleadoId, fecha), ct);
+
+        // Assert: CA-4 -- 404 SIN BODY (mismo criterio que ObtenerTurnoDiario, #289): distingue el
+        // NotFoundResult() del endpoint de un 404 con payload de error, y de la pagina de error del
+        // host si la ruta no existiera.
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        (await response.Content.ReadAsStringAsync(ct)).Should().BeEmpty();
+    }
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ObtenerTurnoVigente_Retorna400_CuandoLaFechaTieneFormatoInvalido()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        // Arrange: formato DD-MM-YYYY en vez de yyyy-MM-dd (mismo patron que ObtenerTurnoDiario, #289).
+        var empleadoId = Guid.CreateVersion7().ToString();
+
+        var response = await _client.GetAsync(
+            $"/api/control-horas/turnos-vigentes/{empleadoId}/09-04-2026", ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/ComposicionServiciosTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/ComposicionServiciosTests.cs
@@ -39,6 +39,7 @@ using OpenTelemetry.Trace;
 using Wolverine;
 using ObtenerTurnoDiarioEndpoint = Bitakora.ControlAsistencia.ControlHoras.ObtenerTurnoDiario.FunctionEndpoint;
 using ListarTurnosDiariosEndpoint = Bitakora.ControlAsistencia.ControlHoras.ListarTurnosDiarios.FunctionEndpoint;
+using ObtenerTurnoVigenteEndpoint = Bitakora.ControlAsistencia.ControlHoras.ObtenerTurnoVigente.FunctionEndpoint;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.Tests.Infraestructura;
 
@@ -350,6 +351,58 @@ public class ComposicionServiciosTests
         var act = () => ActivatorUtilities.CreateInstance<ListarTurnosDiariosEndpoint>(scope.ServiceProvider);
 
         act.Should().NotThrow();
+    }
+
+    // Issue #328 CA-4: test de composicion de la Function GET de TurnoVigente, hermano del de
+    // ObtenerTurnoDiario (#289 CA-7, comentario arriba) y del propio ListarTurnosDiarios (#290
+    // CA-7), a su vez hermanos de MEF-ADR-0029. ActivatorUtilities.CreateInstance reproduce la
+    // activacion por tipo que hace el host de Azure Functions isolated worker, sin levantar el
+    // host real (Alt 1 de MEF-ADR-0029).
+    //
+    // Se prueba solo la RESOLUCION de IDocumentStore/ITenantResolver por constructor -- no el
+    // comportamiento de Run (parseo de empleadoId/fecha con 400 explicito, session.LoadAsync y el
+    // 200/404, CA-4), que es responsabilidad de projection-implementer y del smoke test (CA-8), no
+    // de este guardrail de wiring. Por eso este test queda en verde tan pronto exista el
+    // FunctionEndpoint stub con el constructor correcto -- no es la guarda que fuerza el rojo de
+    // este issue (esa la dan los unit tests de la proyeccion y el config-test del worker).
+    [Fact]
+    public async Task AgregarServiciosControlHoras_ResuelveElEndpointDeObtenerTurnoVigente_CuandoElContenedorEstaCompuesto()
+    {
+        await using var provider = ComponerServiceProvider();
+        await using var scope = provider.CreateAsyncScope();
+
+        var act = () => ActivatorUtilities.CreateInstance<ObtenerTurnoVigenteEndpoint>(scope.ServiceProvider);
+
+        act.Should().NotThrow();
+    }
+
+    // Issue #328, mismo par que TurnoDiarioView tuvo que cerrar en el issue #294 (comentarios
+    // arriba, "AgregarServiciosControlHoras_EsperaLaMismaColumnaDeVersionQueMaterializaElWorker"):
+    // en cuanto TurnoVigenteProjection se registre en el worker (ver ConfiguracionMartenProjections
+    // Tests.ConfigurarControlHoras_RegistraTurnoVigenteProjectionComoAsync), Marten le aplicara
+    // ProjectionDocumentPolicy alla (UseNumericRevisions = true, mt_version bigint) -- este
+    // Function App NO puede registrar esa proyeccion (vive en el ensamblado del worker,
+    // referenciarla violaria CA-ADR-0029) asi que, sin declarar la misma forma explicitamente con
+    // Schema.For<TurnoVigente>().UseNumericRevisions(true), esperaria mt_version uuid sobre la
+    // MISMA tabla fisica y las dos lecturas convergerian en un "alter column" incompatible (42804),
+    // el mismo 500 permanente que produjo el deploy de #290.
+    //
+    // FASE ROJA: ComposicionServicios.AgregarServiciosControlHoras todavia no declara ese
+    // Schema.For -- este test es el que projection-implementer debe poner en verde. Oraculo literal,
+    // espejo del que ConfiguracionMartenProjectionsTests
+    // .ConfigurarControlHoras_MaterializaTurnoVigenteConRevisionNumerica congela desde el worker.
+    [Fact]
+    public async Task AgregarServiciosControlHoras_EsperaLaMismaColumnaDeVersionQueMaterializaraElWorker_ParaTurnoVigente()
+    {
+        await using var provider = ComponerServiceProvider();
+        await using var scope = provider.CreateAsyncScope();
+
+        var mapping = scope.ServiceProvider.GetRequiredService<IDocumentStore>()
+            .Options.FindOrResolveDocumentType(typeof(TurnoVigente));
+
+        mapping.Metadata.Revision.Enabled.Should().BeTrue();
+        mapping.Metadata.Revision.Type.Should().Be("bigint");
+        mapping.Metadata.Version.Enabled.Should().BeFalse();
     }
 
     // --- Sampler efectivo del TracerProvider (issue #308 CA-2, CA-3) ---

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/ComposicionServiciosTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/ComposicionServiciosTests.cs
@@ -405,6 +405,32 @@ public class ComposicionServiciosTests
         mapping.Metadata.Version.Enabled.Should().BeFalse();
     }
 
+    // Issue #328, mitad write-side del par 2 de compatibilidad write-side/read-side (MEF-ADR-0034
+    // seccion 6), hermana de la que #289 dejo para TurnoDiarioView (arriba): este Function App lee
+    // TurnoVigente con session.LoadAsync sin registrar la proyeccion, y el worker la materializa en
+    // otro proceso. Tabla, tenancy e IdMember tienen que converger o el GET devuelve 404 para
+    // siempre con el daemon funcionando.
+    //
+    // Anadida en la revision de #328: los tres valores los resuelve Marten por convencion, pero este
+    // lado ya declara un Schema.For<TurnoVigente>() propio (la linea de UseNumericRevisions del test
+    // de arriba) -- justo el tipo de declaracion por documento que puede desviar la tabla o la
+    // tenancy de un solo lado. Oraculo literal, espejo del que ConfiguracionMartenProjectionsTests
+    // .ConfigurarControlHoras_MaterializaTurnoVigenteSobreLaTablaQueConsultaElWriteSide congela desde
+    // el worker.
+    [Fact]
+    public async Task AgregarServiciosControlHoras_ResuelveTurnoVigenteSobreLaTablaQueMaterializaElWorker_CuandoElContenedorEstaCompuesto()
+    {
+        await using var provider = ComponerServiceProvider();
+        await using var scope = provider.CreateAsyncScope();
+
+        var mapping = scope.ServiceProvider.GetRequiredService<IDocumentStore>()
+            .Options.FindOrResolveDocumentType(typeof(TurnoVigente));
+
+        mapping.TableName.QualifiedName.Should().Be("control_horas.mt_doc_turnovigente");
+        mapping.TenancyStyle.Should().Be(TenancyStyle.Conjoined);
+        mapping.IdMember.Name.Should().Be(nameof(TurnoVigente.Id));
+    }
+
     // --- Sampler efectivo del TracerProvider (issue #308 CA-2, CA-3) ---
     //
     // Hallazgo 1 del issue #308: UseAzureMonitorExporter llama SetSampler internamente

--- a/tests/Bitakora.ControlAsistencia.Projections.Tests/ConfiguracionMartenProjectionsTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Projections.Tests/ConfiguracionMartenProjectionsTests.cs
@@ -328,6 +328,46 @@ public class ConfiguracionMartenProjectionsTests
         mapping.IdMember.Name.Should().Be(nameof(TurnoDiarioView.Id));
     }
 
+    // Issue #328 CA-3: segunda proyeccion concreta del dominio (N1, SingleStreamProjection
+    // <TurnoVigente, string>, mismo stream que TurnoDiarioProjection -- (EmpleadoId, Fecha)).
+    // Complementa ConfigurarControlHoras_NoRegistraNingunaProyeccionInline (que solo prueba que
+    // NADA quedo Inline; una lista sin TurnoVigente la pasaria igual) verificando que la proyeccion
+    // CONCRETA de este issue si quedo registrada con lifecycle Async. FASE ROJA: hoy el seam
+    // (ConfiguracionMartenProjectionsControlHoras.ConfigurarControlHoras) todavia no encadena
+    // opts.Projections.Add<TurnoVigenteProjection>(...) -- eso es alcance de projection-implementer.
+    [Fact]
+    public void ConfigurarControlHoras_RegistraTurnoVigenteProjectionComoAsync()
+    {
+        using var provider = ProviderDeControlHoras();
+
+        provider.GetRequiredService<IControlHorasProjectionStore>()
+            .AssertProyeccionAsyncRegistrada("TurnoVigente");
+    }
+
+    // Issue #328, mismo gotcha de "Numeric Revisioned Documents" que ya peno a TurnoDiarioView
+    // (issue #294): Marten aplica ProjectionDocumentPolicy SOLO a los documentos que son target de
+    // una proyeccion REGISTRADA en el store (UseNumericRevisions = true, Metadata.Revision --
+    // mt_version bigint -- habilitada, Metadata.Version -- mt_version uuid -- deshabilitada). Hasta
+    // que TurnoVigenteProjection se registre arriba, este mapping cae al default (Version
+    // habilitado, Revision deshabilitado) y este test queda en rojo.
+    //
+    // El oraculo es literal y espejo del que ComposicionServiciosTests
+    // .AgregarServiciosControlHoras_EsperaLaMismaColumnaDeVersionQueMaterializaraElWorker_
+    // ParaTurnoVigente congela desde el write-side -- juntos cierran la misma dimension que #294
+    // tuvo que cerrar para TurnoDiarioView, antes de que un 42804 llegue a dev.
+    [Fact]
+    public void ConfigurarControlHoras_MaterializaTurnoVigenteConRevisionNumerica()
+    {
+        using var provider = ProviderDeControlHoras();
+
+        var mapping = provider.GetRequiredService<IControlHorasProjectionStore>()
+            .Options.FindOrResolveDocumentType(typeof(TurnoVigente));
+
+        mapping.Metadata.Revision.Enabled.Should().BeTrue();
+        mapping.Metadata.Revision.Type.Should().Be("bigint");
+        mapping.Metadata.Version.Enabled.Should().BeFalse();
+    }
+
     // Issue #294, mitad worker de la dimension que el par de #289 dejo abierta: la guarda de arriba
     // pinea tabla, tenancy e Id, y las tres convergian -- el 500 en dev entro por la forma de
     // mt_version, que nadie media.

--- a/tests/Bitakora.ControlAsistencia.Projections.Tests/ConfiguracionMartenProjectionsTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Projections.Tests/ConfiguracionMartenProjectionsTests.cs
@@ -368,6 +368,34 @@ public class ConfiguracionMartenProjectionsTests
         mapping.Metadata.Version.Enabled.Should().BeFalse();
     }
 
+    // Issue #328, mitad worker del par 2 de compatibilidad write-side/read-side (MEF-ADR-0034
+    // seccion 6): el daemon materializa TurnoVigente desde este named store y el Function App de
+    // ControlHoras la lee, en otro proceso, con session.LoadAsync. Misma guarda que #289 dejo para
+    // TurnoDiarioView (arriba): que ambos lados converjan en la MISMA tabla fisica, la MISMA tenancy
+    // y el MISMO IdMember no lo garantiza ningun compilador -- son dos configuraciones de Marten
+    // independientes sobre el mismo schema, y una divergencia deja el GET en 404 permanente con el
+    // daemon funcionando (fallo silencioso que solo veria el smoke test contra dev).
+    //
+    // Anadida en la revision de #328: la fase roja la omitio por no tener potencial de rojo (Marten
+    // resuelve los tres valores por convencion), pero el write-side SI declara ahora un
+    // Schema.For<TurnoVigente>() propio -- un punto por donde una divergencia futura puede entrar sin
+    // que nadie la mida. El oraculo es literal y ComposicionServiciosTests
+    // .AgregarServiciosControlHoras_ResuelveTurnoVigenteSobreLaTablaQueMaterializaElWorker... congela
+    // el MISMO literal desde el write-side, sin que ningun ensamblado referencie al otro
+    // (CA-ADR-0028/CA-ADR-0029).
+    [Fact]
+    public void ConfigurarControlHoras_MaterializaTurnoVigenteSobreLaTablaQueConsultaElWriteSide()
+    {
+        using var provider = ProviderDeControlHoras();
+
+        var mapping = provider.GetRequiredService<IControlHorasProjectionStore>()
+            .Options.FindOrResolveDocumentType(typeof(TurnoVigente));
+
+        mapping.TableName.QualifiedName.Should().Be("control_horas.mt_doc_turnovigente");
+        mapping.TenancyStyle.Should().Be(TenancyStyle.Conjoined);
+        mapping.IdMember.Name.Should().Be(nameof(TurnoVigente.Id));
+    }
+
     // Issue #294, mitad worker de la dimension que el par de #289 dejo abierta: la guarda de arriba
     // pinea tabla, tenancy e Id, y las tres convergian -- el 500 en dev entro por la forma de
     // mt_version, que nadie media.

--- a/tests/Bitakora.ControlAsistencia.Projections.Tests/ControlHoras/TurnoVigenteProjectionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Projections.Tests/ControlHoras/TurnoVigenteProjectionTests.cs
@@ -1,0 +1,122 @@
+// Issue #328: fase roja de la segunda proyeccion concreta del BC. Invocacion DIRECTA de los
+// metodos estaticos de TurnoVigenteProjection (N1, MEF-ADR-0035) -- no el DSL Given/When/Then de
+// CommandHandlerTestBase (MEF-ADR-0002, testea command handlers contra el event store): aqui se
+// testean funciones puras evento -> vista, sin abrir ningun stream.
+//
+// Cada assert compara contra un oraculo armado a mano (MEF-ADR-0002, no-tautologia): nunca se
+// reusa la logica de Create/Apply bajo prueba para construir el valor esperado. Los Bloques
+// esperados SI se calculan aplicando a mano el algoritmo documentado de TurnoDiario.Segmentar
+// (issue #327, ya cubierto por sus propios tests) -- Segmentar no es la logica bajo prueba en este
+// archivo; lo que se verifica aqui es que Create/Apply lo invocan sobre el payload del evento
+// (Tell-don't-Ask, MEF-ADR-0012) y mapean cada BloqueTurno resultante al record Bloque propio de
+// la vista (ReadModels, sin relacion de tipo con DomainEvents).
+//
+// using TipoBloqueVigente: alias obligatorio -- DomainEvents.TipoBloque (necesario para construir
+// el evento fundacional) y ReadModels.ControlHoras.TipoBloque (necesario para el oraculo de la
+// vista) comparten nombre a proposito, mismo criterio de "tres islas" que ya aplican Empleado/
+// TurnoDiario/FranjaProgramada entre los ensamblados de eventos. Con ambos "using" activos el
+// simbolo corto "TipoBloque" queda ambiguo (CS0104); el alias resuelve solo el lado ReadModels.
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
+using Bitakora.ControlAsistencia.Projections.ControlHoras;
+using Bitakora.ControlAsistencia.ReadModels.ControlHoras;
+using TipoBloqueVigente = Bitakora.ControlAsistencia.ReadModels.ControlHoras.TipoBloque;
+
+namespace Bitakora.ControlAsistencia.Projections.Tests.ControlHoras;
+
+public class TurnoVigenteProjectionTests
+{
+    private static Empleado EmpleadoDePrueba() =>
+        new("EMP-001", "CC", "1098765432", "Ana", "Ramirez");
+
+    // CA-1: Create mapea stream key, EmpleadoId, NombreCompleto (concatenado Nombres+Apellidos --
+    // unico lugar del sistema donde se hace, issue #328 "Investigacion del planner"), NombreTurno,
+    // HorarioResumido (la Descripcion textual que el evento ya trae) y los Bloques que produce
+    // Segmentar, con los tres tipos posibles (Ordinaria/Descanso/Extra) representados.
+    [Fact]
+    public void Create_ProyectaElTurnoVigenteCompleto_DesdeTurnoDiarioAsignado()
+    {
+        var empleado = EmpleadoDePrueba();
+        var fecha = new DateOnly(2026, 8, 3);
+        var streamKey = "EMP-001:2026-08-03";
+
+        // Franja 06:00-14:00 con un descanso (10:00-10:15) y un extra ANTES del inicio nominal
+        // (05:00-06:00): cubre los tres TipoBloque sin que ningun tramo cruce medianoche, para
+        // poder calcular el oraculo a mano sin ambiguedad (Tramo.RomperEnMedianoche no interviene).
+        var franja = new FranjaProgramada(
+            new TimeOnly(6, 0),
+            new TimeOnly(14, 0),
+            DiaOffsetFin: 0,
+            Descansos: [new SubFranjaProgramada(new TimeOnly(10, 0), new TimeOnly(10, 15), 0, 0, "(10:00-10:15)")],
+            Extras: [new SubFranjaProgramada(new TimeOnly(5, 0), new TimeOnly(6, 0), 0, 0, "(05:00-06:00)")],
+            Descripcion: "(06:00-14:00)[Descansos:(10:00-10:15)][Extras:(05:00-06:00)]");
+        var turnoDiario = new TurnoDiario(
+            "Turno Manana",
+            [franja],
+            "Turno Manana: (06:00-14:00)[Descansos:(10:00-10:15)][Extras:(05:00-06:00)]");
+        var solicitudId = Guid.NewGuid();
+        var evento = new TurnoDiarioAsignado(streamKey, empleado, fecha, turnoDiario, solicitudId);
+
+        var vista = TurnoVigenteProjection.Create(evento);
+
+        var medianoche = fecha.ToDateTime(TimeOnly.MinValue);
+        var bloquesEsperados = new[]
+        {
+            new Bloque(TipoBloqueVigente.Extra, medianoche.AddHours(5), medianoche.AddHours(6)),
+            new Bloque(TipoBloqueVigente.Ordinaria, medianoche.AddHours(6), medianoche.AddHours(10)),
+            new Bloque(TipoBloqueVigente.Descanso, medianoche.AddHours(10), medianoche.AddHours(10).AddMinutes(15)),
+            new Bloque(TipoBloqueVigente.Ordinaria, medianoche.AddHours(10).AddMinutes(15), medianoche.AddHours(14)),
+        };
+
+        vista.Id.Should().Be(streamKey);
+        vista.EmpleadoId.Should().Be("EMP-001");
+        vista.NombreCompleto.Should().Be("Ana Ramirez");
+        vista.Fecha.Should().Be(fecha);
+        vista.NombreTurno.Should().Be("Turno Manana");
+        vista.HorarioResumido.Should().Be(
+            "Turno Manana: (06:00-14:00)[Descansos:(10:00-10:15)][Extras:(05:00-06:00)]");
+        vista.Bloques.Should().Equal(bloquesEsperados);
+    }
+
+    // CA-2: la reasignacion sobrescribe -- dos TurnoDiarioAsignado consecutivos sobre el mismo
+    // (empleado, fecha) dejan la vista con el NombreTurno, HorarioResumido y Bloques del SEGUNDO
+    // evento ("el ultimo gana"). Id, EmpleadoId y Fecha no cambian (mismo stream key). Sin
+    // ShouldDelete (el turno vigente nunca se borra, solo se reasigna) -- no hay metodo que probar.
+    [Fact]
+    public void Apply_SobrescribeTurnoHorarioYBloques_CuandoLlegaOtroTurnoDiarioAsignado()
+    {
+        var empleado = EmpleadoDePrueba();
+        var fecha = new DateOnly(2026, 8, 3);
+        var streamKey = "EMP-001:2026-08-03";
+        var medianoche = fecha.ToDateTime(TimeOnly.MinValue);
+
+        var vistaPrevia = new TurnoVigente(
+            streamKey,
+            "EMP-001",
+            "Ana Ramirez",
+            fecha,
+            "Turno Manana",
+            "Turno Manana: (06:00-14:00)",
+            [new Bloque(TipoBloqueVigente.Ordinaria, medianoche.AddHours(6), medianoche.AddHours(14))]);
+
+        // Segundo turno, sin descansos ni extras: un solo bloque Ordinaria 14:00-22:00.
+        var franjaTarde = new FranjaProgramada(
+            new TimeOnly(14, 0), new TimeOnly(22, 0), DiaOffsetFin: 0,
+            Descansos: [], Extras: [], Descripcion: "(14:00-22:00)");
+        var turnoTarde = new TurnoDiario("Turno Tarde", [franjaTarde], "Turno Tarde: (14:00-22:00)");
+        var nuevaSolicitudId = Guid.NewGuid();
+        var segundoEvento = new TurnoDiarioAsignado(streamKey, empleado, fecha, turnoTarde, nuevaSolicitudId);
+
+        var vista = TurnoVigenteProjection.Apply(segundoEvento, vistaPrevia);
+
+        vista.Id.Should().Be(streamKey);
+        vista.EmpleadoId.Should().Be("EMP-001");
+        vista.Fecha.Should().Be(fecha);
+        vista.NombreCompleto.Should().Be("Ana Ramirez");
+        vista.NombreTurno.Should().Be("Turno Tarde");
+        vista.HorarioResumido.Should().Be("Turno Tarde: (14:00-22:00)");
+        vista.Bloques.Should().Equal(
+            new Bloque(TipoBloqueVigente.Ordinaria, medianoche.AddHours(14), medianoche.AddHours(22)));
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Projections.Tests/ControlHoras/TurnoVigenteProjectionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Projections.Tests/ControlHoras/TurnoVigenteProjectionTests.cs
@@ -119,4 +119,45 @@ public class TurnoVigenteProjectionTests
         vista.Bloques.Should().Equal(
             new Bloque(TipoBloqueVigente.Ordinaria, medianoche.AddHours(14), medianoche.AddHours(22)));
     }
+
+    // CA-2 (borde que el test de arriba no discrimina, porque ahi los dos eventos traen el MISMO
+    // empleado): cada TurnoDiarioAsignado carga el payload Empleado completo, asi que una correccion
+    // del nombre aguas arriba llega con la reasignacion y el "ultimo gana" tambien le aplica --
+    // congelar el nombre de la primera asignacion dejaria la vista mostrando un dato viejo para
+    // siempre. Id, EmpleadoId y Fecha si son invariantes (identidad del stream), y se verifican aqui
+    // junto al refresco para que el test no pueda pasar por sobrescribir la vista entera.
+    [Fact]
+    public void Apply_RefrescaElNombreCompleto_CuandoLaReasignacionTraeElNombreCorregido()
+    {
+        var fecha = new DateOnly(2026, 8, 3);
+        var streamKey = "EMP-001:2026-08-03";
+        var medianoche = fecha.ToDateTime(TimeOnly.MinValue);
+
+        var vistaPrevia = new TurnoVigente(
+            streamKey,
+            "EMP-001",
+            "Ana Ramirez",
+            fecha,
+            "Turno Manana",
+            "Turno Manana: (06:00-14:00)",
+            [new Bloque(TipoBloqueVigente.Ordinaria, medianoche.AddHours(6), medianoche.AddHours(14))]);
+
+        // Mismo EmpleadoId, nombre corregido aguas arriba (dos nombres y dos apellidos).
+        var empleadoCorregido = new Empleado("EMP-001", "CC", "1098765432", "Ana Maria", "Ramirez Solano");
+        var turnoTarde = new TurnoDiario(
+            "Turno Tarde",
+            [new FranjaProgramada(
+                new TimeOnly(14, 0), new TimeOnly(22, 0), DiaOffsetFin: 0,
+                Descansos: [], Extras: [], Descripcion: "(14:00-22:00)")],
+            "Turno Tarde: (14:00-22:00)");
+        var segundoEvento = new TurnoDiarioAsignado(
+            streamKey, empleadoCorregido, fecha, turnoTarde, Guid.NewGuid());
+
+        var vista = TurnoVigenteProjection.Apply(segundoEvento, vistaPrevia);
+
+        vista.NombreCompleto.Should().Be("Ana Maria Ramirez Solano");
+        vista.Id.Should().Be(streamKey);
+        vista.EmpleadoId.Should().Be("EMP-001");
+        vista.Fecha.Should().Be(fecha);
+    }
 }


### PR DESCRIPTION
## Resumen

Pipeline TDD completado:
- Fase roja: tests escritos con stubs
- Fase verde: implementación completa
- Smoke tests: escritos para endpoints detectados
- Fase refactor: revisión de calidad

## Decisiones del pipeline

<details>
<summary>Projection Test Writer (fase roja) — 14m 52s</summary>

# Fase roja read-side -- Issue #328: read model TurnoVigente

## Tests creados

### 1. Unit tests de proyeccion -- `tests/Bitakora.ControlAsistencia.Projections.Tests/ControlHoras/TurnoVigenteProjectionTests.cs`

- `Create_ProyectaElTurnoVigenteCompleto_DesdeTurnoDiarioAsignado` (CA-1): construye un
  `TurnoDiarioAsignado` con una franja que cubre los tres `TipoBloque` (Ordinaria/Descanso/Extra,
  sin cruzar medianoche para poder calcular el oraculo a mano) y verifica que `Create` mapea
  `Id` (stream key), `EmpleadoId`, `NombreCompleto` (concatenacion Nombres+Apellidos),
  `Fecha`, `NombreTurno`, `HorarioResumido` (la `Descripcion` del evento) y `Bloques`
  (secuencia ordenada, comparada con `.Should().Equal(...)`).
- `Apply_SobrescribeTurnoHorarioYBloques_CuandoLlegaOtroTurnoDiarioAsignado` (CA-2): dos
  `TurnoDiarioAsignado` consecutivos sobre el mismo stream; verifica "el ultimo gana"
  (NombreTurno/HorarioResumido/Bloques del segundo evento) e Id/EmpleadoId/Fecha estables.
- Sin test de `ShouldDelete`: el issue lo excluye explicitamente (CA-2, "Sin ShouldDelete").
- Sin test de correlacion multi-stream: es N1 (`SingleStreamProjection<TurnoVigente, string>`),
  no aplica.
- Oraculo independiente (MEF-ADR-0002): los `Bloque` esperados se calculan a mano aplicando el
  algoritmo YA documentado de `TurnoDiario.Segmentar`/`Tramo` (issue #327, dependencia bloqueante
  y ya cubierta por sus propios tests) -- no se reusa ninguna logica de `Create`/`Apply` bajo
  prueba para construir el esperado.

Ambos tests fallan hoy con `System.NotImplementedException` (verificado por ejecucion:
`dotnet test --project tests/Bitakora.ControlAsistencia.Projections.Tests/`).

### 2. Config-test del worker -- `tests/Bitakora.ControlAsistencia.Projections.Tests/ConfiguracionMartenProjectionsTests.cs`

Se sumaron dos guardas especificas de esta proyeccion, hermanas de las que el issue #289 dejo para
`TurnoDiarioProjection` (mismo patron ya establecido en este dominio):

- `ConfigurarControlHoras_RegistraTurnoVigenteProjectionComoAsync`: falla hoy porque
  `ConfiguracionMartenProjectionsControlHoras.ConfigurarControlHoras` todavia no encadena
  `opts.Projections.Add<TurnoVigenteProjection>(ProjectionLifecycle.Async)` -- ese seam ya existe
  con implementacion real (issue #289) y no lo toque; el rojo es exactamente la ausencia de esa
  linea, que le corresponde a `projection-implementer`.
- `ConfigurarControlHoras_MaterializaTurnoVigenteConRevisionNumerica`: falla hoy porque
  `ProjectionDocumentPolicy` (Marten) solo activa `Metadata.Revision` (mt_version bigint) sobre
  documentos target de una proyeccion REGISTRADA -- mismo gotcha que ya peno a `TurnoDiarioView`
  en el issue #294.

Las 3 guardas genericas del Skill (partial del seam, ningun lifecycle `Inline`, metadata de
evento) ya existen a nivel de dominio (`ConfigurarControlHoras_ResuelveElNamedStoreDelDominio`,
`ConfigurarControlHoras_NoRegistraNingunaProyeccionInline`,
`ConfigurarControlHoras_ReplicaLaMetadataDeEventoDelWriteSide`) y no requirieron cambios: ya cazan
cualquier problema de la nueva proyeccion (p.ej. `partial` faltante) en cuanto
`projection-implementer` la registre.

No se agrego una guarda de tabla/tenancy/IdMember (analoga a
`ConfigurarControlHoras_MaterializaTurnoDiarioViewSobreLaTablaQueConsultaElWriteSide`): esos tres
valores los resuelve Marten por convencion sin necesitar ningun registro (`Policies
.AllDocumentsAreMultiTenanted()` ya aplica a todo documento), asi que ese test pasaria en verde
desde ya -- no aporta rojo y se descarto para no incluir aserciones tautologicas en esta fase.

### 3. Test de composicion de la Function GET -- `tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/ComposicionServiciosTests.cs`

- `AgregarServiciosControlHoras_ResuelveElEndpointDeObtenerTurnoVigente_CuandoElContenedorEstaCompuesto`:
  hermano de los de `ObtenerTurnoDiario`/`ListarTurnosDiarios` -- `ActivatorUtilities.CreateInstance`
  contra el contenedor real compuesto con connection strings dummy. Verifica solo la resolucion de
  `IDocumentStore`/`ITenantResolver` por constructor, no el comportamiento de `Run`. **Pasa en
  verde ya** (mismo patron que sus dos hermanos: es una guarda de wiring, no de comportamiento) en
  cuanto el `FunctionEndpoint` stub existe con la firma correcta.
- `AgregarServiciosControlHoras_EsperaLaMismaColumnaDeVersionQueMaterializaraElWorker_ParaTurnoVigente`:
  espejo write-side del test de revision numerica del worker (mismo par que #294 cerro para
  `TurnoDiarioView` con `options.Schema.For<TurnoDiarioView>().UseNumericRevisions(true)` en
  `ComposicionServicios.cs`). Falla hoy porque esa linea equivalente para `TurnoVigente` todavia no
  existe -- decision documentada abajo.

## Estructura elegida

Se siguio al pie la convencion ya establecida por la primera proyeccion del dominio (issue #289,
`TurnoDiarioProjection`/`TurnoDiarioView`), verificada leyendo el codigo existente antes de escribir
nada:

- `Create`/`Apply` toman el evento de dominio directo (`TurnoDiarioAsignado evento`), no
  `IEvent<TEvento>` -- porque `TurnoDiarioAsignado.Id` YA es el stream key
  (`ControlDiarioAggregateRoot.Apply` hace `Id = e.Id`), asi que `IEvent<T>.StreamKey` seria
  redundante. Diverge del ejemplo generico de `modelos-marten.md` (que usa `IEvent<TEvento>` para
  exponer la identidad), pero es exactamente el patron real y ya probado de este repo -- prioridad
  de "explorar convenciones existentes del dominio" sobre el ejemplo ilustrativo del Skill.

## Stubs creados

- `src/Bitakora.ControlAsistencia.ReadModels/ControlHoras/TurnoVigente.cs`: record `TurnoVigente`
  (7 campos, sin sufijo `View` -- divergencia documentada por el propio issue) + record `Bloque`
  (`Tipo`, `Inicio`, `Fin`) + enum `TipoBloque` (Ordinaria/Descanso/Extra), **propios de
  ReadModels**, sin relacion de tipo con `ControlHoras.DomainEvents.BloqueTurno`/`TipoBloque` --
  ReadModels sigue sin ganar ninguna referencia de proyecto nueva (verificado: `ReadModels.csproj`
  no se toco). Records planos, sin `partial`, sin comportamiento propio (ni siquiera `Equals`
  custom): los tests comparan `Bloques` con `.Should().Equal(...)` en vez de forzar igualdad
  estructural del record completo, precisamente para no tener que agregarle comportamiento al
  read model.
- `src/Bitakora.ControlAsistencia.Projections/ControlHoras/TurnoVigenteProjection.cs`: clase
  companion `partial`, `SingleStreamProjection<TurnoVigente, string>`, con `Create`/`Apply` que
  lanzan `NotImplementedException`. Sin `ShouldDelete` (no aplica, CA-2).
- `src/Bitakora.ControlAsistencia.ControlHoras/ObtenerTurnoVigente/FunctionEndpoint.cs`: stub con
  constructor `(IDocumentStore store, ITenantResolver tenantResolver)` (igual al de
  `ObtenerTurnoDiario`) y `Run` que lanza `NotImplementedException`. Ruta
  `control-horas/turnos-vigentes/{empleadoId}/{fecha}`, `AuthorizationLevel.Anonymous` (mismo nivel
  que el endpoint vecino de este dominio).
- **No se creo** ningun stub de seam de composicion ni de marker de named store: ambos
  (`ConfiguracionMartenProjectionsControlHoras.ConfigurarControlHoras` /
  `IControlHorasProjectionStore`) ya existian con implementacion real desde el issue #289 y no se
  tocaron -- el rojo de esta fase viene enteramente de `TurnoVigenteProjection.Create`/`Apply`, del
  registro faltante en ese seam y de la columna de revision faltante en ambos lados (worker y
  write-side).

## Cobertura de criterios de aceptacion

- CA-1 (Create materializa la vista completa): cubierto por el unit test de `Create`.
- CA-2 (Apply sobrescribe "el ultimo gana", sin ShouldDelete): cubierto por el unit test de
  `Apply`; ausencia de `ShouldDelete` documentada en comentario, no testeable por omision.
- CA-3 (config-test del worker en verde con la proyeccion Async): los dos tests nuevos del
  config-test quedan en rojo hasta que `projection-implementer` registre la proyeccion.
- CA-4 (200/404/400 de `ObtenerTurnoVigente`): fuera de mi alcance -- el `FunctionEndpoint` es
  stub y su comportamiento de `Run` (parseo, `LoadAsync`, 200/404) es responsabilidad de
  `projection-implementer`; el smoke test lo cubre en el entorno desplegado.
- CA-5 (suite completa en verde): no aplica a esta fase (fase roja deliberada).

## Desviaciones del plan del planner / decisiones tomadas

1. **Formato de `NombreCompleto`**: el issue dice "concatena Nombres + Apellidos" sin fijar el
   separador. Se fijo `$"{Nombres} {Apellidos}"` (un espacio) como contrato del oraculo de los
   tests -- si `projection-implementer` necesita otro formato, debe ajustar el test, no al reves.
2. **Alias `TipoBloqueVigente`**: `ControlHoras.DomainEvents.TipoBloque` y
   `ReadModels.ControlHoras.TipoBloque` comparten nombre a proposito (mismo criterio de "tres
   islas" que ya aplican `Empleado`/`TurnoDiario`/`FranjaProgramada` entre ensamblados de eventos).
   El test que necesita ambos `using` simultaneos resuelve la ambiguedad (`CS0104`) con
   `using TipoBloqueVigente = Bitakora.ControlAsistencia.ReadModels.ControlHoras.TipoBloque;` --
   documentado en el propio archivo de test; `projection-implementer` necesitara el mismo alias (u
   otro) en `TurnoVigenteProjection.cs` para mapear un tipo al otro.
3. **Guardas adicionales del config-test/composicion mas alla del alcance minimo**: se agregaron
   los dos tests de "revision numerica" (worker y write-side) siguiendo el patron ya establecido
   por el dominio para `TurnoDiarioView` (issue #294) en vez de limitarme a las 3 guardas genericas
   del Skill -- decision justificada porque ese patron ya es la convencion local del dominio para
   toda proyeccion N1 sobre este named store, y omitirlo dejaria un hueco de cobertura evidente
   frente a la proyeccion hermana. Se **omitio**, en cambio, la guarda de tabla/tenancy/IdMember
   porque esa si pasa en verde sin ninguna implementacion (Marten la resuelve por convencion), y
   agregarla violaria el principio de que toda asercion de esta fase debe tener potencial de rojo.
4. **DTO de respuesta HTTP**: el issue deja como "juicio del pipeline" si `ObtenerTurnoVigente`
   devuelve la vista `TurnoVigente` directa o un DTO propio. No tome esta decision -- el
   `FunctionEndpoint` stub no llega a construir ninguna respuesta (`Run` lanza
   `NotImplementedException` antes de necesitarlo), asi que queda abierta para
   `projection-implementer`. Mi lectura, solo como nota: al no haber trazabilidad interna que
   excluir (a diferencia de `TurnoDiarioView`/`UltimaSolicitudId`) y viajar `Id` en la respuesta por
   decision de entrevista, devolver `TurnoVigente` directo parece la opcion mas simple, pero no es
   vinculante.

## Verificacion

- `dotnet build ControlAsistencias.slnx`: compilacion correcta, 0 errores (7 warnings
  preexistentes + 2 `CS9113` nuevos por los parametros del `FunctionEndpoint` stub sin usar,
  esperado mientras `Run` no esta implementado).
- `dotnet test --project tests/Bitakora.ControlAsistencia.Projections.Tests/`: 57 tests, 4 en
  rojo (los 2 unit tests de proyeccion + las 2 guardas nuevas del config-test), 53 en verde
  (ningun test preexistente se rompio).
- `dotnet test --project tests/Bitakora.ControlAsistencia.ControlHoras.Tests/`: 416 tests, 1 en
  rojo (la guarda de revision numerica write-side), 415 en verde (incluye el nuevo test de
  composicion del `FunctionEndpoint`, que pasa por diseno -- es guarda de wiring, no de
  comportamiento).
- No se ejecuto `dotnet test` sobre la suite completa (smoke tests requieren entorno desplegado,
  fuera de alcance de esta fase).

</details>

<details>
<summary>Projection Implementer (fase verde) — 5m 46s</summary>

# Resumen -- projection-implementer (issue #328)

## Enfoque

Fase verde read-side sobre los stubs que dejo `projection-test-writer`. Cuatro archivos de
produccion tocados, ningun test modificado:

1. **`TurnoVigenteProjection` (worker)**: `Create`/`Apply` dejan de lanzar `NotImplementedException`.
   - `Create(TurnoDiarioAsignado evento)` construye la vista completa: `Id` = `evento.Id` (el
     evento ya trae el stream key en su payload, mismo patron que `TurnoDiarioProjection`),
     `EmpleadoId` y `NombreCompleto` (concatenacion `Nombres + " " + Apellidos`, unico lugar del
     sistema donde se hace) desde `evento.InformacionEmpleado`, `NombreTurno`/`HorarioResumido`
     desde `evento.DetalleTurno`, y `Bloques` invocando `evento.DetalleTurno.Segmentar(evento.Fecha)`
     (Tell-don't-Ask MEF-ADR-0012 -- la aritmetica vive en `TurnoDiario`, issue #327) mapeando cada
     `BloqueTurno` al record `Bloque` propio de `ReadModels` (homonimo deliberado, sin relacion de
     tipo).
   - `Apply` sobrescribe `NombreTurno`/`HorarioResumido`/`Bloques` con `vista with { ... }`
     ("el ultimo gana", CA-2); `Id`/`EmpleadoId`/`NombreCompleto`/`Fecha` no cambian. Sin
     `ShouldDelete` (el turno vigente nunca se borra).
   - Mapeo de enum homonimo (`DomainEvents.TipoBloque` -> `ReadModels.ControlHoras.TipoBloque`) via
     `switch` explicito + tres alias `using` (`BloqueVigente`, `TipoBloqueVigente`,
     `TipoBloqueEvento`) para resolver la ambiguedad CS0104 que el propio archivo ya declaraba con
     los dos `using` de namespace.

2. **`ConfiguracionMartenProjectionsControlHoras.ConfigurarControlHoras` (seam del worker)**: el
   seam ya existia implementado (issue #289); se sumo aditivamente
   `opts.Projections.Add<TurnoVigenteProjection>(ProjectionLifecycle.Async)` dentro del mismo
   `AddMartenStore`, junto a `TurnoDiarioProjection`. Sin tocar el resto del metodo.

3. **`ComposicionServicios.AgregarServiciosControlHoras` (write-side, Function App)**: se agrego
   `options.Schema.For<TurnoVigente>().UseNumericRevisions(true)`, espejo exacto del par que el
   issue #294 ya habia cerrado para `TurnoDiarioView` -- el worker registra la proyeccion y Marten
   le aplica `ProjectionDocumentPolicy` (mt_version bigint); el Function App no puede registrar esa
   proyeccion (vive en el ensamblado del worker, CA-ADR-0029) asi que debe declarar la misma forma
   explicitamente para no divergir sobre la misma tabla fisica (mismo 42804 que produjo el deploy
   de #290 si se omite).

4. **`ObtenerTurnoVigente/FunctionEndpoint.Run`**: parseo tipado de `fecha` (`DateOnly.TryParseExact`,
   400 explicito si falla, mismo formato `yyyy-MM-dd` que `ObtenerTurnoDiario`), reconstruccion del
   stream key con `ControlDiarioAggregateRoot.ComputarStreamId(empleadoId, fechaParseada)` (nunca
   una concatenacion propia, MEF-ADR-0037), `QuerySession` acotada al tenant de `ITenantResolver`
   (nunca a un tenant que llegue por ruta/query, MEF-ADR-0028), `session.LoadAsync<TurnoVigente>` y
   200/404. Se devuelve la vista `TurnoVigente` directamente (`OkObjectResult(vista)`) sin DTO
   propio: el issue autoriza esa via ("si la respuesta coincide con la vista, evaluar devolverla
   directa") y `TurnoVigente` ya excluye deliberadamente todo lo que no debia viajar (sin
   `UltimaSolicitudId`, sin identificacion completa del empleado) y SI incluye `Id` (ancla de
   comandos, decision de entrevista del issue).

## Decisiones de diseno

- **Firma de `Create`/`Apply`**: `Create(TurnoDiarioAsignado)` / `Apply(TurnoDiarioAsignado, TurnoVigente)`,
  sin `IEvent<TEvento>` -- igual que `TurnoDiarioProjection` ya establecido (issue #289): el
  identificador de stream viaja como propiedad `Id` dentro del propio payload del evento, no se
  resuelve por metadata de Marten. Firma reconocida por el source generator (lista cerrada de
  `modelos-marten.md`), verificado con el config-test en verde.
- **Mapeo de enum homonimo**: `switch` explicito en vez de cast `(int)` -- mas seguro ante una
  futura divergencia de orden de valores entre los dos enums duplicados por la doctrina de "tres
  islas".

## ADRs / recursos consultados

- MEF-ADR-0035 (doctrina read-side), MEF-ADR-0034 secciones 2/3/6/7 (worker, lifecycle Async,
  config-test, metadata), MEF-ADR-0012 (Tell-don't-Ask), MEF-ADR-0028 (QuerySession acotada al
  tenant de `ITenantResolver`), MEF-ADR-0037 (parseo tipado del id de ruta antes de `LoadAsync`),
  MEF-ADR-0006 (naming de Functions de query).
- `skills/projections/modelos-marten.md` (firma de `Create`, gotcha de la firma
  `Create/Apply(TEvento, TId)`), `read-apis.md` (via (a) por defecto, DTO sin sufijos), `naming.md`
  (feature folder sin sufijo `Function`).
- Precedente verificado (no citado como autoridad, solo replicado porque no viola ningun ADR):
  `TurnoDiarioProjection`, `ObtenerTurnoDiario/FunctionEndpoint`, el par
  `ComposicionServicios`/`ConfiguracionMartenProjectionsControlHoras` que ya habia cerrado la misma
  dimension de `mt_version` para `TurnoDiarioView` en el issue #294.

## Desviaciones

Ninguna. Los tests que dejo `projection-test-writer` (unit tests de la proyeccion, config-test del
worker, test de composicion de la Function) definian con precision la firma esperada de
`Create`/`Apply`, el nombre de proyeccion a registrar (`"TurnoVigente"`) y el wiring del
`FunctionEndpoint`; no hubo contradiccion entre el issue y los stubs que forzara una decision fuera
de guion.

## Resultado

- `dotnet build`: compilacion correcta, 0 errores.
- `dotnet test` (suite completa): 750 tests, 738 correctos, 12 omitidos (smoke tests que requieren
  Postgres/Service Bus locales, sin relacion con este issue), 0 fallidos.
- Tests especificos del issue en verde: `TurnoVigenteProjectionTests` (CA-1/CA-2),
  `ConfiguracionMartenProjectionsTests.ConfigurarControlHoras_RegistraTurnoVigenteProjectionComoAsync`
  y `..._MaterializaTurnoVigenteConRevisionNumerica` (CA-3),
  `ComposicionServiciosTests.AgregarServiciosControlHoras_ResuelveElEndpointDeObtenerTurnoVigente...`
  y `..._EsperaLaMismaColumnaDeVersionQueMaterializaraElWorker_ParaTurnoVigente` (CA-4).
- Formateo: `dotnet format` (MCP JetBrains no disponible en este entorno) sobre los 4 archivos
  tocados; sin cambios adicionales generados.

</details>
<details>
<summary>Smoke Test Writer — 5m 55s</summary>

_(El agente no generó resumen)_

</details>
<details>
<summary>Reviewer (fase refactor) — 16m 48s</summary>

## ES Reviewer - Revision

### Evaluacion general
- Calidad: **buena**
- Cambios realizados: **si** (commit `36ddf53`, refactor + 3 tests nuevos)

Baseline al inicio: 754 tests, 740 verde, 13 omitidos, **1 rojo**
(`ObtenerTurnoVigenteSmokeTests.ObtenerTurnoVigente_Retorna400_CuandoLaFechaTieneFormatoInvalido`).
No hay `blockage-report.md` y ese rojo **no es corregible por codigo**: el smoke test golpea el dev
desplegado, donde la ruta `control-horas/turnos-vigentes/...` todavia no existe, asi que el host
responde 404 en vez de 400. Es el precedente ya documentado en el propio archivo y en
`ObtenerTurnoDiarioSmokeTests` (#289) / `ListarTurnosDiariosSmokeTests` (#290). Verificado ademas que
el CI de PR no lo ejecuta: `ci.yml` itera `tests/Bitakora.ControlAsistencia.*.Tests/`, que excluye
`*.SmokeTests`. Su veredicto real se lee despues del deploy.

Estado final: **757 tests, 743 verde, 13 omitidos, 1 rojo** (el mismo smoke test dependiente del
deploy). Ningun test preexistente se rompio con los refactors.

### Cumplimiento de ADRs aplicables

| ADR | Cumplimiento | Observacion |
|---|---|---|
| MEF-ADR-0035: doctrina read-side (N1, estilo canonico, `QuerySession`) | ok | `SingleStreamProjection<TurnoVigente, string>` (`TId` = `string`, coherente con `StreamIdentity.AsString`), clase companion `partial` en el worker, read model `record` plano sin `partial` en `ReadModels`, `Create`/`Apply` estaticos que retornan copia (`vista with { ... }`), via (a) `session.LoadAsync<TurnoVigente>`. Sin `ShouldDelete` (correcto: el turno vigente se reasigna, no se borra). Ver nota sobre la firma `Create(TEvento)` abajo. |
| MEF-ADR-0034: worker, config-test, lifecycle `Async` | ok | `opts.Projections.Add<TurnoVigenteProjection>(ProjectionLifecycle.Async)` sumado aditivamente en el mismo `AddMartenStore` del named store de ControlHoras, sin tocar `TurnoDiarioProjection`. `ReadModels.csproj` no gana ninguna referencia (seccion 5 intacta). Worker declara `PackageReference Include="Marten"` directo y sin `ExcludeAssets` (analizador presente). Config-test: 3 guardas nuevas (2 del pipeline + 1 que agregue, ver "Tests agregados"). |
| MEF-ADR-0006: naming de Functions de query, feature folder | ok | `[Function("ObtenerTurnoVigente")]` = `Obtener{Concepto}`; feature folder `ObtenerTurnoVigente/` sin sufijo `Function`; clase `FunctionEndpoint` en su propio namespace (sin colision con las otras cinco homonimas del ensamblado); ruta REST por recurso `control-horas/turnos-vigentes/{empleadoId}/{fecha}`, hermana de `turnos-diarios`. Colision de nombre verificada: `ObtenerTurnoVigente` no existia. |
| MEF-ADR-0028: `QuerySession` acotada al tenant del resolver | ok | `store.QuerySession(tenantResolver.TenantId)` -- `TenantId` como propiedad. `empleadoId`/`fecha` vienen de la ruta porque son el **recurso**, nunca el tenant. Ningun tenant id llega por ruta, query string ni body (mitigacion BOLA/IDOR intacta). |
| MEF-ADR-0012: Tell-don't-Ask (`Segmentar` del payload, no aritmetica propia) | ok | `MapearBloques` invoca `evento.DetalleTurno.Segmentar(evento.Fecha)` y solo **mapea** el resultado; cero aritmetica de horas/offsets/medianoche en el worker. Recorrido completo del checklist de antipatrones abajo. |
| Divergencia declarada por el issue: read model sin sufijo `View` | desviacion declarada (por el planner, en el issue) | Evaluada como aceptable, ver "Desviaciones de ADRs". |

El issue **si** trae seccion `## ADRs aplicables` y esta completa. No hay nada que escalar al planner.

#### Checklist de antipatrones MEF-ADR-0012 (recorrido explicito)

| # | Antipatron | Veredicto |
|---|---|---|
| 1 | Propiedad publica nueva en VO/aggregate con unico consumidor externo | n/a -- el diff no toca ningun VO ni aggregate; `TurnoVigente` es read model (`record` plano por doctrina MEF-ADR-0035). |
| 2 | Clase estatica que opera sobre datos crudos de un VO/aggregate | evaluado, ver nota de `NombreCompleto` en "Elegancia". La segmentacion (la operacion con logica real) **si** vive en `TurnoDiario` (#327), no en la proyeccion. |
| 3 | Getter expuesto solo para que los tests afirmen estado | no -- los siete campos de `TurnoVigente` son el contrato HTTP que consume la UI, no una ventana de test. |
| 4 | `InternalsVisibleTo` de un ensamblado de contratos hacia dominio | no aparece. |
| 5 | `[JsonConstructor]` en ctor privado de VO | no aparece (los nuevos tipos son `record` posicionales, sin ctor privado). |
| 6 | `record` con `IReadOnlyList<T>` en la igualdad | presente (`TurnoVigente.Bloques`), **deliberado y correcto aqui**: un read model no tiene semantica de igualdad por valor -- ningun consumidor compara dos `TurnoVigente` -- y MEF-ADR-0035 prohibe explicitamente darle comportamiento (`Equals` custom) al record de la vista. Los tests comparan la coleccion elemento a elemento (`Should().Equal(...)`), no por igualdad del record completo, asi que no hay falso verde. |
| 7 | Evento con marker de bus cargando modelo rico | n/a -- el diff no crea ni modifica ningun evento. `TurnoDiarioAsignado` (sin marker de bus, event store puro) queda intacto. |

#### Gates condicionales del marco

- **MEF-ADR-0037 (identidad de stream)** -- gate **aplica** (el endpoint construye una clave de stream
  y la pasa a `LoadAsync`). Los tres puntos verificados: (1) ningun `ToString("N"/"B"/"D"/...)` ni
  `ToUpper`/`ToLower` sobre un `Guid` en el diff -- las unicas conversiones son `Guid.ToString()` sin
  argumentos en el smoke test y `fecha.ToString("yyyy-MM-dd")`, que es justo el formato explicito que
  el ADR exige para un componente fecha; (2) la clave se compone **solo** via
  `ControlDiarioAggregateRoot.ComputarStreamId(empleadoId, fechaParseada)`, sin concatenacion paralela
  en el endpoint; (3) los dos componentes viajan en segmentos de ruta separados y la fecha se parsea
  una sola vez con `DateOnly.TryParseExact` + `BadRequestObjectResult` **con mensaje**.
  `empleadoId` no se parsea porque en este dominio la identidad del empleado es `string` de origen
  (`Empleado.EmpleadoId`), no un `Guid` -- no es hallazgo.
- **MEF-ADR-0038 (volumen de telemetria)** -- gate **aplica** (el diff toca `ComposicionServicios.cs`).
  Los tres invariantes siguen intactos, el diff no los roza: `SetSampler` en un **segundo**
  `.WithTracing(...)` posterior a `.UseAzureMonitorExporter()`; worker con
  `SamplerQueDescartaPollingDelDaemon(new ParentBasedSampler(new TraceIdRatioBasedSampler(ratio)))`
  (filtro afuera, `ParentBased` como delegado interno); `Durability.DurabilityMetricsEnabled = false`
  presente y ningun `Durability.Mode` dentro del callback. Guardrails de composicion presentes y no
  vacuos en ambos lados (comparan tipo y `Sampler.Description` literal, y el valor de la bandera).
- **MEF-ADR-0034 seccion 6 / issue #447 (compatibilidad Marten write-side/read-side)** -- gate
  **aplica** (el diff toca `ComposicionServicios.cs` y `ConfiguracionMartenProjectionsControlHoras.cs`).
  Resultado parcial, ver la fila del checklist y el detalle abajo.

##### Compatibilidad Marten: lo verificado y lo que quedo sin verificar

`ilspycmd` **no esta instalado** en este entorno (`which ilspycmd` -> no encontrado). Siguiendo la
regla del rol no lo instale: la verificacion por decompilacion de
`Cosmos.EventSourcing.CritterStack` 2.3.1 (`AgregarConfiguracionMartenComandos`, la linea base real
del write-side) queda **no verificada** y por eso la fila del checklist va como `falla`, no `n/a`.
Para completarla: `dotnet tool install -g ilspycmd`.

Lo que **si** pude verificar sin decompilar, y que acota el riesgo:

- **Par 1 (eventos)**: los cambios del diff son estrictamente **aditivos** y no rozan ningun atributo
  de la columna "debe coincidir": `DatabaseSchemaName`, `Events.StreamIdentity`,
  `Events.EventNamingStyle`, `Events.TenancyStyle`, las tres banderas de `MetadataConfig`, el
  serializador y `AddEventTypes` quedan textualmente iguales en ambos lados, y sus guardas de
  config-test siguen verdes.
- **Par 2 (read models)** para el `TurnoVigente` nuevo:
  - tabla / tenancy / `IdMember`: `control_horas.mt_doc_turnovigente`, `TenancyStyle.Conjoined`,
    `Id` -- ahora **pineados con el mismo literal desde los dos procesos** (guardas que agregue, ver
    "Tests agregados"). Antes de este commit esa dimension no se media para la vista nueva.
  - `mt_version`: `UseNumericRevisions(true)` declarado en el write-side y verificado con el par de
    guardas literales que ya trajo el pipeline (misma dimension que el 42804 de #290/#294).
  - serializador de documentos: medido **sobre los dos contenedores reales** (sonda temporal, ya
    eliminada, leyendo `Options.Serializer()` de cada store): worker `EnumStorage=AsInteger`,
    `Casing=Default`; write-side `EnumStorage=AsInteger`, `Casing=Default`. **Convergen.** Esto
    importa mas de lo habitual en este issue: `TurnoVigente` es el primer read model del repo cuyo
    documento JSON contiene un `enum` (`TipoBloque`), asi que la dimension `EnumStorage` pasa de
    inocua a activa. No deje un guardrail literal de esos dos valores para no exceder el alcance del
    issue (el write-side los hereda del paquete; congelarlos es una decision que merece su propio
    issue), pero queda medido y registrado aqui.

### Desviaciones de ADRs

**Desviaciones declaradas por el implementer** (`stage-2-projection-implementer.md`): el implementer
declara explicitamente **"Ninguna"**. Verificado contra el diff: correcto, no encontre ninguna
desviacion silenciosa suya frente a los ADRs listados.

**Desviacion declarada por el planner en el propio issue** (la evaluo porque el implementer la
heredo y la aplico):

#### Desviacion: MEF-ADR-0035 / `skills/projections/naming.md` -- read model sin sufijo `View`
- **Regla del ADR/Skill**: read model se nombra `{Concepto}View` (`TurnoView`, `ResumenEquipoView`).
- **Desviacion aplicada**: el read model se llama `TurnoVigente`, sin sufijo.
- **Razon del planner**: decision del repo, extension al read-side de la proscripcion de sufijos de
  infraestructura del issue #317 CA-2. El issue la declara como insumo para un draft doctrinal en
  Mefisto.
- **Consecuencia conocida**: inconsistencia interna transitoria -- `TurnoDiarioView` (#289) conserva
  el sufijo hasta la contraccion #323, asi que el dominio convive con las dos convenciones. El nombre
  de la clase companion sigue el patron canonico (`TurnoVigenteProjection`), asi que el par
  vista/proyeccion se sigue leyendo con el mismo stem.
- **Evaluacion del reviewer**: **aceptable**. Es una decision de naming explicita, tomada en el issue,
  trazable, sin efecto tecnico alguno (el nombre del tipo solo determina la tabla
  `mt_doc_turnovigente`, y esa convergencia quedo pineada en ambos lados). Documentada en el propio
  XML doc del record, asi que un lector futuro no la confunde con un olvido.
- **Status**: pendiente de evaluacion del usuario.

**Desviaciones detectadas por el reviewer (NO declaradas)**: ninguna frente a los ADRs. Los hallazgos
que si encontre son de calidad/cobertura, no de incumplimiento de ADR -- estan en "Criticas y
hallazgos".

Punto verificado que **no** es desviacion, aunque lo parece a primera vista:

- `Create(TurnoDiarioAsignado evento) => new(evento.Id, ...)` en vez de la forma del Skill
  `Create(IEvent<TEvento> e) => new(e.StreamKey!, ...)`. `Create(TEvento)` **si** es una firma
  admitida por la lista cerrada de MEF-ADR-0035 seccion 2 (la proscrita es `Create(TEvento, TId)`, que
  no aparece). Y la razon por la que el Skill usa `IEvent<T>` -- "la identidad no viaja en el payload"
  -- **no aplica aqui**: verifique la cadena completa y `TurnoDiarioAsignado.Id` **es** el stream key.
  `ProgramacionTurnoDiarioSolicitadaEventHandler` computa
  `ControlDiarioAggregateRoot.ComputarStreamId(...)` y se lo pasa al evento como `id`, el mismo valor
  con el que hace `StartStream`/`GetAggregateRootAsync`, y `ControlDiarioAggregateRoot.Apply` hace
  `Id = e.Id`. Mismo patron que la proyeccion hermana `TurnoDiarioProjection` (#289). Sin hallazgo.

### Precedentes consultados por el implementer

| Precedente | ADR aplicable | Veredicto |
|---|---|---|
| `TurnoDiarioProjection` (#289) | MEF-ADR-0035 (estilo N1, `partial`, metodos estaticos, `with`) | alineado -- companion `partial` en el worker, `Create`/`Apply` estaticos inmutables, `TId = string`. |
| `ObtenerTurnoDiario/FunctionEndpoint` (#289) | MEF-ADR-0006 / 0028 / 0035 / 0037 | alineado -- feature folder sin sufijo, `QuerySession(tenantResolver.TenantId)`, parseo tipado con 400 y `ComputarStreamId`. |
| Par `ComposicionServicios` / `ConfiguracionMartenProjectionsControlHoras` de #294 (`mt_version`) | MEF-ADR-0034 seccion 6 | alineado -- y necesario: replicarlo evita repetir el 42804 del deploy de #290. |
| `TurnoDiario.Segmentar` (#327) | MEF-ADR-0012 | alineado -- la aritmetica quedo en el objeto dueno del dato; la proyeccion solo la invoca. |

Ningun precedente citado viola un ADR. No hay bug de precedente que reportar.

### Convenciones del pipeline (no ADRs)

| Convencion | Estado | Observacion |
|---|---|---|
| Cada test con `Then()` + `And<>()` | n/a | No hay tests de command handler en el diff: son unit tests de funciones puras de proyeccion (invocacion directa de `Create`/`Apply`), config-tests y tests de composicion. El DSL `Given/When/Then` de MEF-ADR-0002 no aplica a ninguno. |
| Overloads correctos para stream IDs compuestos | n/a | Idem -- ningun test abre streams. |
| Fakes manuales (no NSubstitute) | n/a | Ningun handler ni dependencia mockeada en el diff. |
| Feature folders (produccion y tests) | ok | Produccion: `ObtenerTurnoVigente/FunctionEndpoint.cs`, `Projections/ControlHoras/`, `ReadModels/ControlHoras/`. Tests: espejo (`Projections.Tests/ControlHoras/`, `SmokeTests/ObtenerTurnoVigente/`). |
| Smoke tests: SkipWhen, secrets, cobertura | ok | `Assert.SkipWhen(!serviceBus.IsConfigured, ...)` en el unico test que depende del bus (xUnit v3, no `Skip.When`); los casos 400/404/health solo dependen de `ApiFixture`, que ya falla ruidoso si el entorno no responde (precedente del dominio). Un solo archivo por comando. `appsettings.json` sin secrets (no se toco). Sin topic nuevo -> no hace falta suscripcion `smoke-tests` ni cambio de infra: el endpoint es GET y la siembra reusa `programacion-turno-diario-solicitada`, ya provisionado. Efectos secundarios: el 200 verifica la cadena completa (bus -> event store -> daemon -> documento -> HTTP) con `Polling.WaitUntilAsync`; los efectos del handler que siembra (persistencia + `DiaCalculado`) ya los cubre `AsignarTurnoViaSbSmokeTests`, no se duplican. |
| Proyecciones read-side: partial, inmutabilidad, read APIs, naming | ok | Detalle en la fila MEF-ADR-0035 de arriba. El endpoint GET solo delega a `LoadAsync`, asi que no reporto ausencia de unit tests sobre `Run` (carve-out #371). |
| Compatibilidad Marten write-side/read-side | falla | **No verificada por completo**: `ilspycmd` ausente, sin decompilacion de la linea base del write-side. Lo verificable sin la herramienta esta medido y en verde (detalle en "Compatibilidad Marten" arriba). Accion sugerida: `dotnet tool install -g ilspycmd`. |
| Identidad de stream (MEF-ADR-0037) | ok | Detalle en "Gates condicionales". |
| Control de volumen de telemetria (MEF-ADR-0038) | ok | Detalle en "Gates condicionales". |
| Tests via ToString/comportamiento | ok | Los tests de la proyeccion comparan la vista que retorna `Create`/`Apply` (valor de retorno publico), no estado interno; el smoke test compara la respuesta HTTP. |
| Sin numeros magicos | ok | `FormatoFecha = "yyyy-MM-dd"` como constante; horas de los tests son datos del escenario, no constantes de dominio. |
| Condiciones en positivo (guardas if/else afirmativas) | ok | Las dos condiciones del endpoint son guard clauses con early-return (`if (!TryParseExact) return 400`, `if (vista is null) return 404`) -- la excepcion explicita de la convencion; no hay `if`/`else` con la rama negada primero. |

### Elegancia del codigo

El codigo llego en buen estado: compacto, con LINQ idiomatico en el mapeo, `switch` expression para
el enum, `with` para la copia inmutable, sin codigo muerto ni debug cruft, y con XML doc que explica
el *por que* (no el *que*). Build sin warnings nuevos: los unicos del solution son `NU1902`
preexistentes de `OpenTelemetry.Api` en Programacion, ajenos al diff. `dotnet format
--verify-no-changes` reporta 5 `IDE0005` y **ninguno** cae en un archivo de este diff (son `using`
sobrantes preexistentes en tests de serializacion de otros issues; no los toco, regla de no
refactorizar codigo ajeno a la HU).

Hallazgos de elegancia que si corregi:

1. **Un tipo publico por archivo** (legibilidad/consistencia): `TurnoVigente.cs` traia tres tipos
   publicos (`TipoBloque`, `Bloque`, `TurnoVigente`). Todo ensamblado de este repo con tipos
   equivalentes usa un archivo por tipo -- `ControlHoras.DomainEvents` separa justamente
   `TipoBloque.cs` y `BloqueTurno.cs`, los dos homonimos de estos. Separados: el espejo
   ReadModels <-> DomainEvents ahora se lee 1:1.
2. **Alias de `using` sobrante** (compacidad): `BloqueVigente = ...ReadModels.ControlHoras.Bloque` no
   desambiguaba nada -- `Bloque` solo existe en `ReadModels` y `BloqueTurno` solo en `DomainEvents`;
   el unico nombre realmente homonimo es `TipoBloque`. Eliminado el alias y usado el tipo real, con
   un comentario que deja explicito por que los otros dos no lo necesitan.

Hallazgo de elegancia evaluado y **no** cambiado, con su razon:

3. **`NombreCompleto(Empleado)` como helper privado de la proyeccion** en vez de un metodo de
   `Empleado` (Tell-don't-Ask, MEF-ADR-0012). Lo considere en serio porque el commit inmediatamente
   anterior (#327, `eeaaea5`) hizo exactamente ese movimiento con la segmentacion. Lo deje donde
   esta: (a) `$"{Nombres} {Apellidos}"` es **formato de presentacion de un read model concreto**, no
   una regla de dominio de `Empleado` -- a diferencia de `Segmentar`, que es aritmetica real sobre el
   estado del turno; (b) los payloads de `*.DomainEvents` son DTOs deliberadamente anemicos por rol
   (CA-ADR-0029), y `Empleado` es compartido por todo el dominio, asi que un `NombreCompleto` ahi se
   leeria como regla del dominio y no como decision de esta vista; (c) el issue fija explicitamente
   que la concatenacion viva "en un unico lugar del sistema": la proyeccion. No es una desviacion,
   es una frontera de responsabilidad; queda registrada para que un tercer consumidor futuro
   (Rule of Three, MEF-ADR-0018) reabra la discusion con evidencia.
4. **`switch` expression del mapeo de enums** en vez de lookup `Dictionary`: cae en la excepcion de
   la convencion (pattern matching exhaustivo, type-safe) y su rama `_` lanza
   `ArgumentOutOfRangeException` con el valor real -- mas informativo que el `KeyNotFoundException`
   que daria un diccionario. Se mantiene.
5. **`$"{Nombres} {Apellidos}"` sin `Trim`**: si `Apellidos` llegara vacio, el nombre viajaria con un
   espacio final. Cosmetico, no cubierto por ningun CA y sin evidencia de que pase (el payload lo
   produce Programacion con ambos campos). No lo cambie para no especular; queda anotado.

### Criticas y hallazgos

1. **`Apply` congelaba `NombreCompleto` con una justificacion factualmente incorrecta** (severidad
   **mayor**, corregido). El comentario decia "el evento no trae informacion distinta de empleado en
   una reasignacion", pero cada `TurnoDiarioAsignado` **si** trae el payload `Empleado` completo, y
   `Apply` lo ignoraba. Efecto: una correccion de nombre aguas arriba nunca llegaria a la vista --
   la UI mostraria para siempre el nombre de la primera asignacion. La proyeccion hermana sobre el
   mismo stream (`TurnoDiarioProjection.Apply`, #289) **si** refresca `Empleado` entero, asi que era
   ademas una inconsistencia entre las dos vistas del mismo evento. CA-2 no lo impide: enumera como
   invariantes `Id`, `EmpleadoId` y `Fecha` (la identidad del stream), y omite `NombreCompleto` a
   proposito. Corregido: `Apply` refresca `NombreCompleto` y el comentario ahora explica el criterio
   real. El test existente de reasignacion **no discriminaba** (usaba el mismo empleado en los dos
   eventos), asi que agregue el test que si lo hace.
2. **Par 2 de compatibilidad sin medir para el read model nuevo** (severidad **mayor**, corregido).
   `TurnoVigente` se materializa en el worker y se consulta desde el Function App, en dos procesos
   distintos, y ninguna guarda pineaba que tabla, tenancy e `IdMember` convergieran -- la dimension
   que #289 si cerro para `TurnoDiarioView` con un par de guardas literales espejo. La fase roja lo
   omitio con un argumento valido para su fase (Marten resuelve los tres por convencion, no habia
   potencial de rojo), pero el write-side **ahora declara un `Schema.For<TurnoVigente>()` propio**:
   exactamente el tipo de declaracion por documento que puede desviar tabla o tenancy de un solo lado
   sin que nada avise, y cuyo sintoma es un 404 permanente con el daemon funcionando. Agregadas las
   dos guardas espejo con el mismo literal.
3. **Tres tipos publicos en un archivo** (severidad **menor**, corregido) -- ver "Elegancia" #1.
4. **Alias `using` sin funcion** (severidad **cosmetico**, corregido) -- ver "Elegancia" #2.
5. **Verificacion de compatibilidad Marten incompleta por falta de `ilspycmd`** (severidad **menor**,
   no corregible aqui): declarada como no verificada, con el detalle de lo que si quedo medido.
   No bloqueante para este diff -- los cambios son aditivos y no rozan ningun atributo de la columna
   "debe coincidir" --, pero la fila del checklist queda en `falla` por honestidad.
6. **Smoke test rojo hasta el deploy** (severidad **informativa**, sin accion): comportamiento
   esperado y documentado, fuera del CI de PR. Ver "Evaluacion general".

### Refactorings aplicados

Commit `36ddf53` (`dotnet test` en verde despues de cada cambio, ningun revert necesario):

1. `TipoBloque` y `Bloque` extraidos a `ReadModels/ControlHoras/TipoBloque.cs` y `Bloque.cs`
   (convencion de un tipo publico por archivo; espejo exacto de `ControlHoras.DomainEvents`).
2. Alias `BloqueVigente` eliminado de `TurnoVigenteProjection`; `MapearBloques`/`MapearBloque` usan
   `Bloque` directo. Comentario nuevo que explica que solo `TipoBloque` es homonimo.
3. `Apply` refresca `NombreCompleto` desde `evento.InformacionEmpleado`, con el comentario reescrito
   (los invariantes reales son `Id`/`EmpleadoId`/`Fecha`, la identidad del stream).
4. XML doc de la proyeccion actualizado para reflejar los alias que quedaron.

### Cobertura de criterios de aceptacion

| Criterio | Estado | Test(s) |
|---|---|---|
| CA-1: `Create` materializa la vista completa (stream key, `NombreCompleto` concatenado, turno, horario, `Bloques` de `Segmentar`) | cubierto | `Create_ProyectaElTurnoVigenteCompleto_DesdeTurnoDiarioAsignado` -- oraculo a mano con los tres `TipoBloque` (Extra/Ordinaria/Descanso/Ordinaria) y sin cruce de medianoche |
| CA-2: `Apply` de reasignacion sobrescribe turno/horario/bloques; `Id`, `EmpleadoId`, `Fecha` estables; sin `ShouldDelete` | cubierto | `Apply_SobrescribeTurnoHorarioYBloques_CuandoLlegaOtroTurnoDiarioAsignado` + `Apply_RefrescaElNombreCompleto_CuandoLaReasignacionTraeElNombreCorregido` (nuevo). Ausencia de `ShouldDelete` no es testeable por omision -- verificada por lectura. |
| CA-3: config-test del worker en verde con la proyeccion `Async` en el named store de ControlHoras | cubierto | `ConfigurarControlHoras_RegistraTurnoVigenteProjectionComoAsync`, `ConfigurarControlHoras_MaterializaTurnoVigenteConRevisionNumerica`, `ConfigurarControlHoras_MaterializaTurnoVigenteSobreLaTablaQueConsultaElWriteSide` (nuevo), mas las 3 guardas genericas del dominio ya existentes |
| CA-4: `ObtenerTurnoVigente` 200 con la vista / 404 sin body / 400 con fecha invalida | cubierto (veredicto de runtime tras el deploy) | Wiring: `AgregarServiciosControlHoras_ResuelveElEndpointDeObtenerTurnoVigente_...`, `..._EsperaLaMismaColumnaDeVersionQueMaterializaraElWorker_ParaTurnoVigente`, `..._ResuelveTurnoVigenteSobreLaTablaQueMaterializaElWorker_...` (nuevo). Comportamiento: los 3 smoke tests de `ObtenerTurnoVigenteSmokeTests` (carve-out #371: el endpoint solo delega a `LoadAsync`, su cobertura es composicion + smoke) |
| CA-5: suite completa en verde | cubierto con la excepcion conocida | 743/743 verde en los proyectos `*.Tests`; unico rojo = smoke test dependiente del deploy de dev |

### Tests agregados

1. `TurnoVigenteProjectionTests.Apply_RefrescaElNombreCompleto_CuandoLaReasignacionTraeElNombreCorregido`
   -- borde que el test de reasignacion existente no discriminaba (mismo empleado en ambos eventos).
   Verifica el refresco del nombre **y** los tres invariantes de identidad, para que no pueda pasar
   por el atajo de sobrescribir la vista entera.
2. `ConfiguracionMartenProjectionsTests.ConfigurarControlHoras_MaterializaTurnoVigenteSobreLaTablaQueConsultaElWriteSide`
   -- mitad worker del par 2 (tabla `control_horas.mt_doc_turnovigente`, `TenancyStyle.Conjoined`,
   `IdMember = Id`).
3. `ComposicionServiciosTests.AgregarServiciosControlHoras_ResuelveTurnoVigenteSobreLaTablaQueMaterializaElWorker_CuandoElContenedorEstaCompuesto`
   -- mitad write-side del mismo par, con el mismo literal, sin que ningun ensamblado referencie al
   otro (CA-ADR-0028/CA-ADR-0029).

Sin tests de contrato de igualdad ni de round-trip de serializacion: el diff no introduce ningun
`IEquatable<T>` ni ningun `ConfigurarSerializacion`, y no crea ni modifica eventos con marker de bus
(`IPrivateEvent`/`IPublicEvent`), asi que el guardrail de portabilidad por el bus no aplica.

</details>

## Commits

36ddf53 refactor(hu-328): un tipo por archivo en ReadModels, refresco de NombreCompleto y par 2 de TurnoVigente
ffae826 test(hu-328): smoke tests de ObtenerTurnoVigente contra dev
b81a428 feat(hu-328): proyeccion read-side del read model TurnoVigente (fase verde)
93adbd2 test(hu-328): tests read-side para el read model TurnoVigente (fase roja)

Closes #328