### PR TITLE
Registrar la sede en la solicitud de programacion de turnos

### DIFF
--- a/src/Bitakora.ControlAsistencia.PrivateEvents/Programacion/DetalleSede.cs
+++ b/src/Bitakora.ControlAsistencia.PrivateEvents/Programacion/DetalleSede.cs
@@ -1,0 +1,13 @@
+namespace Bitakora.ControlAsistencia.PrivateEvents.Programacion;
+
+/// <summary>
+/// Representacion plana de la sede que viaja en eventos privados intra-BC.
+/// </summary>
+/// <remarks>
+/// Issue #331: payload por rol (CA-ADR-0029 decision #5) -- gemelo deliberado de SedeProgramada
+/// (Programacion.DomainEvents) con paridad exacta de campos, sin referenciarlo: los ensamblados de
+/// eventos son tres islas sin referencias entre si. Todos los campos son string: portable por el
+/// serializador por defecto del bus (MEF-ADR-0023/0024). Sin Equals custom: la igualdad por valor
+/// del record por defecto ya es correcta (mismo criterio que DetalleEmpleado, issue #318).
+/// </remarks>
+public record DetalleSede(string Id, string Nombre);

--- a/src/Bitakora.ControlAsistencia.PrivateEvents/Programacion/ProgramacionTurnoDiarioSolicitada.cs
+++ b/src/Bitakora.ControlAsistencia.PrivateEvents/Programacion/ProgramacionTurnoDiarioSolicitada.cs
@@ -18,16 +18,23 @@ public sealed class ProgramacionTurnoDiarioSolicitada : IPrivateEvent
     public DateOnly Fecha { get; private set; }
     public DetalleTurno DetalleTurno { get; private set; } = null!;
 
+    // Issue #331: sede efectiva del dia, opcional (null = sin sede asignada). Campo aditivo y
+    // tolerante: los mensajes publicados antes de este issue no llevan la clave "sede" en el JSON
+    // del bus; STJ deja null en el parametro posicional opcional (precedente Descripcion, #288).
+    public DetalleSede? Sede { get; private set; }
+
     public ProgramacionTurnoDiarioSolicitada(
         Guid solicitudId,
         DetalleEmpleado empleado,
         DateOnly fecha,
-        DetalleTurno detalleTurno)
+        DetalleTurno detalleTurno,
+        DetalleSede? sede = null)
     {
         SolicitudId = solicitudId;
         Empleado = empleado;
         Fecha = fecha;
         DetalleTurno = detalleTurno;
+        Sede = sede;
     }
 
     // Constructor para Marten/serializacion

--- a/src/Bitakora.ControlAsistencia.Programacion.DomainEvents/ProgramacionTurnoSolicitada.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion.DomainEvents/ProgramacionTurnoSolicitada.cs
@@ -19,16 +19,24 @@ public sealed class ProgramacionTurnoSolicitada
     public IReadOnlyList<DateOnly> Fechas { get; private set; } = [];
     public TurnoProgramado DetalleTurno { get; private set; } = null!;
 
+    // Issue #331: sede efectiva del dia, opcional (null = sin sede asignada). Campo aditivo: los
+    // streams escritos antes de este issue no llevan la clave "Sede" en el JSON persistido; STJ
+    // deja null en el parametro posicional opcional (ver ProgramacionTurnoSolicitadaSerializacionTests,
+    // precedente #288/#319).
+    public SedeProgramada? Sede { get; private set; }
+
     public ProgramacionTurnoSolicitada(
         Guid id,
         Empleado empleado,
         IReadOnlyList<DateOnly> fechas,
-        TurnoProgramado detalleTurno)
+        TurnoProgramado detalleTurno,
+        SedeProgramada? sede = null)
     {
         Id = id;
         Empleado = empleado;
         Fechas = fechas;
         DetalleTurno = detalleTurno;
+        Sede = sede;
     }
 
     // Constructor para Marten/serializacion

--- a/src/Bitakora.ControlAsistencia.Programacion.DomainEvents/SedeProgramada.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion.DomainEvents/SedeProgramada.cs
@@ -1,0 +1,18 @@
+namespace Bitakora.ControlAsistencia.Programacion.DomainEvents;
+
+/// <summary>
+/// Sede efectiva donde rige la programacion del turno para el dia solicitado.
+/// </summary>
+/// <remarks>
+/// Issue #331: snapshot de la sede resuelta por el cliente (sede natural del empleado como
+/// default silencioso, o la que el Programador indique) -- el servidor NUNCA consulta el maestro
+/// de sedes (#330), la verdad queda grabada en el evento. Id es un identificador opaco provisto
+/// por el cliente (mismo precedente que EmpleadoId/DispositivoId: puede o no ser un guid). Nombre
+/// viaja para que el evento persistido quede autocontenido.
+/// Sin comportamiento, sin Equals custom: todos los campos son string, la igualdad por valor del
+/// record por defecto ya es correcta (mismo criterio que Empleado, issue #319).
+/// El nombre puro "Sede" queda RESERVADO para el concepto rico del futuro maestro de sedes (#338,
+/// direccion/ciudad/dispositivos asociados) -- este record es deliberadamente "Programada" para no
+/// hacer squatting de ese nombre.
+/// </remarks>
+public record SedeProgramada(string Id, string Nombre);

--- a/src/Bitakora.ControlAsistencia.Programacion/Entities/SolicitudProgramacionAggregateRoot.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/Entities/SolicitudProgramacionAggregateRoot.cs
@@ -12,12 +12,16 @@ public partial class SolicitudProgramacionAggregateRoot : AggregateRoot
     internal IReadOnlyList<DateOnly> Fechas { get; private set; } = [];
     internal TurnoProgramado? DetalleTurno { get; private set; }
 
+    // Issue #331: sede efectiva del dia, opcional (null = sin sede asignada).
+    internal SedeProgramada? Sede { get; private set; }
+
     public void Apply(ProgramacionTurnoSolicitada e)
     {
         Id = e.Id.ToString();
         Empleado = e.Empleado;
         Fechas = e.Fechas;
         DetalleTurno = e.DetalleTurno;
+        Sede = e.Sede;
     }
 
     internal static SolicitudProgramacionAggregateRoot Iniciar(ProgramacionTurnoSolicitada evento)

--- a/src/Bitakora.ControlAsistencia.Programacion/SolicitarProgramacionTurnoFunction/CommandHandler/SolicitarProgramacionTurnoCommandHandler.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/SolicitarProgramacionTurnoFunction/CommandHandler/SolicitarProgramacionTurnoCommandHandler.cs
@@ -42,7 +42,8 @@ public partial class SolicitarProgramacionTurnoCommandHandler
         // Issue #319 CA-2/CA-5: el comando HTTP conserva InformacionEmpleado (PublicEvents, fuera
         // de alcance); el evento persistido tipa con Empleado (dominio) -- el mapeo vive aqui.
         var empleadoDominio = MapearEmpleadoDominio(command.Empleado);
-        var evento = new ProgramacionTurnoSolicitada(command.Id, empleadoDominio, fechas, turnoProgramado);
+        var evento = new ProgramacionTurnoSolicitada(
+            command.Id, empleadoDominio, fechas, turnoProgramado, command.Sede);
         var solicitud = SolicitudProgramacionAggregateRoot.Iniciar(evento);
 
         _eventStore.StartStream(solicitud);
@@ -56,9 +57,12 @@ public partial class SolicitarProgramacionTurnoCommandHandler
         // Issue #319 CA-5: DetalleTurno (PrivateEvents) se deriva de TurnoProgramado (dominio),
         // no directamente del catalogo -- unico punto de mapeo hacia el payload de bus.
         var detalleTurno = MapearTurno(turnoProgramado);
+        // Issue #331: la sede es un gemelo deliberado (CA-ADR-0029 decision #5) -- mismo mapeo
+        // campo a campo que Empleado/DetalleTurno hacia su forma de bus.
+        var sede = MapearSede(command.Sede);
         var eventosPrivados = command.Fechas
             .Select(fecha => new ProgramacionTurnoDiarioSolicitada(
-                command.Id, empleado, fecha, detalleTurno))
+                command.Id, empleado, fecha, detalleTurno, sede))
             .ToArray();
 
         await _privateEventSender.PublishAsync(eventosPrivados);
@@ -91,4 +95,9 @@ public partial class SolicitarProgramacionTurnoCommandHandler
     private static DetalleSubFranja MapearSubFranja(SubFranjaProgramada subFranja) =>
         new(subFranja.HoraInicio, subFranja.HoraFin, subFranja.DiaOffsetInicio,
             subFranja.DiaOffsetFin, subFranja.Descripcion);
+
+    // Issue #331: unico punto de mapeo desde SedeProgramada (dominio) hacia el payload que cruza
+    // el bus interno (DetalleSede, PrivateEvents). Opcional: null se conserva.
+    private static DetalleSede? MapearSede(SedeProgramada? sede) =>
+        sede is null ? null : new DetalleSede(sede.Id, sede.Nombre);
 }

--- a/src/Bitakora.ControlAsistencia.Programacion/SolicitarProgramacionTurnoFunction/CommandHandler/SolicitarProgramacionTurnoValidator.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/SolicitarProgramacionTurnoFunction/CommandHandler/SolicitarProgramacionTurnoValidator.cs
@@ -21,5 +21,13 @@ public class SolicitarProgramacionTurnoValidator
         });
 
         RuleFor(x => x.Fechas).NotEmpty();
+
+        // Issue #331 CA-3: sede es opcional (null = sin sede asignada), pero cuando el objeto
+        // viene presente, sus propiedades Id y Nombre son obligatorias y no vacias.
+        When(x => x.Sede is not null, () =>
+        {
+            RuleFor(x => x.Sede!.Id).NotEmpty();
+            RuleFor(x => x.Sede!.Nombre).NotEmpty();
+        });
     }
 }

--- a/src/Bitakora.ControlAsistencia.Programacion/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurno.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurno.cs
@@ -1,9 +1,15 @@
+using Bitakora.ControlAsistencia.Programacion.DomainEvents;
 using Bitakora.ControlAsistencia.PublicEvents.Empleados;
 
 namespace Bitakora.ControlAsistencia.Programacion.SolicitarProgramacionTurnoFunction;
 
+// Issue #331: Sede es opcional (null = sin sede asignada). El cliente la resuelve (sede natural
+// del empleado por default, o la que el Programador indique) -- el servidor NUNCA consulta el
+// maestro de sedes (#330). Reutiliza SedeProgramada (Programacion.DomainEvents), mismo precedente
+// que Empleado reutilizando InformacionEmpleado (PublicEvents).
 public record SolicitarProgramacionTurno(
     Guid Id,
     Guid TurnoId,
     InformacionEmpleado Empleado,
-    List<DateOnly> Fechas);
+    List<DateOnly> Fechas,
+    SedeProgramada? Sede = null);

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/ProgramacionTurnoDiarioSolicitadaPortabilidadTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/ProgramacionTurnoDiarioSolicitadaPortabilidadTests.cs
@@ -8,6 +8,7 @@
 // privados como SubFranja/FranjaOrdinaria).
 
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.ControlHoras.Infraestructura;
 using Bitakora.ControlAsistencia.PrivateEvents.Programacion;
@@ -81,18 +82,35 @@ public class ProgramacionTurnoDiarioSolicitadaPortabilidadTests
     }
 
     // Issue #331 CA-2/CA-4: sede es opcional y aditiva -- los mensajes publicados antes de este
-    // issue no llevan el campo "sede", STJ deja null en el parametro posicional opcional.
+    // issue no llevan la clave "sede" en el JSON del bus. Serializar el evento con Sede = null y
+    // volver a leerlo solo probaria que un null explicito ("sede": null) sobrevive; lo que este
+    // test ejercita es la AUSENCIA de la clave, que es la forma real de los mensajes viejos --
+    // el mismo camino que ya cubre Deserializar_DejaDescripcionEnCadenaVacia_... para #288.
     [Fact]
-    public void Deserializar_DejaSedeEnNull_CuandoEventoNoLlevaElCampo()
+    public void Deserializar_DejaSedeEnNull_CuandoElMensajeNoLlevaLaClaveSede()
     {
-        var evento = new ProgramacionTurnoDiarioSolicitada(SolicitudId, Empleado, Fecha, CrearDetalleTurno());
-
-        var json = JsonSerializer.Serialize(evento, CrearOpcionesProductor());
         var restaurado = ServiceBusDeserializador.Deserializar<ProgramacionTurnoDiarioSolicitada>(
-            BinaryData.FromString(json));
+            BinaryData.FromString(JsonSinLaClaveSede()));
 
         restaurado.Should().NotBeNull();
         restaurado.Sede.Should().BeNull();
+        restaurado.DetalleTurno.Nombre.Should().Be("Turno Manana");
+    }
+
+    // La forma anterior a #331 es exactamente la actual SIN la clave "sede" -- quitarla del JSON
+    // canonico expresa esa relacion mejor que reescribir el mensaje completo a mano (mismo recurso
+    // que JsonConFormaPersistidaSinDescripcion en Programacion.Tests). Se parte de un evento CON
+    // sede para que la asercion sobre Remove() delate un test vacuo si la clave cambiara de nombre.
+    private static string JsonSinLaClaveSede()
+    {
+        var conSede = new ProgramacionTurnoDiarioSolicitada(
+            SolicitudId, Empleado, Fecha, CrearDetalleTurno(), new DetalleSede("SEDE-01", "Sede Principal"));
+
+        var nodo = JsonNode.Parse(JsonSerializer.Serialize(conSede, CrearOpcionesProductor()))!;
+        nodo.AsObject().Remove("sede").Should().BeTrue(
+            "el JSON del bus debe llevar la clave 'sede' para que quitarla represente la forma anterior a #331");
+
+        return nodo.ToJsonString();
     }
 
     // Retro-compatibilidad: los eventos publicados antes de #288 no llevan el campo. STJ dejaria

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/ProgramacionTurnoDiarioSolicitadaPortabilidadTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/ProgramacionTurnoDiarioSolicitadaPortabilidadTests.cs
@@ -62,6 +62,39 @@ public class ProgramacionTurnoDiarioSolicitadaPortabilidadTests
             .Should().Be(detalleTurno.FranjasOrdinarias[0].Descansos[0].Descripcion);
     }
 
+    // Issue #331 CA-5: la sede es un DTO plano de strings (DetalleSede) -- portable por el
+    // serializador por defecto del bus, igual que DetalleTurno/DetalleEmpleado.
+    [Fact]
+    public void RoundTrip_PreservaLaSede_ConSerializadorPorDefectoDelBus()
+    {
+        var detalleTurno = CrearDetalleTurno();
+        var sede = new DetalleSede("SEDE-01", "Sede Principal");
+        var evento = new ProgramacionTurnoDiarioSolicitada(SolicitudId, Empleado, Fecha, detalleTurno, sede);
+
+        var json = JsonSerializer.Serialize(evento, CrearOpcionesProductor());
+
+        var body = BinaryData.FromString(json);
+        var restaurado = ServiceBusDeserializador.Deserializar<ProgramacionTurnoDiarioSolicitada>(body);
+
+        restaurado.Should().NotBeNull();
+        restaurado.Sede.Should().Be(sede);
+    }
+
+    // Issue #331 CA-2/CA-4: sede es opcional y aditiva -- los mensajes publicados antes de este
+    // issue no llevan el campo "sede", STJ deja null en el parametro posicional opcional.
+    [Fact]
+    public void Deserializar_DejaSedeEnNull_CuandoEventoNoLlevaElCampo()
+    {
+        var evento = new ProgramacionTurnoDiarioSolicitada(SolicitudId, Empleado, Fecha, CrearDetalleTurno());
+
+        var json = JsonSerializer.Serialize(evento, CrearOpcionesProductor());
+        var restaurado = ServiceBusDeserializador.Deserializar<ProgramacionTurnoDiarioSolicitada>(
+            BinaryData.FromString(json));
+
+        restaurado.Should().NotBeNull();
+        restaurado.Sede.Should().BeNull();
+    }
+
     // Retro-compatibilidad: los eventos publicados antes de #288 no llevan el campo. STJ dejaria
     // null en un parametro posicional declarado como string no anulable, lo que seria una mina
     // para cualquier consumidor. Los DTOs lo normalizan a cadena vacia -- la consecuencia que el

--- a/tests/Bitakora.ControlAsistencia.PrivateEvents.Tests/Programacion/DetalleSedeIgualdadTests.cs
+++ b/tests/Bitakora.ControlAsistencia.PrivateEvents.Tests/Programacion/DetalleSedeIgualdadTests.cs
@@ -1,0 +1,23 @@
+// Issue #331: Tests de contrato IEquatable para DetalleSede, por simetria con la familia
+// Detalle*IgualdadTests. Todos los campos son string: la igualdad por valor del record por
+// defecto ya es correcta, sin Equals/GetHashCode propios (MEF-ADR-0012) -- mismo criterio que
+// DetalleEmpleado.
+
+using Bitakora.ControlAsistencia.PrivateEvents.Programacion;
+
+namespace Bitakora.ControlAsistencia.PrivateEvents.Tests.Programacion;
+
+public class DetalleSedeIgualdadTests : IgualdadTestBase<DetalleSede>
+{
+    protected override DetalleSede CrearInstancia() =>
+        new("SEDE-01", "Sede Principal");
+
+    protected override DetalleSede CrearInstanciaCopia() =>
+        new("SEDE-01", "Sede Principal");
+
+    protected override IEnumerable<(string, DetalleSede)> CrearInstanciasDiferentes()
+    {
+        yield return ("Id", new DetalleSede("SEDE-02", "Sede Principal"));
+        yield return ("Nombre", new DetalleSede("SEDE-01", "Sede Norte"));
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoSmokeTests.cs
@@ -127,7 +127,7 @@ public class SolicitarProgramacionTurnoSmokeTests(ApiFixture api, ServiceBusFixt
 
     [Fact]
     [Trait("Category", "Smoke")]
-    public async Task DebePublicarProgramacionTurnoDiarioSolicitada_ConSedeCorrecta_CuandoSolicitudIncluyeSede()
+    public async Task SolicitarProgramacionTurno_PublicaElEventoDiarioConLaSede_CuandoLaSolicitudIncluyeSede()
     {
         Assert.SkipWhen(!serviceBus.IsConfigured,
             "ServiceBus no configurado. Usa appsettings.local.json o variable ServiceBus__ConnectionString.");
@@ -188,6 +188,19 @@ public class SolicitarProgramacionTurnoSmokeTests(ApiFixture api, ServiceBusFixt
 
         var sedeEsperada = new DetalleSede(sedeId, sedeNombre);
         evento.Sede.Should().Be(sedeEsperada);
+
+        // Assert: el campo nuevo es aditivo y TOLERANTE para el consumidor real -- ControlHoras
+        // todavia no conoce "sede" (lo consumira en #336) y debe seguir procesando el mensaje sin
+        // dead-letter. Es la unica evidencia end-to-end de esa tolerancia: el test de arriba
+        // (sin sede) nunca pone el campo nuevo en el cable.
+        await Task.Delay(TimeSpan.FromSeconds(5), ct);
+
+        var existeDeadLetter = await serviceBus.ExisteDeadLetterDeEstaCorridaAsync<ProgramacionTurnoDiarioSolicitadaMinimo>(
+            TopicSalida, SuscripcionConsumidor, e => e.SolicitudId == solicitudId);
+
+        existeDeadLetter.Should().BeFalse(
+            "el campo 'sede' es aditivo: ControlHoras debe ignorarlo sin fallar (SolicitudId {0}, suscripcion '{1}')",
+            solicitudId, SuscripcionConsumidor);
     }
 
     [Fact]
@@ -377,7 +390,7 @@ public class SolicitarProgramacionTurnoSmokeTests(ApiFixture api, ServiceBusFixt
     // Issue #331 CA-3: sede presente pero con Id vacio se rechaza con 400, sin emitir eventos.
     [Fact]
     [Trait("Category", "Smoke")]
-    public async Task SolicitarProgramacionTurno_DebeRetornar400_CuandoSedeTieneIdVacio()
+    public async Task SolicitarProgramacionTurno_Retorna400_CuandoSedeTieneIdVacio()
     {
         var ct = TestContext.Current.CancellationToken;
         var payload = new
@@ -404,7 +417,7 @@ public class SolicitarProgramacionTurnoSmokeTests(ApiFixture api, ServiceBusFixt
     // Issue #331 CA-3: sede presente pero con Nombre en blanco se rechaza con 400, sin emitir eventos.
     [Fact]
     [Trait("Category", "Smoke")]
-    public async Task SolicitarProgramacionTurno_DebeRetornar400_CuandoSedeTieneNombreEnBlanco()
+    public async Task SolicitarProgramacionTurno_Retorna400_CuandoSedeTieneNombreEnBlanco()
     {
         var ct = TestContext.Current.CancellationToken;
         var payload = new

--- a/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoSmokeTests.cs
@@ -107,6 +107,11 @@ public class SolicitarProgramacionTurnoSmokeTests(ApiFixture api, ServiceBusFixt
         evento1.DetalleTurno.Nombre.Should().Be("[TEST] Turno Smoke SB");
         evento1.DetalleTurno.FranjasOrdinarias.Should().HaveCount(1);
 
+        // Issue #331 CA-2: la solicitud no incluye sede -> el comportamiento actual (anterior al
+        // issue) queda intacto: el evento diario publicado lleva Sede = null.
+        evento1.Sede.Should().BeNull();
+        evento2.Sede.Should().BeNull();
+
         // Assert: verificar ausencia de dead letter de ESTA corrida en la suscripcion del consumidor real
         // (issue #223: acotado por SolicitudId, no "DLQ globalmente vacio" - residuales de otras
         // corridas no deben tumbar este test).
@@ -118,6 +123,71 @@ public class SolicitarProgramacionTurnoSmokeTests(ApiFixture api, ServiceBusFixt
         existeDeadLetter.Should().BeFalse(
             "no deberia haber un dead letter de esta corrida (SolicitudId {0}) en '{1}' - si lo hay, el consumidor fallo al procesar el evento",
             solicitudId, SuscripcionConsumidor);
+    }
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task DebePublicarProgramacionTurnoDiarioSolicitada_ConSedeCorrecta_CuandoSolicitudIncluyeSede()
+    {
+        Assert.SkipWhen(!serviceBus.IsConfigured,
+            "ServiceBus no configurado. Usa appsettings.local.json o variable ServiceBus__ConnectionString.");
+
+        var ct = TestContext.Current.CancellationToken;
+
+        // Arrange: purgar mensajes preexistentes de ejecuciones anteriores
+        await serviceBus.PurgeAsync(TopicSalida, Suscripcion);
+
+        // Arrange: crear turno en catalogo
+        var turnoId = Guid.CreateVersion7();
+        var turnoPayload = new
+        {
+            turnoId,
+            nombre = "[TEST] Turno Smoke Sede",
+            ordinarias = new[]
+            {
+                new
+                {
+                    inicio = "08:00:00",
+                    fin = "16:00:00",
+                    descansos = Array.Empty<object>(),
+                    extras = Array.Empty<object>()
+                }
+            }
+        };
+        var crearTurnoResponse = await _client.PostAsJsonAsync("/api/programacion/turnos", turnoPayload, ct);
+        crearTurnoResponse.StatusCode.Should().Be(HttpStatusCode.Accepted);
+
+        // Arrange: solicitud con sede -- issue #331 CA-1
+        var solicitudId = Guid.CreateVersion7();
+        var empleadoId = Guid.CreateVersion7().ToString();
+        var sedeId = "SEDE-01";
+        var sedeNombre = "[TEST] Sede Principal";
+        var payload = new
+        {
+            id = solicitudId,
+            turnoId,
+            empleado = new
+            {
+                empleadoId,
+                tipoIdentificacion = "CC",
+                numeroIdentificacion = "111222333",
+                nombres = "[TEST] Smoke Sede",
+                apellidos = "[TEST] Publicacion"
+            },
+            fechas = new[] { "2026-05-01" },
+            sede = new { id = sedeId, nombre = sedeNombre }
+        };
+
+        // Act: enviar solicitud via HTTP
+        var response = await _client.PostAsJsonAsync("/api/programacion/solicitudes", payload, ct);
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+
+        // Assert: el evento diario publicado lleva la sede resuelta por el cliente
+        var evento = await serviceBus.WaitForMessageAsync<ProgramacionTurnoDiarioSolicitada>(
+            TopicSalida, Suscripcion, e => e.SolicitudId == solicitudId, Timeout);
+
+        var sedeEsperada = new DetalleSede(sedeId, sedeNombre);
+        evento.Sede.Should().Be(sedeEsperada);
     }
 
     [Fact]
@@ -297,6 +367,60 @@ public class SolicitarProgramacionTurnoSmokeTests(ApiFixture api, ServiceBusFixt
                 apellidos = "[TEST] Perez"
             },
             fechas = Array.Empty<string>()
+        };
+
+        var response = await _client.PostAsJsonAsync("/api/programacion/solicitudes", payload, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    // Issue #331 CA-3: sede presente pero con Id vacio se rechaza con 400, sin emitir eventos.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task SolicitarProgramacionTurno_DebeRetornar400_CuandoSedeTieneIdVacio()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var payload = new
+        {
+            id = Guid.CreateVersion7(),
+            turnoId = Guid.CreateVersion7(),
+            empleado = new
+            {
+                empleadoId = Guid.CreateVersion7().ToString(),
+                tipoIdentificacion = "CC",
+                numeroIdentificacion = "123456789",
+                nombres = "[TEST] Juan",
+                apellidos = "[TEST] Perez"
+            },
+            fechas = new[] { "2025-08-01" },
+            sede = new { id = "", nombre = "[TEST] Sede Principal" }
+        };
+
+        var response = await _client.PostAsJsonAsync("/api/programacion/solicitudes", payload, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    // Issue #331 CA-3: sede presente pero con Nombre en blanco se rechaza con 400, sin emitir eventos.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task SolicitarProgramacionTurno_DebeRetornar400_CuandoSedeTieneNombreEnBlanco()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var payload = new
+        {
+            id = Guid.CreateVersion7(),
+            turnoId = Guid.CreateVersion7(),
+            empleado = new
+            {
+                empleadoId = Guid.CreateVersion7().ToString(),
+                tipoIdentificacion = "CC",
+                numeroIdentificacion = "123456789",
+                nombres = "[TEST] Juan",
+                apellidos = "[TEST] Perez"
+            },
+            fechas = new[] { "2025-08-01" },
+            sede = new { id = "SEDE-01", nombre = "   " }
         };
 
         var response = await _client.PostAsJsonAsync("/api/programacion/solicitudes", payload, ct);

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/Eventos/ProgramacionTurnoSolicitadaSerializacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/Eventos/ProgramacionTurnoSolicitadaSerializacionTests.cs
@@ -41,6 +41,9 @@ public class ProgramacionTurnoSolicitadaSerializacionTests
     private static readonly Empleado EmpleadoEsperado =
         new("E001", "CC", "12345678", "Juan", "Perez");
 
+    // Issue #331: sede efectiva del dia, campo aditivo y opcional.
+    private static readonly SedeProgramada SedeEsperada = new("SEDE-01", "Sede Principal");
+
     private static readonly TurnoProgramado TurnoEsperado = new(
         "Turno Manana",
         new List<FranjaProgramada>
@@ -200,5 +203,32 @@ public class ProgramacionTurnoSolicitadaSerializacionTests
 
         evento.Empleado.Should().Be(EmpleadoEsperado);
         evento.DetalleTurno.Should().Be(TurnoEsperado);
+    }
+
+    // Issue #331 CA-4: retrocompatibilidad. Los streams escritos antes de este issue no llevan la
+    // clave "Sede" en el JSON persistido -- STJ deja null en el parametro posicional opcional
+    // (mismo mecanismo que Descripcion, #288/#319).
+    [Fact]
+    public void Deserializar_DejaSedeEnNull_CuandoElJsonPersistidoNoLlevaEseCampo()
+    {
+        var evento = Deserializar(JsonConFormaPersistidaAntesDelCambioDeTipos());
+
+        evento.Sede.Should().BeNull();
+    }
+
+    // Issue #331 CA-5: round-trip de serializacion con Marten (CrearOpcionesMarten()) cuando la
+    // sede esta poblada -- el evento persistido debe reconstruir SedeProgramada identica.
+    [Fact]
+    public void RoundTrip_PreservaLaSede_CuandoLaSedeEstaPoblada()
+    {
+        var evento = new ProgramacionTurnoSolicitada(
+            Id, EmpleadoEsperado, [Fecha1], TurnoEsperado, SedeEsperada);
+        var opciones = ConfiguracionSerializacionProgramacion.CrearOpcionesMarten();
+
+        var json = JsonSerializer.Serialize(evento, opciones);
+        var restaurado = JsonSerializer.Deserialize<ProgramacionTurnoSolicitada>(json, opciones);
+
+        restaurado.Should().NotBeNull();
+        restaurado!.Sede.Should().Be(SedeEsperada);
     }
 }

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoCommandHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoCommandHandlerTests.cs
@@ -188,18 +188,23 @@ public class SolicitarProgramacionTurnoCommandHandlerTests
 
     // Issue #331 CA-1: la sede viaja resuelta en el comando (el cliente la resuelve, el servidor
     // NUNCA consulta el maestro) y queda grabada tanto en el evento persistido (SedeProgramada,
-    // dominio) como en cada evento diario publicado al bus interno (DetalleSede, gemelo deliberado).
+    // dominio) como en CADA evento diario publicado al bus interno (DetalleSede, gemelo deliberado).
+    // Dos fechas a proposito: CA-1 dice "cada ProgramacionTurnoDiarioSolicitada", asi que con una
+    // sola fecha una implementacion que solo poblara el primer evento pasaria en verde.
     [Fact]
     public async Task SolicitarProgramacionTurno_PersisteYPublicaLaSedeProgramada_CuandoLaSolicitudIncluyeSede()
     {
         Given(TurnoId.ToString(), CrearEventoTurno());
         await WhenAsync(new SolicitarProgramacionTurno(
-            GuidAggregateId, TurnoId, Empleado, [Fecha1], SedePrincipal));
+            GuidAggregateId, TurnoId, Empleado, [Fecha1, Fecha2], SedePrincipal));
 
         Then(new ProgramacionTurnoSolicitada(
-            GuidAggregateId, EmpleadoProgramado, [Fecha1], TurnoProgramadoEsperado, SedePrincipal));
-        ThenIsPublishedPrivately(new ProgramacionTurnoDiarioSolicitada(
-            GuidAggregateId, EmpleadoDetalle, Fecha1, DetalleEsperado, SedePrincipalDetalle));
+            GuidAggregateId, EmpleadoProgramado, [Fecha1, Fecha2], TurnoProgramadoEsperado, SedePrincipal));
+        ThenIsPublishedPrivately(
+            new ProgramacionTurnoDiarioSolicitada(
+                GuidAggregateId, EmpleadoDetalle, Fecha1, DetalleEsperado, SedePrincipalDetalle),
+            new ProgramacionTurnoDiarioSolicitada(
+                GuidAggregateId, EmpleadoDetalle, Fecha2, DetalleEsperado, SedePrincipalDetalle));
         And<SolicitudProgramacionAggregateRoot, SedeProgramada?>(s => s.Sede, SedePrincipal);
     }
 

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoCommandHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoCommandHandlerTests.cs
@@ -99,6 +99,11 @@ public class SolicitarProgramacionTurnoCommandHandlerTests
     private const string DescripcionTurnoConHijas =
         "Turno Partido (06:00-14:00)[Descansos:(10:00-10:15)][Extras:(13:00-14:00)]";
 
+    // Issue #331: sede efectiva del dia, en los dos roles de payload (evento persistido y evento
+    // que cruza el bus interno) -- gemelos deliberados con paridad de campos (CA-ADR-0029/MEF-ADR-0039).
+    private static readonly SedeProgramada SedePrincipal = new("SEDE-01", "Sede Principal");
+    private static readonly DetalleSede SedePrincipalDetalle = new("SEDE-01", "Sede Principal");
+
     private static readonly TurnoProgramado TurnoConHijasProgramadoEsperado = new(
         "Turno Partido",
         new List<FranjaProgramada>
@@ -179,6 +184,40 @@ public class SolicitarProgramacionTurnoCommandHandlerTests
             new ProgramacionTurnoDiarioSolicitada(
                 GuidAggregateId, EmpleadoDetalle, Fecha2, DetalleEsperado));
         And<SolicitudProgramacionAggregateRoot, int>(s => s.Fechas.Count, 2);
+    }
+
+    // Issue #331 CA-1: la sede viaja resuelta en el comando (el cliente la resuelve, el servidor
+    // NUNCA consulta el maestro) y queda grabada tanto en el evento persistido (SedeProgramada,
+    // dominio) como en cada evento diario publicado al bus interno (DetalleSede, gemelo deliberado).
+    [Fact]
+    public async Task SolicitarProgramacionTurno_PersisteYPublicaLaSedeProgramada_CuandoLaSolicitudIncluyeSede()
+    {
+        Given(TurnoId.ToString(), CrearEventoTurno());
+        await WhenAsync(new SolicitarProgramacionTurno(
+            GuidAggregateId, TurnoId, Empleado, [Fecha1], SedePrincipal));
+
+        Then(new ProgramacionTurnoSolicitada(
+            GuidAggregateId, EmpleadoProgramado, [Fecha1], TurnoProgramadoEsperado, SedePrincipal));
+        ThenIsPublishedPrivately(new ProgramacionTurnoDiarioSolicitada(
+            GuidAggregateId, EmpleadoDetalle, Fecha1, DetalleEsperado, SedePrincipalDetalle));
+        And<SolicitudProgramacionAggregateRoot, SedeProgramada?>(s => s.Sede, SedePrincipal);
+    }
+
+    // Issue #331 CA-2: sede es opcional -- una solicitud sin sede (campo ausente) deja Sede en
+    // null tanto en el evento persistido como en el evento diario publicado; el comportamiento
+    // actual (anterior a este issue) queda intacto.
+    [Fact]
+    public async Task SolicitarProgramacionTurno_DejaSedeEnNull_CuandoLaSolicitudNoIncluyeSede()
+    {
+        Given(TurnoId.ToString(), CrearEventoTurno());
+        await WhenAsync(new SolicitarProgramacionTurno(
+            GuidAggregateId, TurnoId, Empleado, [Fecha1]));
+
+        Then(new ProgramacionTurnoSolicitada(
+            GuidAggregateId, EmpleadoProgramado, [Fecha1], TurnoProgramadoEsperado, sede: null));
+        ThenIsPublishedPrivately(new ProgramacionTurnoDiarioSolicitada(
+            GuidAggregateId, EmpleadoDetalle, Fecha1, DetalleEsperado, sede: null));
+        And<SolicitudProgramacionAggregateRoot, SedeProgramada?>(s => s.Sede, null);
     }
 
     // CA-6: idempotencia - solicitud ya existe lanza excepcion que el endpoint mapea a 409

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoValidatorTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoValidatorTests.cs
@@ -1,6 +1,7 @@
 // HU-10: Solicitar programacion de turno del catalogo - tests del validator
 
 using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Programacion.DomainEvents;
 using Bitakora.ControlAsistencia.Programacion.SolicitarProgramacionTurnoFunction;
 using Bitakora.ControlAsistencia.Programacion.SolicitarProgramacionTurnoFunction.CommandHandler;
 using Bitakora.ControlAsistencia.PublicEvents.Empleados;
@@ -161,5 +162,59 @@ public class SolicitarProgramacionTurnoValidatorTests
         resultado.IsValid.Should().BeFalse();
         resultado.Errors.Should().Contain(e =>
             e.PropertyName == nameof(SolicitarProgramacionTurno.Fechas));
+    }
+
+    // Issue #331 CA-1/CA-2: Sede es opcional -- ausente (null) sigue siendo un comando valido, el
+    // comportamiento actual (anterior a este issue) queda intacto.
+    [Fact]
+    public async Task Validar_EsValido_CuandoSedeEsNull()
+    {
+        var comando = ComandoValido() with { Sede = null };
+
+        var resultado = await _validator.ValidateAsync(
+            comando, TestContext.Current.CancellationToken);
+
+        resultado.IsValid.Should().BeTrue();
+    }
+
+    // Issue #331 CA-1: sede presente y con Id/Nombre validos sigue siendo un comando valido.
+    [Fact]
+    public async Task Validar_EsValido_CuandoSedeTieneIdYNombre()
+    {
+        var comando = ComandoValido() with { Sede = new SedeProgramada("SEDE-01", "Sede Principal") };
+
+        var resultado = await _validator.ValidateAsync(
+            comando, TestContext.Current.CancellationToken);
+
+        resultado.IsValid.Should().BeTrue();
+    }
+
+    // Issue #331 CA-3: sede presente pero con Id vacio se rechaza en el validator (400), antes de
+    // tocar el aggregate.
+    [Fact]
+    public async Task Validar_TieneErrorEnSedeId_CuandoSedeTieneIdVacio()
+    {
+        var comando = ComandoValido() with { Sede = new SedeProgramada("", "Sede Principal") };
+
+        var resultado = await _validator.ValidateAsync(
+            comando, TestContext.Current.CancellationToken);
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e =>
+            e.PropertyName.Contains(nameof(SedeProgramada.Id)));
+    }
+
+    // Issue #331 CA-3: sede presente pero con Nombre en blanco se rechaza en el validator (400).
+    [Fact]
+    public async Task Validar_TieneErrorEnSedeNombre_CuandoSedeTieneNombreEnBlanco()
+    {
+        var comando = ComandoValido() with { Sede = new SedeProgramada("SEDE-01", "   ") };
+
+        var resultado = await _validator.ValidateAsync(
+            comando, TestContext.Current.CancellationToken);
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e =>
+            e.PropertyName.Contains(nameof(SedeProgramada.Nombre)));
     }
 }

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/ValueObjects/SedeProgramadaIgualdadTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/ValueObjects/SedeProgramadaIgualdadTests.cs
@@ -1,0 +1,22 @@
+// Issue #331: Tests de contrato IEquatable para SedeProgramada (record propio de
+// Programacion.DomainEvents). Todos los campos son string: la igualdad por valor del record por
+// defecto ya es correcta, sin Equals/GetHashCode custom -- mismo criterio que Empleado (issue #319).
+
+using Bitakora.ControlAsistencia.Programacion.DomainEvents;
+
+namespace Bitakora.ControlAsistencia.Programacion.Tests.ValueObjects;
+
+public class SedeProgramadaIgualdadTests : IgualdadTestBase<SedeProgramada>
+{
+    protected override SedeProgramada CrearInstancia() =>
+        new("SEDE-01", "Sede Principal");
+
+    protected override SedeProgramada CrearInstanciaCopia() =>
+        new("SEDE-01", "Sede Principal");
+
+    protected override IEnumerable<(string, SedeProgramada)> CrearInstanciasDiferentes()
+    {
+        yield return ("Id", new SedeProgramada("SEDE-02", "Sede Principal"));
+        yield return ("Nombre", new SedeProgramada("SEDE-01", "Sede Norte"));
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/ValueObjects/SedeProgramadaParidadConDetalleSedeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/ValueObjects/SedeProgramadaParidadConDetalleSedeTests.cs
@@ -1,0 +1,29 @@
+// Issue #331: guardrail de la duplicacion deliberada de payload por rol (tres islas,
+// CA-ADR-0029 decisiones #2 y #5): SedeProgramada (Programacion.DomainEvents) y DetalleSede
+// (PrivateEvents) declaran el mismo dato en dos ensamblados que no se referencian entre si.
+// Sin este guardrail, agregar un campo a uno de los dos no rompe nada y el dato se pierde en
+// silencio en MapearSede -- el mismo modo de fallo que ya cubren los cuatro pares de gemelos
+// anteriores (Empleado/InformacionEmpleado #319, TurnoProgramado/DetalleTurno,
+// FranjaProgramada/DetalleFranjaOrdinaria, SubFranjaProgramada/DetalleSubFranja).
+
+using System.Reflection;
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.PrivateEvents.Programacion;
+using Bitakora.ControlAsistencia.Programacion.DomainEvents;
+
+namespace Bitakora.ControlAsistencia.Programacion.Tests.ValueObjects;
+
+public class SedeProgramadaParidadConDetalleSedeTests
+{
+    private static IEnumerable<(string Nombre, Type Tipo)> Campos<T>() =>
+        typeof(T).GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Select(p => (p.Name, p.PropertyType));
+
+    [Fact]
+    public void SedeProgramada_DeclaraLosMismosCamposQueDetalleSede()
+    {
+        var campos = Campos<SedeProgramada>();
+
+        campos.Should().Equal(Campos<DetalleSede>());
+    }
+}


### PR DESCRIPTION
## Resumen

Pipeline TDD completado:
- Fase roja: tests escritos con stubs
- Fase verde: implementación completa
- Smoke tests: escritos para endpoints detectados
- Fase refactor: revisión de calidad

## Decisiones del pipeline

<details>
<summary>Test Writer (fase roja) — 11m 49s</summary>

## ES Test Writer - Decisiones (Issue #331)

### Tests creados

- `SolicitarProgramacionTurnoCommandHandlerTests.cs`: +2 tests (sobre la clase existente)
  - `SolicitarProgramacionTurno_PersisteYPublicaLaSedeProgramada_CuandoLaSolicitudIncluyeSede` - CA-1 (rojo: `Sede` nunca se mapea del comando al evento)
  - `SolicitarProgramacionTurno_DejaSedeEnNull_CuandoLaSolicitudNoIncluyeSede` - CA-2 (verde por diseno: es la ruta "sin cambio")
- `SolicitarProgramacionTurnoValidatorTests.cs`: +4 tests
  - `Validar_EsValido_CuandoSedeEsNull` - CA-2 (verde: no hay regla que lo bloquee)
  - `Validar_EsValido_CuandoSedeTieneIdYNombre` - documenta que sede valida no rompe el validator (verde)
  - `Validar_TieneErrorEnSedeId_CuandoSedeTieneIdVacio` - CA-3 (rojo: el validator aun no tiene la regla)
  - `Validar_TieneErrorEnSedeNombre_CuandoSedeTieneNombreEnBlanco` - CA-3 (rojo)
- `ProgramacionTurnoSolicitadaSerializacionTests.cs`: +2 tests
  - `Deserializar_DejaSedeEnNull_CuandoElJsonPersistidoNoLlevaEseCampo` - CA-4 (verde: retrocompat, mismo mecanismo que Descripcion #288)
  - `RoundTrip_PreservaLaSede_CuandoLaSedeEstaPoblada` - CA-5 lado event store, con `CrearOpcionesMarten()` (verde: guardrail de tipo, no de wiring)
- `ProgramacionTurnoDiarioSolicitadaPortabilidadTests.cs` (ControlHoras.Tests, precedente establecido en #288): +2 tests
  - `RoundTrip_PreservaLaSede_ConSerializadorPorDefectoDelBus` - CA-5 lado bus (verde: DTO plano, portable sin resolver)
  - `Deserializar_DejaSedeEnNull_CuandoEventoNoLlevaElCampo` - CA-2/CA-4 parity en el lado del bus (verde)
- `SedeProgramadaIgualdadTests.cs` (Programacion.Tests/ValueObjects, nuevo) - 8 tests heredados de `IgualdadTestBase<SedeProgramada>` (verde: record por defecto)
- `DetalleSedeIgualdadTests.cs` (PrivateEvents.Tests/Programacion, nuevo) - 8 tests heredados de `IgualdadTestBase<DetalleSede>` (verde: record por defecto)

Total: 4 archivos de test nuevos, 5 archivos de test existentes extendidos.

### Estructura elegida

- Tests del handler/validator/serializacion/portabilidad se **agregaron a los archivos
  existentes** (no se crearon archivos nuevos) porque extienden la MISMA responsabilidad
  ya cubierta ahi (mismo handler, mismo validator, mismo evento) -- consistente con la
  regla "un archivo de test por clase de produccion" y con el precedente de #288/#319
  (campos aditivos se agregan al archivo existente).
- Los tests de igualdad de los DOS records nuevos siguen el patron `IgualdadTestBase<T>`
  ya establecido (`EmpleadoIgualdadTests.cs`, `DetalleEmpleadoIgualdadTests.cs`), un
  archivo por tipo, ubicados en el mismo proyecto/carpeta que sus hermanos.

### Stubs y cambios minimos de produccion

Todos son campos aditivos y opcionales (`= null` por defecto), diseñados para que el
handler compile SIN tocarlo (ninguna linea de mapeo `command.Sede -> evento.Sede` fue
escrita por este agente, esa es la implementacion real que le corresponde al implementer):

- `SedeProgramada` (Programacion.DomainEvents, nuevo) - record plano `(string Id, string Nombre)`.
- `DetalleSede` (PrivateEvents/Programacion, nuevo) - record plano gemelo, mismos campos.
- `SolicitarProgramacionTurno` (comando) - gana `SedeProgramada? Sede = null`.
- `ProgramacionTurnoSolicitada` (evento persistido) - gana `SedeProgramada? Sede` (ctor
  param opcional, asignacion directa -- dato, no logica).
- `ProgramacionTurnoDiarioSolicitada` (evento privado) - gana `DetalleSede? Sede` (mismo patron).
- `SolicitudProgramacionAggregateRoot` - gana `internal SedeProgramada? Sede` y
  `Apply` lo copia del evento (pass-through trivial, mismo criterio ya usado para
  Empleado/Fechas/DetalleTurno en este mismo Apply).
- `SolicitarProgramacionTurnoCommandHandler.cs` - **sin cambios**. El comando y los dos
  eventos tienen el nuevo parametro con default `null`, asi que el handler sigue
  compilando construyendo los eventos con la firma vieja -- el resultado es que `Sede`
  siempre viaja en `null` hasta que el implementer agregue el pase de `command.Sede`.
- `SolicitarProgramacionTurnoValidator.cs` - **sin cambios**. Sin regla para Sede, por
  eso CA-3 esta en rojo.

### Decisiones de diseno

- **Por que el handler no se toco**: a diferencia del precedente #319 (donde el mapeo
  requeria TRANSFORMAR un tipo en otro y por eso se stubeo con
  `throw new NotImplementedException()`), aqui el comando YA reutiliza el tipo del
  evento persistido (`SedeProgramada`), asi que un simple pase directo del campo seria
  la implementacion real de CA-1. Dejar el handler intacto (los nuevos parametros
  opcionales caen en su default `null`) logra el mismo efecto -- CA-1 en rojo -- sin
  necesidad de un stub que lance excepcion, y sin escribir el mapeo real.
- **Por que CA-2/CA-4 (y las 16 pruebas de igualdad, y el round-trip CA-5) pasan en
  verde ya en esta fase**: son guardias de regresion/tipo, no aserciones sobre la
  feature nueva. CA-2 verifica que "ausencia de sede => Sede null" (la ruta que YA es el
  comportamiento por defecto de un campo opcional sin wiring); CA-4 verifica
  retrocompatibilidad de JSON viejo (mismo mecanismo mecanico que Descripcion, #288); el
  round-trip de serializacion (CA-5) y los tests de igualdad certifican que los TIPOS
  `SedeProgramada`/`DetalleSede` estan bien formados, independientemente de si el
  handler ya los popula. Esto es consistente con el principio fundamental del rol: los
  tests que ejercitan la FEATURE (CA-1, CA-3) estan en rojo; los que ejercitan
  invariantes tecnicas colaterales (serializacion, igualdad, backward-compat) pasan
  porque no dependen de logica de negocio pendiente.
- **DetalleSede no lleva mapeo explicito en el handler**: no hizo falta declarar un
  metodo `MapearSede` stub porque el handler nunca invoca ningun mapeo nuevo (se dejo
  intacto). El implementer debera anadir tanto el pase directo hacia el evento
  persistido como una conversion `SedeProgramada -> DetalleSede` (analoga a
  `MapearEmpleado`) para el evento que cruza el bus.
- **CA-3 sin .resx**: el validator existente (`SolicitarProgramacionTurnoValidator`) no
  usa mensajes custom -- sus tests solo verifican `PropertyName`, nunca el texto del
  mensaje (ver tests preexistentes de Empleado en el mismo archivo). Se siguio el mismo
  criterio para Sede: no se creo infraestructura de mensajes .resx porque no hace falta
  verificar contenido de mensaje, solo que la propiedad quede marcada con error.

### Cobertura de criterios

| Criterio de aceptacion | Test(s) |
|---|---|
| CA-1: sede presente persiste con Sede poblada en ambos eventos | `SolicitarProgramacionTurno_PersisteYPublicaLaSedeProgramada_CuandoLaSolicitudIncluyeSede`, `Validar_EsValido_CuandoSedeTieneIdYNombre` |
| CA-2: sede ausente/null deja Sede en null, comportamiento intacto | `SolicitarProgramacionTurno_DejaSedeEnNull_CuandoLaSolicitudNoIncluyeSede`, `Validar_EsValido_CuandoSedeEsNull`, `Deserializar_DejaSedeEnNull_CuandoEventoNoLlevaElCampo` |
| CA-3: sede con Id o Nombre vacio responde 400 sin emitir eventos | `Validar_TieneErrorEnSedeId_CuandoSedeTieneIdVacio`, `Validar_TieneErrorEnSedeNombre_CuandoSedeTieneNombreEnBlanco` |
| CA-4: JSON persistido sin campo Sede deserializa con Sede=null | `Deserializar_DejaSedeEnNull_CuandoElJsonPersistidoNoLlevaEseCampo` |
| CA-5: round-trip de serializacion con sede poblada (Marten + bus) | `RoundTrip_PreservaLaSede_CuandoLaSedeEstaPoblada`, `RoundTrip_PreservaLaSede_ConSerializadorPorDefectoDelBus` |
| CA-6: suite completa en verde | Verificado por el implementer al cerrar el ciclo; en esta fase 196/199 (Programacion.Tests) en verde y 3 en rojo exactamente donde se espera (CA-1 x1, CA-3 x2) |

### Verificacion manual de la fase roja

- `dotnet build` -> compila sin errores.
- `dotnet test` sobre `Programacion.Tests`: 199 tests, 3 en error (los de CA-1/CA-3
  arriba), 196 correctos.
- `dotnet test` sobre `ControlHoras.Tests` y `PrivateEvents.Tests`: 100% verde (417 y 50
  respectivamente) -- confirma que el cambio aditivo no rompe nada del lado consumidor
  ni de los contratos de igualdad.

### Desviaciones del plan del planner

Ninguna - las sugerencias del planner (tipos `SedeProgramada`/`DetalleSede` como records
posicionales sin Equals custom, reuso de `SedeProgramada` en el comando, sin mensajes
.resx nuevos) se aplicaron tal cual.

</details>

<details>
<summary>Implementer (fase verde) — 3m 5s</summary>

## ES Implementer - Decisiones

### Enfoque de implementacion

El test-writer ya habia dejado la mayor parte del trabajo de forma (records `SedeProgramada` y
`DetalleSede`, el campo `Sede` en `ProgramacionTurnoSolicitada`/`ProgramacionTurnoDiarioSolicitada`,
la propiedad `Sede` en `SolicitudProgramacionAggregateRoot` con su `Apply`, y el campo `Sede` en el
record del comando `SolicitarProgramacionTurno`) ya compilando y con los tests de serializacion/
igualdad en verde desde el commit de fase roja. Lo que faltaba era estrictamente el orquestador
(`SolicitarProgramacionTurnoCommandHandler`) y el `SolicitarProgramacionTurnoValidator`:

1. **CommandHandler**: propagar `command.Sede` (ya `SedeProgramada?`) al construir
   `ProgramacionTurnoSolicitada` -- snapshot directo, sin transformacion, porque el evento
   persistido y el comando comparten el mismo tipo (`SedeProgramada`, `Programacion.DomainEvents`).
   Para el evento que cruza el bus, se agrego el metodo `MapearSede` (mismo patron que
   `MapearEmpleado`/`MapearTurno`/`MapearFranja`/`MapearSubFranja` ya existentes): unico punto de
   traduccion `SedeProgramada -> DetalleSede`, con `null` conservado si la sede esta ausente.
2. **Validator**: agregar un bloque `When(x => x.Sede is not null, ...)` con `NotEmpty()` sobre
   `Sede!.Id` y `Sede!.Nombre` -- mismo patron que el bloque `When` ya existente para `Empleado`.
   Sede ausente (null) sigue siendo valido; sede presente con Id o Nombre vacio/en blanco falla la
   validacion (400), sin tocar el aggregate.

### Decisiones de diseno

- El mapeo `SedeProgramada -> DetalleSede` es simetrico y campo a campo (Id, Nombre), igual que
  `Empleado -> DetalleEmpleado`: ambos son records planos de strings sin logica de transformacion.
- Se dejo `MapearSede` como metodo privado estatico junto a los demas metodos `Mapear*` del
  handler, respetando el "unico punto de mapeo" que documentan los comentarios existentes del
  archivo (precedente issue #319 CA-5).
- El validator usa `Sede!.Id`/`Sede!.Nombre` (null-forgiving) dentro del bloque `When`, mismo
  patron que el bloque `When` de `Empleado` en el mismo archivo -- FluentValidation solo evalua las
  reglas internas cuando el predicado del `When` es verdadero, asi que el `!` es seguro en runtime.

### ADRs consultados

- CA-ADR-0029 / MEF-ADR-0039: tres islas y payload por rol -- verificado que `SedeProgramada`
  (dominio) y `DetalleSede` (bus) son gemelos sin referencias cruzadas; el unico punto que conoce
  ambos tipos es el CommandHandler de la Function App (mismo criterio que Empleado/DetalleEmpleado
  y TurnoProgramado/DetalleTurno).
- CA-ADR-0029 decision #6 / MEF-ADR-0036: no se modifico ningun alias ni tipo de evento existente,
  solo se agrego un campo opcional -- no aplica registro nuevo en `IdentidadEventos{Dominio}`
  porque `ProgramacionTurnoSolicitada` ya estaba registrado (sin cambio de tipo ni de namespace).
- MEF-ADR-0012: records por valor con igualdad por defecto (`SedeProgramada`, `DetalleSede`) ya
  verificados en verde por los tests de igualdad del test-writer; no se toco serializacion.
- MEF-ADR-0009: no se agregaron mensajes nuevos en `.resx` -- las reglas `NotEmpty()` del
  validator no requieren mensaje custom (los tests solo verifican `PropertyName`, no el texto).

### Desviaciones de ADRs

Ninguna desviacion -- todos los ADRs aplicados al pie de la letra.

### Desviaciones del plan del planner

Ninguna desviacion -- el "Impacto esperado en archivos" del issue listaba exactamente el
CommandHandler y el Validator como los archivos a modificar para completar la cadena; el resto ya
lo habia resuelto el test-writer.

### Precedentes consultados

- `MapearEmpleado`/`MapearTurno`/`MapearFranja`/`MapearSubFranja` (mismo archivo, issue #319):
  patron de mapeo campo a campo hacia el payload de bus -- alineado con CA-ADR-0029 decision #5,
  replicado tal cual para `MapearSede`.
- Bloque `When(x => x.Empleado is not null, ...)` del validator (issue original HU-225): patron de
  validacion condicional de un objeto anidado opcional -- alineado, replicado para `Sede`.

### Infraestructura modificada

Ninguna. El topic `programacion-turno-diario-solicitada` y sus subscripciones ya existen (lo
consume ControlHoras desde antes de este issue); el campo `Sede` es aditivo sobre un evento
privado ya publicado, sin nuevo topic ni nueva subscripcion.

### Complejidad encontrada

Ninguna. El test-writer dejo el modelo de datos (records, propiedades del aggregate, campo del
comando) completamente resuelto y compilando; el trabajo de la fase verde se redujo a conectar el
dato ya tipado a traves del unico orquestador (CommandHandler) y a la regla de validacion en el
borde HTTP (Validator). Un solo intento por archivo, sin iteraciones.

### Resultado

- Tests pasando: 761/761 (12 omitidos por falta de infraestructura externa -- ServiceBus/Postgres
  no configurados en este entorno local, comportamiento esperado y preexistente en smoke tests).

</details>
<details>
<summary>Smoke Test Writer — 3m 3s</summary>

_(El agente no generó resumen)_

</details>
<details>
<summary>Reviewer (fase refactor) — 14m 58s</summary>

## ES Reviewer - Revision

### Evaluacion general
- Calidad: **buena**
- Cambios realizados: **si** (commit `29dc0e4`, solo tests -- ningun cambio de codigo de produccion)

El diff de produccion es minimo, aditivo y correcto: dos records planos gemelos, un campo opcional
en cada uno de los dos eventos, una propiedad en el aggregate, un mapeo en el unico punto que ve
los tres ensamblados (el CommandHandler) y un bloque `When` en el validator. No encontre ningun
defecto en el codigo de produccion. Los cuatro cambios que hice son sobre **guardrails de test**
que estaban debiles o faltaban.

---

### Cumplimiento de ADRs aplicables

| ADR | Cumplimiento | Observacion |
|---|---|---|
| CA-ADR-0029 (ensamblados de eventos por rol) | ok | `SedeProgramada` (DomainEvents) y `DetalleSede` (PrivateEvents) son gemelos con paridad de campos, cero referencias cruzadas; el unico punto que ve ambos es `SolicitarProgramacionTurnoCommandHandler.MapearSede`. **Faltaba el guardrail de paridad** que el repo ya tiene para los otros cuatro pares -- lo agregue (ver "Tests agregados"). |
| CA-ADR-0029 decision #6 / MEF-ADR-0036 (identidad del evento persistido) | ok | Ningun tipo movido ni renombrado; `IdentidadEventosProgramacion.TiposPersistidos` intacto; alias sin cambio. No aplica protocolo de dos despliegues. |
| MEF-ADR-0012 (modelado de objetos de dominio) | ok | Ver checklist de antipatrones abajo. |
| MEF-ADR-0002 / MEF-ADR-0016 (testing y naming) | **desviacion NO declarada, corregida** | El DSL Given/WhenAsync/Then/And, `[Fact]` y fakes manuales estan bien. Tres smoke tests nuevos violaban MEF-ADR-0016 (`Debe...` sin sujeto / `DebeRetornar400`). Renombrados. |
| MEF-ADR-0009 (mensajes en .resx) | ok / no aplica | El ADR excluye explicitamente a FluentValidation del patron .resx (linea 104: "*Mensajes de validacion de FluentValidation -> inline en el validator con `.WithMessage(...)`*"). El validator no agrega mensajes custom, igual que sus reglas hermanas. La redaccion del issue ("si el validator agrega mensajes nuevos, van en .resx") es imprecisa frente al ADR; no hay nada que corregir. |
| MEF-ADR-0039 | **no verificable** | **No existe en el plugin instalado** (`mefisto/0.20.0` llega hasta MEF-ADR-0038; `find` sobre el cache no encuentra `*adr-0039*` ni referencias a el en ningun ADR del marco). Verifique contra **CA-ADR-0029**, que se declara "aplicacion local" de ese canon y cita sus decisiones #2/#5/#6 textualmente. **Escalar al planner**: o el plugin esta desactualizado frente al harness, o la numeracion citada en el issue (y en comentarios de produccion preexistentes) apunta a un ADR que no esta publicado. |

#### Checklist de antipatrones MEF-ADR-0012 (recorrido explicito)

| # | Antipatron | Veredicto |
|---|---|---|
| 1 | Propiedad publica nueva en VO/aggregate cuyo unico consumidor es un externo | no aplica. `SolicitudProgramacionAggregateRoot.Sede` es `internal`, no publica, y replica exactamente el patron de `Empleado`/`Fechas`/`DetalleTurno` que ya vivian ahi (estado acumulado por `Apply`, visible a tests via `InternalsVisibleTo`, que es lo que el `And<>()` del DSL exige). No hay servicio externo operando sobre ella. |
| 2 | Clase estatica que opera sobre datos crudos de un VO | no aplica. `MapearSede` es un mapeo campo a campo entre dos ensamblados que **no pueden** referenciarse (tres islas) -- es exactamente el caso que CA-ADR-0029 decision #5 manda ubicar en el Function App, no una operacion de dominio extraida del objeto. |
| 3 | Getter expuesto solo para tests | no aplica (ver #1: `internal`, patron preexistente del aggregate). |
| 4 | `InternalsVisibleTo` de Contracts hacia dominio | no aplica (`Contracts` ya no existe; los `InternalsVisibleTo` presentes son dominio -> su propio proyecto de tests). |
| 5 | `[JsonConstructor]` en ctor privado | no aplica. Ningun `[JsonConstructor]` en el diff. |
| 6 | `record` con `IReadOnlyList<T>` en la igualdad | no aplica. Ambos gemelos son `record` de dos `string`: la igualdad por defecto es correcta y esta cubierta por `IgualdadTestBase<T>`. |
| 7 | Evento con marker de bus cargando modelo rico | **verificado ok**. `ProgramacionTurnoDiarioSolicitada : IPrivateEvent` gana `DetalleSede?`, un record de dos `string` -- plano y portable con `JsonSerializerOptions` por defecto. El guardrail de round-trip **sin resolver custom** existe (`RoundTrip_PreservaLaSede_ConSerializadorPorDefectoDelBus`, con `new JsonSerializerOptions(JsonSerializerDefaults.Web)` + `ServiceBusDeserializador`), no es el falso verde de `CrearOpcionesMarten()`. |

---

### Desviaciones de ADRs

**Desviaciones declaradas por el implementer**: ninguna (su resumen dice "Ninguna desviacion").
Coincido: no encontre ninguna que ameritara declaracion en el codigo de produccion.

**Desviaciones detectadas por el reviewer (NO declaradas por el implementer)**:

#### Desviacion: MEF-ADR-0016 (convencion de naming de tests)
- **Regla del ADR**: patron unico `<Sujeto>_<LoQuePasa>[_Cuando<Condicion>]`, aplicable
  explicitamente tambien a smoke tests (ejemplo del ADR:
  `RegistrarMarcacion_PublicaMarcacionRegistrada_CuandoSeInvocaElEndpoint`). El sujeto de un
  command handler / endpoint es el nombre del comando, nunca `Debe...`.
- **Desviacion encontrada en el diff**:
  `SolicitarProgramacionTurnoSmokeTests.cs` -- `DebePublicarProgramacionTurnoDiarioSolicitada_ConSedeCorrecta_...`
  (sin sujeto, prefijo `Debe`) y `..._DebeRetornar400_CuandoSedeTieneIdVacio` /
  `..._DebeRetornar400_CuandoSedeTieneNombreEnBlanco` (`DebeRetornar400` en vez de `Retorna400`).
- **Accion tomada**: corregida en refactor. El ADR reconoce que ~60 tests legados conviven con el
  patron viejo y se migran en issue aparte; eso cubre a los hermanos preexistentes del archivo,
  no a tests nuevos.
- **Status**: pendiente de evaluacion del usuario.

#### Desviacion: MEF-ADR-0039 no localizable
- **Regla del ADR**: no verificable.
- **Desviacion encontrada**: el issue lo lista como ADR aplicable y varios comentarios de
  produccion (preexistentes, de #319) lo citan por numero, pero no existe en el plugin instalado.
- **Accion tomada**: verifique contra CA-ADR-0029 (aplicacion local declarada del mismo canon).
  No corregible desde este PR.
- **Status**: escalado al planner; pendiente de evaluacion del usuario.

---

### Precedentes consultados por el implementer

| Precedente | ADR aplicable | Veredicto |
|---|---|---|
| `MapearEmpleado`/`MapearTurno`/`MapearFranja`/`MapearSubFranja` (mismo archivo, #319) | CA-ADR-0029 #5 | alineado. Es el punto unico de traduccion en el unico proyecto que ve los tres ensamblados. |
| Bloque `When(x => x.Empleado is not null, ...)` del validator | -- (convencion FluentValidation) | alineado. Mismo predicado + `NotEmpty()`; `NotEmpty()` cubre null, vacio y blanco, que es lo que CA-3 pide. |
| `Empleado` / `DetalleEmpleado` como gemelos sin `Equals` custom (#318/#319) | MEF-ADR-0012 | alineado. Y el precedente trae ademas el guardrail de paridad que el diff habia omitido -- ese si fue un hallazgo (ver abajo). |
| Campo aditivo tolerante `Descripcion` (#288) | MEF-ADR-0005 | alineado, pero el precedente es **mas fuerte** que lo que el diff copio: el test de #288 deserializa un JSON literal **sin la clave**; el nuevo serializaba un `null` explicito. Corregido. |

---

### Convenciones del pipeline (no ADRs)

| Convencion | Estado | Observacion |
|---|---|---|
| Cada test con `Then()` + `And<>()` | ok | Los dos tests nuevos del handler tienen `Then(...)`, `ThenIsPublishedPrivately(...)` y `And<SolicitudProgramacionAggregateRoot, SedeProgramada?>(s => s.Sede, ...)`. |
| Overloads correctos para stream IDs compuestos | ok / n/a | `SolicitudProgramacionAggregateRoot` no tiene `ComputarStreamId`; su `Id` sale de `e.Id.ToString()` sobre el mismo `GuidAggregateId` del DSL, asi que el overload sin `aggregateId` es el correcto (igual que todos los tests preexistentes del archivo). |
| Fakes manuales (no NSubstitute) | ok | El handler solo depende de `IEventStore` e `IPrivateEventSender`, ambos provistos por `CommandHandlerAsyncTest`. Cero NSubstitute. |
| Feature folders (produccion y tests) | ok | Sin carpetas nuevas de produccion; `SedeProgramada.cs` en la raiz de `Programacion.DomainEvents` y `DetalleSede.cs` en `PrivateEvents/Programacion/`, junto a sus hermanos. Tests espejo: `Programacion.Tests/ValueObjects/`, `PrivateEvents.Tests/Programacion/`. |
| Smoke tests: SkipWhen, secrets, cobertura | ok con reserva | `Assert.SkipWhen` presente en el test que usa `ServiceBusFixture`; `appsettings.json` con connection string vacio; `deploy-programacion.yml` pasa `SERVICEBUS_CONNECTION_STRING` y `expected_sha`; filtro por `SolicitudId` (nunca por posicion); un solo archivo por comando. Reserva: cobertura del efecto de persistencia -- ver "Criticas y hallazgos" #4. |
| Proyecciones read-side | n/a | El diff no toca `ReadModels`/`Projections` ni ninguna Function GET. |
| Compatibilidad Marten write-side/read-side | n/a | El diff no toca version de `Cosmos.EventSourcing.*` ni `ComposicionServicios*`, `ConfiguracionMarten*`, `ConfiguracionSerializacion*`, `IdentidadEventos*` ni ninguna linea de configuracion de Marten. |
| Identidad de stream (MEF-ADR-0037) | n/a | El diff no toca ninguna lectura/escritura de identidad de stream: `StartStream`/`ExistsAsync`/`GetAggregateRootAsync` conservan sus argumentos (`command.Id`, `command.TurnoId`), sin `ToString("N")` ni concatenaciones nuevas, y no hay endpoint GET. |
| Control de volumen de telemetria (MEF-ADR-0038) | n/a | El diff no toca `ComposicionServicios*`, `ConfiguracionObservabilidad*` ni el callback de Wolverine. |
| Tests via ToString/comportamiento | ok | Ningun getter nuevo abierto para tests. |
| Sin numeros magicos | ok | Los unicos literales nuevos son datos de prueba (`"SEDE-01"`, `"Sede Principal"`), ya extraidos a campos con nombre en cada archivo de test. |
| Condiciones en positivo | ok | `MapearSede` usa `sede is null ? null : new DetalleSede(...)`: es la forma "null-first" idiomatica para un mapeo opcional, no una guarda `if (!x)` en una bifurcacion `if/else`. `When(x => x.Sede is not null, ...)` ya esta en positivo. |

---

### Elegancia del codigo

El codigo de produccion ya era elegante y no lo toque:

- **Compacto**: 5 lineas de logica nueva en el handler (una asignacion, una llamada, un mapeo de
  una expresion) y 4 en el validator. Cero codigo muerto.
- **Legible**: los nombres revelan intencion (`SedeProgramada` = "la sede donde quedo programado",
  con la reserva del nombre `Sede` documentada en el propio `<remarks>`; `DetalleSede` sigue la
  convencion `Detalle*` = DTO del bus). Los comentarios explican el *por que* (snapshot, gemelos,
  nombre reservado), no el *que*.
- **Idiomatico**: records posicionales, parametro opcional con default `null`, expresion ternaria
  de una linea para el mapeo, `When(...)` de FluentValidation para la validacion condicional.
- **Robusto**: la validacion vive en el borde HTTP (400 antes de tocar el aggregate, verificado
  leyendo `FunctionEndpoint`: `ValidarAsync` corre antes de `InvokeAsync`), y `NotEmpty()` cubre
  null / vacio / blanco. `sede: {}` (objeto sin campos) tambien cae en 400 por la misma regla.
- **Eficiente**: `MapearSede` se evalua **una vez** fuera del `Select`, no una por fecha.
- **Limpio**: `dotnet build` sin ningun warning CS. Las 4 advertencias del build son `NU1902`
  (vulnerabilidad transitiva de `OpenTelemetry.Api` 1.14.0) y las 5 de `dotnet format` son
  `IDE0005` en archivos que este issue no toca -- deuda preexistente en `main`, fuera de alcance
  (regla #4).

Una observacion de elegancia que **no** convertí en refactor: el bloque "crear turno en catalogo"
del smoke test esta ahora duplicado en tres tests (el nuevo lo llevo al tercero). Es el disparador
tipico de la Rule of Three, pero MEF-ADR-0018 fija que *"el reviewer no debe pedir extraccion si el
implementer no la ofrece"*; lo dejo registrado como candidato para un issue de limpieza.

---

### Criticas y hallazgos

1. **Faltaba el guardrail de paridad del par de gemelos nuevo** (severidad: **mayor**, corregido).
   El repo tiene un test de paridad por reflexion para **cada** par de gemelos de CA-ADR-0029
   decision #5: `EmpleadoParidadConInformacionEmpleadoTests`,
   `TurnoProgramadoParidadConDetalleTurnoTests`, `FranjaProgramadaParidadConDetalleFranjaOrdinariaTests`,
   `SubFranjaProgramadaParidadConDetalleSubFranjaTests`. El quinto par (`SedeProgramada` /
   `DetalleSede`) no lo traia. Sin el, agregar un campo a uno solo de los dos gemelos compila,
   pasa todos los tests y **pierde el dato en silencio** en `MapearSede` -- exactamente el modo de
   fallo que la decision #5 documenta. Agregado.

2. **El test de retrocompatibilidad del lado bus no probaba lo que decia** (severidad: **mayor**,
   corregido). `Deserializar_DejaSedeEnNull_CuandoEventoNoLlevaElCampo` serializaba un evento con
   `Sede = null` y lo volvia a leer; con `JsonSerializerDefaults.Web` eso emite `"sede": null`
   explicito, asi que el test verificaba "un null sobrevive", no "la clave ausente produce null" --
   que es la forma real de los mensajes ya publicados. El precedente que el propio archivo cita
   (`Deserializar_DejaDescripcionEnCadenaVacia_...`, #288) si usa un JSON sin la clave. Reescrito
   para quitar la clave del JSON canonico, con `Remove("sede").Should().BeTrue()` para que el test
   no pueda volverse vacuo si la clave cambiara de nombre.

3. **CA-1 dice "cada evento diario" y el test usaba una sola fecha** (severidad: **menor**,
   corregido). Con una fecha, una implementacion que solo poblara el primer evento publicado
   pasaba en verde. El test ahora ejercita dos fechas y afirma la sede en ambos eventos.

4. **Smoke test con sede sin verificacion de dead letter del consumidor real** (severidad:
   **menor**, corregido). El issue afirma que "ControlHoras hoy IGNORA el campo nuevo (cambio
   aditivo y tolerante)" -- esa tolerancia era la unica afirmacion del issue sin ninguna evidencia
   end-to-end: el test que si revisa la DLQ de `control-horas-escucha-programacion` publica un
   mensaje **sin** el campo nuevo. Agregue la verificacion de DLQ acotada por `SolicitudId` al test
   que si lo pone en el cable.

5. **Cobertura del efecto de persistencia en smoke tests** (severidad: **menor**, NO corregido,
   fuera de alcance). El handler tiene dos efectos: `StartStream` (Postgres) y `PublishAsync`
   (Service Bus). El smoke test cubre el segundo; el primero no es observable porque
   `Programacion.SmokeTests` no tiene `PostgresFixture` (solo existe en `ControlHoras.SmokeTests`)
   ni `deploy-programacion.yml` pasa `Postgres__ConnectionString`. No lo marco `n/a`: es una
   brecha real, pero **no la introduce este issue** (el efecto de persistencia ya existia sin
   cobertura de smoke) y cerrarla implica fixture nuevo + secret nuevo en el workflow. La sede en
   el evento **persistido** si queda cubierta por tests unitarios (CA-4 y CA-5, contra
   `CrearOpcionesMarten()`). **Recomiendo issue aparte** para dotar a `Programacion.SmokeTests` de
   `PostgresFixture`.

6. **El comando HTTP reutiliza un tipo de `Programacion.DomainEvents`** (severidad: **cosmetico /
   observacion de diseno**, NO corregido). `SolicitarProgramacionTurno` declara
   `SedeProgramada? Sede`, es decir el contrato HTTP queda amarrado al tipo del event store -- el
   contrato mas longevo del sistema segun CA-ADR-0029. El issue lo propone explicitamente ("el
   record del comando reutiliza el tipo de DomainEvents") y el precedente vivo es identico
   (`InformacionEmpleado` de `PublicEvents` en el mismo comando, deliberadamente dejado fuera del
   alcance de #319), asi que **no es una violacion**: la decision #5 restringe que un payload cruce
   *ensamblados de eventos*, y la Function App los ve los tres. Lo dejo anotado porque el ejemplo
   canonico de la propia decision #5 (`CrearTurno` con su `Franja` anidado propio + `ToDatosFranjas()`)
   apunta en la direccion contraria; vale la pena que #335 decida conscientemente si la sede en la
   franja replica este atajo o declara su propio record de contrato HTTP.

7. **Dos smoke tests en rojo local: es el estado esperado pre-deploy, no un defecto**
   (severidad: informativa, NO corregido a proposito). `SolicitarProgramacionTurno_Retorna400_CuandoSedeTieneIdVacio`
   y `..._CuandoSedeTieneNombreEnBlanco` fallan con **404 en vez de 400**. Diagnostico verificado,
   no inferido: `GET https://func-asist-dev-programacion.azurewebsites.net/api/version` responde
   `fd641b7`, que `git merge-base --is-ancestor` confirma como **ancestro de la base de esta rama**
   (es el merge de #325 / issue #319). Es decir, dev todavia sirve codigo sin la regla de sede: el
   validator no rechaza, el handler corre y devuelve 404 porque el `turnoId` aleatorio del payload
   no existe en el catalogo. Con el codigo de este PR desplegado, el validator responde 400 antes
   de llegar al handler. **No afecta a CI**: tanto `ci.yml` como el job `build-and-test` de
   `deploy-programacion.yml` iteran sobre `tests/Bitakora.ControlAsistencia.*.Tests/`, glob que
   **no** matchea `*.SmokeTests/`; y el job de smoke corre despues del deploy, tras el readiness
   gate por SHA de `smoke-tests-dominio.yml`. **No modifique estos tests**: hacerlo seria degradar
   la especificacion para acomodar un entorno desactualizado. Suite unitaria: **734/734 en verde**
   (ControlHoras 417, Programacion 200, Projections 54, PrivateEvents 50, PublicEvents 13).

---

### Refactorings aplicados

Ninguno sobre codigo de produccion (no habia nada que mejorar). Sobre tests, commit `29dc0e4`:

1. `SedeProgramadaParidadConDetalleSedeTests.cs` (nuevo) -- cierra el hallazgo #1.
2. `ProgramacionTurnoDiarioSolicitadaPortabilidadTests.cs` -- reescrito el test de
   retrocompatibilidad del bus (hallazgo #2), con helper `JsonSinLaClaveSede()` que quita la clave
   del JSON canonico en vez de reescribir el mensaje a mano.
3. `SolicitarProgramacionTurnoCommandHandlerTests.cs` -- CA-1 con dos fechas (hallazgo #3).
4. `SolicitarProgramacionTurnoSmokeTests.cs` -- verificacion de dead letter (hallazgo #4) y tres
   renombres por MEF-ADR-0016.

Verificacion tras cada cambio: `dotnet test` del proyecto afectado, y `dotnet build` +
`dotnet format --verify-no-changes` al cierre. Ningun cambio hubo que revertir.

---

### Cobertura de criterios de aceptacion

| Criterio | Estado | Test(s) |
|---|---|---|
| CA-1: sede `{id, nombre}` persiste `SedeProgramada` y cada evento diario lleva `DetalleSede` | cubierto (reforzado) | `SolicitarProgramacionTurno_PersisteYPublicaLaSedeProgramada_CuandoLaSolicitudIncluyeSede` (ahora con dos fechas -- cubre el "cada"), `Validar_EsValido_CuandoSedeTieneIdYNombre`, smoke `SolicitarProgramacionTurno_PublicaElEventoDiarioConLaSede_CuandoLaSolicitudIncluyeSede` |
| CA-2: sin sede -> `Sede = null` en ambos eventos, comportamiento intacto | cubierto | `SolicitarProgramacionTurno_DejaSedeEnNull_CuandoLaSolicitudNoIncluyeSede`, `Validar_EsValido_CuandoSedeEsNull`, `Deserializar_DejaSedeEnNull_CuandoElMensajeNoLlevaLaClaveSede`, smoke `DebePublicarProgramacionTurnoDiarioSolicitada_CuandoSolicitudEsAceptada` (asercion `Sede == null` en ambos eventos) |
| CA-3: sede con Id o Nombre vacio/blanco -> 400 sin emitir eventos | cubierto | `Validar_TieneErrorEnSedeId_CuandoSedeTieneIdVacio`, `Validar_TieneErrorEnSedeNombre_CuandoSedeTieneNombreEnBlanco`, smoke `SolicitarProgramacionTurno_Retorna400_CuandoSedeTieneIdVacio` / `..._CuandoSedeTieneNombreEnBlanco` (rojas hasta el deploy, ver hallazgo #7). El "sin emitir eventos" lo garantiza estructuralmente `FunctionEndpoint`: `ValidarAsync` retorna antes de `commandRouter.InvokeAsync`. |
| CA-4: JSON persistido sin campo `Sede` deserializa con `Sede = null` | cubierto (reforzado) | `Deserializar_DejaSedeEnNull_CuandoElJsonPersistidoNoLlevaEseCampo` (event store, JSON literal sin la clave), `Deserializar_DejaSedeEnNull_CuandoElMensajeNoLlevaLaClaveSede` (bus, ahora si con la clave ausente) |
| CA-5: round-trip con sede poblada (Marten + serializador por defecto del bus) | cubierto | `RoundTrip_PreservaLaSede_CuandoLaSedeEstaPoblada` (`CrearOpcionesMarten()`), `RoundTrip_PreservaLaSede_ConSerializadorPorDefectoDelBus` (`JsonSerializerDefaults.Web` + `ServiceBusDeserializador`, sin resolver custom -- el guardrail que MEF-ADR-0012 exige para un `IPrivateEvent`) |
| CA-6: suite completa en verde | cubierto con salvedad | 734/734 tests unitarios verdes. Los 2 smoke tests rojos son el estado esperado pre-deploy (hallazgo #7), no gatean CI. |

---

### Tests agregados

- `tests/Bitakora.ControlAsistencia.Programacion.Tests/ValueObjects/SedeProgramadaParidadConDetalleSedeTests.cs`
  (nuevo): guardrail de paridad de campos del par de gemelos, por reflexion -- el quinto par de
  CA-ADR-0029 decision #5 que faltaba.
- Reescritura de `Deserializar_DejaSedeEnNull_CuandoElMensajeNoLlevaLaClaveSede` (antes
  `..._CuandoEventoNoLlevaElCampo`) para que ejercite la ausencia real de la clave.
- Extension de la cobertura de CA-1 a dos fechas.
- Asercion de ausencia de dead letter en el consumidor real dentro del smoke test con sede.
- Tests de contrato de igualdad y de serializacion: **ya venian completos** del test-writer
  (`SedeProgramadaIgualdadTests`, `DetalleSedeIgualdadTests` sobre `IgualdadTestBase<T>`, mas los
  dos round-trips). No hizo falta agregar ninguno.

</details>

## Commits

29dc0e4 refactor(issue-331): endurecer guardrails de la sede y alinear naming de tests
5d10f95 test(issue-331): smoke tests para sede en la solicitud de programacion
0041b26 feat(issue-331): registrar la sede en la solicitud de programacion (fase verde)
645c622 test(issue-331): tests para sede en la solicitud de programacion (fase roja)

Closes #331