### PR TITLE
Prearmar la sede por franja en los turnos del catalogo

### DIFF
--- a/.github/workflows/deploy-programacion.yml
+++ b/.github/workflows/deploy-programacion.yml
@@ -208,3 +208,7 @@ jobs:
       expected_sha: ${{ needs.deploy.outputs.sha }}
     secrets:
       SERVICEBUS_CONNECTION_STRING: ${{ secrets.SERVICEBUS_CONNECTION_STRING }}
+      # Issue #335: turno_creado no cruza ningun bus, asi que la unica verificacion black-box de su
+      # contenido persistido es leer mt_events del schema 'programacion' (MEF-ADR-0013, cobertura
+      # completa de efectos secundarios). El reusable ya aceptaba este secret opcional.
+      POSTGRES_CONNECTION_STRING: ${{ secrets.POSTGRES_CONNECTION_STRING }}

--- a/src/Bitakora.ControlAsistencia.Programacion.DomainEvents/DatosFranja.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion.DomainEvents/DatosFranja.cs
@@ -5,8 +5,7 @@ namespace Bitakora.ControlAsistencia.Programacion.DomainEvents;
 // el factory no dependa del comando CrearTurno, que vive en la Function App y dejaria el
 // grafo de referencias en ciclo. El comando se convierte con CrearTurno.ToDatosFranjas().
 // Issue #335: Sede es campo aditivo y opcional -- se propaga a FranjaOrdinaria.Crear() dentro de
-// TurnoCreado.Crear(). El mapeo comando -> DatosFranja (CrearTurno.ToDatosFranjas()) queda
-// pendiente para el implementer (fase roja).
+// TurnoCreado.Crear(). El mapeo comando -> DatosFranja lo hace CrearTurno.ToDatosFranjas().
 public record DatosFranja(
     TimeOnly Inicio,
     TimeOnly Fin,

--- a/src/Bitakora.ControlAsistencia.Programacion.DomainEvents/DatosFranja.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion.DomainEvents/DatosFranja.cs
@@ -4,8 +4,12 @@ namespace Bitakora.ControlAsistencia.Programacion.DomainEvents;
 // No es payload del evento -- el payload es FranjaOrdinaria, el VO rico. Existe para que
 // el factory no dependa del comando CrearTurno, que vive en la Function App y dejaria el
 // grafo de referencias en ciclo. El comando se convierte con CrearTurno.ToDatosFranjas().
+// Issue #335: Sede es campo aditivo y opcional -- se propaga a FranjaOrdinaria.Crear() dentro de
+// TurnoCreado.Crear(). El mapeo comando -> DatosFranja (CrearTurno.ToDatosFranjas()) queda
+// pendiente para el implementer (fase roja).
 public record DatosFranja(
     TimeOnly Inicio,
     TimeOnly Fin,
     List<(TimeOnly inicio, TimeOnly fin)> Descansos,
-    List<(TimeOnly inicio, TimeOnly fin)> Extras);
+    List<(TimeOnly inicio, TimeOnly fin)> Extras,
+    SedeProgramada? Sede = null);

--- a/src/Bitakora.ControlAsistencia.Programacion.DomainEvents/FranjaOrdinaria.Mensajes.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion.DomainEvents/FranjaOrdinaria.Mensajes.cs
@@ -1,0 +1,28 @@
+using System.Resources;
+
+namespace Bitakora.ControlAsistencia.Programacion.DomainEvents;
+
+// Issue #335: mensajes propios de FranjaOrdinaria (invariante y label de Sede), en .resx separado
+// (MEF-ADR-0009). Los demas mensajes/labels de FranjaOrdinaria (InicioYFinIguales, Descansos,
+// Extras) siguen viviendo en FranjaTemporal.Mensajes (compartido con SubFranja) -- Sede es
+// exclusiva de FranjaOrdinaria (SubFranja no tiene sede), asi que su Mensajes vive aqui, no alla.
+// internal: accesible desde tests via InternalsVisibleTo en el .csproj (mismo patron que
+// TurnoCreado.Mensajes).
+public sealed partial class FranjaOrdinaria
+{
+    private static readonly ResourceManager ResourceManager = new(
+        "Bitakora.ControlAsistencia.Programacion.DomainEvents.FranjaOrdinariaMensajes",
+        typeof(FranjaOrdinaria).Assembly);
+
+    // 'new' explicito: FranjaOrdinaria ya hereda FranjaTemporal.Mensajes (InicioYFinIguales,
+    // Descansos/Extras, contencion/solapamiento) -- este Mensajes propio SOLO cubre lo exclusivo
+    // de la sede, sin duplicar ni reemplazar los mensajes heredados.
+    internal new static class Mensajes
+    {
+        public static string SedeIncompleta =>
+            ResourceManager.GetString(nameof(SedeIncompleta))!;
+
+        public static string LabelSede =>
+            ResourceManager.GetString(nameof(LabelSede))!;
+    }
+}

--- a/src/Bitakora.ControlAsistencia.Programacion.DomainEvents/FranjaOrdinaria.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion.DomainEvents/FranjaOrdinaria.cs
@@ -6,19 +6,25 @@ namespace Bitakora.ControlAsistencia.Programacion.DomainEvents;
 // Segmento continuo de trabajo dentro de un turno.
 // Contiene sub-franjas de descanso y extras.
 // ADR-0015: sealed class con factory static, constructor privado, campos readonly.
-public sealed class FranjaOrdinaria : FranjaTemporal, IEquatable<FranjaOrdinaria>
+public sealed partial class FranjaOrdinaria : FranjaTemporal, IEquatable<FranjaOrdinaria>
 {
     private readonly List<SubFranja> _descansos;
     private readonly List<SubFranja> _extras;
 
+    // Issue #335: sede prearmada para esta franja del catalogo (null = sin sede asignada). Campo
+    // interno, sin propiedad publica (MEF-ADR-0012, Tell-don't-Ask) -- se expone SOLO via
+    // ToDetalle() y ToString() (pendiente de wiring: ver comentarios en Crear/ToDetalle/ToString).
+    private readonly SedeProgramada? _sede;
+
     // Constructor real: usado por el factory
     // diaOffsetInicio siempre es 0 — la ordinaria empieza en el dia base
     private FranjaOrdinaria(TimeOnly horaInicio, TimeOnly horaFin, int diaOffsetFin,
-        List<SubFranja> descansos, List<SubFranja> extras)
+        List<SubFranja> descansos, List<SubFranja> extras, SedeProgramada? sede)
         : base(horaInicio, horaFin, diaOffsetInicio: 0, diaOffsetFin)
     {
         _descansos = descansos;
         _extras = extras;
+        _sede = sede;
     }
 
     // Constructor vacio para STJ/Marten
@@ -33,12 +39,15 @@ public sealed class FranjaOrdinaria : FranjaTemporal, IEquatable<FranjaOrdinaria
     // CA-13: infiere offset +1 cuando fin < inicio
     // CA-14 a CA-16: valida que descansos y extras esten contenidos
     // CA-17 a CA-19: valida que descansos y extras no se solapen entre si
+    // Issue #335 (fase roja): el parametro sede se acepta y se guarda en _sede, pero su invariante
+    // (Id/Nombre no vacios) NO se valida todavia -- queda pendiente para el implementer (CA-3).
     public static FranjaOrdinaria Crear(
         TimeOnly horaInicio,
         TimeOnly horaFin,
         int diaOffsetFin = 0,
         IEnumerable<SubFranja>? descansos = null,
-        IEnumerable<SubFranja>? extras = null)
+        IEnumerable<SubFranja>? extras = null,
+        SedeProgramada? sede = null)
     {
         // CA-13: inferir offset cuando fin < inicio y no se especifico
         if (diaOffsetFin == 0 && horaFin < horaInicio)
@@ -46,13 +55,13 @@ public sealed class FranjaOrdinaria : FranjaTemporal, IEquatable<FranjaOrdinaria
 
         // CA-7: rechazar duracion cero
         if (horaInicio == horaFin && diaOffsetFin == 0)
-            throw new ArgumentException(Mensajes.InicioYFinIguales);
+            throw new ArgumentException(FranjaTemporal.Mensajes.InicioYFinIguales);
 
         var listaDescansos = descansos?.ToList() ?? [];
         var listaExtras = extras?.ToList() ?? [];
 
         var ordinaria = new FranjaOrdinaria(horaInicio, horaFin, diaOffsetFin,
-            listaDescansos, listaExtras);
+            listaDescansos, listaExtras, sede);
 
         // Proyectar todas las hijas como FranjaTemporal para validaciones unificadas
         var hijas = listaDescansos.Cast<FranjaTemporal>().Concat(listaExtras).ToList();
@@ -71,6 +80,7 @@ public sealed class FranjaOrdinaria : FranjaTemporal, IEquatable<FranjaOrdinaria
     // -- el FA mapea FranjaProgramada -> DetalleFranjaOrdinaria solo para los eventos que cruzan
     // el bus (CA-5). Tell-don't-Ask preservado: la conversion sigue viviendo en este VO, sin abrir
     // _descansos/_extras (MEF-ADR-0012).
+    // Issue #335 (fase roja): NO copia _sede todavia al DTO -- pendiente para el implementer (CA-1).
     public FranjaProgramada ToDetalle() => new(
         _horaInicio, _horaFin, _diaOffsetFin,
         _descansos.Select(d => d.ToDetalle()).ToList().AsReadOnly(),
@@ -78,20 +88,23 @@ public sealed class FranjaOrdinaria : FranjaTemporal, IEquatable<FranjaOrdinaria
         ToString());
 
     // CA-20, CA-21: formato "(06:00-12:00)" o "(22:00-06:00+1)"
+    // Issue #335 (fase roja): NO incluye el label de sede todavia -- pendiente para el implementer.
     public override string ToString()
     {
         var resultado = $"({FormatearHora(_horaInicio, 0)}-{FormatearHora(_horaFin, _diaOffsetFin)})";
 
         if (_descansos.Count > 0)
-            resultado += $"[{Mensajes.LabelDescansos}:{string.Join(", ", _descansos)}]";
+            resultado += $"[{FranjaTemporal.Mensajes.LabelDescansos}:{string.Join(", ", _descansos)}]";
 
         if (_extras.Count > 0)
-            resultado += $"[{Mensajes.LabelExtras}:{string.Join(", ", _extras)}]";
+            resultado += $"[{FranjaTemporal.Mensajes.LabelExtras}:{string.Join(", ", _extras)}]";
 
         return resultado;
     }
 
     // Igualdad por valor
+    // Issue #335 (fase roja): _sede NO entra todavia en Equals/GetHashCode -- pendiente para el
+    // implementer (CA-5, la sede es dato de identidad del diseno de la franja).
     public bool Equals(FranjaOrdinaria? other)
     {
         if (other is null) return false;
@@ -115,7 +128,7 @@ public sealed class FranjaOrdinaria : FranjaTemporal, IEquatable<FranjaOrdinaria
     private static void ValidarContencion(FranjaOrdinaria contenedor, List<FranjaTemporal> hijas)
     {
         if (hijas.Any(h => !h.EstaContenidaEn(contenedor)))
-            throw new ArgumentException(Mensajes.FranjaHijaFueraDeContenedor);
+            throw new ArgumentException(FranjaTemporal.Mensajes.FranjaHijaFueraDeContenedor);
     }
 
     // Verifica que ningun par de franjas hijas se solapen
@@ -125,10 +138,12 @@ public sealed class FranjaOrdinaria : FranjaTemporal, IEquatable<FranjaOrdinaria
         for (var i = 0; i < hijas.Count; i++)
             for (var j = i + 1; j < hijas.Count; j++)
                 if (hijas[i].SeSolapaCon(hijas[j]))
-                    throw new ArgumentException(Mensajes.FranjasHijasSeSuperponen);
+                    throw new ArgumentException(FranjaTemporal.Mensajes.FranjasHijasSeSuperponen);
     }
 
     // Mapping de serializacion - vive aqui porque cambia con la clase
+    // Issue #335 (fase roja): _sede NO se registra todavia -- pendiente para el implementer (CA-5,
+    // el round-trip pierde el valor hasta que se agregue un RegistrarCampo/JsonPropertyInfo para el).
     public static void ConfigurarSerializacion(DefaultJsonTypeInfoResolver resolver)
     {
         var ctor = typeof(FranjaOrdinaria)

--- a/src/Bitakora.ControlAsistencia.Programacion.DomainEvents/FranjaOrdinaria.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion.DomainEvents/FranjaOrdinaria.cs
@@ -13,7 +13,7 @@ public sealed partial class FranjaOrdinaria : FranjaTemporal, IEquatable<FranjaO
 
     // Issue #335: sede prearmada para esta franja del catalogo (null = sin sede asignada). Campo
     // interno, sin propiedad publica (MEF-ADR-0012, Tell-don't-Ask) -- se expone SOLO via
-    // ToDetalle() y ToString() (pendiente de wiring: ver comentarios en Crear/ToDetalle/ToString).
+    // ToDetalle() y ToString().
     private readonly SedeProgramada? _sede;
 
     // Constructor real: usado por el factory
@@ -57,9 +57,8 @@ public sealed partial class FranjaOrdinaria : FranjaTemporal, IEquatable<FranjaO
         if (horaInicio == horaFin && diaOffsetFin == 0)
             throw new ArgumentException(FranjaTemporal.Mensajes.InicioYFinIguales);
 
-        // CA-3: rechazar sede con Id o Nombre vacios/en blanco
-        if (sede is not null &&
-            (string.IsNullOrWhiteSpace(sede.Id) || string.IsNullOrWhiteSpace(sede.Nombre)))
+        // CA-3: rechazar sede incompleta -- la regla de completitud la responde la propia sede
+        if (sede is not null && !sede.EstaCompleta())
             throw new ArgumentException(Mensajes.SedeIncompleta);
 
         var listaDescansos = descansos?.ToList() ?? [];

--- a/src/Bitakora.ControlAsistencia.Programacion.DomainEvents/FranjaOrdinaria.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion.DomainEvents/FranjaOrdinaria.cs
@@ -39,8 +39,8 @@ public sealed partial class FranjaOrdinaria : FranjaTemporal, IEquatable<FranjaO
     // CA-13: infiere offset +1 cuando fin < inicio
     // CA-14 a CA-16: valida que descansos y extras esten contenidos
     // CA-17 a CA-19: valida que descansos y extras no se solapen entre si
-    // Issue #335 (fase roja): el parametro sede se acepta y se guarda en _sede, pero su invariante
-    // (Id/Nombre no vacios) NO se valida todavia -- queda pendiente para el implementer (CA-3).
+    // Issue #335 CA-3: la sede prearmada, si viene, debe tener Id y Nombre no vacios/en blanco --
+    // se valida junto a las demas invariantes de la franja (no en el RequestValidator del comando).
     public static FranjaOrdinaria Crear(
         TimeOnly horaInicio,
         TimeOnly horaFin,
@@ -56,6 +56,11 @@ public sealed partial class FranjaOrdinaria : FranjaTemporal, IEquatable<FranjaO
         // CA-7: rechazar duracion cero
         if (horaInicio == horaFin && diaOffsetFin == 0)
             throw new ArgumentException(FranjaTemporal.Mensajes.InicioYFinIguales);
+
+        // CA-3: rechazar sede con Id o Nombre vacios/en blanco
+        if (sede is not null &&
+            (string.IsNullOrWhiteSpace(sede.Id) || string.IsNullOrWhiteSpace(sede.Nombre)))
+            throw new ArgumentException(Mensajes.SedeIncompleta);
 
         var listaDescansos = descansos?.ToList() ?? [];
         var listaExtras = extras?.ToList() ?? [];
@@ -80,15 +85,16 @@ public sealed partial class FranjaOrdinaria : FranjaTemporal, IEquatable<FranjaO
     // -- el FA mapea FranjaProgramada -> DetalleFranjaOrdinaria solo para los eventos que cruzan
     // el bus (CA-5). Tell-don't-Ask preservado: la conversion sigue viviendo en este VO, sin abrir
     // _descansos/_extras (MEF-ADR-0012).
-    // Issue #335 (fase roja): NO copia _sede todavia al DTO -- pendiente para el implementer (CA-1).
+    // Issue #335 CA-1/CA-2: copia la sede prearmada al DTO plano (o null si no hay).
     public FranjaProgramada ToDetalle() => new(
         _horaInicio, _horaFin, _diaOffsetFin,
         _descansos.Select(d => d.ToDetalle()).ToList().AsReadOnly(),
         _extras.Select(e => e.ToDetalle()).ToList().AsReadOnly(),
-        ToString());
+        ToString(),
+        _sede);
 
     // CA-20, CA-21: formato "(06:00-12:00)" o "(22:00-06:00+1)"
-    // Issue #335 (fase roja): NO incluye el label de sede todavia -- pendiente para el implementer.
+    // Issue #335: incluye el label de sede (.resx) cuando la franja la trae prearmada.
     public override string ToString()
     {
         var resultado = $"({FormatearHora(_horaInicio, 0)}-{FormatearHora(_horaFin, _diaOffsetFin)})";
@@ -99,19 +105,23 @@ public sealed partial class FranjaOrdinaria : FranjaTemporal, IEquatable<FranjaO
         if (_extras.Count > 0)
             resultado += $"[{FranjaTemporal.Mensajes.LabelExtras}:{string.Join(", ", _extras)}]";
 
+        if (_sede is not null)
+            resultado += $"[{Mensajes.LabelSede}:{_sede.Nombre}]";
+
         return resultado;
     }
 
     // Igualdad por valor
-    // Issue #335 (fase roja): _sede NO entra todavia en Equals/GetHashCode -- pendiente para el
-    // implementer (CA-5, la sede es dato de identidad del diseno de la franja).
+    // Issue #335 CA-5: _sede entra en Equals/GetHashCode -- es dato de identidad del diseno de la
+    // franja (que sede prearmo el catalogo), a diferencia de Descripcion (derivado, en FranjaProgramada).
     public bool Equals(FranjaOrdinaria? other)
     {
         if (other is null) return false;
         if (_horaInicio != other._horaInicio || _horaFin != other._horaFin
             || _diaOffsetFin != other._diaOffsetFin) return false;
         return _descansos.SequenceEqual(other._descansos)
-            && _extras.SequenceEqual(other._extras);
+            && _extras.SequenceEqual(other._extras)
+            && _sede == other._sede;
     }
 
     public override bool Equals(object? obj) => Equals(obj as FranjaOrdinaria);
@@ -121,7 +131,7 @@ public sealed partial class FranjaOrdinaria : FranjaTemporal, IEquatable<FranjaO
         var hash = HashCode.Combine(_horaInicio, _horaFin, _diaOffsetFin);
         foreach (var d in _descansos) hash = HashCode.Combine(hash, d);
         foreach (var e in _extras) hash = HashCode.Combine(hash, e);
-        return hash;
+        return HashCode.Combine(hash, _sede);
     }
 
     // Verifica que cada franja hija este contenida dentro de la ordinaria
@@ -142,8 +152,9 @@ public sealed partial class FranjaOrdinaria : FranjaTemporal, IEquatable<FranjaO
     }
 
     // Mapping de serializacion - vive aqui porque cambia con la clase
-    // Issue #335 (fase roja): _sede NO se registra todavia -- pendiente para el implementer (CA-5,
-    // el round-trip pierde el valor hasta que se agregue un RegistrarCampo/JsonPropertyInfo para el).
+    // Issue #335 CA-4/CA-5: _sede se registra como campo opcional -- STJ omite la clave "sede"
+    // del JSON cuando el valor es null (retrocompatibilidad, CA-4), y la restaura en el round-trip
+    // cuando esta presente (CA-5).
     public static void ConfigurarSerializacion(DefaultJsonTypeInfoResolver resolver)
     {
         var ctor = typeof(FranjaOrdinaria)
@@ -175,6 +186,15 @@ public sealed partial class FranjaOrdinaria : FranjaTemporal, IEquatable<FranjaO
             pExtras.Get = obj => fExtras.GetValue(obj)!;
             pExtras.Set = (obj, val) => fExtras.SetValue(obj, val);
             typeInfo.Properties.Add(pExtras);
+
+            // Sede prearmada: campo opcional -- se omite del JSON cuando es null (CA-4).
+            var fSede = typeof(FranjaOrdinaria)
+                .GetField("_sede", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            var pSede = typeInfo.CreateJsonPropertyInfo(typeof(SedeProgramada), "sede");
+            pSede.Get = obj => fSede.GetValue(obj);
+            pSede.Set = (obj, val) => fSede.SetValue(obj, val);
+            pSede.ShouldSerialize = (_, val) => val is not null;
+            typeInfo.Properties.Add(pSede);
         });
     }
 }

--- a/src/Bitakora.ControlAsistencia.Programacion.DomainEvents/FranjaOrdinariaMensajes.resx
+++ b/src/Bitakora.ControlAsistencia.Programacion.DomainEvents/FranjaOrdinariaMensajes.resx
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" msdata:Ordinal="0" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter</value></resheader>
+  <data name="SedeIncompleta" xml:space="preserve">
+    <value>La sede de la franja debe tener Id y Nombre no vacios</value>
+  </data>
+  <data name="LabelSede" xml:space="preserve">
+    <value>sede</value>
+  </data>
+</root>

--- a/src/Bitakora.ControlAsistencia.Programacion.DomainEvents/FranjaProgramada.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion.DomainEvents/FranjaProgramada.cs
@@ -13,6 +13,13 @@ namespace Bitakora.ControlAsistencia.Programacion.DomainEvents;
 /// Equals/GetHashCode propios comparan Descansos/Extras POR VALOR (SequenceEqual, el record por
 /// defecto compararia por referencia -- ADR-0015) y EXCLUYEN Descripcion (dato derivado, no
 /// identidad de la franja) -- mismo criterio que DetalleFranjaOrdinaria (issues #129 y #288).
+///
+/// Issue #335: Sede es campo aditivo y opcional (null = sin sede prearmada). A diferencia de
+/// Descripcion, SI entra en Equals/GetHashCode -- es dato de identidad del diseno de la franja
+/// (que sede prearmo el catalogo), no un derivado. Divergencia deliberada de payload por rol
+/// (CA-ADR-0029 decision #5) frente a DetalleFranjaOrdinaria (PrivateEvents): el mapeo hacia el
+/// bus interno queda fuera de alcance de este issue (ver
+/// FranjaProgramadaParidadConDetalleFranjaOrdinariaTests).
 /// </remarks>
 public record FranjaProgramada(
     TimeOnly HoraInicio,
@@ -20,7 +27,8 @@ public record FranjaProgramada(
     int DiaOffsetFin,
     IReadOnlyList<SubFranjaProgramada> Descansos,
     IReadOnlyList<SubFranjaProgramada> Extras,
-    string Descripcion)
+    string Descripcion,
+    SedeProgramada? Sede = null)
 {
     /// <summary>
     /// Los eventos anteriores a este record no llevan el campo: STJ deja null en el parametro
@@ -37,7 +45,8 @@ public record FranjaProgramada(
             && HoraFin == other.HoraFin
             && DiaOffsetFin == other.DiaOffsetFin
             && Descansos.SequenceEqual(other.Descansos)
-            && Extras.SequenceEqual(other.Extras);
+            && Extras.SequenceEqual(other.Extras)
+            && Sede == other.Sede;
     }
 
     public override int GetHashCode()
@@ -48,6 +57,7 @@ public record FranjaProgramada(
         hash.Add(DiaOffsetFin);
         foreach (var d in Descansos) hash.Add(d);
         foreach (var e in Extras) hash.Add(e);
+        hash.Add(Sede);
         return hash.ToHashCode();
     }
 }

--- a/src/Bitakora.ControlAsistencia.Programacion.DomainEvents/SedeProgramada.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion.DomainEvents/SedeProgramada.cs
@@ -9,10 +9,23 @@ namespace Bitakora.ControlAsistencia.Programacion.DomainEvents;
 /// de sedes (#330), la verdad queda grabada en el evento. Id es un identificador opaco provisto
 /// por el cliente (mismo precedente que EmpleadoId/DispositivoId: puede o no ser un guid). Nombre
 /// viaja para que el evento persistido quede autocontenido.
-/// Sin comportamiento, sin Equals custom: todos los campos son string, la igualdad por valor del
-/// record por defecto ya es correcta (mismo criterio que Empleado, issue #319).
+/// Sin Equals custom: todos los campos son string, la igualdad por valor del record por defecto ya
+/// es correcta (mismo criterio que Empleado, issue #319).
 /// El nombre puro "Sede" queda RESERVADO para el concepto rico del futuro maestro de sedes (#338,
 /// direccion/ciudad/dispositivos asociados) -- este record es deliberadamente "Programada" para no
 /// hacer squatting de ese nombre.
 /// </remarks>
-public record SedeProgramada(string Id, string Nombre);
+public record SedeProgramada(string Id, string Nombre)
+{
+    /// <summary>
+    /// Una sede referenciada esta completa cuando trae ambos datos: el id opaco del cliente y el
+    /// nombre con que quedara autocontenida en el evento.
+    /// </summary>
+    /// <remarks>
+    /// Issue #335: la regla vive aqui y no en quien compone la sede (MEF-ADR-0012, Tell-don't-Ask):
+    /// depende solo de datos propios, asi que FranjaOrdinaria.Crear() pregunta en vez de leer Id y
+    /// Nombre para decidir por su cuenta.
+    /// </remarks>
+    public bool EstaCompleta() =>
+        !string.IsNullOrWhiteSpace(Id) && !string.IsNullOrWhiteSpace(Nombre);
+}

--- a/src/Bitakora.ControlAsistencia.Programacion.DomainEvents/TurnoCreado.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion.DomainEvents/TurnoCreado.cs
@@ -82,7 +82,7 @@ public sealed partial class TurnoCreado
                 var descansos = franja.Descansos.Select(d => SubFranja.Crear(d.inicio, d.fin));
                 var extras = franja.Extras.Select(e => SubFranja.Crear(e.inicio, e.fin));
                 franjasOrdinarias.Add(FranjaOrdinaria.Crear(franja.Inicio, franja.Fin,
-                    descansos: descansos, extras: extras));
+                    descansos: descansos, extras: extras, sede: franja.Sede));
             }
             catch (ArgumentException ex)
             {

--- a/src/Bitakora.ControlAsistencia.Programacion/CrearTurnoFunction/CrearTurno.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/CrearTurnoFunction/CrearTurno.cs
@@ -11,7 +11,7 @@ public record CrearTurno(
 {
     // CA-1: record anidado con las sub-franjas del turno
     // Issue #335: Sede es opcional -- prearma la sede de esta franja en el catalogo (ver
-    // ToDatosFranjas(), que todavia no la propaga -- fase roja).
+    // ToDatosFranjas(), que la propaga a DatosFranja).
     public record Franja(
         TimeOnly Inicio,
         TimeOnly Fin,
@@ -21,9 +21,9 @@ public record CrearTurno(
 
     // Issue #237: el contrato HTTP se queda aqui y se traduce a la entrada del factory de
     // TurnoCreado. Un solo lugar con el mapeo: lo reusan el handler y sus tests.
-    // Issue #335 (fase roja): NO propaga todavia o.Sede -- pendiente para el implementer (CA-1).
+    // Issue #335 CA-1: propaga o.Sede -- prearma la sede de la franja del catalogo.
     public List<DatosFranja> ToDatosFranjas() =>
         Ordinarias
-            .Select(o => new DatosFranja(o.Inicio, o.Fin, o.Descansos, o.Extras))
+            .Select(o => new DatosFranja(o.Inicio, o.Fin, o.Descansos, o.Extras, o.Sede))
             .ToList();
 }

--- a/src/Bitakora.ControlAsistencia.Programacion/CrearTurnoFunction/CrearTurno.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/CrearTurnoFunction/CrearTurno.cs
@@ -10,14 +10,18 @@ public record CrearTurno(
     List<CrearTurno.Franja> Ordinarias)
 {
     // CA-1: record anidado con las sub-franjas del turno
+    // Issue #335: Sede es opcional -- prearma la sede de esta franja en el catalogo (ver
+    // ToDatosFranjas(), que todavia no la propaga -- fase roja).
     public record Franja(
         TimeOnly Inicio,
         TimeOnly Fin,
         List<(TimeOnly inicio, TimeOnly fin)> Descansos,
-        List<(TimeOnly inicio, TimeOnly fin)> Extras);
+        List<(TimeOnly inicio, TimeOnly fin)> Extras,
+        SedeProgramada? Sede = null);
 
     // Issue #237: el contrato HTTP se queda aqui y se traduce a la entrada del factory de
     // TurnoCreado. Un solo lugar con el mapeo: lo reusan el handler y sus tests.
+    // Issue #335 (fase roja): NO propaga todavia o.Sede -- pendiente para el implementer (CA-1).
     public List<DatosFranja> ToDatosFranjas() =>
         Ordinarias
             .Select(o => new DatosFranja(o.Inicio, o.Fin, o.Descansos, o.Extras))

--- a/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/Bitakora.ControlAsistencia.Programacion.SmokeTests.csproj
+++ b/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/Bitakora.ControlAsistencia.Programacion.SmokeTests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.*" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.*" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.*" />
+    <PackageReference Include="Npgsql" Version="9.*" />
     <PackageReference Include="xunit.v3.mtp-v2" Version="3.*" />
   </ItemGroup>
 

--- a/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/CrearTurnoFunction/CrearTurnoSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/CrearTurnoFunction/CrearTurnoSmokeTests.cs
@@ -75,4 +75,105 @@ public class CrearTurnoSmokeTests(ApiFixture api)
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
+
+    // Issue #335 CA-1: turno "partido" con sede prearmada por franja (ej. narrativa del issue:
+    // "Vigilante partido" -> manana en Suba, tarde en Chapinero). Solo se verifica el status code:
+    // TurnoCreado no cruza el bus (no hay Service Bus que consumir) y este dominio no expone un
+    // endpoint GET del catalogo ni tiene PostgresFixture -- no hay forma black-box de inspeccionar
+    // el contenido persistido desde este smoke test.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task CrearTurno_DebeRetornar202_CuandoAlgunasFranjasTienenSedePrearmada()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var payload = new
+        {
+            turnoId = Guid.CreateVersion7(),
+            nombre = "[TEST] Vigilante Partido",
+            ordinarias = new object[]
+            {
+                new
+                {
+                    inicio = "06:00:00",
+                    fin = "12:00:00",
+                    descansos = Array.Empty<object>(),
+                    extras = Array.Empty<object>(),
+                    sede = new { id = "SEDE-SUBA", nombre = "[TEST] Suba" }
+                },
+                new
+                {
+                    inicio = "13:00:00",
+                    fin = "19:00:00",
+                    descansos = Array.Empty<object>(),
+                    extras = Array.Empty<object>(),
+                    sede = new { id = "SEDE-CHAPINERO", nombre = "[TEST] Chapinero" }
+                }
+            }
+        };
+
+        var response = await _client.PostAsJsonAsync("/api/programacion/turnos", payload, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+    }
+
+    // Issue #335 CA-2: regresion -- una franja sin la clave "sede" en el payload conserva el
+    // comportamiento actual (mismo camino que CrearTurno_DebeRetornar202_CuandoPayloadEsValido,
+    // que ya usa PayloadValido() sin sede).
+
+    // Issue #335 CA-3: sede presente pero con Id vacio se rechaza junto a las demas invariantes
+    // de la franja (error acumulado en TurnoCreado.Crear -> AggregateException -> 400).
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task CrearTurno_DebeRetornar400_CuandoSedeDeFranjaTieneIdVacio()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var payload = new
+        {
+            turnoId = Guid.CreateVersion7(),
+            nombre = "[TEST] Turno Sede Incompleta",
+            ordinarias = new object[]
+            {
+                new
+                {
+                    inicio = "08:00:00",
+                    fin = "16:00:00",
+                    descansos = Array.Empty<object>(),
+                    extras = Array.Empty<object>(),
+                    sede = new { id = "", nombre = "[TEST] Suba" }
+                }
+            }
+        };
+
+        var response = await _client.PostAsJsonAsync("/api/programacion/turnos", payload, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    // Issue #335 CA-3: sede presente pero con Nombre en blanco se rechaza igual que Id vacio.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task CrearTurno_DebeRetornar400_CuandoSedeDeFranjaTieneNombreEnBlanco()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var payload = new
+        {
+            turnoId = Guid.CreateVersion7(),
+            nombre = "[TEST] Turno Sede Incompleta",
+            ordinarias = new object[]
+            {
+                new
+                {
+                    inicio = "08:00:00",
+                    fin = "16:00:00",
+                    descansos = Array.Empty<object>(),
+                    extras = Array.Empty<object>(),
+                    sede = new { id = "SEDE-SUBA", nombre = "   " }
+                }
+            }
+        };
+
+        var response = await _client.PostAsJsonAsync("/api/programacion/turnos", payload, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
 }

--- a/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/CrearTurnoFunction/CrearTurnoSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/CrearTurnoFunction/CrearTurnoSmokeTests.cs
@@ -1,12 +1,31 @@
 using System.Net;
 using System.Net.Http.Json;
+using System.Text.Json;
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.Programacion.SmokeTests.Fixtures;
 
 namespace Bitakora.ControlAsistencia.Programacion.SmokeTests.CrearTurnoFunction;
 
-public class CrearTurnoSmokeTests(ApiFixture api)
+public class CrearTurnoSmokeTests(ApiFixture api, PostgresFixture postgres)
 {
+    private const string SchemaProgramacion = "programacion";
+    private const string TipoEventoTurnoCreado = "turno_creado";
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
+
+    // Forma minima de SedeProgramada para asertar sobre el JSON persistido sin referenciar
+    // Programacion.DomainEvents desde los smoke tests (mismo criterio que DeadLetterMinimos).
+    private sealed record SedeMinima(string Id, string Nombre);
+
+    private static readonly JsonSerializerOptions OpcionesLectura = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    private static SedeMinima? SedeDe(JsonElement franja) =>
+        franja.TryGetProperty("sede", out var sede)
+            ? sede.Deserialize<SedeMinima>(OpcionesLectura)
+            : null;
+
     private readonly HttpClient _client = api.Client;
 
     private static object PayloadValido(Guid? turnoId = null, string nombre = "[TEST] Turno Diurno") => new
@@ -76,20 +95,26 @@ public class CrearTurnoSmokeTests(ApiFixture api)
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
-    // Issue #335 CA-1: turno "partido" con sede prearmada por franja (ej. narrativa del issue:
-    // "Vigilante partido" -> manana en Suba, tarde en Chapinero). Solo se verifica el status code:
-    // TurnoCreado no cruza el bus (no hay Service Bus que consumir) y este dominio no expone un
-    // endpoint GET del catalogo ni tiene PostgresFixture -- no hay forma black-box de inspeccionar
-    // el contenido persistido desde este smoke test.
+    // Issue #335 CA-1/CA-2: turno "partido" con sede prearmada por franja (narrativa del issue:
+    // "Vigilante partido" -> manana en Suba, tarde en Chapinero) mas una tercera franja SIN sede.
+    // Verifica los dos efectos del handler: el 202 del endpoint y la persistencia en el event store
+    // (CrearTurnoCommandHandler -> IEventStore.StartStream). turno_creado no cruza ningun bus, asi
+    // que mt_events es la unica ventana black-box a lo que quedo grabado -- y es la que cierra el
+    // riesgo real de este issue: que el resolver de serializacion del Function App desplegado no
+    // registre la clave "sede" y el dato se pierda en silencio con un 202 igual de verde.
     [Fact]
     [Trait("Category", "Smoke")]
-    public async Task CrearTurno_DebeRetornar202_CuandoAlgunasFranjasTienenSedePrearmada()
+    public async Task CrearTurno_PersisteLaSedePrearmadaDeCadaFranja_CuandoAlgunasFranjasTraenSede()
     {
+        Assert.SkipWhen(!postgres.IsConfigured, postgres.SkipReason ?? "Postgres no disponible.");
+
         var ct = TestContext.Current.CancellationToken;
+        var turnoId = Guid.CreateVersion7();
+        const string nombreTurno = "[TEST] Vigilante Partido";
         var payload = new
         {
-            turnoId = Guid.CreateVersion7(),
-            nombre = "[TEST] Vigilante Partido",
+            turnoId,
+            nombre = nombreTurno,
             ordinarias = new object[]
             {
                 new
@@ -107,6 +132,13 @@ public class CrearTurnoSmokeTests(ApiFixture api)
                     descansos = Array.Empty<object>(),
                     extras = Array.Empty<object>(),
                     sede = new { id = "SEDE-CHAPINERO", nombre = "[TEST] Chapinero" }
+                },
+                new
+                {
+                    inicio = "20:00:00",
+                    fin = "22:00:00",
+                    descansos = Array.Empty<object>(),
+                    extras = Array.Empty<object>()
                 }
             }
         };
@@ -114,17 +146,39 @@ public class CrearTurnoSmokeTests(ApiFixture api)
         var response = await _client.PostAsJsonAsync("/api/programacion/turnos", payload, ct);
 
         response.StatusCode.Should().Be(HttpStatusCode.Accepted);
-    }
 
-    // Issue #335 CA-2: regresion -- una franja sin la clave "sede" en el payload conserva el
-    // comportamiento actual (mismo camino que CrearTurno_DebeRetornar202_CuandoPayloadEsValido,
-    // que ya usa PayloadValido() sin sede).
+        // CatalogoTurnos.Apply asigna Id = evento.TurnoId.ToString() -- el stream id es el guid
+        // canonico, sin formato explicito (MEF-ADR-0037).
+        var streamId = turnoId.ToString();
+
+        var existe = await postgres.ExisteEventoAsync(
+            SchemaProgramacion, streamId, TipoEventoTurnoCreado, Timeout);
+
+        existe.Should().BeTrue(
+            $"el evento {TipoEventoTurnoCreado} deberia existir en el stream {streamId} tras crear el turno");
+
+        var eventoPersistido = await postgres.ObtenerEventoAsync<JsonElement>(
+            SchemaProgramacion, streamId, TipoEventoTurnoCreado,
+            campoJson: "Nombre", valorJson: nombreTurno, Timeout);
+
+        var franjas = eventoPersistido.GetProperty("FranjasOrdinarias").EnumerateArray().ToList();
+        franjas.Should().HaveCount(3);
+
+        // CA-1: cada franja prearmada conserva SU sede (no la del vecino).
+        SedeDe(franjas[0]).Should().Be(new SedeMinima("SEDE-SUBA", "[TEST] Suba"));
+        SedeDe(franjas[1]).Should().Be(new SedeMinima("SEDE-CHAPINERO", "[TEST] Chapinero"));
+
+        // CA-2/CA-4: la franja sin sede no agrega la clave al JSON persistido -- misma forma que
+        // los streams escritos antes de este issue (ShouldSerialize omite el campo cuando es null).
+        franjas[2].TryGetProperty("sede", out _).Should().BeFalse(
+            "una franja sin sede prearmada no debe escribir la clave 'sede' en el evento persistido");
+    }
 
     // Issue #335 CA-3: sede presente pero con Id vacio se rechaza junto a las demas invariantes
     // de la franja (error acumulado en TurnoCreado.Crear -> AggregateException -> 400).
     [Fact]
     [Trait("Category", "Smoke")]
-    public async Task CrearTurno_DebeRetornar400_CuandoSedeDeFranjaTieneIdVacio()
+    public async Task CrearTurno_Retorna400_CuandoSedeDeFranjaTieneIdVacio()
     {
         var ct = TestContext.Current.CancellationToken;
         var payload = new
@@ -152,7 +206,7 @@ public class CrearTurnoSmokeTests(ApiFixture api)
     // Issue #335 CA-3: sede presente pero con Nombre en blanco se rechaza igual que Id vacio.
     [Fact]
     [Trait("Category", "Smoke")]
-    public async Task CrearTurno_DebeRetornar400_CuandoSedeDeFranjaTieneNombreEnBlanco()
+    public async Task CrearTurno_Retorna400_CuandoSedeDeFranjaTieneNombreEnBlanco()
     {
         var ct = TestContext.Current.CancellationToken;
         var payload = new

--- a/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/Fixtures/AssemblyFixture.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/Fixtures/AssemblyFixture.cs
@@ -2,3 +2,4 @@ using Bitakora.ControlAsistencia.Programacion.SmokeTests.Fixtures;
 
 [assembly: AssemblyFixture(typeof(ApiFixture))]
 [assembly: AssemblyFixture(typeof(ServiceBusFixture))]
+[assembly: AssemblyFixture(typeof(PostgresFixture))]

--- a/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/Fixtures/PostgresFixture.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/Fixtures/PostgresFixture.cs
@@ -1,0 +1,131 @@
+using System.Net.Sockets;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Configuration;
+using Npgsql;
+
+namespace Bitakora.ControlAsistencia.Programacion.SmokeTests.Fixtures;
+
+// Issue #335: gemelo del PostgresFixture de ControlHoras.SmokeTests. Programacion tambien persiste
+// en el event store (CrearTurnoCommandHandler -> IEventStore.StartStream), asi que sus smoke tests
+// necesitan verificar ese efecto secundario y no solo el status code (MEF-ADR-0013, "Alcance de un
+// smoke test: cobertura completa de efectos secundarios"). turno_creado no cruza ningun bus: la
+// unica verificacion black-box posible de su contenido es leer mt_events.
+public class PostgresFixture : IAsyncLifetime
+{
+    private string _connectionString = null!;
+
+    public bool IsConfigured { get; private set; }
+
+    public string? SkipReason { get; private set; }
+
+    public async ValueTask InitializeAsync()
+    {
+        var configuration = new ConfigurationBuilder()
+            .SetBasePath(AppContext.BaseDirectory)
+            .AddJsonFile("appsettings.json", optional: false)
+            .AddJsonFile("appsettings.local.json", optional: true)
+            .AddEnvironmentVariables()
+            .Build();
+
+        var connectionString = configuration["Postgres:ConnectionString"];
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            IsConfigured = false;
+            SkipReason = "Postgres no configurado. Usa appsettings.local.json o variable Postgres__ConnectionString.";
+            return;
+        }
+
+        try
+        {
+            await using var conn = new NpgsqlConnection(connectionString);
+            await conn.OpenAsync();
+        }
+        catch (NpgsqlException ex) when (ex.InnerException is SocketException or TimeoutException)
+        {
+            IsConfigured = false;
+            SkipReason = $"No se pudo conectar a Postgres. Verifica que tu IP este en el firewall de Azure (psql-asist-dev). Detalle: {ex.InnerException.Message}";
+            return;
+        }
+
+        IsConfigured = true;
+        _connectionString = connectionString;
+    }
+
+    public Task<bool> ExisteEventoAsync(
+        string schema, string streamId, string tipoEvento, TimeSpan timeout,
+        string? campoJson = null, string? valorJson = null)
+    {
+        return Polling.WaitUntilTrueAsync(async () =>
+        {
+            var eventos = await ObtenerEventosInternoAsync(schema, streamId, tipoEvento);
+
+            if (campoJson is null || valorJson is null)
+                return eventos.Count > 0;
+
+            return eventos.Any(e =>
+                e.TryGetProperty(campoJson, out var prop) &&
+                prop.ToString() == valorJson);
+        }, timeout);
+    }
+
+    public async Task<T> ObtenerEventoAsync<T>(
+        string schema, string streamId, string tipoEvento,
+        string campoJson, string valorJson, TimeSpan timeout)
+    {
+        var json = await Polling.WaitUntilAsync(async () =>
+        {
+            var eventos = await ObtenerEventosInternoAsync(schema, streamId, tipoEvento);
+
+            var match = eventos.FirstOrDefault(e =>
+                e.TryGetProperty(campoJson, out var prop) &&
+                prop.ToString() == valorJson);
+
+            if (match.ValueKind == JsonValueKind.Undefined)
+                return null;
+
+            return JsonSerializer.Serialize(match);
+        }, timeout);
+
+        return JsonSerializer.Deserialize<T>(json)!;
+    }
+
+    private async Task<List<JsonElement>> ObtenerEventosInternoAsync(
+        string schema, string streamId, string tipoEvento)
+    {
+        await using var conn = new NpgsqlConnection(_connectionString);
+        await conn.OpenAsync();
+
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"""
+            SELECT data
+            FROM {EscaparSchema(schema)}.mt_events
+            WHERE stream_id = @streamId
+              AND type = @tipoEvento
+            ORDER BY seq_id
+            """;
+        cmd.Parameters.AddWithValue("streamId", streamId);
+        cmd.Parameters.AddWithValue("tipoEvento", tipoEvento);
+
+        var eventos = new List<JsonElement>();
+        await using var reader = await cmd.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            var json = reader.GetString(0);
+            var elemento = JsonSerializer.Deserialize<JsonElement>(json);
+            eventos.Add(elemento);
+        }
+
+        return eventos;
+    }
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    private static string EscaparSchema(string schema)
+    {
+        // Solo permitir caracteres alfanumericos y guion bajo para prevenir SQL injection
+        if (!Regex.IsMatch(schema, @"^[a-zA-Z_][a-zA-Z0-9_]*$"))
+            throw new ArgumentException($"Nombre de schema invalido: {schema}");
+        return schema;
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/appsettings.json
+++ b/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/appsettings.json
@@ -4,5 +4,8 @@
   },
   "ServiceBus": {
     "ConnectionString": ""
+  },
+  "Postgres": {
+    "ConnectionString": ""
   }
 }

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/CrearTurnoFunction/CrearTurnoCommandHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/CrearTurnoFunction/CrearTurnoCommandHandlerTests.cs
@@ -55,4 +55,27 @@ public class CrearTurnoCommandHandlerTests : CommandHandlerAsyncTest<CrearTurno>
         await act.Should().ThrowExactlyAsync<InvalidOperationException>()
             .WithMessage($"*{CrearTurnoCommandHandler.Mensajes.TurnoYaExiste}*");
     }
+
+    // Issue #335 CA-1: la sede prearmada de cada franja del catalogo llega hasta el detalle del
+    // aggregate cuando el comando la trae en algunas franjas (turno partido multi-sede).
+    [Fact]
+    public async Task CrearTurno_PersisteSedePorFranja_CuandoComandoTraeSedeEnAlgunasFranjas()
+    {
+        var sedeManana = new SedeProgramada("SEDE-SUBA", "Suba");
+        var franjaConSede = new CrearTurno.Franja(
+            new TimeOnly(6, 0), new TimeOnly(14, 0), [], [], sedeManana);
+        var franjaSinSede = new CrearTurno.Franja(
+            new TimeOnly(14, 0), new TimeOnly(22, 0), [], []);
+        var comando = new CrearTurno(GuidAggregateId, "Turno Partido", [franjaConSede, franjaSinSede]);
+        var eventoEsperado = TurnoCreado.Crear(comando.TurnoId, comando.Nombre, comando.ToDatosFranjas());
+
+        Given();
+        await WhenAsync(comando);
+
+        Then(eventoEsperado);
+        And<CatalogoTurnos, SedeProgramada?>(
+            c => c.ObtenerDetalle().FranjasOrdinarias[0].Sede, sedeManana);
+        And<CatalogoTurnos, SedeProgramada?>(
+            c => c.ObtenerDetalle().FranjasOrdinarias[1].Sede, null);
+    }
 }

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/CrearTurnoFunction/CrearTurnoTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/CrearTurnoFunction/CrearTurnoTests.cs
@@ -1,0 +1,38 @@
+// Issue #335: tests del mapeo CrearTurno.ToDatosFranjas() -- traduce el contrato HTTP a la
+// entrada del factory de TurnoCreado. Cubre la propagacion (o no) de la sede prearmada por franja.
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Programacion.CrearTurnoFunction;
+using Bitakora.ControlAsistencia.Programacion.DomainEvents;
+
+namespace Bitakora.ControlAsistencia.Programacion.Tests.CrearTurnoFunction;
+
+public class CrearTurnoTests
+{
+    private const string NombreTurno = "Turno Manana";
+
+    // CA-1: la sede prearmada de la franja del comando llega a DatosFranja.
+    [Fact]
+    public void ToDatosFranjas_PropagaLaSedeDeCadaFranja_CuandoComandoTraeSedes()
+    {
+        var sede = new SedeProgramada("SEDE-SUBA", "Suba");
+        var comando = new CrearTurno(Guid.NewGuid(), NombreTurno,
+            [new CrearTurno.Franja(new TimeOnly(6, 0), new TimeOnly(14, 0), [], [], sede)]);
+
+        var datos = comando.ToDatosFranjas();
+
+        datos[0].Sede.Should().Be(sede);
+    }
+
+    // CA-2: regresion -- una franja sin sede en el comando conserva el comportamiento actual.
+    [Fact]
+    public void ToDatosFranjas_DejaSedeNull_CuandoFranjaDelComandoNoTraeSede()
+    {
+        var comando = new CrearTurno(Guid.NewGuid(), NombreTurno,
+            [new CrearTurno.Franja(new TimeOnly(6, 0), new TimeOnly(14, 0), [], [])]);
+
+        var datos = comando.ToDatosFranjas();
+
+        datos[0].Sede.Should().BeNull();
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/CrearTurnoFunction/Eventos/TurnoCreadoSerializacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/CrearTurnoFunction/Eventos/TurnoCreadoSerializacionTests.cs
@@ -1,7 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
 using AwesomeAssertions;
-using Bitakora.ControlAsistencia.Programacion.CrearTurnoFunction;
 using Bitakora.ControlAsistencia.Programacion.DomainEvents;
 
 namespace Bitakora.ControlAsistencia.Programacion.Tests.CrearTurnoFunction.Eventos;

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/CrearTurnoFunction/Eventos/TurnoCreadoSerializacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/CrearTurnoFunction/Eventos/TurnoCreadoSerializacionTests.cs
@@ -50,4 +50,45 @@ public class TurnoCreadoSerializacionTests
         deserializado.FranjasOrdinarias[0].ToString()
             .Should().Be("(06:00-16:00)[Descansos:(10:00-10:15)][Extras:(06:00-08:00)]");
     }
+
+    // Issue #335 CA-5: round-trip con sedes diferentes en cada franja ordinaria.
+    [Fact]
+    public void Deserializar_PreservaSedePorFranja_CuandoOrdinariasTraenSedesDiferentes()
+    {
+        var sedeManana = new SedeProgramada("SEDE-SUBA", "Suba");
+        var sedeTarde = new SedeProgramada("SEDE-CHAPINERO", "Chapinero");
+        var evento = TurnoCreado.Crear(
+            TurnoId, "Turno Partido",
+            [
+                new DatosFranja(new TimeOnly(6, 0), new TimeOnly(12, 0), [], [], sedeManana),
+                new DatosFranja(new TimeOnly(14, 0), new TimeOnly(18, 0), [], [], sedeTarde)
+            ]);
+
+        var opciones = CrearOpcionesMarten();
+        var json = JsonSerializer.Serialize(evento, opciones);
+        var deserializado = JsonSerializer.Deserialize<TurnoCreado>(json, opciones);
+
+        deserializado.Should().NotBeNull();
+        deserializado!.FranjasOrdinarias[0].ToDetalle().Sede.Should().Be(sedeManana);
+        deserializado.FranjasOrdinarias[1].ToDetalle().Sede.Should().Be(sedeTarde);
+    }
+
+    // Issue #335 CA-4: retrocompatibilidad -- una franja sin sede prearmada no agrega la clave
+    // "sede" al JSON persistido (equivalente al JSON escrito antes de este issue), y deserializa
+    // con Sede null.
+    [Fact]
+    public void Deserializar_DejaSedeNull_CuandoFranjaNoTraeSede()
+    {
+        var evento = TurnoCreado.Crear(
+            TurnoId, "Turno Completo",
+            [new DatosFranja(new TimeOnly(6, 0), new TimeOnly(16, 0), [], [])]);
+
+        var opciones = CrearOpcionesMarten();
+        var json = JsonSerializer.Serialize(evento, opciones);
+        var deserializado = JsonSerializer.Deserialize<TurnoCreado>(json, opciones);
+
+        json.Should().NotContain("\"sede\"");
+        deserializado.Should().NotBeNull();
+        deserializado!.FranjasOrdinarias[0].ToDetalle().Sede.Should().BeNull();
+    }
 }

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/CrearTurnoFunction/TurnoCreadoTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/CrearTurnoFunction/TurnoCreadoTests.cs
@@ -236,4 +236,50 @@ public class TurnoCreadoTests
         var ex = act.Should().ThrowExactly<AggregateException>().Which;
         ex.InnerExceptions.Should().AllBeAssignableTo<ArgumentException>();
     }
+
+    // ---------- Issue #335: sede prearmada por franja ----------
+
+    // CA-1: la sede prearmada de una franja fluye hasta el evento persistido.
+    [Fact]
+    public void Crear_PropagaSedePorFranja_CuandoDatosFranjaTraeSedeValida()
+    {
+        var sede = new SedeProgramada("SEDE-SUBA", "Suba");
+
+        var evento = TurnoCreado.Crear(
+            TurnoId, NombreValido,
+            [new DatosFranja(new TimeOnly(6, 0), new TimeOnly(14, 0), [], [], sede)]);
+
+        evento.FranjasOrdinarias[0].ToDetalle().Sede.Should().Be(sede);
+    }
+
+    // CA-3: sede con Id vacio se acumula junto a las demas invariantes del factory.
+    [Fact]
+    public void Crear_LanzaAggregateException_CuandoSedeDeFranjaTieneIdVacio()
+    {
+        var sedeInvalida = new SedeProgramada("", "Suba");
+
+        var act = () => TurnoCreado.Crear(
+            TurnoId, NombreValido,
+            [new DatosFranja(new TimeOnly(6, 0), new TimeOnly(14, 0), [], [], sedeInvalida)]);
+
+        var ex = act.Should().ThrowExactly<AggregateException>().Which;
+        ex.InnerExceptions.OfType<ArgumentException>()
+            .Should().ContainSingle(ae => ae.Message.Contains(FranjaOrdinaria.Mensajes.SedeIncompleta));
+    }
+
+    // CA-3: sede invalida se acumula junto a otros errores (no fail-fast).
+    [Fact]
+    public void Crear_LanzaAggregateExceptionConErroresPropiosYDeSede_CuandoNombreVacioYSedeIncompleta()
+    {
+        var sedeInvalida = new SedeProgramada("SEDE-SUBA", "   ");
+
+        var act = () => TurnoCreado.Crear(
+            TurnoId, "",
+            [new DatosFranja(new TimeOnly(6, 0), new TimeOnly(14, 0), [], [], sedeInvalida)]);
+
+        var ex = act.Should().ThrowExactly<AggregateException>().Which;
+        ex.InnerExceptions.Should().HaveCount(2);
+        ex.InnerExceptions.Should().Contain(e => e.Message.Contains(TurnoCreado.Mensajes.NombreVacio));
+        ex.InnerExceptions.Should().Contain(e => e.Message.Contains(FranjaOrdinaria.Mensajes.SedeIncompleta));
+    }
 }

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/Entities/CatalogoTurnosTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/Entities/CatalogoTurnosTests.cs
@@ -46,4 +46,34 @@ public class CatalogoTurnosTests
         detalle.FranjasOrdinarias.Should().HaveCount(2);
         detalle.FranjasOrdinarias[0].Descansos[0].Descripcion.Should().Be("(09:00-09:15)");
     }
+
+    // ---------- Issue #335 CA-1/CA-2: sede prearmada por franja en el catalogo ----------
+
+    // CA-1: turno partido con sede diferente en cada franja (ej. "Vigilante partido": manana ->
+    // Suba, tarde -> Chapinero) -- el detalle del catalogo expone la sede de cada franja.
+    [Fact]
+    public void ObtenerDetalle_ExponeSedePorFranja_CuandoTurnoPrearmaSedesDiferentesEnCadaFranja()
+    {
+        var sedeManana = new SedeProgramada("SEDE-SUBA", "Suba");
+        var sedeTarde = new SedeProgramada("SEDE-CHAPINERO", "Chapinero");
+        var catalogo = CrearCatalogo(
+            new DatosFranja(new TimeOnly(6, 0), new TimeOnly(14, 0), [], [], sedeManana),
+            new DatosFranja(new TimeOnly(14, 0), new TimeOnly(22, 0), [], [], sedeTarde));
+
+        var detalle = catalogo.ObtenerDetalle();
+
+        detalle.FranjasOrdinarias[0].Sede.Should().Be(sedeManana);
+        detalle.FranjasOrdinarias[1].Sede.Should().Be(sedeTarde);
+    }
+
+    // CA-2: regresion -- un turno sin sedes prearmadas conserva el comportamiento actual.
+    [Fact]
+    public void ObtenerDetalle_DejaSedeNull_CuandoTurnoNoPrearmaNingunaSede()
+    {
+        var catalogo = CrearCatalogo(Ordinaria(new TimeOnly(6, 0), new TimeOnly(14, 0)));
+
+        var detalle = catalogo.ObtenerDetalle();
+
+        detalle.FranjasOrdinarias[0].Sede.Should().BeNull();
+    }
 }

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoCommandHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoCommandHandlerTests.cs
@@ -20,6 +20,8 @@ public class SolicitarProgramacionTurnoCommandHandlerTests
         Guid.Parse("018e4c1a-4f2b-7000-8000-aabbccddeeff");
     private static readonly Guid TurnoConHijasId =
         Guid.Parse("018e4c1a-4f2b-7000-8000-112233445566");
+    private static readonly Guid TurnoConSedePrearmadaId =
+        Guid.Parse("018e4c1a-4f2b-7000-8000-778899aabbcc");
     private static readonly DateOnly Fecha1 = new(2026, 4, 7);
     private static readonly DateOnly Fecha2 = new(2026, 4, 8);
 
@@ -126,6 +128,43 @@ public class SolicitarProgramacionTurnoCommandHandlerTests
         }.AsReadOnly(),
         DescripcionTurnoConHijas);
 
+    // --- Issue #335: turno del catalogo con la sede PREARMADA por franja ---
+    //
+    // No la trae la solicitud (esa es la sede de #331, que aqui va en null): la trae el turno,
+    // desde que se creo. El handler no la conoce ni la mapea -- fluye sola por el snapshot
+    // existente (CatalogoTurnos.ObtenerDetalle -> FranjaOrdinaria.ToDetalle).
+    private static readonly SedeProgramada SedeSuba = new("SEDE-SUBA", "Suba");
+
+    private static TurnoCreado CrearEventoTurnoConSedePrearmada() =>
+        TurnoCreado.Crear(
+            TurnoConSedePrearmadaId,
+            "Turno Con Sede",
+            [new DatosFranja(new TimeOnly(6, 0), new TimeOnly(14, 0), [], [], SedeSuba)]);
+
+    // La sede entra al ToString() de la franja, asi que la Descripcion derivada la incluye. Es la
+    // consecuencia aceptada en el issue (los turnos ya creados no cambian) y el UNICO rastro de la
+    // sede que hoy alcanza el payload de bus: DetalleFranjaOrdinaria no tiene campo Sede (#341).
+    private static readonly string DescripcionFranjaConSede =
+        $"(06:00-14:00)[{FranjaOrdinaria.Mensajes.LabelSede}:Suba]";
+    private static readonly string DescripcionTurnoConSede =
+        $"Turno Con Sede {DescripcionFranjaConSede}";
+
+    private static readonly TurnoProgramado TurnoConSedePrearmadaEsperado = new(
+        "Turno Con Sede",
+        new List<FranjaProgramada>
+        {
+            new(new TimeOnly(6, 0), new TimeOnly(14, 0), 0, [], [], DescripcionFranjaConSede, SedeSuba)
+        }.AsReadOnly(),
+        DescripcionTurnoConSede);
+
+    private static readonly DetalleTurno DetalleConSedePrearmadaEsperado = new(
+        "Turno Con Sede",
+        new List<DetalleFranjaOrdinaria>
+        {
+            new(new TimeOnly(6, 0), new TimeOnly(14, 0), 0, [], [], DescripcionFranjaConSede)
+        }.AsReadOnly(),
+        DescripcionTurnoConSede);
+
     // --- Tests del camino feliz ---
 
     // CA-9, CA-10, CA-11, CA-12: emite evento de ES y publica evento publico por cada fecha
@@ -223,6 +262,27 @@ public class SolicitarProgramacionTurnoCommandHandlerTests
         ThenIsPublishedPrivately(new ProgramacionTurnoDiarioSolicitada(
             GuidAggregateId, EmpleadoDetalle, Fecha1, DetalleEsperado, sede: null));
         And<SolicitudProgramacionAggregateRoot, SedeProgramada?>(s => s.Sede, null);
+    }
+
+    // Issue #335: la sede PREARMADA en el catalogo llega al evento persistido sin que el flujo de
+    // solicitud la toque -- el handler no la lee ni la mapea, viaja dentro del snapshot del turno.
+    // Es el cimiento sobre el que #341 arma la cascada (sede de la franja ?? sede de la solicitud):
+    // si un refactor de ToDetalle/ObtenerDetalle dejara de copiarla, el defecto aparece aqui y no
+    // recien en #341. La solicitud va deliberadamente SIN sede propia para que el unico origen
+    // posible del dato sea el catalogo.
+    [Fact]
+    public async Task SolicitarProgramacionTurno_PersisteLaSedePrearmadaDelCatalogo_CuandoElTurnoLaTraePorFranja()
+    {
+        Given(TurnoConSedePrearmadaId.ToString(), CrearEventoTurnoConSedePrearmada());
+        await WhenAsync(new SolicitarProgramacionTurno(
+            GuidAggregateId, TurnoConSedePrearmadaId, Empleado, [Fecha1]));
+
+        Then(new ProgramacionTurnoSolicitada(
+            GuidAggregateId, EmpleadoProgramado, [Fecha1], TurnoConSedePrearmadaEsperado, sede: null));
+        ThenIsPublishedPrivately(new ProgramacionTurnoDiarioSolicitada(
+            GuidAggregateId, EmpleadoDetalle, Fecha1, DetalleConSedePrearmadaEsperado, sede: null));
+        And<SolicitudProgramacionAggregateRoot, SedeProgramada?>(
+            s => s.DetalleTurno!.FranjasOrdinarias[0].Sede, SedeSuba);
     }
 
     // CA-6: idempotencia - solicitud ya existe lanza excepcion que el endpoint mapea a 409

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/ValueObjects/FranjaOrdinariaIgualdadTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/ValueObjects/FranjaOrdinariaIgualdadTests.cs
@@ -27,6 +27,10 @@ public class FranjaOrdinariaIgualdadTests : IgualdadTestBase<FranjaOrdinaria>
         yield return ("Extras",
             FranjaOrdinaria.Crear(new TimeOnly(6, 0), new TimeOnly(12, 0),
                 extras: [SubFranja.Crear(new TimeOnly(6, 0), new TimeOnly(7, 0))]));
+        // Issue #335 CA-5: la sede prearmada es dato de identidad del diseno de la franja.
+        yield return ("Sede",
+            FranjaOrdinaria.Crear(new TimeOnly(6, 0), new TimeOnly(12, 0),
+                sede: new SedeProgramada("SEDE-SUBA", "Suba")));
     }
 
     // Tests adicionales especificos de FranjaOrdinaria (colecciones de hijos)

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/ValueObjects/FranjaOrdinariaSerializacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/ValueObjects/FranjaOrdinariaSerializacionTests.cs
@@ -91,4 +91,19 @@ public class FranjaOrdinariaSerializacionTests
 
         restaurado.Should().Be(original);
     }
+
+    // Issue #335 CA-5: round-trip de una ordinaria con sede prearmada.
+    [Fact]
+    public void RoundTrip_PreservaLaSede_CuandoOrdinariaTieneSedeAsignada()
+    {
+        var sede = new SedeProgramada("SEDE-SUBA", "Suba");
+        var original = FranjaOrdinaria.Crear(new TimeOnly(6, 0), new TimeOnly(14, 0), sede: sede);
+        var opciones = CrearOpciones();
+
+        var json = JsonSerializer.Serialize(original, opciones);
+        var restaurado = JsonSerializer.Deserialize<FranjaOrdinaria>(json, opciones);
+
+        restaurado.Should().NotBeNull();
+        restaurado!.ToDetalle().Sede.Should().Be(sede);
+    }
 }

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/ValueObjects/FranjaOrdinariaTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/ValueObjects/FranjaOrdinariaTests.cs
@@ -345,4 +345,40 @@ public class FranjaOrdinariaTests
 
         franja.ToString().Should().Be("(22:00-06:00+1)[Descansos:(23:00-23:15)][Extras:(23:15-00:00+1)]");
     }
+
+    // ---------- Issue #335: sede prearmada por franja ----------
+
+    [Fact]
+    public void ToString_IncluyeLabelDeSede_CuandoFranjaTieneSedeAsignada()
+    {
+        var sede = new SedeProgramada("SEDE-SUBA", "Suba");
+
+        var franja = FranjaOrdinaria.Crear(new TimeOnly(6, 0), new TimeOnly(12, 0), sede: sede);
+
+        franja.ToString().Should().Be($"(06:00-12:00)[{FranjaOrdinaria.Mensajes.LabelSede}:Suba]");
+    }
+
+    [Fact]
+    public void Crear_LanzaExcepcion_CuandoSedeTieneIdVacio()
+    {
+        var sedeInvalida = new SedeProgramada("", "Suba");
+
+        var act = () => FranjaOrdinaria.Crear(
+            new TimeOnly(6, 0), new TimeOnly(12, 0), sede: sedeInvalida);
+
+        act.Should().ThrowExactly<ArgumentException>()
+            .WithMessage($"*{FranjaOrdinaria.Mensajes.SedeIncompleta}*");
+    }
+
+    [Fact]
+    public void Crear_LanzaExcepcion_CuandoSedeTieneNombreEnBlanco()
+    {
+        var sedeInvalida = new SedeProgramada("SEDE-SUBA", "   ");
+
+        var act = () => FranjaOrdinaria.Crear(
+            new TimeOnly(6, 0), new TimeOnly(12, 0), sede: sedeInvalida);
+
+        act.Should().ThrowExactly<ArgumentException>()
+            .WithMessage($"*{FranjaOrdinaria.Mensajes.SedeIncompleta}*");
+    }
 }

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/ValueObjects/FranjaOrdinariaToDetalleTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/ValueObjects/FranjaOrdinariaToDetalleTests.cs
@@ -46,4 +46,28 @@ public class FranjaOrdinariaToDetalleTests
 
         detalle.Descansos[0].Descripcion.Should().Be(descanso.ToString());
     }
+
+    // ---------- Issue #335 CA-1/CA-2: la sede prearmada fluye (o no) al DTO plano ----------
+
+    [Fact]
+    public void ToDetalle_CopiaLaSede_CuandoFranjaTieneSedeAsignada()
+    {
+        var sede = new SedeProgramada("SEDE-SUBA", "Suba");
+        var franja = FranjaOrdinaria.Crear(new TimeOnly(6, 0), new TimeOnly(14, 0), sede: sede);
+
+        var detalle = franja.ToDetalle();
+
+        detalle.Sede.Should().Be(sede);
+    }
+
+    // CA-2: regresion -- una franja sin sede prearmada conserva el comportamiento actual.
+    [Fact]
+    public void ToDetalle_DejaSedeNull_CuandoFranjaNoTieneSedeAsignada()
+    {
+        var franja = FranjaOrdinaria.Crear(new TimeOnly(6, 0), new TimeOnly(14, 0));
+
+        var detalle = franja.ToDetalle();
+
+        detalle.Sede.Should().BeNull();
+    }
 }

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/ValueObjects/FranjaProgramadaIgualdadTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/ValueObjects/FranjaProgramadaIgualdadTests.cs
@@ -35,6 +35,11 @@ public class FranjaProgramadaIgualdadTests : IgualdadTestBase<FranjaProgramada>
             new FranjaProgramada(new TimeOnly(8, 0), new TimeOnly(17, 0), 0, [], [Extra()], ""));
         yield return ("Extras",
             new FranjaProgramada(new TimeOnly(8, 0), new TimeOnly(17, 0), 0, [Descanso()], [], ""));
+        // Issue #335: Sede entra en Equals/GetHashCode -- es dato de identidad del diseno de la
+        // franja, a diferencia de Descripcion (derivado, excluido).
+        yield return ("Sede",
+            new FranjaProgramada(new TimeOnly(8, 0), new TimeOnly(17, 0), 0, [Descanso()], [Extra()], "",
+                new SedeProgramada("SEDE-01", "Sede Principal")));
     }
 
     // Cobertura especifica del override: las listas se comparan por valor, no por referencia.

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/ValueObjects/FranjaProgramadaParidadConDetalleFranjaOrdinariaTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/ValueObjects/FranjaProgramadaParidadConDetalleFranjaOrdinariaTests.cs
@@ -6,6 +6,13 @@
 // verifica en dos pasos: nombres de propiedad iguales, y las dos propiedades de lista apuntando
 // al tipo hijo correcto de cada lado (cuya propia paridad la cubre
 // SubFranjaProgramadaParidadConDetalleSubFranjaTests).
+//
+// Issue #335 (desviacion documentada, MEF-ADR-0012/CA-ADR-0029 decision #5): FranjaProgramada gana
+// el campo Sede (payload propio del dominio); el mapeo hacia el bus interno (DetalleFranjaOrdinaria)
+// queda explicitamente fuera de alcance de este issue -- ver
+// SolicitarProgramacionTurnoCommandHandler.MapearFranja, que no lo propaga todavia. El guardrail de
+// paridad exacta se relaja para permitir ESTA UNICA divergencia (Sede); cualquier otro campo nuevo
+// que no aparezca en ambos lados sigue rompiendo el test.
 
 using System.Reflection;
 using AwesomeAssertions;
@@ -20,9 +27,14 @@ public class FranjaProgramadaParidadConDetalleFranjaOrdinariaTests
         typeof(T).GetProperties(BindingFlags.Public | BindingFlags.Instance).Select(p => p.Name);
 
     [Fact]
-    public void FranjaProgramada_DeclaraLosMismosNombresDeCampoQueDetalleFranjaOrdinaria()
+    public void FranjaProgramada_DeclaraLosMismosNombresDeCampoQueDetalleFranjaOrdinaria_MasSedePropiaDelDominio()
     {
-        NombresDeCampos<FranjaProgramada>().Should().Equal(NombresDeCampos<DetalleFranjaOrdinaria>());
+        var nombresProgramada = NombresDeCampos<FranjaProgramada>().ToList();
+        var nombresDetalle = NombresDeCampos<DetalleFranjaOrdinaria>().ToList();
+
+        nombresProgramada.Where(n => n != nameof(FranjaProgramada.Sede))
+            .Should().Equal(nombresDetalle);
+        nombresProgramada.Should().Contain(nameof(FranjaProgramada.Sede));
     }
 
     [Fact]

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/ValueObjects/FranjaProgramadaParidadConDetalleFranjaOrdinariaTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/ValueObjects/FranjaProgramadaParidadConDetalleFranjaOrdinariaTests.cs
@@ -27,7 +27,7 @@ public class FranjaProgramadaParidadConDetalleFranjaOrdinariaTests
         typeof(T).GetProperties(BindingFlags.Public | BindingFlags.Instance).Select(p => p.Name);
 
     [Fact]
-    public void FranjaProgramada_DeclaraLosMismosNombresDeCampoQueDetalleFranjaOrdinaria_MasSedePropiaDelDominio()
+    public void FranjaProgramada_DeclaraLosMismosNombresDeCampoQueDetalleFranjaOrdinariaMasSedePropia()
     {
         var nombresProgramada = NombresDeCampos<FranjaProgramada>().ToList();
         var nombresDetalle = NombresDeCampos<DetalleFranjaOrdinaria>().ToList();


### PR DESCRIPTION
## Resumen

Pipeline TDD completado:
- Fase roja: tests escritos con stubs
- Fase verde: implementación completa
- Smoke tests: escritos para endpoints detectados
- Fase refactor: revisión de calidad

## Decisiones del pipeline

<details>
<summary>Test Writer (fase roja) — 19m 12s</summary>

## ES Test Writer - Decisiones (Issue #335)

### Tests creados / modificados

- `ValueObjects/FranjaOrdinariaTests.cs` (modificado, +3 tests):
  - `ToString_IncluyeLabelDeSede_CuandoFranjaTieneSedeAsignada` - interfaz publica propuesta (label .resx en ToString)
  - `Crear_LanzaExcepcion_CuandoSedeTieneIdVacio` - CA-3
  - `Crear_LanzaExcepcion_CuandoSedeTieneNombreEnBlanco` - CA-3
- `ValueObjects/FranjaOrdinariaToDetalleTests.cs` (modificado, +2 tests):
  - `ToDetalle_CopiaLaSede_CuandoFranjaTieneSedeAsignada` - CA-1
  - `ToDetalle_DejaSedeNull_CuandoFranjaNoTieneSedeAsignada` - CA-2 (regresion, pasa en verde)
- `ValueObjects/FranjaOrdinariaIgualdadTests.cs` (modificado): agregado caso `"Sede"` a `CrearInstanciasDiferentes()` - CA-5
- `ValueObjects/FranjaOrdinariaSerializacionTests.cs` (modificado, +1 test):
  - `RoundTrip_PreservaLaSede_CuandoOrdinariaTieneSedeAsignada` - CA-5
- `ValueObjects/FranjaProgramadaIgualdadTests.cs` (modificado): agregado caso `"Sede"` a `CrearInstanciasDiferentes()` - CA-5 (pasa en verde, DTO plano con shape completo)
- `ValueObjects/FranjaProgramadaParidadConDetalleFranjaOrdinariaTests.cs` (modificado, ver "Desviaciones")
- `CrearTurnoFunction/TurnoCreadoTests.cs` (modificado, +3 tests):
  - `Crear_PropagaSedePorFranja_CuandoDatosFranjaTraeSedeValida` - CA-1
  - `Crear_LanzaAggregateException_CuandoSedeDeFranjaTieneIdVacio` - CA-3
  - `Crear_LanzaAggregateExceptionConErroresPropiosYDeSede_CuandoNombreVacioYSedeIncompleta` - CA-3 (acumulacion, no fail-fast)
- `CrearTurnoFunction/Eventos/TurnoCreadoSerializacionTests.cs` (modificado, +2 tests):
  - `Deserializar_PreservaSedePorFranja_CuandoOrdinariasTraenSedesDiferentes` - CA-5
  - `Deserializar_DejaSedeNull_CuandoFranjaNoTraeSede` - CA-4 (regresion, pasa en verde)
- `Entities/CatalogoTurnosTests.cs` (modificado, +2 tests):
  - `ObtenerDetalle_ExponeSedePorFranja_CuandoTurnoPrearmaSedesDiferentesEnCadaFranja` - CA-1 (turno partido multi-sede, el escenario central del issue)
  - `ObtenerDetalle_DejaSedeNull_CuandoTurnoNoPrearmaNingunaSede` - CA-2 (regresion, pasa en verde)
- `CrearTurnoFunction/CrearTurnoCommandHandlerTests.cs` (modificado, +1 test):
  - `CrearTurno_PersisteSedePorFranja_CuandoComandoTraeSedeEnAlgunasFranjas` - CA-1 via comando HTTP completo
- `CrearTurnoFunction/CrearTurnoTests.cs` (nuevo archivo, 2 tests): cubre `CrearTurno.ToDatosFranjas()`, que no tenia archivo de test dedicado
  - `ToDatosFranjas_PropagaLaSedeDeCadaFranja_CuandoComandoTraeSedes` - CA-1 (mapeo comando -> DatosFranja)
  - `ToDatosFranjas_DejaSedeNull_CuandoFranjaDelComandoNoTraeSede` - CA-2 (regresion, pasa en verde)

### Resultado de la fase roja (verificado con `dotnet test`, informativo)

216 tests totales, 13 en rojo (exactamente los que cubren comportamiento nuevo pendiente de
implementar), 203 en verde (incluye toda la regresion existente + los tests de CA-2/CA-4 que
verifican que el comportamiento actual sin sedes no cambia).

### Estructura elegida

- Una clase de test por clase de produccion (regla de organizacion): `CrearTurno.ToDatosFranjas()`
  no tenia archivo dedicado -> se creo `CrearTurnoTests.cs` en vez de mezclarlo en
  `CrearTurnoCommandHandlerTests.cs` o `CrearTurnoValidatorTests.cs`.
- Los tests de comportamiento nuevo se agregaron a los archivos EXISTENTES correspondientes
  (`FranjaOrdinariaTests`, `TurnoCreadoTests`, `CatalogoTurnosTests`, etc.) en vez de crear
  archivos paralelos "...SedeTests.cs" -- la sede es una extension del mismo comportamiento que
  esos archivos ya cubren, no una responsabilidad nueva separada.

### Stubs creados (produccion)

Diseño deliberado: todo lo que es "shape" (DTOs/records/parametros, sin logica de negocio) se
implemento COMPLETO; el "wiring" real (invariantes, formato, mapeo entre capas, serializacion)
se dejo pendiente en los puntos exactos que hacen fallar cada CA. Mismo patron usado por el
test-writer de #331 (el evento/aggregate quedaron completos, solo el handler quedo con el mapeo
pendiente).

- `DatosFranja.Sede` (nuevo param opcional, record) -- shape completo.
- `CrearTurno.Franja.Sede` (nuevo param opcional, record) -- shape completo.
- `CrearTurno.ToDatosFranjas()` -- **NO propaga** `o.Sede` a `DatosFranja` (wiring pendiente, CA-1).
- `TurnoCreado.Crear(...)` -- SI propaga `franja.Sede` a `FranjaOrdinaria.Crear(..., sede: ...)`
  (plumbing trivial, analogo a como #331 dejo completo el evento/aggregate).
- `FranjaProgramada.Sede` (nuevo param opcional, record) -- shape completo, incluido en
  `Equals`/`GetHashCode` custom (dato de identidad, no derivado).
- `FranjaOrdinaria._sede` (campo privado nuevo) -- se guarda en el constructor real.
- `FranjaOrdinaria.Crear(..., sede: null)` -- acepta el parametro, **NO valida** invariante
  Id/Nombre no vacios (CA-3 pendiente).
- `FranjaOrdinaria.ToDetalle()` -- **NO copia** `_sede` al DTO (CA-1 pendiente).
- `FranjaOrdinaria.ToString()` -- **NO incluye** el label de sede (interfaz publica pendiente).
- `FranjaOrdinaria.Equals`/`GetHashCode` -- **NO comparan** `_sede` (CA-5 pendiente).
- `FranjaOrdinaria.ConfigurarSerializacion` -- **NO registra** `_sede` en el resolver (CA-5
  round-trip pendiente: el valor se pierde al serializar/deserializar).
- `FranjaOrdinariaMensajes.resx` + `FranjaOrdinaria.Mensajes.cs` (nuevo, partial class, `internal`):
  mensajes `SedeIncompleta` (invariante) y `LabelSede` (formato ToString). Vive separado de
  `FranjaTemporal.Mensajes` porque Sede es exclusiva de `FranjaOrdinaria` (SubFranja no tiene
  sede) -- requirio `new static class Mensajes` explicito para ocultar el heredado sin ambiguedad,
  y calificar `FranjaTemporal.Mensajes.XXX` en las referencias existentes dentro de
  `FranjaOrdinaria.cs` (InicioYFinIguales, LabelDescansos, LabelExtras,
  FranjaHijaFueraDeContenedor, FranjasHijasSeSuperponen) que antes resolvian por herencia directa.

### Decisiones de diseno

1. **Validacion de sede vive en `FranjaOrdinaria`, no en `TurnoCreado` ni en el validator del
   comando**: el issue es explicito ("aqui la franja SI tiene su sistema de invariantes propio y
   la sede pertenece a el"). El `ArgumentException` que lanzara `FranjaOrdinaria.Crear()` ya es
   capturado por el `try/catch` existente de `TurnoCreado.Crear()` (CA-9 del issue #3) -- no hizo
   falta tocar ese mecanismo.
2. **Mensajes de `FranjaOrdinaria` en archivo propio** (`FranjaOrdinariaMensajes.resx` +
   `FranjaOrdinaria.Mensajes.cs`) en vez de agregar a `FranjaTemporalMensajes.resx` (compartido con
   `SubFranja`): la sede es exclusiva de la franja ordinaria: mezclarla en el Mensajes compartido
   heredado por `SubFranja` habria sido conceptualmente incorrecto (SubFranja no tiene sede).
3. **`FranjaOrdinaria.Crear` acepta `sede` sin validar (stub) en vez de usar `NotImplementedException`**:
   lanzar `NotImplementedException` en `Crear()` habria roto los ~19 tests EXISTENTES de esa
   funcion (CA-7 a CA-19 del issue #3) que no pasan sede. El patron correcto para extender un
   factory ya probado es aceptar el dato y diferir su uso, no explotar.
4. **`TurnoCreado.Crear` SI propaga `franja.Sede` a `FranjaOrdinaria.Crear`** (no se dejo como
   hueco): es plumbing trivial de un punto a otro, sin logica de negocio -- permite que
   `TurnoCreadoTests` (factory directo con `DatosFranja`) ejercite el VO subyacente sin pasar por
   el comando HTTP. El hueco real vive mas arriba, en `CrearTurno.ToDatosFranjas()` (el mapeo
   comando -> factory), analogo a donde #331 dejo el hueco (el handler).
5. **Oraculo independiente en `CrearTurnoCommandHandlerTests`**: se evaluo construir el
   `eventoEsperado` directamente con `DatosFranja` (bypaseando `comando.ToDatosFranjas()`) para
   forzar que `Then()` detectara el hueco de CA-1. Se descarto: como `FranjaOrdinaria.Equals` NO
   compara `_sede` (hueco de CA-5), ese oraculo habria hecho pasar `Then()` en verde de todas
   formas (ambos objetos "iguales" para el Equals actual) sin aportar señal real, y habria sido un
   oraculo mas fragil que el patron existente del archivo. Se mantuvo el patron existente
   (`comando.ToDatosFranjas()`) para `Then()` y se delego la deteccion real de CA-1 al `And<>()`
   que inspecciona `ObtenerDetalle().FranjasOrdinarias[i].Sede` directamente sobre el estado del
   aggregate -- ese SI es sensible al hueco de `ToDatosFranjas()`. Confirmado en ejecucion: el test
   falla exactamente en el primer `And<>()`, no en `Then()`.

### Cobertura de criterios

| Criterio de aceptacion | Test(s) |
|---|---|
| CA-1: sede prearmada persiste y `ObtenerDetalle()` la expone (franjas sin sede quedan null) | `CatalogoTurnosTests.ObtenerDetalle_ExponeSedePorFranja_CuandoTurnoPrearmaSedesDiferentesEnCadaFranja`, `TurnoCreadoTests.Crear_PropagaSedePorFranja_CuandoDatosFranjaTraeSedeValida`, `FranjaOrdinariaToDetalleTests.ToDetalle_CopiaLaSede_CuandoFranjaTieneSedeAsignada`, `CrearTurnoCommandHandlerTests.CrearTurno_PersisteSedePorFranja_CuandoComandoTraeSedeEnAlgunasFranjas`, `CrearTurnoTests.ToDatosFranjas_PropagaLaSedeDeCadaFranja_CuandoComandoTraeSedes` |
| CA-2: turno sin sedes conserva comportamiento actual | `FranjaOrdinariaToDetalleTests.ToDetalle_DejaSedeNull_CuandoFranjaNoTieneSedeAsignada`, `CatalogoTurnosTests.ObtenerDetalle_DejaSedeNull_CuandoTurnoNoPrearmaNingunaSede`, `CrearTurnoTests.ToDatosFranjas_DejaSedeNull_CuandoFranjaDelComandoNoTraeSede` |
| CA-3: sede con Id/Nombre vacio se rechaza (error acumulado, endpoint 400) | `FranjaOrdinariaTests.Crear_LanzaExcepcion_CuandoSedeTieneIdVacio`, `FranjaOrdinariaTests.Crear_LanzaExcepcion_CuandoSedeTieneNombreEnBlanco`, `TurnoCreadoTests.Crear_LanzaAggregateException_CuandoSedeDeFranjaTieneIdVacio`, `TurnoCreadoTests.Crear_LanzaAggregateExceptionConErroresPropiosYDeSede_CuandoNombreVacioYSedeIncompleta` (el 400 del endpoint ya esta cubierto genericamente por `FunctionEndpointTests.DebeRetornar400ConMensajes_CuandoFranjasDelComandoSonInvalidas`, agnostico al tipo de error -- no requirio test nuevo) |
| CA-4: JSON viejo (sin clave "sede") deserializa con sede null | `TurnoCreadoSerializacionTests.Deserializar_DejaSedeNull_CuandoFranjaNoTraeSede` |
| CA-5: round-trip Marten/STJ + igualdad por valor con sede | `FranjaOrdinariaSerializacionTests.RoundTrip_PreservaLaSede_CuandoOrdinariaTieneSedeAsignada`, `TurnoCreadoSerializacionTests.Deserializar_PreservaSedePorFranja_CuandoOrdinariasTraenSedesDiferentes`, `FranjaOrdinariaIgualdadTests` (caso "Sede"), `FranjaProgramadaIgualdadTests` (caso "Sede") |
| CA-6: suite completa en verde | Se valida en la fase verde (implementer); en esta fase roja, 13/216 tests fallan intencionalmente |

### Desviaciones del plan del planner

| Sugerencia del issue | Desviacion aplicada | Razon tecnica | Consecuencia |
|---|---|---|---|
| Ninguna explicita sobre paridad, pero el issue declara "Consumidores: ninguno nuevo; TurnoCreado no cruza el bus" | Se modifico el test EXISTENTE `FranjaProgramadaParidadConDetalleFranjaOrdinariaTests` (guardrail de paridad exacta de nombres de campo entre `FranjaProgramada` y `DetalleFranjaOrdinaria`, PrivateEvents) para tolerar la divergencia deliberada del campo `Sede` | Agregar `Sede` a `FranjaProgramada` (DTO propio del dominio) sin tocar `DetalleFranjaOrdinaria` (DTO del bus, fuera de alcance del issue) rompe el guardrail de paridad EXACTA existente. Es una contradiccion estructural inevitable: el issue exige el campo en un lado y excluye explicitamente el otro lado de su alcance (regla 19, autoridad del test-writer para resolver). | El guardrail se relaja para permitir SOLO esta divergencia nombrada (`Sede`); cualquier otro campo nuevo no compartido sigue rompiendo el test. Documentado inline en el archivo con referencia a `SolicitarProgramacionTurnoCommandHandler.MapearFranja` como el punto donde se retomaria el mapeo si un issue futuro decide propagar la sede al bus interno. |
| "Interfaz publica propuesta": `ToString()` incluye el nombre de la sede cuando presente, formato sugerido `(06:00-12:00)[sede:Suba]` | Aplicada tal cual, con el label en minuscula ("sede") segun el ejemplo del issue, distinto de `Descansos`/`Extras` (mayuscula inicial) | El propio issue especifica el formato exacto con minuscula | Test `ToString_IncluyeLabelDeSede_CuandoFranjaTieneSedeAsignada` verifica el formato literal |

### Notas para el implementer

Los comentarios `// Issue #335 (fase roja): ... pendiente para el implementer` dejados en
`FranjaOrdinaria.cs` marcan los 5 puntos exactos que deben completarse: validacion en `Crear()`,
copia en `ToDetalle()`, label en `ToString()`, comparacion en `Equals`/`GetHashCode`, y registro en
`ConfigurarSerializacion`. Adicionalmente, `CrearTurno.ToDatosFranjas()` debe propagar `o.Sede`.

</details>

<details>
<summary>Implementer (fase verde) — 5m 26s</summary>

## ES Implementer - Decisiones

### Enfoque de implementacion

El test-writer ya habia dejado la mayor parte del wiring estructural en su lugar (campo `_sede`
privado en `FranjaOrdinaria`, `SedeProgramada` en `DatosFranja`/`CrearTurno.Franja`,
`FranjaProgramada.Sede` con Equals/GetHashCode custom, mensajes en `.resx`). El trabajo de esta
fase se redujo a cinco puntos puntuales, todos dentro de `FranjaOrdinaria.cs` salvo el ultimo:

1. `Crear(...)`: valida la invariante de sede (Id/Nombre no vacios/en blanco) junto a las demas
   invariantes de la franja -- lanza `ArgumentException(Mensajes.SedeIncompleta)` cuando falla.
2. `ToDetalle()`: copia `_sede` al DTO plano `FranjaProgramada`.
3. `ToString()`: agrega el bloque `[{Mensajes.LabelSede}:{_sede.Nombre}]` cuando `_sede` no es
   null, despues de los bloques de Descansos/Extras.
4. `Equals`/`GetHashCode`: incluyen `_sede` (dato de identidad del diseno de la franja, segun
   documenta el issue).
5. `ConfigurarSerializacion`: registra `_sede` con `CreateJsonPropertyInfo` (mismo patron que
   `_descansos`/`_extras`), con `ShouldSerialize = (_, val) => val is not null` para que la clave
   `"sede"` no aparezca en el JSON cuando el valor es null (CA-4, retrocompatibilidad).
6. `CrearTurno.ToDatosFranjas()`: propaga `o.Sede` al construir cada `DatosFranja`.

`TurnoCreado.Crear` y `CatalogoTurnos.ObtenerDetalle()` ya estaban completos (verificado en
codigo antes de tocar nada) -- el primero ya pasaba `sede: franja.Sede` a
`FranjaOrdinaria.Crear()`, y el segundo ya fluye la sede via `ToDetalle()` sin cambios, tal como
anticipaba la investigacion del planner en el issue.

### Decisiones de diseno

- La validacion de sede se ubica en `FranjaOrdinaria.Crear()`, no en `CrearTurnoValidator` (el
  RequestValidator del comando) -- exactamente como proponia el issue: las invariantes de la
  franja viven en su propio factory, y la sede es una invariante mas de esa franja, no de la
  solicitud HTTP.
- El bloque de sede en `ToString()` se coloca despues de Descansos y Extras (ningun test combina
  sede con hijos, asi que el orden no es observable por los tests, pero es el orden natural de
  aparicion en el codigo: hijos temporales primero, atributo de diseno despues).
- `ShouldSerialize` en el `JsonPropertyInfo` de `_sede` es el mecanismo elegido para la
  retrocompatibilidad de CA-4 (omitir la clave cuando es null) -- ninguna otra clave existente en
  `FranjaOrdinaria` necesitaba ese comportamiento (todas eran no-nullables), asi que este es el
  primer uso del patron en este VO.

### ADRs consultados

- MEF-ADR-0012: encapsulamiento del VO -- `_sede` se mantuvo privado sin propiedad publica; la
  conversion a DTO sigue viviendo en `ToDetalle()` (Tell-don't-Ask preservado).
- MEF-ADR-0009: el mensaje de validacion (`SedeIncompleta`) y el label de `ToString()`
  (`LabelSede`) ya estaban en el `.resx` propio de `FranjaOrdinaria` creado por el test-writer;
  no fue necesario agregar entradas nuevas.
- CA-ADR-0029 / MEF-ADR-0039: `TurnoCreado` no cruza el bus -- ningun cambio de este issue toca
  `PublicEvents`/`PrivateEvents`.
- CA-ADR-0029 decision #6 / MEF-ADR-0036: campo aditivo (`sede`), ningun evento se movio ni
  renombro -- no aplica registro en `IdentidadEventos{Dominio}` porque no hay tipo de evento
  nuevo, solo un campo nuevo en un tipo ya registrado.

### Desviaciones de ADRs

Ninguna desviacion -- todos los ADRs aplicados al pie de la letra.

### Desviaciones del plan del planner

Ninguna desviacion -- la interfaz publica propuesta (`Crear(..., sede: null)`, `ToDetalle()`,
`ToString()`, `FranjaProgramada.Sede`, `CrearTurno.Franja.Sede`) se implemento tal cual.

### Precedentes consultados

- Patron de `RegistrarCampo`/`CreateJsonPropertyInfo` de `_descansos`/`_extras` en la misma clase
  (`FranjaOrdinaria.ConfigurarSerializacion`) -- alineado con MEF-ADR-0012, reusado para `_sede`
  con el agregado de `ShouldSerialize` (necesario solo porque `_sede` es el primer campo nullable
  de este VO).
- `Descripcion` en `FranjaProgramada` (issue #288) como precedente de campo opcional
  retrocompatible -- alineado, y el issue ya documentaba explicitamente por que `Sede` diverge de
  ese precedente en Equals (Sede es identidad, Descripcion es derivado).

### Infraestructura modificada

Ninguna. `TurnoCreado` es un evento de event-sourcing puro (no implementa `IPrivateEvent` ni
`IPublicEvent`) y nunca cruza el bus -- no hay topics ni subscriptions que agregar en
`infra/environments/dev/main.tf`. Verificado con grep: no existen referencias a `turno-creado`
en ese archivo, consistente con la seccion "Consumidores" del issue ("ninguno nuevo").

### Complejidad encontrada

Ninguna significativa. El test-writer dejo comentarios explicitos "(fase roja): pendiente para
el implementer" en cada punto exacto donde faltaba codigo, lo que redujo la exploracion
necesaria. Se actualizaron esos comentarios (y uno equivalente en `DatosFranja.cs` y
`CrearTurno.cs`) para reflejar el estado post-implementacion, sin tocar ningun assert de test.

### Resultado

- Tests pasando: 216/216 en `Bitakora.ControlAsistencia.Programacion.Tests`.
- Suite completa del repo: 780/793 correctos, 13 omitidos (smoke tests que requieren Postgres/
  ServiceBus locales no configurados en este entorno -- comportamiento esperado, no relacionado
  con este issue).

</details>
<details>
<summary>Smoke Test Writer — 3m 2s</summary>

_(El agente no generó resumen)_

</details>
<details>
<summary>Reviewer (fase refactor) — 16m 28s</summary>

## ES Reviewer - Revision

### Evaluacion general
- Calidad: **buena** (el diff de las fases roja y verde era solido; las correcciones son de
  cobertura y encapsulamiento, no de correccion funcional)
- Cambios realizados: **si** (commit `26d2f01`)

### Estado de la suite

| Proyecto | Resultado |
|---|---|
| Todos los `*.Tests` (unitarios) | **781 correctos, 0 errores** |
| `Programacion.SmokeTests` | 2 rojos **estructurales pre-deploy** (ver abajo), 4 omitidos |

**Los 2 rojos NO son defecto de codigo y no son corregibles desde el codigo.**
`CrearTurno_Retorna400_CuandoSedeDeFranjaTieneIdVacio` y `..._NombreEnBlanco` corren contra
`func-asist-dev-programacion` **desplegado**, que todavia ejecuta el binario anterior a este PR:
sin la validacion de sede, STJ ignora la clave `sede` desconocida y el endpoint responde 202.
Post-deploy pasan. Verificado ademas que el gate de CI no los ve: tanto `ci.yml` como el job
`build-and-test` de `deploy-programacion.yml` iteran el glob `tests/Bitakora.ControlAsistencia.*.Tests/`,
que excluye `*.SmokeTests`; estos corren en el job `smoke-tests`, despues del deploy. No se abrio
`blockage-report.md` porque no hay bloqueo que reportar: la validacion local esta cubierta y verde
(`Crear_LanzaExcepcion_CuandoSedeTieneIdVacio`, `Crear_LanzaAggregateException_...`).

### Cumplimiento de ADRs aplicables

| ADR | Cumplimiento | Observacion |
|---|---|---|
| MEF-ADR-0012: encapsulamiento del VO | ok (tras correccion) | `_sede` privado sin propiedad publica, expuesto solo via `ToDetalle()`/`ToString()`. **Desviacion no declarada corregida**: `Crear()` leia `sede.Id`/`sede.Nombre` para decidir completitud -- regla movida a `SedeProgramada.EstaCompleta()`. Detalle abajo. |
| ADR local de eventos (citado como ADR-0015 en el codigo) | ok | `FranjaOrdinaria` sigue siendo `sealed class` con factory static y ctor privado; `SedeProgramada`/`FranjaProgramada`/`DatosFranja` siguen siendo records DTO planos. `partial` agregado solo para alojar la clase `Mensajes` (mismo patron que `TurnoCreado`). |
| MEF-ADR-0009: mensajes en .resx | ok | `FranjaOrdinariaMensajes.resx` propio + clase `Mensajes` anidada en archivo `.Mensajes.cs`. Correcto no meter `SedeIncompleta`/`LabelSede` en `FranjaTemporalMensajes.resx`: ese lo comparte `SubFranja`, que no tiene sede. Ver observacion sobre el `new` en "Criticas". |
| CA-ADR-0029 / MEF-ADR-0039: islas de eventos | ok | La sede tipa con `SedeProgramada` (propio de `Programacion.DomainEvents`); nada de este issue cruza el bus. `TurnoCreado` no implementa `IPrivateEvent`/`IPublicEvent` -- el guardrail de portabilidad con serializador vanilla no aplica. |
| CA-ADR-0029 decision #6 / MEF-ADR-0036: identidad del evento persistido | ok | Campo **aditivo**: ningun tipo se movio ni renombro, `IdentidadEventosProgramacion.TiposPersistidos` sin cambios. No aplica el protocolo de dos despliegues. |
| MEF-ADR-0002 / MEF-ADR-0016: DSL y naming de tests | ok (tras correccion) | DSL Given/WhenAsync/Then/And correcto. **Desviacion no declarada corregida**: 3 nombres fuera de convencion. Detalle abajo. |

### Desviaciones de ADRs

**Desviaciones declaradas por el implementer** (`stage-2-implementer.md`): el implementer declaro
"Ninguna desviacion". Evaluacion del reviewer: correcto en lo que el implementer escribio; las dos
desviaciones de abajo venian de la fase roja y no fueron detectadas en la fase verde.

**Desviaciones detectadas por el reviewer (NO declaradas)**:

#### Desviacion: MEF-ADR-0012 (Tell-don't-Ask sobre `SedeProgramada`)
- **Regla del ADR**: "si una clase externa necesita conocer la representacion interna del VO para
  operar sobre el, la operacion vive en el VO". Heuristica #1: "La operacion, ¿depende solo de
  datos del propio objeto? -> vive en el objeto".
- **Desviacion encontrada en el diff**: `FranjaOrdinaria.cs:60-63` -- `Crear()` leia `sede.Id` y
  `sede.Nombre` y aplicaba `IsNullOrWhiteSpace` sobre ambos para decidir si la sede es valida. La
  regla "una sede esta completa cuando trae Id y Nombre" depende **solo** de datos de
  `SedeProgramada`, asi que pertenece a `SedeProgramada`. Sintoma colateral: la misma regla ya
  estaba escrita a mano en `SolicitarProgramacionTurnoValidator` (#331) -- dos copias del mismo
  conocimiento en dos fronteras distintas.
- **Accion tomada**: **corregida en refactor**. `SedeProgramada.EstaCompleta()` publica la regla;
  `Crear()` pasa a `if (sede is not null && !sede.EstaCompleta())`. Tests verdes sin tocar ningun
  assert.
- **No corregido (fuera del diff)**: `SolicitarProgramacionTurnoValidator` sigue con
  `RuleFor(x => x.Sede!.Id).NotEmpty()`. Deliberado: es codigo de #331, y migrarlo a
  `Must(s => s.EstaCompleta())` perderia los mensajes por-propiedad de FluentValidation. Queda
  como candidato para #341, que va a tocar esa cascada de todos modos.
- **Status**: pendiente de evaluacion del usuario

#### Desviacion: MEF-ADR-0016 (naming de tests nuevos)
- **Regla del ADR**: `<Sujeto>_<LoQuePasa>[_Cuando<Condicion>]`; el tercer segmento existe solo
  para `Cuando<Condicion>`. Ejemplo canonico del propio ADR para este endpoint:
  `CrearTurno_Retorna202_CuandoPayloadEsValido`.
- **Desviacion encontrada en el diff**: 3 tests nuevos con `LoQuePasa` prefijado por `Debe`
  (`CrearTurno_DebeRetornar202_...`, `..._DebeRetornar400_...` x2) y 1 con tercer segmento que no
  es `Cuando` (`..._MasSedePropiaDelDominio`).
- **Accion tomada**: **corregida en refactor**, mismo criterio que aplico el reviewer de #331
  (commit `29dc0e4`: "Naming de tests nuevos alineado a MEF-ADR-0016"). Los nombres `Debe...`
  preexistentes en los mismos archivos **no** se tocaron: son los ~60 legacy que el propio ADR
  difiere a un issue de migracion dedicado.
- **Status**: pendiente de evaluacion del usuario

### Precedentes consultados por el implementer

| Precedente | ADR aplicable | Veredicto |
|---|---|---|
| `FranjaOrdinaria.ConfigurarSerializacion` (`_descansos`/`_extras`) | MEF-ADR-0012 | **alineado**. `CreateJsonPropertyInfo` + `Get`/`Set` por reflexion sobre campo privado, con `CreateObject` desde el ctor vacio privado. Sin `[JsonConstructor]`. El agregado de `ShouldSerialize` para omitir la clave cuando es null es correcto y necesario para CA-4. |
| `Descripcion` en `FranjaProgramada` (#288) como campo opcional retrocompatible | MEF-ADR-0012 | **alineado**, y la divergencia esta bien razonada: `Descripcion` se excluye de `Equals` por derivado, `Sede` entra por ser identidad del diseno. |
| `TurnoCreado.Mensajes` como patron de `Mensajes` internal + IVT | MEF-ADR-0009 | **alineado**. |

### Convenciones del pipeline (no ADRs)

| Convencion | Estado | Observacion |
|---|---|---|
| Cada test con `Then()` + `And<>()` | ok | `CrearTurno_PersisteSedePorFranja_...` tiene `Then` + 2 `And<>`; el test nuevo del reviewer sobre `SolicitarProgramacionTurno` tambien. Los tests de VO puro (`ToDetalle`, `ToString`, round-trip) no usan el DSL de handler -- correcto, no aplica. |
| Overloads correctos para stream IDs compuestos | ok | `CatalogoTurnos` usa `Id = evento.TurnoId.ToString()` (guid, no compuesto); los tests usan `GuidAggregateId` y los del handler de solicitud, `Given(TurnoId.ToString(), ...)` con el overload de stream id explicito. |
| Fakes manuales (no NSubstitute) | n/a | Ningun handler nuevo; los existentes usan `EventStore`/`PrivateEventSender` del harness. Cero NSubstitute en el diff. |
| Feature folders (produccion y tests) | ok | `CrearTurnoFunction/CrearTurno.cs`, `CommandHandler/`, tests espejo. `CrearTurnoTests.cs` nuevo en el feature folder correcto (un archivo por responsabilidad: el mapeo `ToDatosFranjas`, separado del handler). |
| Smoke tests: SkipWhen, secrets, cobertura | **falla -> corregido** | Ver "Criticas", hallazgo mayor #1. `Assert.SkipWhen` correcto en el test nuevo; `appsettings.json` sin secrets reales (`""`). |
| Proyecciones read-side | n/a | El diff no toca `ReadModels`/`Projections` ni ninguna Function GET. Verificado que el worker ya consume `ConfiguracionSerializacionProgramacion.ConfigurarResolver` -- no hay copia que sincronizar. |
| Compatibilidad Marten write-side/read-side | ok | El diff no toca version del paquete ni `ComposicionServicios`/`ConfiguracionMartenProjections*`/`IdentidadEventos*`. El unico cambio de serializacion (`sede`) entra por `FranjaOrdinaria.ConfigurarSerializacion`, que **ambos** lados invocan a traves de la misma funcion (`ConfiguracionSerializacionProgramacion.ConfigurarResolver`) -- coinciden por construccion, no por replica. Sin decompilacion (gate no disparado). |
| Identidad de stream (MEF-ADR-0037) | ok | El smoke test nuevo usa `turnoId.ToString()` **sin especificador de formato**, identico a lo que hace `CatalogoTurnos.Apply`. Sin claves compuestas, sin construccion manual fuera de un punto unico, sin GET de read-side en el diff. |
| Control de volumen de telemetria (MEF-ADR-0038) | n/a | El diff no toca `ComposicionServicios*`, `ConfiguracionObservabilidad*`, `AddOpenTelemetry`, `SetSampler` ni el callback de `AgregarWolverineParaComandosServerless`. |
| Tests via ToString/comportamiento | ok | La sede se verifica via `ToDetalle()`, `ToString()` e igualdad. **No** se agrego ninguna propiedad publica al VO para que los tests miren adentro. |
| Sin numeros magicos | ok | Constantes con nombre en el smoke test (`SchemaProgramacion`, `TipoEventoTurnoCreado`, `Timeout`); los literales de sede son datos del escenario, no magia. |
| Condiciones en positivo | ok | La guarda `if (sede is not null && !sede.EstaCompleta())` es guard-clause con throw (excepcion explicita de la regla: la negacion expresa la precondicion de salida). |

### Elegancia del codigo

- **Compacto**: la guarda de sede paso de 3 lineas con doble `IsNullOrWhiteSpace` a una condicion
  de una linea que se lee como la regla de negocio (`!sede.EstaCompleta()`).
- **Idiomatico**: `ShouldSerialize = (_, val) => val is not null` es la forma correcta de omitir la
  clave en STJ, mejor que serializar `null` explicito -- y es lo que hace que CA-4 sea real
  (ausencia de clave) y no una aproximacion (`"sede": null`).
- **Legible**: los comentarios del diff son de alta calidad y explican el *por que* (por que `Sede`
  entra en `Equals` y `Descripcion` no; por que el `.resx` es propio y no el de `FranjaTemporal`).
  Un solo comentario habia quedado obsoleto de la fase roja ("pendiente de wiring: ver comentarios
  en Crear/ToDetalle/ToString") -- corregido.
- **Limpieza**: se elimino un `using` innecesario (IDE0005) en `TurnoCreadoSerializacionTests.cs`,
  archivo del diff. Quedan 4 IDE0005 preexistentes en `ControlHoras.Tests`, archivos que este PR no
  toca -- **no** se limpiaron por la regla de no refactorizar codigo ajeno a la HU. Cero
  advertencias de compilador propias del diff (las 4 `NU1902` son de `OpenTelemetry.Api`,
  preexistentes). Cero caracteres `─` (U+2500).
- **Eficiencia**: nada relevante; el campo es escalar y no entra en ningun bucle nuevo.

### Criticas y hallazgos

**Mayor #1 -- cobertura incompleta de efectos secundarios en el smoke test (corregido).**
`CrearTurnoCommandHandler` persiste via `IEventStore.StartStream`, y el smoke test de CA-1
verificaba **solo** el 202. MEF-ADR-0013 lo tipifica como defecto bloqueante, y aqui era
especialmente grave: el riesgo real que introduce este issue es que el resolver de serializacion del
Function App **desplegado** no registre la clave `sede` -- en ese escenario el turno se crea, el
endpoint responde 202 y el dato se pierde en silencio. El smoke test tal como estaba pasaba en verde
igual. El comentario del smoke-test-writer ("este dominio no tiene `PostgresFixture`") describia el
sintoma, no una imposibilidad: el reusable `smoke-tests-dominio.yml` **ya** aceptaba
`POSTGRES_CONNECTION_STRING`, solo faltaba el fixture y el pase del secret. Corregido:
- `Fixtures/PostgresFixture.cs` (gemelo del de `ControlHoras.SmokeTests`, `IsConfigured` +
  `SkipReason`, sin lanzar si falta configuracion), registrado en `AssemblyFixture`.
- `Npgsql` en el csproj, `"Postgres": { "ConnectionString": "" }` en `appsettings.json` (vacio,
  nunca secret real).
- `POSTGRES_CONNECTION_STRING` pasado desde `deploy-programacion.yml`.
- El smoke test de CA-1 pasa a 3 franjas (Suba / Chapinero / **sin sede**) y verifica en
  `mt_events`: el evento existe en el stream, cada franja conserva **su** sede, y la franja sin sede
  **no** escribe la clave `sede`. Esto cubre CA-1, CA-2 y CA-4 end-to-end contra dev.

**Mayor #2 -- Tell-don't-Ask sobre `SedeProgramada` (corregido).** Ver "Desviaciones".

**Menor #1 -- el bonus del issue no tenia guardrail (corregido).** El issue afirma que la sede
prearmada "fluye sola hasta `ProgramacionTurnoSolicitada` sin tocar nada del flujo de solicitud", y
#341 se construye encima de eso. No habia ningun test que lo fijara: un refactor de `ToDetalle()` o
`ObtenerDetalle()` que dejara de copiar `_sede` habria pasado en verde aqui y explotado en #341.
Agregado `SolicitarProgramacionTurno_PersisteLaSedePrearmadaDelCatalogo_CuandoElTurnoLaTraePorFranja`
(la solicitud va **sin** sede propia a proposito, para que el unico origen posible del dato sea el
catalogo). Paso a la primera -- confirma que la afirmacion del issue es correcta.

**Menor #2 -- efecto colateral aceptado, ahora explicito.** Como la sede entra al `ToString()` de la
franja, la `Descripcion` derivada la incluye (`(06:00-14:00)[sede:Suba]`), y esa `Descripcion` **si**
cruza el bus dentro de `DetalleFranjaOrdinaria`. Es decir: hoy la sede ya llega a ControlHoras como
texto, aunque el campo estructurado no exista hasta #341. El issue lo anticipo y lo acepto ("los
turnos viejos no cambian"). No es un defecto -- pero no estaba fijado en ningun test; el guardrail
nuevo de Menor #1 lo asienta con literales explicitos en ambos payloads.

**Cosmetico #1 -- `internal new static class Mensajes` oculta `FranjaTemporal.Mensajes` (no
corregido, deliberado).** `FranjaOrdinaria.Mensajes` esconde el `public` de la clase base, lo que
obligo a calificar 5 referencias como `FranjaTemporal.Mensajes.X` dentro de `FranjaOrdinaria.cs`, y
hace que `FranjaOrdinaria.Mensajes.InicioYFinIguales` signifique cosas distintas dentro y fuera del
ensamblado (adentro no compila; afuera resuelve a la base). **No lo cambie** porque las alternativas
son peores: mover `SedeIncompleta`/`LabelSede` al `.resx` de `FranjaTemporal` lo contaminaria con un
concepto que `SubFranja` no tiene (contra MEF-ADR-0009), y renombrar la clase anidada romperia la
convencion `Mensajes` que el ADR prescribe. El `new` es explicito y esta comentado, y ningun test
quedo roto (los tests ya calificaban con `FranjaTemporal.Mensajes` desde antes). Lo dejo registrado
como aristas conocida, no como deuda accionable.

**Verificado sin hallazgos**: `Equals`/`GetHashCode` de ambos tipos (uso correcto de `==` de record
sobre `SedeProgramada?`, null-safe); relajacion del guardrail de paridad
`FranjaProgramada`/`DetalleFranjaOrdinaria` (bien acotada: permite **solo** `Sede` y sigue rompiendo
ante cualquier otro campo divergente); ausencia de infraestructura nueva de Service Bus (correcto,
`TurnoCreado` no cruza ningun bus).

### Refactorings aplicados

1. `SedeProgramada.EstaCompleta()` + uso en `FranjaOrdinaria.Crear()` -- MEF-ADR-0012.
2. Comentario obsoleto de fase roja eliminado en `FranjaOrdinaria.cs`.
3. Renombre de 4 tests a MEF-ADR-0016 (3 smoke + 1 de paridad).
4. `using` innecesario eliminado en `TurnoCreadoSerializacionTests.cs`.
5. `PostgresFixture` + wiring de secret + smoke test de persistencia (hallazgo Mayor #1).
6. Guardrail del flujo catalogo -> evento persistido (hallazgo Menor #1).

Ningun refactor rompio un test: `dotnet test` verde despues de cada paso.

### Cobertura de criterios de aceptacion

| Criterio | Estado | Test(s) |
|---|---|---|
| CA-1: la sede persiste por franja y `ObtenerDetalle()` la expone | cubierto | `CrearTurno_PersisteSedePorFranja_CuandoComandoTraeSedeEnAlgunasFranjas`, `ObtenerDetalle_ExponeSedePorFranja_CuandoTurnoPrearmaSedesDiferentesEnCadaFranja`, `Crear_PropagaSedePorFranja_CuandoDatosFranjaTraeSedeValida`, `ToDatosFranjas_PropagaLaSedeDeCadaFranja_CuandoComandoTraeSedes`, `ToDetalle_CopiaLaSede_CuandoFranjaTieneSedeAsignada`, **smoke** `CrearTurno_PersisteLaSedePrearmadaDeCadaFranja_CuandoAlgunasFranjasTraenSede` (agregado) |
| CA-2: turno sin sedes conserva el comportamiento actual | cubierto | `ObtenerDetalle_DejaSedeNull_CuandoTurnoNoPrearmaNingunaSede`, `ToDetalle_DejaSedeNull_CuandoFranjaNoTieneSedeAsignada`, `ToDatosFranjas_DejaSedeNull_CuandoFranjaDelComandoNoTraeSede`, **smoke** (tercera franja sin sede en el test agregado) |
| CA-3: sede con Id/Nombre vacio se rechaza acumulado, endpoint 400 | cubierto | `Crear_LanzaExcepcion_CuandoSedeTieneIdVacio`, `Crear_LanzaExcepcion_CuandoSedeTieneNombreEnBlanco`, `Crear_LanzaAggregateException_CuandoSedeDeFranjaTieneIdVacio`, `Crear_LanzaAggregateExceptionConErroresPropiosYDeSede_CuandoNombreVacioYSedeIncompleta`, **smoke** `CrearTurno_Retorna400_CuandoSedeDeFranjaTieneIdVacio` / `..._NombreEnBlanco` (rojos hasta el deploy, ver "Estado de la suite") |
| CA-4: JSON sin clave `sede` deserializa null (retrocompatibilidad) | cubierto | `Deserializar_DejaSedeNull_CuandoFranjaNoTraeSede` (con `json.Should().NotContain("\"sede\"")`, lo que impide que el test se vuelva vacuo), **smoke** (assert de ausencia de la clave en el evento realmente persistido) |
| CA-5: round-trip Marten/STJ + igualdad por valor con sede | cubierto | `Deserializar_PreservaSedePorFranja_CuandoOrdinariasTraenSedesDiferentes`, `RoundTrip_PreservaLaSede_CuandoOrdinariaTieneSedeAsignada`, caso `"Sede"` en `FranjaOrdinariaIgualdadTests` y en `FranjaProgramadaIgualdadTests` |
| CA-6: suite completa en verde | cubierto con salvedad | 781/781 unitarios verdes. Los 2 smoke rojos son pre-deploy y quedan fuera del gate de CI (ver "Estado de la suite") |

### Tests agregados

- `SolicitarProgramacionTurno_PersisteLaSedePrearmadaDelCatalogo_CuandoElTurnoLaTraePorFranja`
  (guardrail del flujo catalogo -> snapshot -> evento persistido; cimiento de #341).
- `CrearTurno_PersisteLaSedePrearmadaDeCadaFranja_CuandoAlgunasFranjasTraenSede` (smoke, reemplaza
  al que solo miraba el 202; verifica persistencia real en `mt_events` con 3 franjas: dos sedes
  distintas + una sin sede).
- Tests de contrato de igualdad y serializacion: **ya existian** y el diff los extendio
  correctamente (`FranjaOrdinariaIgualdadTests`, `FranjaProgramadaIgualdadTests`,
  `FranjaOrdinariaSerializacionTests`, `TurnoCreadoSerializacionTests`) -- no hubo que crearlos.
- Guardrail de round-trip con serializador vanilla: **no aplica**, `TurnoCreado` no lleva marker de
  bus.

</details>

## Cobertura

| Archivo | Cobertura | Umbral | Estado |
|---|---|---|---|
| FranjaOrdinaria.Mensajes.cs | - | excluido | - |
| DatosFranja.cs | - | no evaluado | - |
| FranjaOrdinaria.cs | - | no evaluado | - |
| FranjaProgramada.cs | - | no evaluado | - |
| SedeProgramada.cs | - | no evaluado | - |
| TurnoCreado.cs | - | no evaluado | - |
| CrearTurno.cs | - | no evaluado | - |
## Commits

26d2f01 refactor(issue-335): cerrar la cobertura de persistencia y mover la regla de sede al VO
b3af4be test(hu-335): smoke tests para endpoints
5bdcb97 feat(issue-335): prearmar la sede por franja en los turnos del catalogo (fase verde)
a47af3c test(issue-335): tests para sede prearmada por franja en turnos del catalogo (fase roja)

Closes #335