### PR TITLE
Exponer el panorama de turnos vigentes por rango de fechas

### DIFF
--- a/src/Bitakora.ControlAsistencia.ControlHoras/ListarTurnosVigentes/FunctionEndpoint.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ListarTurnosVigentes/FunctionEndpoint.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+using Bitakora.ControlAsistencia.ReadModels.ControlHoras;
 using Cosmos.MultiTenancy;
 using Marten;
 using Microsoft.AspNetCore.Http;
@@ -24,32 +26,87 @@ namespace Bitakora.ControlAsistencia.ControlHoras.ListarTurnosVigentes;
 // mitigacion estructural contra BOLA/IDOR). desde/hasta/empleadoId SI vienen del query string: son
 // el filtro del recurso, no el tenant.
 //
-// FASE ROJA (projection-test-writer): Run es un stub. projection-implementer completa el parseo de
-// desde/hasta/empleadoId, la consulta session.Query<TurnoVigente>() (via (a'), read-apis.md), el
-// recorte de rango (CA-3, mismo patron de tope que RangoConsulta de #290) y el mapeo al envelope de
-// respuesta (CA-1). El constructor SI debe resolver limpio del contenedor -- eso es lo que verifica
-// el test de composicion de ComposicionServiciosTests, hermano de MEF-ADR-0029: no depende de que
-// Run este implementado.
-//
-// Issue #329 "Capas de test esperadas": config-test del worker y unit tests de proyeccion NO
-// aplican a este issue (sin proyeccion nueva) -- unica capa read-side declarada es el test de
-// composicion de esta Function, que verifica solo la resolucion de IDocumentStore/ITenantResolver
-// por constructor (carve-out de coverage de Functions GET, MEF-ADR-0035/issue #371): el
-// comportamiento real de Run (parseo, recorte, filtro por empleadoId, mapeo al envelope) queda para
-// projection-implementer y para el smoke test contra dev (CA-8 del precedente #290).
+// Mismo patron que ListarTurnosDiarios (#290): desde/hasta obligatorios con formato yyyy-MM-dd
+// (CA-4), rango invertido rechazado con 400, empleadoId opcional filtra a un solo empleado (CA-2),
+// recorte de rango con RangoConsulta.Recortar (CA-3) y 200 con lista vacia cuando no hay datos en
+// el rango (CA-4) -- nunca 404: un rango sin turnos asignados no es un error.
 public class FunctionEndpoint(IDocumentStore store, ITenantResolver tenantResolver)
 {
+    private const string FormatoFecha = "yyyy-MM-dd";
+
     [Function("ListarTurnosVigentes")]
-    public Task<IActionResult> Run(
+    public async Task<IActionResult> Run(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "control-horas/turnos-vigentes")]
         HttpRequest req,
         CancellationToken ct)
     {
-        // Referencia minima a store/tenantResolver para evitar CS9113 (parametro de constructor
-        // primario sin lectura) mientras Run no tiene implementacion real -- projection-implementer
-        // reemplaza este cuerpo por la consulta/recorte/mapeo real (CA-1 a CA-4).
-        _ = store;
-        _ = tenantResolver;
-        throw new NotImplementedException();
+        // CA-4: desde/hasta son obligatorios -- ausencia o formato invalido devuelve 400. DateOnly
+        // no liga directo desde el query string en el modelo aislado de Functions, se parsea con
+        // formato explicito yyyy-MM-dd (mismo patron que ListarTurnosDiarios, #290).
+        if (!TryLeerFecha(req, "desde", out var desde, out var errorDesde))
+            return new BadRequestObjectResult(errorDesde);
+
+        if (!TryLeerFecha(req, "hasta", out var hasta, out var errorHasta))
+            return new BadRequestObjectResult(errorHasta);
+
+        // CA-4: rango invertido (hasta < desde) -> 400, mismo criterio que ListarTurnosDiarios.
+        if (hasta < desde)
+            return new BadRequestObjectResult("El parametro 'hasta' no puede ser anterior a 'desde'");
+
+        // CA-2: empleadoId es opcional -- ausente = panorama de todos los empleados (consulta del
+        // Programador); presente = filtrado a un solo empleado (consulta del Trabajador).
+        // StringValues.ToString() devuelve cadena vacia cuando el parametro no viene, asi que
+        // ausente y vacio se tratan igual -- sin filtro por empleado.
+        var empleadoId = req.Query["empleadoId"].ToString();
+
+        // CA-3: recorte de la cota de 31 dias, siempre hacia adelante desde `desde`.
+        var rangoAplicado = RangoConsulta.Recortar(desde, hasta);
+
+        // CA-1/CA-2: la QuerySession se abre SIEMPRE acotada al tenant que resuelve
+        // ITenantResolver -- nunca a un tenant id que llegara por query string (mitigacion
+        // estructural contra BOLA/IDOR, MEF-ADR-0028/skills/projections/read-apis.md).
+        // empleadoId/desde/hasta SI vienen del query string: son el filtro del recurso, no el
+        // tenant.
+        await using var session = store.QuerySession(tenantResolver.TenantId);
+
+        // Composicion en pasos (no un unico Where con el filtro de empleadoId embebido
+        // condicionalmente) -- mismo estilo que ListarTurnosDiarios, mas legible que anidar el
+        // ternario dentro de la expresion LINQ.
+        IQueryable<TurnoVigente> query = session.Query<TurnoVigente>()
+            .Where(v => v.Fecha >= desde && v.Fecha <= rangoAplicado.HastaAplicado);
+
+        if (!string.IsNullOrEmpty(empleadoId))
+            query = query.Where(v => v.EmpleadoId == empleadoId);
+
+        // Orden sugerido por la investigacion del planner: por EmpleadoId y luego por Fecha --
+        // estable para pintar grillas multi-empleado x rango de fechas.
+        var turnos = await query
+            .OrderBy(v => v.EmpleadoId)
+            .ThenBy(v => v.Fecha)
+            .ToListAsync(ct);
+
+        var respuesta = new ListaTurnosVigentes(
+            desde, rangoAplicado.HastaAplicado, rangoAplicado.RangoRecortado, turnos);
+
+        // CA-4: nunca 404 -- un rango sin turnos vigentes es 200 con Turnos: [].
+        return new OkObjectResult(respuesta);
+    }
+
+    // Ausente y mal formado comparten respuesta y mensaje a proposito: StringValues.ToString()
+    // devuelve cadena vacia cuando el parametro no viene, y TryParseExact la rechaza igual que a
+    // "31-12-2026". Un solo camino de fallo, un solo 400 (CA-4).
+    private static bool TryLeerFecha(
+        HttpRequest req, string nombreParametro, out DateOnly fecha, out string? error)
+    {
+        if (DateOnly.TryParseExact(
+                req.Query[nombreParametro].ToString(),
+                FormatoFecha, CultureInfo.InvariantCulture, DateTimeStyles.None, out fecha))
+        {
+            error = null;
+            return true;
+        }
+
+        error = $"El parametro '{nombreParametro}' es obligatorio y debe tener el formato {FormatoFecha}";
+        return false;
     }
 }

--- a/src/Bitakora.ControlAsistencia.ControlHoras/ListarTurnosVigentes/FunctionEndpoint.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ListarTurnosVigentes/FunctionEndpoint.cs
@@ -1,0 +1,55 @@
+using Cosmos.MultiTenancy;
+using Marten;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.ListarTurnosVigentes;
+
+// Issue #329: tercera Function GET del BC sobre la vista materializada TurnoVigente (#328) --
+// ninguna proyeccion nueva, ningun cambio al seam del worker (issue #329, "Necesidad de lectura":
+// "Este issue NO crea read model, ni clase de proyeccion, ni lifecycle: solo la Function GET de
+// listado"). Feature folder propio (un namespace por query, skills/projections/naming.md y
+// read-apis.md): esta clase FunctionEndpoint no colisiona con las demas homonimas del ensamblado
+// (ObtenerTurnoDiario/ListarTurnosDiarios/ObtenerTurnoVigente/RegistrarMarcacionFunction/...)
+// porque cada una vive en su propio namespace.
+//
+// Ruta sin {empleadoId}/{fecha}: reutiliza el mismo segmento de recurso
+// "control-horas/turnos-vigentes" que ObtenerTurnoVigente (#328) -- naming.md: "una query reutiliza
+// el mismo segmento de recurso que ya usa el comando/query de ese recurso". Sin colision de
+// plantilla: la de ObtenerTurnoVigente lleva dos segmentos adicionales ({empleadoId}/{fecha}).
+//
+// CA-1/CA-2: la QuerySession se abre SIEMPRE acotada al tenant que resuelve ITenantResolver --
+// nunca a un tenant id que llegue por query string (MEF-ADR-0028/skills/projections/read-apis.md,
+// mitigacion estructural contra BOLA/IDOR). desde/hasta/empleadoId SI vienen del query string: son
+// el filtro del recurso, no el tenant.
+//
+// FASE ROJA (projection-test-writer): Run es un stub. projection-implementer completa el parseo de
+// desde/hasta/empleadoId, la consulta session.Query<TurnoVigente>() (via (a'), read-apis.md), el
+// recorte de rango (CA-3, mismo patron de tope que RangoConsulta de #290) y el mapeo al envelope de
+// respuesta (CA-1). El constructor SI debe resolver limpio del contenedor -- eso es lo que verifica
+// el test de composicion de ComposicionServiciosTests, hermano de MEF-ADR-0029: no depende de que
+// Run este implementado.
+//
+// Issue #329 "Capas de test esperadas": config-test del worker y unit tests de proyeccion NO
+// aplican a este issue (sin proyeccion nueva) -- unica capa read-side declarada es el test de
+// composicion de esta Function, que verifica solo la resolucion de IDocumentStore/ITenantResolver
+// por constructor (carve-out de coverage de Functions GET, MEF-ADR-0035/issue #371): el
+// comportamiento real de Run (parseo, recorte, filtro por empleadoId, mapeo al envelope) queda para
+// projection-implementer y para el smoke test contra dev (CA-8 del precedente #290).
+public class FunctionEndpoint(IDocumentStore store, ITenantResolver tenantResolver)
+{
+    [Function("ListarTurnosVigentes")]
+    public Task<IActionResult> Run(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "control-horas/turnos-vigentes")]
+        HttpRequest req,
+        CancellationToken ct)
+    {
+        // Referencia minima a store/tenantResolver para evitar CS9113 (parametro de constructor
+        // primario sin lectura) mientras Run no tiene implementacion real -- projection-implementer
+        // reemplaza este cuerpo por la consulta/recorte/mapeo real (CA-1 a CA-4).
+        _ = store;
+        _ = tenantResolver;
+        throw new NotImplementedException();
+    }
+}

--- a/src/Bitakora.ControlAsistencia.ControlHoras/ListarTurnosVigentes/ListaTurnosVigentes.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ListarTurnosVigentes/ListaTurnosVigentes.cs
@@ -1,0 +1,21 @@
+using Bitakora.ControlAsistencia.ReadModels.ControlHoras;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.ListarTurnosVigentes;
+
+/// <summary>
+/// Envelope de respuesta de ListarTurnosVigentes (issue #329). NO es un read model -- vive en el
+/// Function App (ControlHoras), no en ReadModels: es el contrato HTTP de esta query, con el recorte
+/// de rango ya aplicado (CA-3) y el seam donde aterrizan paginacion y tope de resultados sin romper
+/// clientes existentes el dia que se agreguen (Rule of Three, MEF-ADR-0018), mismo patron que
+/// <c>ListarTurnosDiarios.ListaTurnosDiarios</c> (issue #290).
+///
+/// <c>Turnos</c> reutiliza <see cref="TurnoVigente"/> tal cual la materializa la proyeccion (#328),
+/// ancla <c>Id</c> y <c>Bloques</c> incluidos -- decision de entrevista del issue #329 ("Notas
+/// tecnicas"): una sola proyeccion sirve grilla y calendario; el recorte resumido/detallado, si
+/// algun dia se necesita, aterriza en un DTO nuevo (Rule of Three), no en este.
+/// </summary>
+public sealed record ListaTurnosVigentes(
+    DateOnly DesdeAplicado,
+    DateOnly HastaAplicado,
+    bool RangoRecortado,
+    IReadOnlyList<TurnoVigente> Turnos);

--- a/src/Bitakora.ControlAsistencia.ControlHoras/ListarTurnosVigentes/RangoConsulta.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ListarTurnosVigentes/RangoConsulta.cs
@@ -1,0 +1,39 @@
+namespace Bitakora.ControlAsistencia.ControlHoras.ListarTurnosVigentes;
+
+/// <summary>
+/// Resultado de aplicar la cota de <see cref="RangoConsulta.CotaDias"/> sobre el rango de fechas
+/// pedido a ListarTurnosVigentes (issue #329, CA-3).
+/// </summary>
+public readonly record struct RangoAplicado(DateOnly HastaAplicado, bool RangoRecortado);
+
+/// <summary>
+/// Logica pura de recorte del rango de consulta de ListarTurnosVigentes (issue #329, CA-3),
+/// mismo patron que <c>ListarTurnosDiarios.RangoConsulta</c> (issue #290).
+///
+/// Duplicada a proposito en vez de compartida entre los dos namespaces: cada Function GET es un
+/// feature folder propio (skills/projections/naming.md) y, con solo dos consumidores, MEF-ADR-0018
+/// (Rule of Three) tolera la duplicacion hasta que un tercer consumidor justifique extraerla.
+///
+/// El recorte es SIEMPRE hacia adelante desde <c>desde</c> -- nunca relativo a la fecha de hoy
+/// (mismo razonamiento que #290, seccion "El envelope, y por que existe"): un recorte relativo a
+/// "hoy" haria que la misma consulta devolviera datos distintos segun el dia en que se ejecuta.
+///
+/// Sin dependencias de Marten/Postgres: se prueba como funcion pura sobre <see cref="DateOnly"/>,
+/// sin QuerySession (skills/projections/read-apis.md).
+/// </summary>
+public static class RangoConsulta
+{
+    /// <summary>Cota maxima del rango, en dias, INCLUSIVE (CA-3): desde y desde + 30 dias caben.</summary>
+    public const int CotaDias = 31;
+
+    public static RangoAplicado Recortar(DateOnly desde, DateOnly hasta)
+    {
+        // CotaDias es INCLUSIVE: desde + (CotaDias - 1) dias es el limite exacto que todavia no
+        // excede la cota (31 dias inclusive = desde + 30 dias).
+        var hastaMaxima = desde.AddDays(CotaDias - 1);
+
+        return hasta > hastaMaxima
+            ? new RangoAplicado(hastaMaxima, true)
+            : new RangoAplicado(hasta, false);
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/ListarTurnosVigentes/ListarTurnosVigentesSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/ListarTurnosVigentes/ListarTurnosVigentesSmokeTests.cs
@@ -1,0 +1,386 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.ControlHoras.SmokeTests.Fixtures;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.SmokeTests.ListarTurnosVigentes;
+
+// Issue #329: smoke tests de ListarTurnosVigentes, GET control-horas/turnos-vigentes con desde/hasta
+// obligatorios y empleadoId opcional. Tercera Function GET read-side del BC sobre la MISMA vista
+// TurnoVigente que ya materializa #328 -- se siembran datos publicando ProgramacionTurnoDiario-
+// Solicitada al bus interno, exactamente el mismo mecanismo de ObtenerTurnoVigenteSmokeTests (#328)
+// y ListarTurnosDiariosSmokeTests (#290).
+//
+// Estos tests quedan ROJOS hasta que el deploy publique ListarTurnosVigentes en dev: mientras la
+// revision anterior siga corriendo, la ruta no existe y el host responde 404 a todo -- los casos
+// 400 y 200 fallan por esa razon, no por el contrato. Mismo precedente que ListarTurnosDiarios
+// (#290) y ObtenerTurnoVigente (#328). El CI de PR no los ejecuta (solo corre *.Tests); su
+// veredicto real se lee despues del deploy.
+//
+// La proyeccion tiene lifecycle Async (MEF-ADR-0034): el worker la materializa DESPUES de que
+// ControlHoras persiste turno_diario_asignado. Los casos que dependen de datos sembrados envuelven
+// la consulta en Polling.WaitUntilAsync/WaitUntilTrueAsync (timeout estandar 30s) -- si el timeout
+// se agota es un fallo real (worker no desplegado o proyeccion sin registrar), nunca un skip.
+//
+// Formas locales DESACOPLADAS del read model de produccion (Bitakora.ControlAsistencia.ReadModels.
+// ControlHoras.TurnoVigente/Bloque/TipoBloque) y del envelope de produccion (ControlHoras.
+// ListarTurnosVigentes.ListaTurnosVigentes): el smoke test no referencia ReadModels (isla, MEF-ADR-
+// 0034 seccion 5) ni el Function App. TipoBloqueSmoke replica el orden de valores del enum de
+// produccion porque STJ lo serializa como el entero subyacente (mismo razonamiento documentado en
+// ObtenerTurnoVigenteSmokeTests). El limite de 31 dias se afirma como literal (desde + 30 dias),
+// nunca leyendo RangoConsulta.CotaDias.
+//
+// Sin PostgresFixture: la verificacion de persistencia del evento turno_diario_asignado ya la cubre
+// AsignarTurnoViaSbSmokeTests (issue #322); aqui solo interesa que la vista materializada llegue al
+// endpoint HTTP -- mismo alcance que ObtenerTurnoVigenteSmokeTests.
+public class ListarTurnosVigentesSmokeTests(ApiFixture api, ServiceBusFixture serviceBus)
+{
+    private readonly HttpClient _client = api.Client;
+
+    private const string TopicEntrada = "programacion-turno-diario-solicitada";
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
+
+    // Case-insensitive: la respuesta viaja en camelCase (ComposicionServicios configura
+    // JsonNamingPolicy.CamelCase), mientras que las formas locales de este archivo son PascalCase.
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    private enum TipoBloqueSmoke
+    {
+        Ordinaria,
+        Descanso,
+        Extra
+    }
+
+    private sealed record BloqueSmoke(TipoBloqueSmoke Tipo, DateTime Inicio, DateTime Fin);
+
+    private sealed record TurnoVigenteRespuestaSmoke(
+        string Id,
+        string EmpleadoId,
+        string NombreCompleto,
+        DateOnly Fecha,
+        string NombreTurno,
+        string HorarioResumido,
+        IReadOnlyList<BloqueSmoke> Bloques);
+
+    private sealed record ListaTurnosVigentesSmoke(
+        DateOnly DesdeAplicado,
+        DateOnly HastaAplicado,
+        bool RangoRecortado,
+        IReadOnlyList<TurnoVigenteRespuestaSmoke> Turnos);
+
+    private static string Ruta(DateOnly desde, DateOnly hasta, string? empleadoId = null)
+    {
+        var query = $"desde={desde:yyyy-MM-dd}&hasta={hasta:yyyy-MM-dd}";
+        if (empleadoId is not null)
+            query += $"&empleadoId={Uri.EscapeDataString(empleadoId)}";
+
+        return $"/api/control-horas/turnos-vigentes?{query}";
+    }
+
+    private async Task PublicarTurnoAsync(
+        Guid solicitudId, string empleadoId, DateOnly fecha, string nombreTurno)
+    {
+        var evento = new
+        {
+            SolicitudId = solicitudId,
+            Empleado = new
+            {
+                EmpleadoId = empleadoId,
+                TipoIdentificacion = "CC",
+                NumeroIdentificacion = "444555666",
+                Nombres = "[TEST] Smoke Listar",
+                Apellidos = "[TEST] TurnosVigentes"
+            },
+            Fecha = fecha.ToString("yyyy-MM-dd"),
+            DetalleTurno = new
+            {
+                Nombre = nombreTurno,
+                FranjasOrdinarias = new[]
+                {
+                    new
+                    {
+                        HoraInicio = "08:00:00",
+                        HoraFin = "16:00:00",
+                        DiaOffsetFin = 0,
+                        Descansos = Array.Empty<object>(),
+                        Extras = Array.Empty<object>(),
+                        Descripcion = (string?)null
+                    }
+                },
+                Descripcion = "[TEST] Turno Vigente Listar 08:00-16:00"
+            }
+        };
+
+        await serviceBus.PublishAsync(TopicEntrada, evento, solicitudId.ToString());
+    }
+
+    // Sensa la materializacion asincrona consultando ESTE mismo endpoint sobre un rango de un solo
+    // dia (desde == hasta) filtrado por empleadoId, que nunca activa el recorte -- no via
+    // ObtenerTurnoVigente (#328), para no acoplar el veredicto de este archivo a la salud de otra
+    // Function.
+    private async Task<bool> EsperarTurnoEnLaListaAsync(
+        string empleadoId, DateOnly fecha, CancellationToken ct)
+    {
+        return await Polling.WaitUntilTrueAsync(async () =>
+        {
+            var response = await _client.GetAsync(Ruta(fecha, fecha, empleadoId), ct);
+            if (response.StatusCode != HttpStatusCode.OK)
+                return false;
+
+            var body = await response.Content.ReadFromJsonAsync<ListaTurnosVigentesSmoke>(
+                JsonOptions, cancellationToken: ct);
+            return body?.Turnos.Any(t => t.EmpleadoId == empleadoId && t.Fecha == fecha) ?? false;
+        }, Timeout);
+    }
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task DebeEstarDisponible_CuandoSeConsultaHealthCheck()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var response = await _client.GetAsync("/api/health", ct);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarTurnosVigentes_Retorna400_CuandoFaltaElParametroDesde()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        var response = await _client.GetAsync(
+            "/api/control-horas/turnos-vigentes?hasta=2026-05-10", ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarTurnosVigentes_Retorna400_CuandoFaltaElParametroHasta()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        var response = await _client.GetAsync(
+            "/api/control-horas/turnos-vigentes?desde=2026-05-01", ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarTurnosVigentes_Retorna400_CuandoDesdeTieneFormatoInvalido()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        // Formato DD-MM-YYYY en vez de yyyy-MM-dd, mismo precedente que ListarTurnosDiarios (#290).
+        var response = await _client.GetAsync(
+            "/api/control-horas/turnos-vigentes?desde=01-05-2026&hasta=2026-05-10", ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarTurnosVigentes_Retorna400_CuandoHastaEsAnteriorADesde()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        // Rango invertido: decision documentada en FunctionEndpoint.cs (400, no lista vacia).
+        var desde = new DateOnly(2026, 5, 10);
+        var hasta = new DateOnly(2026, 5, 5);
+
+        var response = await _client.GetAsync(Ruta(desde, hasta), ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarTurnosVigentes_Retorna200ConListaVacia_CuandoNoHayTurnoVigenteParaEseEmpleado()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        // Arrange: empleadoId nuevo, nunca creado por ningun test -- no puede tener turno vigente.
+        var empleadoId = Guid.CreateVersion7().ToString();
+        var desde = new DateOnly(2026, 5, 1);
+        var hasta = new DateOnly(2026, 5, 5);
+
+        var response = await _client.GetAsync(Ruta(desde, hasta, empleadoId), ct);
+
+        // Assert: CA-4 -- 200 con Turnos: [], nunca 404. Rango dentro de la cota, sin recorte.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var respuesta = await response.Content.ReadFromJsonAsync<ListaTurnosVigentesSmoke>(
+            JsonOptions, cancellationToken: ct);
+
+        respuesta.Should().NotBeNull();
+        respuesta!.Turnos.Should().BeEmpty();
+        respuesta.DesdeAplicado.Should().Be(desde);
+        respuesta.HastaAplicado.Should().Be(hasta);
+        respuesta.RangoRecortado.Should().BeFalse();
+    }
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarTurnosVigentes_Retorna200ConElTurnoDelEmpleado_CuandoSeConsultaConEmpleadoId()
+    {
+        // CA-2: la consulta del Trabajador -- empleadoId presente filtra la lista a ese empleado.
+        Assert.SkipWhen(!serviceBus.IsConfigured,
+            "ServiceBus no configurado. Usa appsettings.local.json o variable ServiceBus__ConnectionString.");
+
+        var ct = TestContext.Current.CancellationToken;
+
+        var solicitudId = Guid.CreateVersion7();
+        var empleadoId = Guid.CreateVersion7().ToString();
+        var fechaTurno = new DateOnly(2026, 5, 10);
+        var desde = new DateOnly(2026, 5, 1);
+        var hasta = new DateOnly(2026, 5, 15); // 15 dias, dentro de la cota de 31
+
+        await PublicarTurnoAsync(solicitudId, empleadoId, fechaTurno, "[TEST] Turno Vigente Trabajador");
+
+        // Act + Assert: reintentar el GET hasta que la proyeccion asincrona materialice la vista.
+        var ruta = Ruta(desde, hasta, empleadoId);
+        var respuesta = await Polling.WaitUntilAsync(async () =>
+        {
+            var response = await _client.GetAsync(ruta, ct);
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+            var body = await response.Content.ReadFromJsonAsync<ListaTurnosVigentesSmoke>(
+                JsonOptions, cancellationToken: ct);
+            return body is { Turnos.Count: > 0 } ? body : null;
+        }, Timeout);
+
+        // Assert: CA-4 -- rango dentro de la cota, sin recorte. Filtrado por empleadoId (GUID unico
+        // de esta ejecucion), asi que la lista contiene exactamente el turno sembrado.
+        respuesta.DesdeAplicado.Should().Be(desde);
+        respuesta.HastaAplicado.Should().Be(hasta);
+        respuesta.RangoRecortado.Should().BeFalse();
+        respuesta.Turnos.Should().ContainSingle();
+
+        // Assert: cada elemento lleva la forma completa de la vista (Id y Bloques incluidos --
+        // decision de entrevista del issue #329, "Notas tecnicas": una sola proyeccion sirve grilla
+        // y calendario).
+        var turno = respuesta.Turnos[0];
+        turno.Id.Should().Be($"{empleadoId}:{fechaTurno:yyyy-MM-dd}");
+        turno.EmpleadoId.Should().Be(empleadoId);
+        turno.NombreCompleto.Should().Be("[TEST] Smoke Listar [TEST] TurnosVigentes");
+        turno.Fecha.Should().Be(fechaTurno);
+        turno.NombreTurno.Should().Be("[TEST] Turno Vigente Trabajador");
+        turno.HorarioResumido.Should().Be("[TEST] Turno Vigente Listar 08:00-16:00");
+
+        var bloqueEsperado = new BloqueSmoke(
+            TipoBloqueSmoke.Ordinaria,
+            fechaTurno.ToDateTime(new TimeOnly(8, 0)),
+            fechaTurno.ToDateTime(new TimeOnly(16, 0)));
+        turno.Bloques.Should().BeEquivalentTo([bloqueEsperado]);
+    }
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarTurnosVigentes_IncluyeATodosLosEmpleados_CuandoNoSeFiltraPorEmpleadoId()
+    {
+        // CA-1: el panorama del Programador -- SIN empleadoId, la lista trae los turnos vigentes de
+        // TODOS los empleados en el rango. Se publican 2 empleados distintos (no 1) para distinguir
+        // "trae el panorama completo" de "trae un solo turno".
+        Assert.SkipWhen(!serviceBus.IsConfigured,
+            "ServiceBus no configurado. Usa appsettings.local.json o variable ServiceBus__ConnectionString.");
+
+        var ct = TestContext.Current.CancellationToken;
+
+        var fecha = new DateOnly(2026, 5, 20);
+        var solicitudA = Guid.CreateVersion7();
+        var solicitudB = Guid.CreateVersion7();
+        var empleadoIdA = Guid.CreateVersion7().ToString();
+        var empleadoIdB = Guid.CreateVersion7().ToString();
+
+        await PublicarTurnoAsync(solicitudA, empleadoIdA, fecha, "[TEST] Turno Panorama A");
+        await PublicarTurnoAsync(solicitudB, empleadoIdB, fecha, "[TEST] Turno Panorama B");
+
+        // Sin empleadoId: la lista puede incluir turnos de otras ejecuciones de esta suite (sin
+        // cleanup, GUIDs unicos por corrida) -- se espera a que AMBOS aparezcan antes de assertar,
+        // filtrando siempre por EmpleadoId, nunca por posicion/indice.
+        var ambosMaterializados = await Polling.WaitUntilTrueAsync(async () =>
+        {
+            var response = await _client.GetAsync(Ruta(fecha, fecha), ct);
+            if (response.StatusCode != HttpStatusCode.OK)
+                return false;
+
+            var body = await response.Content.ReadFromJsonAsync<ListaTurnosVigentesSmoke>(
+                JsonOptions, cancellationToken: ct);
+            return (body?.Turnos.Any(t => t.EmpleadoId == empleadoIdA) ?? false)
+                && (body?.Turnos.Any(t => t.EmpleadoId == empleadoIdB) ?? false);
+        }, Timeout);
+
+        ambosMaterializados.Should().BeTrue(
+            "ambos empleados deberian aparecer en el panorama dentro del timeout");
+
+        var response = await _client.GetAsync(Ruta(fecha, fecha), ct);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var respuesta = await response.Content.ReadFromJsonAsync<ListaTurnosVigentesSmoke>(
+            JsonOptions, cancellationToken: ct);
+        respuesta.Should().NotBeNull();
+
+        // Assert: CA-1 -- el panorama trae ambos empleados, cada uno con su propio turno.
+        var turnoA = respuesta!.Turnos.Single(t => t.EmpleadoId == empleadoIdA);
+        var turnoB = respuesta.Turnos.Single(t => t.EmpleadoId == empleadoIdB);
+        turnoA.NombreTurno.Should().Be("[TEST] Turno Panorama A");
+        turnoB.NombreTurno.Should().Be("[TEST] Turno Panorama B");
+        respuesta.RangoRecortado.Should().BeFalse();
+    }
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarTurnosVigentes_RecortaHaciaAdelanteYExcluyeLoQueQuedaFuera_CuandoElRangoExcedeLaCotaDe31Dias()
+    {
+        // CA-3: se verifica que el recorte SI restringe la consulta, no solo que se declara en el
+        // envelope.
+        Assert.SkipWhen(!serviceBus.IsConfigured,
+            "ServiceBus no configurado. Usa appsettings.local.json o variable ServiceBus__ConnectionString.");
+
+        var ct = TestContext.Current.CancellationToken;
+
+        var empleadoId = Guid.CreateVersion7().ToString();
+        var desde = new DateOnly(2026, 6, 1);
+        var hastaSolicitado = new DateOnly(2026, 9, 30); // ~121 dias, muy por encima de la cota
+        var hastaAplicadaEsperada = desde.AddDays(30); // CA-3: cota de 31 dias inclusive
+
+        var solicitudDentro = Guid.CreateVersion7();
+        var solicitudFuera = Guid.CreateVersion7();
+        var fechaDentro = desde; // dentro del rango recortado
+        var fechaFuera = hastaAplicadaEsperada.AddDays(5); // dentro de lo pedido, fuera del recorte
+
+        await PublicarTurnoAsync(solicitudDentro, empleadoId, fechaDentro, "[TEST] Turno Vigente Dentro De La Cota");
+        await PublicarTurnoAsync(solicitudFuera, empleadoId, fechaFuera, "[TEST] Turno Vigente Fuera De La Cota");
+
+        // Espera a que AMBAS vistas esten materializadas antes de verificar el recorte: si no
+        // esperaramos, la ausencia de "fuera" podria deberse a lag asincrono y no al recorte mismo.
+        var dentroMaterializado = await EsperarTurnoEnLaListaAsync(empleadoId, fechaDentro, ct);
+        dentroMaterializado.Should().BeTrue(
+            $"la vista de {empleadoId} en {fechaDentro} deberia materializarse dentro del timeout");
+
+        var fueraMaterializado = await EsperarTurnoEnLaListaAsync(empleadoId, fechaFuera, ct);
+        fueraMaterializado.Should().BeTrue(
+            $"la vista de {empleadoId} en {fechaFuera} deberia materializarse dentro del timeout");
+
+        var response = await _client.GetAsync(Ruta(desde, hastaSolicitado, empleadoId), ct);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var respuesta = await response.Content.ReadFromJsonAsync<ListaTurnosVigentesSmoke>(
+            JsonOptions, cancellationToken: ct);
+        respuesta.Should().NotBeNull();
+
+        // Assert: CA-3 -- recorte SIEMPRE hacia adelante desde `desde`.
+        respuesta!.DesdeAplicado.Should().Be(desde);
+        respuesta.HastaAplicado.Should().Be(hastaAplicadaEsperada);
+        respuesta.RangoRecortado.Should().BeTrue();
+
+        // El turno dentro del rango recortado aparece; el que queda fuera NO, aunque su vista ya
+        // este materializada (verificado arriba) -- prueba que el recorte restringe la consulta.
+        respuesta.Turnos.Should().Contain(t => t.Fecha == fechaDentro);
+        respuesta.Turnos.Should().NotContain(t => t.Fecha == fechaFuera);
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/ComposicionServiciosTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/ComposicionServiciosTests.cs
@@ -40,6 +40,7 @@ using Wolverine;
 using ObtenerTurnoDiarioEndpoint = Bitakora.ControlAsistencia.ControlHoras.ObtenerTurnoDiario.FunctionEndpoint;
 using ListarTurnosDiariosEndpoint = Bitakora.ControlAsistencia.ControlHoras.ListarTurnosDiarios.FunctionEndpoint;
 using ObtenerTurnoVigenteEndpoint = Bitakora.ControlAsistencia.ControlHoras.ObtenerTurnoVigente.FunctionEndpoint;
+using ListarTurnosVigentesEndpoint = Bitakora.ControlAsistencia.ControlHoras.ListarTurnosVigentes.FunctionEndpoint;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.Tests.Infraestructura;
 
@@ -429,6 +430,32 @@ public class ComposicionServiciosTests
         mapping.TableName.QualifiedName.Should().Be("control_horas.mt_doc_turnovigente");
         mapping.TenancyStyle.Should().Be(TenancyStyle.Conjoined);
         mapping.IdMember.Name.Should().Be(nameof(TurnoVigente.Id));
+    }
+
+    // Issue #329: test de composicion de la Function GET de listado sobre TurnoVigente (#328),
+    // hermano del de ObtenerTurnoDiario (#289 CA-7), ListarTurnosDiarios (#290 CA-7) y
+    // ObtenerTurnoVigente (#328 CA-4), a su vez hermanos de MEF-ADR-0029. ActivatorUtilities
+    // .CreateInstance reproduce la activacion por tipo que hace el host de Azure Functions isolated
+    // worker, sin levantar el host real (Alt 1 de MEF-ADR-0029).
+    //
+    // Se prueba solo la RESOLUCION de IDocumentStore/ITenantResolver por constructor -- no el
+    // comportamiento de Run (parseo de desde/hasta/empleadoId, recorte de rango, session.Query y
+    // mapeo al envelope de respuesta), que es responsabilidad de projection-implementer y del smoke
+    // test, no de este guardrail de wiring. Este issue no crea proyeccion nueva ni toca el seam del
+    // worker (issue #329, "Necesidad de lectura"): esta es la UNICA capa read-side declarada para
+    // el, junto con la ausencia deliberada de config-test/unit tests de proyeccion (carve-out de
+    // coverage de Functions GET, MEF-ADR-0035/issue #371) -- por eso este test queda en verde tan
+    // pronto exista el FunctionEndpoint stub con el constructor correcto, igual que su hermano de
+    // ObtenerTurnoVigente arriba.
+    [Fact]
+    public async Task AgregarServiciosControlHoras_ResuelveElEndpointDeListarTurnosVigentes_CuandoElContenedorEstaCompuesto()
+    {
+        await using var provider = ComponerServiceProvider();
+        await using var scope = provider.CreateAsyncScope();
+
+        var act = () => ActivatorUtilities.CreateInstance<ListarTurnosVigentesEndpoint>(scope.ServiceProvider);
+
+        act.Should().NotThrow();
     }
 
     // --- Sampler efectivo del TracerProvider (issue #308 CA-2, CA-3) ---

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ListarTurnosVigentes/FunctionEndpointTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ListarTurnosVigentes/FunctionEndpointTests.cs
@@ -1,0 +1,97 @@
+// Issue #329 CA-4: validacion del borde HTTP de ListarTurnosVigentes (desde/hasta obligatorios y
+// con formato yyyy-MM-dd, rango invertido rechazado). Estos casos son los unicos del endpoint que
+// NO dependen de Marten: cortocircuitan antes de abrir la QuerySession, asi que se prueban sobre
+// el mismo FunctionEndpoint real que activa el host. Espejo de
+// ListarTurnosDiarios/FunctionEndpointTests.cs (#290).
+//
+// Agregado en la revision: sin este archivo, CA-4 (fechas invalidas o desde > hasta -> 400) queda
+// cubierto UNICAMENTE por el smoke test contra dev, que exige deploy y no corre en el CI del PR --
+// exactamente el hueco que el precedente #290 ya habia cerrado para su propio endpoint. El
+// carve-out de coverage de Functions GET (MEF-ADR-0035, issue #371) exime al endpoint que SOLO
+// delega a LoadAsync/Query; este tiene tres ramas de validacion propias antes de tocar Marten.
+//
+// El IDocumentStore y el ITenantResolver se pasan nulos a proposito: si un cambio futuro moviera la
+// apertura de la sesion ANTES de la validacion, estos tests se pondrian rojos -- que es exactamente
+// la senal que se quiere (validar el request antes de tocar la base de datos).
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.ControlHoras.ListarTurnosVigentes;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Tests.ListarTurnosVigentes;
+
+public class FunctionEndpointTests
+{
+    private static FunctionEndpoint Endpoint() => new(store: null!, tenantResolver: null!);
+
+    private static HttpRequest FakeHttpRequest(string queryString)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.QueryString = new QueryString(queryString);
+        return context.Request;
+    }
+
+    private static async Task<BadRequestObjectResult> EjecutarEsperandoBadRequest(string queryString)
+    {
+        var resultado = await Endpoint().Run(FakeHttpRequest(queryString), CancellationToken.None);
+
+        return resultado.Should().BeOfType<BadRequestObjectResult>().Subject;
+    }
+
+    [Fact]
+    public async Task ListarTurnosVigentes_Retorna400_CuandoFaltaElParametroDesde()
+    {
+        var resultado = await EjecutarEsperandoBadRequest("?hasta=2026-05-10");
+
+        // El mensaje nombra el parametro que falla: un cliente que recibe "400" a secas no sabe
+        // cual de los dos corregir.
+        resultado.Value.Should().BeOfType<string>().Which.Should().Contain("desde");
+    }
+
+    [Fact]
+    public async Task ListarTurnosVigentes_Retorna400_CuandoFaltaElParametroHasta()
+    {
+        var resultado = await EjecutarEsperandoBadRequest("?desde=2026-05-01");
+
+        resultado.Value.Should().BeOfType<string>().Which.Should().Contain("hasta");
+    }
+
+    [Fact]
+    public async Task ListarTurnosVigentes_Retorna400_CuandoDesdeTieneFormatoInvalido()
+    {
+        // dd-MM-yyyy en vez de yyyy-MM-dd, mismo caso que ObtenerTurnoVigente (#328).
+        var resultado = await EjecutarEsperandoBadRequest("?desde=01-05-2026&hasta=2026-05-10");
+
+        resultado.Value.Should().BeOfType<string>().Which.Should().Contain("yyyy-MM-dd");
+    }
+
+    [Fact]
+    public async Task ListarTurnosVigentes_Retorna400_CuandoHastaTieneFormatoInvalido()
+    {
+        var resultado = await EjecutarEsperandoBadRequest("?desde=2026-05-01&hasta=10-05-2026");
+
+        resultado.Value.Should().BeOfType<string>().Which.Should().Contain("hasta");
+    }
+
+    [Fact]
+    public async Task ListarTurnosVigentes_Retorna400_CuandoHastaEsAnteriorADesde()
+    {
+        // Rango invertido: decision documentada en FunctionEndpoint.cs (400, no lista vacia), misma
+        // eleccion que #290 congelo para ListarTurnosDiarios. Este test la fija para que un cambio
+        // de contrato sea deliberado y no un efecto colateral.
+        var resultado = await EjecutarEsperandoBadRequest("?desde=2026-05-10&hasta=2026-05-05");
+
+        resultado.Value.Should().BeOfType<string>().Which.Should().Contain("anterior");
+    }
+
+    [Fact]
+    public async Task ListarTurnosVigentes_Retorna400_CuandoEmpleadoIdEsValidoPeroElRangoNoLoEs()
+    {
+        // CA-2 + CA-4: la presencia del filtro opcional empleadoId no relaja la validacion del
+        // rango -- la consulta del Trabajador pasa por el mismo borde que la del Programador.
+        var resultado = await EjecutarEsperandoBadRequest("?desde=2026-05-10&hasta=2026-05-05&empleadoId=EMP-001");
+
+        resultado.Value.Should().BeOfType<string>().Which.Should().Contain("anterior");
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ListarTurnosVigentes/RangoConsultaTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ListarTurnosVigentes/RangoConsultaTests.cs
@@ -1,0 +1,80 @@
+// Issue #329 CA-3: logica pura de recorte del rango de ListarTurnosVigentes. Sin Marten, sin
+// Postgres, sin QuerySession -- funciona sobre DateOnly (skills/projections/read-apis.md: la cota
+// y el recorte son logica de la Function, no de la proyeccion, que este issue no toca). Cada
+// oraculo se arma a mano (MEF-ADR-0002): nunca se deriva ejecutando RangoConsulta.Recortar sobre
+// si mismo.
+//
+// Agregado en la revision: la fase verde duplico RangoConsulta desde ListarTurnosDiarios (#290)
+// sin duplicar sus tests, asi que CA-3 quedaba cubierto UNICAMENTE por el smoke test contra dev
+// -- que exige deploy y no corre en el CI del PR. Espejo de
+// ListarTurnosDiarios/RangoConsultaTests.cs: mientras las dos copias de la logica convivan
+// (MEF-ADR-0018, Rule of Three), cada una necesita su propia guarda -- si no, una divergencia
+// silenciosa entre ambas cotas no la detecta nadie.
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.ControlHoras.ListarTurnosVigentes;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Tests.ListarTurnosVigentes;
+
+public class RangoConsultaTests
+{
+    [Fact]
+    public void Recortar_DevuelveHastaSinCambios_CuandoElRangoEstaDentroDeLaCotaDe31Dias()
+    {
+        var desde = new DateOnly(2026, 8, 1);
+        var hasta = new DateOnly(2026, 8, 10);
+
+        var resultado = RangoConsulta.Recortar(desde, hasta);
+
+        resultado.Should().Be(new RangoAplicado(new DateOnly(2026, 8, 10), false));
+    }
+
+    [Fact]
+    public void Recortar_DevuelveHastaSinCambios_CuandoElRangoEsExactamente31DiasInclusive()
+    {
+        // CA-3: 31 dias inclusive (desde + 30 dias) es el limite exacto de la cota, no la excede.
+        var desde = new DateOnly(2026, 8, 1);
+        var hasta = new DateOnly(2026, 8, 31);
+
+        var resultado = RangoConsulta.Recortar(desde, hasta);
+
+        resultado.Should().Be(new RangoAplicado(new DateOnly(2026, 8, 31), false));
+    }
+
+    [Fact]
+    public void Recortar_RecortaHaciaAdelanteDesdeDesde_CuandoElRangoExcedeLargamenteLaCotaDe31Dias()
+    {
+        var desde = new DateOnly(2026, 8, 1);
+        var hasta = new DateOnly(2026, 12, 31);
+
+        var resultado = RangoConsulta.Recortar(desde, hasta);
+
+        // CA-3: hastaAplicado = desde + 30 dias (31 dias inclusive), rangoRecortado: true. El
+        // recorte es hacia ADELANTE desde `desde` -- nunca hacia atras desde `hasta`, y nunca
+        // relativo a la fecha de hoy.
+        resultado.Should().Be(new RangoAplicado(new DateOnly(2026, 8, 31), true));
+    }
+
+    [Fact]
+    public void Recortar_RecortaUnSoloDiaDeExceso_CuandoElRangoSuperaLaCotaPorUnSoloDia()
+    {
+        var desde = new DateOnly(2026, 8, 1);
+        var hasta = new DateOnly(2026, 9, 1); // 32 dias inclusive: un dia por encima de la cota
+
+        var resultado = RangoConsulta.Recortar(desde, hasta);
+
+        resultado.Should().Be(new RangoAplicado(new DateOnly(2026, 8, 31), true));
+    }
+
+    [Fact]
+    public void Recortar_DevuelveElMismoDia_CuandoDesdeYHastaCoinciden()
+    {
+        // Consulta de un solo dia (desde == hasta): el panorama del programador para una fecha
+        // puntual, forma que el smoke test usa como sensor de materializacion.
+        var desde = new DateOnly(2026, 8, 5);
+
+        var resultado = RangoConsulta.Recortar(desde, desde);
+
+        resultado.Should().Be(new RangoAplicado(desde, false));
+    }
+}


### PR DESCRIPTION
## Resumen

Pipeline TDD completado:
- Fase roja: tests escritos con stubs
- Fase verde: implementación completa
- Smoke tests: escritos para endpoints detectados
- Fase refactor: revisión de calidad

## Decisiones del pipeline

<details>
<summary>Projection Test Writer (fase roja) — 0m 0s</summary>

# Stage 1 (projection-test-writer) — Issue #329

## Issue

Exponer el panorama de turnos vigentes por rango de fechas (`ListarTurnosVigentes`, GET
`control-horas/turnos-vigentes`). `tipo:projection`, pero **no crea proyeccion nueva**: consulta la
vista `TurnoVigente` ya materializada por #328. Declarado explicitamente en el issue: "Este issue
NO crea read model, ni clase de proyeccion, ni lifecycle: solo la Function GET de listado."

## Tests creados

- `tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/ComposicionServiciosTests.cs`
  — nuevo metodo `AgregarServiciosControlHoras_ResuelveElEndpointDeListarTurnosVigentes_CuandoElContenedorEstaCompuesto`,
  hermano de los de `ObtenerTurnoDiario` (#289), `ListarTurnosDiarios` (#290) y `ObtenerTurnoVigente`
  (#328). Verifica que `ActivatorUtilities.CreateInstance<ListarTurnosVigentesEndpoint>` resuelve
  `IDocumentStore`/`ITenantResolver` desde el contenedor DI real de `ControlHoras`
  (`ComponerServiceProvider()`, connection strings dummy, sin Postgres) sin excepcion.

Es la **unica** capa read-side declarada en la seccion "Capas de test esperadas" del issue:
config-test del worker y unit tests de proyeccion estan marcados explicitamente como "no aplica"
(sin proyeccion nueva, sin cambios al seam). No se creo ningun `RangoConsulta`-equivalente ni sus
tests: el issue no lista esa capa (a diferencia de #290, que si la listaba porque ahi se creaba por
primera vez) — el recorte de rango de 31 dias que la investigacion del planner sugiere reutiliza el
mismo patron/tope que `RangoConsulta` de #290 fijo, y esa logica ya esta cubierta por
`RangoConsultaTests.cs` existente; corresponde a `projection-implementer` decidir si reutiliza el
tipo existente o declara uno propio, sin que este agente le prescriba esa decision con un test nuevo
que el issue no pidio.

## Estructura elegida

- `src/Bitakora.ControlAsistencia.ControlHoras/ListarTurnosVigentes/FunctionEndpoint.cs` — feature
  folder propio (un namespace por query, `skills/projections/naming.md`), mismo patron que
  `ObtenerTurnoDiario`/`ListarTurnosDiarios`/`ObtenerTurnoVigente`. Ruta `control-horas/turnos-vigentes`
  (GET, `AuthorizationLevel.Anonymous`): reutiliza el mismo segmento de recurso que `ObtenerTurnoVigente`
  (#328), sin colision de plantilla (esa lleva `{empleadoId}/{fecha}` adicionales).

## Stubs creados

- `FunctionEndpoint` (constructor `(IDocumentStore store, ITenantResolver tenantResolver)`, `Run`
  lanza `NotImplementedException`; `_ = store; _ = tenantResolver;` para evitar CS9113 mientras no
  hay logica real) — mismo patron exacto que el stub de `ListarTurnosDiarios` en el fase roja de
  #290.
- No se creo el envelope de respuesta (`ListaTurnosVigentes` o equivalente): ningun test de esta
  etapa lo referencia (el composition test solo valida el constructor), y el issue documenta que su
  forma es una decision de `projection-implementer` (cada elemento de `Turnos` lleva la vista
  `TurnoVigente` completa, `Id`+`Bloques` incluidos — nota tecnica del issue). No se crearon
  read model, clase de proyeccion, marker de named store ni seam de composicion: el issue no los
  necesita (reutiliza los de #328 sin tocarlos).

## Cobertura de criterios (fase roja)

- CA-1/CA-2/CA-3/CA-4: quedan para `projection-implementer` y para el smoke test contra dev — el
  carve-out de coverage de Functions GET frente al gate (MEF-ADR-0035, issue #371) exime a la logica
  de parseo/recorte/filtro/mapeo de este endpoint de un unit test obligatorio en esta etapa; el
  issue mismo declara que la unica capa read-side esperada es el test de composicion.
- CA-5 (suite completa en verde): verificado — `dotnet build` de la solucion completa sin errores
  nuevos (solo warnings preexistentes de otros dominios) y `dotnet test` del proyecto
  `Bitakora.ControlAsistencia.ControlHoras.Tests` completo: 418/418 en verde, incluido el test nuevo.

## Desviaciones del plan del planner

Ninguna. Se siguio al pie de la letra la seccion "Capas de test esperadas" del issue (solo test de
composicion; config-test y unit tests de proyeccion declarados "no aplica").

Nota documentada explicitamente (no es una desviacion, es una tension inherente al issue, ya resuelta
por el precedente de #328/`ObtenerTurnoVigente`): el test de composicion agregado queda en VERDE
inmediatamente al compilar el stub — no fuerza por si solo el rojo de la fase (el "rojo" de este
issue, antes de crear el stub, es que `ListarTurnosVigentesEndpoint` no existe y el build de
`ComposicionServiciosTests.cs` falla). Esto es exactamente lo que el comentario del test hermano de
`ObtenerTurnoVigente` (issue #328, en el mismo archivo) ya documenta para su propio caso: el test de
composicion "no es la guarda que fuerza el rojo" cuando el issue no crea proyeccion nueva; ahi el
rojo lo daban los unit tests de proyeccion y el config-test, que en #329 no aplican por diseno. Dado
que el issue explicitamente exime a este endpoint del coverage gate (MEF-ADR-0035/#371) y delega su
verificacion de comportamiento al smoke test (stage 3, fuera del alcance de este agente), no se
fuerzo un rojo adicional inventando una capa de test que el issue no pidio.

## Comando de verificacion

```
dotnet build ControlAsistencias.slnx   # correcto, sin errores nuevos
dotnet test --project tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Bitakora.ControlAsistencia.ControlHoras.Tests.csproj
# 418/418 correcto
```

</details>

<details>
<summary>Projection Implementer (fase verde) — 5m 15s</summary>

# projection-implementer -- Issue #329: Exponer el panorama de turnos vigentes por rango de fechas

## Enfoque

El issue declara explícitamente que **no crea read model, ni clase de proyección, ni lifecycle**:
la vista `TurnoVigente` y su `TurnoVigenteProjection` ya existen y están en verde desde #328
(mergeado antes de este worktree). El único trabajo read-side de #329 es la Function GET de
listado, vía (a) sobre esa proyección materializada.

`projection-test-writer` dejó un único commit de fase roja con dos archivos: el stub de
`ListarTurnosVigentes/FunctionEndpoint.cs` (constructor real, `Run` lanzando
`NotImplementedException`) y una ampliación de `ComposicionServiciosTests` con el test de
composición hermano de MEF-ADR-0029 (`AgregarServiciosControlHoras_ResuelveElEndpointDeListarTurnosVigentes_...`).
Verifiqué que ese test (y toda la suite: 418 tests en `ControlHoras.Tests`, 59 en
`Projections.Tests`, más los tres ensamblados de eventos) ya pasaba en verde incluso con el stub
-- el test de composición solo ejercita la resolución del constructor por
`ActivatorUtilities.CreateInstance`, no el comportamiento de `Run` (carve-out declarado de
coverage de Functions GET, MEF-ADR-0035/issue #371). Implementé igual el comportamiento real
descrito por las CA del issue, porque es responsabilidad de producción, no solo "hacer pasar
tests".

## Decisiones de diseño

1. **Patrón replicado 1:1 de `ListarTurnosDiarios` (#290)**, adaptado al read model `TurnoVigente`:
   - `desde`/`hasta` obligatorios, formato `yyyy-MM-dd`, 400 explícito con el nombre del parámetro
     que falla (CA-4).
   - Rango invertido (`hasta < desde`) -> 400 (mismo criterio no forzado por CA en #290 pero ya
     congelado como comportamiento del dominio).
   - `empleadoId` opcional vía query string, filtra a un solo empleado cuando está presente (CA-2).
   - Recorte de rango a 31 días inclusive, siempre hacia adelante desde `desde` (CA-3).
   - Nunca 404: rango sin datos -> 200 con `Turnos: []` (CA-4).
2. **`RangoConsulta` duplicado** en el namespace `ListarTurnosVigentes` (no reutilizado desde
   `ListarTurnosDiarios.RangoConsulta`): cada Function GET es un feature folder propio
   (`skills/projections/naming.md`) y MEF-ADR-0018 (Rule of Three) tolera la duplicación con solo
   dos consumidores -- se documentó explícitamente en el archivo nuevo para que un tercer
   consumidor futuro dispare la extracción, no antes.
3. **Sin DTO nuevo para el ítem de la lista**: el envelope `ListaTurnosVigentes` usa `TurnoVigente`
   tal cual la materializa la proyección (`Id` y `Bloques` incluidos) como tipo de `Turnos` --
   decisión de entrevista documentada en el issue ("Notas técnicas": "una sola proyección sirve
   grilla y calendario; el recorte resumido/detallado, si algún día se necesita, aterriza en el DTO
   de respuesta"). A diferencia de `ListarTurnosDiarios`, que sí reutiliza un DTO (`TurnoDiarioRespuesta`)
   sin el `Id` del documento -- aquí el issue pide explícitamente lo contrario.
4. **Orden de resultados**: `OrderBy(EmpleadoId).ThenBy(Fecha)`, siguiendo la sugerencia de la
   investigación del planner (estable para pintar grillas multi-empleado x rango de fechas).
5. **`QuerySession` acotada a `tenantResolver.TenantId`** (MEF-ADR-0028), nunca a un tenant que
   llegue por query string -- `empleadoId`/`desde`/`hasta` son filtro del recurso, no tenant.
6. **Sin registro adicional en `ComposicionServicios.cs`**: el `Schema.For<TurnoVigente>()
   .UseNumericRevisions(true)` que el par write-side/read-side de #328 exige ya estaba declarado
   (verificado antes de tocar nada); Marten resuelve `TView` por convención sin necesidad de
   registrar el tipo explícitamente para una Function GET (MEF-ADR-0035 sección 4).
7. **Sin cambios al worker ni a `ReadModels`**: ninguna proyección nueva, ningún seam de registro
   tocado -- tal como lo exige el issue.

## ADRs / recursos consultados

- MEF-ADR-0035 (superficie de consulta sobre `QuerySession`, vía (a) por defecto).
- MEF-ADR-0028 (tenancy: `QuerySession` acotada a `ITenantResolver`).
- MEF-ADR-0018 (Rule of Three: justifica la duplicación de `RangoConsulta`).
- MEF-ADR-0006 / `skills/projections/naming.md` (naming de Functions de query, feature folder sin
  sufijo `Function`).
- `skills/projections/read-apis.md` (vía (a), apertura de `QuerySession` sin tenant de ruta).
- Precedente directo `ListarTurnosDiarios/FunctionEndpoint.cs` y `RangoConsulta.cs` (#290).

## Desviaciones

Ninguna. La implementación sigue el patrón del precedente #290 sin apartarse de ninguna regla del
Skill ni de los ADRs citados. La única decisión no forzada por un CA explícito (rango invertido ->
400) replica el criterio ya congelado en #290 para mantener consistencia de contrato entre las dos
Functions de listado del mismo dominio.

## Resultado

- `dotnet build`: compilación correcta, 0 errores.
- `ControlHoras.Tests`: 418/418 en verde (incluye el test de composición del issue #329 y todos los
  de write-side, sin romper nada existente).
- `Projections.Tests`: 59/59 en verde (sin cambios, issue no toca el worker).
- `PrivateEvents.Tests`: 42/42, `PublicEvents.Tests`: 13/13, `Programacion.Tests`: 183/183 -- sin
  regresión en otros dominios/ensamblados.
- Archivos creados: `ListarTurnosVigentes/RangoConsulta.cs`, `ListarTurnosVigentes/ListaTurnosVigentes.cs`.
- Archivo modificado: `ListarTurnosVigentes/FunctionEndpoint.cs` (stub -> implementación real).
- Ningún test modificado ni eliminado.

</details>
<details>
<summary>Smoke Test Writer — 5m 7s</summary>

_(El agente no generó resumen)_

</details>
<details>
<summary>Reviewer (fase refactor) — 9m 3s</summary>

# ES Reviewer - Revision

## Alcance real del diff

El diff que recibi se calculo contra un ref `main` local desactualizado (`fd641b7`) e incluia el
trabajo ya mergeado de #322, #327 y #328. `origin/main` esta en `f11a597` (merge del PR #333,
issue #328), asi que **el alcance de #329 son 5 archivos**:

| Archivo | Estado |
|---|---|
| `src/.../ListarTurnosVigentes/FunctionEndpoint.cs` | nuevo |
| `src/.../ListarTurnosVigentes/ListaTurnosVigentes.cs` | nuevo |
| `src/.../ListarTurnosVigentes/RangoConsulta.cs` | nuevo |
| `tests/.../ControlHoras.Tests/Infraestructura/ComposicionServiciosTests.cs` | +27 lineas |
| `tests/.../ControlHoras.SmokeTests/ListarTurnosVigentes/ListarTurnosVigentesSmokeTests.cs` | nuevo |

La revision se acota a esos archivos (regla 4: no refactorizar codigo ajeno a la HU).

### Evaluacion general
- Calidad: **buena** (codigo de produccion), con un hueco de cobertura corregido en esta fase.
- Cambios realizados: **si** (2 archivos de test agregados, 11 tests).

### Estado de la suite

| Momento | Resultado |
|---|---|
| Baseline | 746 correctos / 5 errores / 16 omitidos |
| Final | **757 correctos / 5 errores / 16 omitidos** |

Los **5 errores son los mismos antes y despues**: `ListarTurnosVigentesSmokeTests` recibiendo `404`
porque la ruta todavia no esta desplegada en dev. Es el estado esperado pre-deploy, documentado en
la cabecera del propio archivo y con precedente en #290 y #328; el CI del PR solo corre `*.Tests`.
No hay `blockage-report.md` ni hacia falta: no es un bloqueo, es una dependencia de deploy.

### Cumplimiento de ADRs aplicables

| ADR | Cumplimiento | Observacion |
|---|---|---|
| MEF-ADR-0035: superficie de consulta sobre `QuerySession` | ok | Via (a') de la tabla de la seccion 4: `session.Query<TurnoVigente>()` con LINQ sobre la vista materializada. No se usa `FetchLatest` (opt-in no adoptado) ni se abre sesion de escritura. |
| MEF-ADR-0006: naming de Functions de query | ok | `Listar{X}s` -> `ListarTurnosVigentes`; feature folder propio sin sufijo `Function`; clase `FunctionEndpoint.cs`; un namespace por query, sin colision con las 4 clases homonimas del ensamblado. Ruta `control-horas/turnos-vigentes` reutiliza el segmento de recurso de `ObtenerTurnoVigente` (#328) sin colision de plantilla (aquella lleva `{empleadoId}/{fecha}`). |
| MEF-ADR-0028: `QuerySession` acotada al tenant de `ITenantResolver` | ok | `store.QuerySession(tenantResolver.TenantId)`, exactamente el patron canonico de la seccion 5 de MEF-ADR-0035. `desde`/`hasta`/`empleadoId` llegan por query string pero son filtro del **recurso**, nunca el tenant. Sin superficie BOLA/IDOR. |
| MEF-ADR-0018 (Rule of Three): el envelope es el seam de paginacion futura | ok, con matiz | El envelope `ListaTurnosVigentes` existe y no se pagina hoy: correcto. La duplicacion de `RangoConsulta` la comento aparte (ver "Desviaciones detectadas"). |

### Desviaciones de ADRs

**Desviaciones declaradas por el implementer**: ninguna. Su resumen declara explicitamente
"Ninguna", y la unica decision no forzada por un CA (rango invertido -> 400) replica el criterio ya
congelado en #290 -- lo verifique contra `ListarTurnosDiarios/FunctionEndpoint.cs` y es exacto.

**Desviaciones detectadas por el reviewer (NO declaradas por el implementer)**:

#### Observacion (no bloqueante): MEF-ADR-0018 -- la cita que justifica duplicar `RangoConsulta` no es la aplicable

- **Regla del ADR**: la tabla de heuristicas fija Rule of Three ("con dos sitios, la duplicacion se
  mantiene"), pero la seccion "Lo que esta heuristica NO regula" excluye explicitamente el
  **"reuso de utilidades sin riesgo de divergencia (helpers de fechas, formatters, etc.)"**: la
  heuristica aplica cuando el codigo expresa reglas del dominio que pueden divergir, no mecanica
  neutral.
- **Situacion en el diff**: `ListarTurnosVigentes/RangoConsulta.cs` es copia literal de
  `ListarTurnosDiarios/RangoConsulta.cs` (misma `CotaDias = 31`, mismo `Recortar`, mismo
  `RangoAplicado`). El comentario del archivo cita Rule of Three como justificacion -- pero el
  recorte de un rango de `DateOnly` es justo la "mecanica neutral" que el ADR saca del alcance de
  esa heuristica. La cita es imprecisa; la duplicacion en si **no** queda por ello prohibida.
- **Por que NO lo convierto en hallazgo bloqueante**: la misma tabla fija **"Autoridad de
  extraccion"** -- *"el reviewer no debe pedir extraccion si el implementer no la ofrece, salvo
  evidencia documentada de evolucion conjunta de los sitios... La excepcion es cuando un cambio
  reciente toco simultaneamente los dos sitios"*. Este PR no toco `ListarTurnosDiarios`: creo una
  segunda copia. Ademas el issue mismo declara el tope "revisable", es decir, admite que ambos
  endpoints diverjan (el panorama multi-empleado y el listado por empleado no tienen por que
  compartir cota). Iniciar yo la extraccion contradiria la heuristica de autoridad.
- **Accion tomada**: no se extrae. **Si** se cerro el riesgo concreto que la duplicacion abria: que
  las dos cotas divergieran en silencio. Ahora cada copia tiene su propia guarda (ver abajo).
- **Status**: pendiente de evaluacion del usuario.

### Precedentes consultados por el implementer

| Precedente | ADR aplicable | Veredicto |
|---|---|---|
| `ListarTurnosDiarios/FunctionEndpoint.cs` (#290) | MEF-ADR-0035, MEF-ADR-0028 | **alineado** -- verificado linea a linea: misma via (a'), mismo patron de tenant, mismo orden validacion-antes-de-sesion. |
| `ListarTurnosDiarios/RangoConsulta.cs` (#290) | MEF-ADR-0018 | alineado como codigo; ver matiz de la cita arriba. |
| `ObtenerTurnoVigente` (#328) | MEF-ADR-0006 | **alineado** -- el segmento de recurso compartido y la ausencia de colision de plantilla los verifique contra el `Route` real de ambos endpoints. |
| `ListarTurnosDiariosSmokeTests` (#290) | MEF-ADR-0013 | **alineado**, pero el implementer **no replico sus dos archivos de test unitario** -- ver hallazgo mayor. |

### Convenciones del pipeline (no ADRs)

| Convencion | Estado | Observacion |
|---|---|---|
| Cada test con `Then()` + `And<>()` | n/a | No hay command handler tests en el diff. Los tests de este issue son funcion pura y borde HTTP: Arrange/Act/Assert plano, mismo estilo que el precedente y que los tests de proyeccion. |
| Overloads correctos para stream IDs compuestos | n/a | El diff no ejercita el harness de aggregates. |
| Fakes manuales (no NSubstitute) | ok | Cero NSubstitute. Los tests que agregue pasan `null!` deliberadamente (patron del precedente) y el smoke test usa fixtures reales. |
| Feature folders (produccion y tests) | ok | `ListarTurnosVigentes/` en produccion, smoke tests y (ahora) unit tests: los tres espejados. |
| Smoke tests: SkipWhen, secrets, cobertura | ok | Detalle abajo. |
| Proyecciones read-side: partial, inmutabilidad, read APIs, naming | ok | El issue no crea proyeccion ni read model (verificado: `Projections/` y `ReadModels/` intactos). Solo aplica la parte de read APIs y naming, ambas correctas. |
| Compatibilidad Marten write-side/read-side | n/a | El gate no dispara: el diff de #329 no toca version del paquete ni configuracion de Marten. `ComposicionServicios.cs` (el `Schema.For<TurnoVigente>().UseNumericRevisions(true)`) llego con #328 y ya esta en `origin/main`; #329 no lo modifica. |
| Identidad de stream (MEF-ADR-0037) | n/a | El gate no dispara: el endpoint consulta por `Fecha`/`EmpleadoId` (campos de dominio del documento), nunca por el stream key. Sin `ToString()` con formato explicito sobre un `Guid`, sin construccion manual de clave, sin segmento de ruta reenviado a `LoadAsync`. La interpolacion `$"{empleadoId}:{fechaTurno:yyyy-MM-dd}"` del smoke test es un **oraculo de asercion** (el proyecto de smoke tests no referencia el Function App a proposito), no una clave usada como stream id. |
| Control de volumen de telemetria (MEF-ADR-0038) | ok | El gate dispara solo por tocar un archivo `ComposicionServicios*` -- y lo tocado es el archivo de **tests**, con un test de composicion del endpoint, no el seam de OTel ni el callback de Wolverine. Verifique igual que los guardrails existen y no son vacuos: `AgregarServiciosControlHoras_ResuelveElSamplerConfiguradoPorElProyecto_EnVezDeRateLimitedSampler` lee por reflexion el `Sampler` interno del `TracerProviderSdk` y compara el tipo efectivo, y `..._ApagaLaRecoleccionDeMetricasDeDurabilidad_...` verifica la bandera. Ambos reales. |
| Tests via ToString/comportamiento | ok | Sin getters expuestos solo para test. |
| Sin numeros magicos | ok | `CotaDias = 31` y `FormatoFecha = "yyyy-MM-dd"` son constantes con nombre. |
| Condiciones en positivo (guardas if/else afirmativas) | ok | Las tres negaciones (`!TryLeerFecha`, `!string.IsNullOrEmpty`) son guard clauses / early-return, la excepcion explicita de la convencion -- no bifurcaciones `if`/`else` permutables. |

### Smoke tests -- revision detallada

| Aspecto | Estado |
|---|---|
| `Assert.SkipWhen` en tests con fixture opcional | ok -- los 3 tests que dependen de `ServiceBusFixture` lo llevan; los que solo usan `ApiFixture` no lo necesitan (ese fixture lanza en `InitializeAsync` si el entorno no responde, misma convencion que el precedente). Es `Assert.SkipWhen`, no `Skip.When`. |
| Filtrado por identificador unico, nunca por posicion | ok -- `Single(t => t.EmpleadoId == ...)` y `Any(t => t.EmpleadoId == ...)` con GUIDs por ejecucion. Sin `[^1]` ni `First()` sin filtro. |
| Sin archivos duplicados para el mismo comando | ok -- una sola clase `ListarTurnosVigentesSmokeTests`. |
| `appsettings.json` sin secrets | ok -- no se toca. |
| Suscripcion `smoke-tests` en infra | n/a -- GET sin efectos secundarios; la siembra reusa el topic `programacion-turno-diario-solicitada` que ya existe. |
| Cobertura de escenarios | ok -- camino feliz filtrado (CA-2), panorama multi-empleado con **dos** empleados distintos para distinguir "panorama" de "un turno" (CA-1), 4 casos de validacion (CA-4), lista vacia sin 404 (CA-4), y recorte (CA-3) verificando que el turno fuera de la cota **si esta materializado pero no aparece** -- prueba que el recorte restringe de verdad, no solo que se declara en el envelope. Buen diseño. |

### Elegancia del codigo

El codigo de produccion es compacto, legible e idiomatico; no requirio refactor:

- `TryLeerFecha` unifica "ausente" y "mal formado" en un solo camino de fallo con un mensaje que
  **nombra el parametro** que falla -- un `400` a secas dejaria al cliente adivinando.
- La composicion condicional del `IQueryable` en pasos (en vez de embeber el ternario dentro del
  `Where`) es mas legible que la alternativa, y correcta: LINQ es perezoso, el filtro opcional se
  suma antes de materializar.
- `RangoAplicado` como `readonly record struct` evita una asignacion en heap para dos valores.
- Toda la validacion ocurre **antes** de abrir la `QuerySession`: no se toca la base de datos para
  responder un `400`.

Observacion cosmetica (no corregida, deliberadamente):
`ListarTurnosVigentes_IncluyeATodosLosEmpleados_...` hace un `GET` extra despues del polling, en vez
de reusar el body que `Polling.WaitUntilAsync` ya devuelve (como si hace su test hermano en el mismo
archivo). Es un round-trip redundante y un `body?...?? false` duplicado. **No lo cambie** porque el
trade-off esta parejo: `WaitUntilTrueAsync` + `Should().BeTrue(mensaje)` da un mensaje de fallo mas
especifico que el `TimeoutException` generico, y no puedo obtener senal verde de un smoke test
contra dev para validar el cambio. No justifica churn.

### Criticas y hallazgos

#### Mayor (corregido): CA-3 y CA-4 sin ninguna cobertura verde en CI

La fase verde copio `RangoConsulta` desde `ListarTurnosDiarios` (#290) **sin copiar sus tests**, y
tampoco replico `FunctionEndpointTests`. Consecuencia: de los 4 CAs funcionales del issue, **CA-3
(recorte) y CA-4 (validaciones -> 400) quedaban cubiertos exclusivamente por los smoke tests** --
que estan **rojos hasta el deploy** y **no corren en el CI del PR** (solo corre `*.Tests`). Es decir,
dos CAs sin una sola asercion verificable en el momento de mergear.

Tres señales convergentes de que era un hueco y no una decision:

1. El precedente que el issue manda replicar (#290) tiene **ambos** archivos, y la cabecera de su
   `FunctionEndpointTests.cs` documenta literalmente el motivo por el que se escribieron: *"Hasta
   este archivo, CA-2 solo estaba cubierto por el smoke test contra dev -- que exige deploy y no
   corre en el CI del PR."* #329 reabrio exactamente ese hueco.
2. El docstring de `RangoConsulta.cs` **promete una guarda que no existia**: *"Sin dependencias de
   Marten/Postgres: se prueba como funcion pura sobre `DateOnly`, sin QuerySession."*
3. El carve-out de coverage de Functions GET exime al endpoint *"que solo delega a
   `LoadAsync`/`Query`"*. Este no: tiene tres ramas de validacion propias y el recorte de rango
   **antes** de tocar Marten. Y `RangoConsulta` no es un `FunctionEndpoint` en absoluto -- el
   carve-out no lo alcanza por ningun lado.

**Accion tomada**: agregados los dos archivos, espejo del precedente (detalle en "Tests agregados").
Riesgo cerrado de paso: con dos copias de la logica de recorte conviviendo, ahora **cada una tiene
su propia guarda** -- una divergencia futura entre ambas cotas se detecta en CI en vez de en dev.

#### Menor (no accionado): warnings preexistentes ajenos al issue

`dotnet build` reporta 4 warnings `NU1902` (`OpenTelemetry.Api` 1.14.0, vulnerabilidad moderada) en
`Bitakora.ControlAsistencia.Programacion`, y `dotnet format --verify-no-changes` reporta 6 `IDE0005`
(using innecesario) en archivos de serializacion de otros issues. **Ninguno pertenece a los archivos
de #329** -- son preexistentes. No los toco (regla 4), pero quedan anotados: el `NU1902` merece un
issue propio de bump de paquete.

#### Sin hallazgos en

Encapsulamiento/Tell-don't-Ask (no hay VO ni aggregate nuevo), serializacion (ningun evento nuevo,
ningun marker de bus), portabilidad por el bus (n/a), caracteres U+2500 (verificado: ninguno),
`[Theory]` (ninguno), NSubstitute (ninguno).

### Refactorings aplicados

Ninguno. El codigo de produccion no lo necesitaba: replica un precedente maduro con adaptaciones
correctas y comentarios que explican el *por que*, no el *que*. El unico cambio de esta fase fue
sumar cobertura de test faltante, no reescribir codigo.

### Cobertura de criterios de aceptacion

| Criterio | Estado | Test(s) |
|---|---|---|
| CA-1: GET con `desde`/`hasta` devuelve 200 con turnos de TODOS los empleados, en el envelope | cubierto (smoke, verde post-deploy) | `ListarTurnosVigentes_IncluyeATodosLosEmpleados_CuandoNoSeFiltraPorEmpleadoId` |
| CA-2: con `empleadoId`, la lista queda filtrada a ese empleado | cubierto (smoke, verde post-deploy) | `ListarTurnosVigentes_Retorna200ConElTurnoDelEmpleado_CuandoSeConsultaConEmpleadoId`; borde en CI: `ListarTurnosVigentes_Retorna400_CuandoEmpleadoIdEsValidoPeroElRangoNoLoEs` |
| CA-3: rango que excede el tope se recorta y `RangoRecortado` lo declara | **cubierto en CI** (era solo smoke) | `Recortar_DevuelveHastaSinCambios_CuandoElRangoEstaDentroDeLaCotaDe31Dias`, `..._CuandoElRangoEsExactamente31DiasInclusive`, `Recortar_RecortaHaciaAdelanteDesdeDesde_CuandoElRangoExcedeLargamenteLaCotaDe31Dias`, `Recortar_RecortaUnSoloDiaDeExceso_CuandoElRangoSuperaLaCotaPorUnSoloDia`, `Recortar_DevuelveElMismoDia_CuandoDesdeYHastaCoinciden` + smoke `ListarTurnosVigentes_RecortaHaciaAdelanteYExcluyeLoQueQuedaFuera_...` |
| CA-4: rango sin datos -> 200 lista vacia; fechas invalidas o `desde > hasta` -> 400 | **parcialmente cubierto en CI** (era solo smoke) | 400 en CI: los 6 de `ListarTurnosVigentes/FunctionEndpointTests`. 200 con lista vacia: solo smoke (`ListarTurnosVigentes_Retorna200ConListaVacia_...`) -- exige `QuerySession` real, no es testeable sin Postgres. |
| CA-5: suite completa en verde | cubierto con salvedad | 757/757 verdes en todos los `*.Tests` (lo que corre el CI del PR). Los 5 rojos son smoke tests contra dev pendientes de deploy, no regresiones. |
| Capa: test de composicion de la Function GET (MEF-ADR-0029) | cubierto | `AgregarServiciosControlHoras_ResuelveElEndpointDeListarTurnosVigentes_CuandoElContenedorEstaCompuesto` |
| Capa: config-test del worker / unit tests de proyeccion | n/a (declarado en el issue) | Verificado: el diff no toca `Projections/` ni `ReadModels/`. |

### Tests agregados

`tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ListarTurnosVigentes/` (11 tests, todos verdes):

- **`RangoConsultaTests.cs`** (5): dentro de la cota, limite exacto de 31 dias inclusive, exceso
  largo, exceso de un solo dia, y `desde == hasta`. Oraculos armados a mano (MEF-ADR-0002): ningun
  valor esperado se deriva ejecutando `Recortar` sobre si mismo.
- **`FunctionEndpointTests.cs`** (6): los 5 del precedente (`desde`/`hasta` ausentes, `desde`/`hasta`
  mal formados, rango invertido) mas uno propio de #329 -- rango invertido **con `empleadoId`
  presente**, porque el filtro opcional es la diferencia de contrato frente a #290 y debe pasar por
  el mismo borde de validacion. `store` y `tenantResolver` se pasan `null!` a proposito: si un
  cambio futuro moviera la apertura de la sesion antes de la validacion, estos tests se pondrian
  rojos -- que es justo la señal deseada.

Naming segun MEF-ADR-0016 (`<Sujeto>_<LoQuePasa>_Cuando<Condicion>`), solo `[Fact]`, sin `[Theory]`.

Commit: `dc10bfa test(hu-329): cubrir el recorte de rango y la validacion del borde HTTP en CI`

</details>

## Commits

dc10bfa test(hu-329): cubrir el recorte de rango y la validacion del borde HTTP en CI
9765907 test(hu-329): smoke tests de ListarTurnosVigentes contra dev
8912347 feat(hu-329): Function GET del panorama de turnos vigentes por rango (fase verde)
a2f9083 test(hu-329): tests read-side para listar el panorama de turnos vigentes (fase roja)
f11a597 Merge pull request #333 from augusto-romero-arango/worktree-issue-328-crear-el-read-model-turnovigente-con-su
36ddf53 refactor(hu-328): un tipo por archivo en ReadModels, refresco de NombreCompleto y par 2 de TurnoVigente
ffae826 test(hu-328): smoke tests de ObtenerTurnoVigente contra dev
b81a428 feat(hu-328): proyeccion read-side del read model TurnoVigente (fase verde)
93adbd2 test(hu-328): tests read-side para el read model TurnoVigente (fase roja)
d839a9e Merge pull request #332 from augusto-romero-arango/worktree-issue-327-segmentar-el-turno-asignado-en-bloques-a
eeaaea5 refactor(issue-327): mover la aritmetica de segmentacion al objeto dueno del dato
1e781e2 feat(issue-327): implementar TurnoDiario.Segmentar en bloques absolutos (fase verde)
4c69743 test(issue-327): tests para TurnoDiario.Segmentar y stubs BloqueTurno/TipoBloque (fase roja)
f6c58ff Merge pull request #326 from augusto-romero-arango/worktree-issue-322-retirar-las-referencias-de-controlhorasd
5aacc6b refactor(issue-322): reforzar los guardrails de paridad del payload por rol
985e6c3 test(issue-322): smoke test verifica el evento persistido con su tipo dueno
37dd7ae feat(issue-322): completar Equals/GetHashCode e islas de ControlHoras.DomainEvents (fase verde)
1832963 test(issue-322): tests para Empleado/TurnoDiario/FranjaProgramada/SubFranjaProgramada y stubs de mapeo (fase roja)

Closes #329