### PR TITLE
Aplicar la cascada de sedes al copiar el turno en la solicitud

### DIFF
--- a/src/Bitakora.ControlAsistencia.PrivateEvents/Programacion/DetalleFranjaOrdinaria.cs
+++ b/src/Bitakora.ControlAsistencia.PrivateEvents/Programacion/DetalleFranjaOrdinaria.cs
@@ -12,6 +12,15 @@ namespace Bitakora.ControlAsistencia.PrivateEvents.Programacion;
 /// Issue #288: Descripcion (representacion textual normalizada, formato del tipo rico
 /// FranjaOrdinaria.ToString()) se agrega como dato derivado persistido. NO se agrega a
 /// Equals/GetHashCode: es texto derivado de los demas campos, no identidad de la franja.
+///
+/// Issue #341: Sede es campo aditivo y opcional (null = sin sede asignada), gemelo deliberado de
+/// FranjaProgramada.Sede (Programacion.DomainEvents, issue #335) -- cierra la divergencia que
+/// FranjaProgramadaParidadConDetalleFranjaOrdinariaTests toleraba temporalmente. Lleva la sede
+/// EFECTIVA ya resuelta por la cascada (SolicitarProgramacionTurnoCommandHandler,
+/// TurnoProgramado.ConSedePorDefecto) -- este DTO de bus nunca aplica la cascada, solo transporta
+/// el resultado (snapshot: la verdad viaja en el evento). A diferencia de Descripcion, SI entra en
+/// Equals/GetHashCode -- es dato de identidad de la franja, no un derivado (mismo criterio que
+/// FranjaProgramada.Sede).
 /// </remarks>
 public record DetalleFranjaOrdinaria(
     TimeOnly HoraInicio,
@@ -19,7 +28,8 @@ public record DetalleFranjaOrdinaria(
     int DiaOffsetFin,
     IReadOnlyList<DetalleSubFranja> Descansos,
     IReadOnlyList<DetalleSubFranja> Extras,
-    string Descripcion)
+    string Descripcion,
+    DetalleSede? Sede = null)
 {
     /// <summary>
     /// Los eventos anteriores al issue #288 no llevan el campo: STJ deja null en el parametro
@@ -36,7 +46,8 @@ public record DetalleFranjaOrdinaria(
             && HoraFin == other.HoraFin
             && DiaOffsetFin == other.DiaOffsetFin
             && Descansos.SequenceEqual(other.Descansos)
-            && Extras.SequenceEqual(other.Extras);
+            && Extras.SequenceEqual(other.Extras)
+            && Sede == other.Sede;
     }
 
     public override int GetHashCode()
@@ -47,6 +58,7 @@ public record DetalleFranjaOrdinaria(
         hash.Add(DiaOffsetFin);
         foreach (var d in Descansos) hash.Add(d);
         foreach (var e in Extras) hash.Add(e);
+        hash.Add(Sede);
         return hash.ToHashCode();
     }
 }

--- a/src/Bitakora.ControlAsistencia.Programacion.DomainEvents/FranjaProgramada.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion.DomainEvents/FranjaProgramada.cs
@@ -14,12 +14,16 @@ namespace Bitakora.ControlAsistencia.Programacion.DomainEvents;
 /// defecto compararia por referencia -- ADR-0015) y EXCLUYEN Descripcion (dato derivado, no
 /// identidad de la franja) -- mismo criterio que DetalleFranjaOrdinaria (issues #129 y #288).
 ///
-/// Issue #335: Sede es campo aditivo y opcional (null = sin sede prearmada). A diferencia de
-/// Descripcion, SI entra en Equals/GetHashCode -- es dato de identidad del diseno de la franja
-/// (que sede prearmo el catalogo), no un derivado. Divergencia deliberada de payload por rol
-/// (CA-ADR-0029 decision #5) frente a DetalleFranjaOrdinaria (PrivateEvents): el mapeo hacia el
-/// bus interno queda fuera de alcance de este issue (ver
-/// FranjaProgramadaParidadConDetalleFranjaOrdinariaTests).
+/// Issue #335: Sede es campo aditivo y opcional (null = sin sede asignada). A diferencia de
+/// Descripcion, SI entra en Equals/GetHashCode -- es dato de identidad de la franja, no un
+/// derivado.
+///
+/// Issue #341: el campo tiene ya su gemelo de payload por rol (CA-ADR-0029 decision #5) en
+/// DetalleFranjaOrdinaria.Sede (PrivateEvents, tipado DetalleSede) -- la divergencia temporal que
+/// #335 abrio quedo cerrada y FranjaProgramadaParidadConDetalleFranjaOrdinariaTests vuelve a
+/// exigir paridad exacta. Su significado depende del evento que lo lleva: en el snapshot del
+/// catalogo es la sede PREARMADA por el diseno del turno; dentro de ProgramacionTurnoSolicitada es
+/// la sede EFECTIVA que resolvio la cascada (TurnoProgramado.ConSedePorDefecto).
 /// </remarks>
 public record FranjaProgramada(
     TimeOnly HoraInicio,

--- a/src/Bitakora.ControlAsistencia.Programacion.DomainEvents/TurnoProgramado.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion.DomainEvents/TurnoProgramado.cs
@@ -42,4 +42,20 @@ public record TurnoProgramado(
         foreach (var franja in FranjasOrdinarias) hash.Add(franja);
         return hash.ToHashCode();
     }
+
+    /// <summary>
+    /// Issue #341: cascada de sede al copiar el turno del catalogo en la solicitud de
+    /// programacion. Cada franja resuelve su sede efectiva con
+    /// <c>franja.Sede ?? sedePorDefecto</c> -- el catalogo (intencion explicita de diseno) le gana
+    /// al default de la solicitud. Funcion pura sobre records (<c>with</c>): no muta esta
+    /// instancia, retorna un turno nuevo. Con <paramref name="sedePorDefecto"/> null la cascada es
+    /// identidad (permite invocacion incondicional desde el handler, sin ramificar por si la
+    /// solicitud trae sede).
+    /// </summary>
+    /// <remarks>
+    /// Tell-don't-Ask (MEF-ADR-0012): la cascada vive en el dueno de las franjas, no en el
+    /// handler -- mismo precedente que TurnoDiario.Segmentar (#327).
+    /// </remarks>
+    public TurnoProgramado ConSedePorDefecto(SedeProgramada? sedePorDefecto) =>
+        throw new NotImplementedException();
 }

--- a/src/Bitakora.ControlAsistencia.Programacion.DomainEvents/TurnoProgramado.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion.DomainEvents/TurnoProgramado.cs
@@ -56,6 +56,11 @@ public record TurnoProgramado(
     /// Tell-don't-Ask (MEF-ADR-0012): la cascada vive en el dueno de las franjas, no en el
     /// handler -- mismo precedente que TurnoDiario.Segmentar (#327).
     /// </remarks>
-    public TurnoProgramado ConSedePorDefecto(SedeProgramada? sedePorDefecto) =>
-        throw new NotImplementedException();
+    public TurnoProgramado ConSedePorDefecto(SedeProgramada? sedePorDefecto) => this with
+    {
+        FranjasOrdinarias = FranjasOrdinarias
+            .Select(franja => franja with { Sede = franja.Sede ?? sedePorDefecto })
+            .ToList()
+            .AsReadOnly()
+    };
 }

--- a/src/Bitakora.ControlAsistencia.Programacion/SolicitarProgramacionTurnoFunction/CommandHandler/SolicitarProgramacionTurnoCommandHandler.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/SolicitarProgramacionTurnoFunction/CommandHandler/SolicitarProgramacionTurnoCommandHandler.cs
@@ -36,7 +36,11 @@ public partial class SolicitarProgramacionTurnoCommandHandler
         // de bus (DetalleTurno, PrivateEvents) -- produce el tipo propio del dominio
         // (TurnoProgramado, Programacion.DomainEvents). El FA mapea a DetalleTurno solo para los
         // eventos que cruzan el bus (CA-5).
-        var turnoProgramado = catalogo.ObtenerDetalle();
+        // Issue #341: la cascada de sede se aplica ANTES de construir cualquier evento -- ambos
+        // payloads (persistido y bus) derivan del mismo turno ya resuelto (un solo punto de
+        // resolucion). Sin ramificar por si la solicitud trae sede: con command.Sede null la
+        // cascada es identidad (Tell-don't-Ask, MEF-ADR-0012).
+        var turnoProgramado = catalogo.ObtenerDetalle().ConSedePorDefecto(command.Sede);
         var fechas = command.Fechas.AsReadOnly();
 
         // Issue #319 CA-2/CA-5: el comando HTTP conserva InformacionEmpleado (PublicEvents, fuera
@@ -86,11 +90,15 @@ public partial class SolicitarProgramacionTurnoCommandHandler
             turno.FranjasOrdinarias.Select(MapearFranja).ToList().AsReadOnly(),
             turno.Descripcion);
 
+    // Issue #341: la sede EFECTIVA de la franja (ya resuelta por la cascada, ConSedePorDefecto)
+    // se propaga al payload de bus con el mismo mapeo campo a campo que usa la sede de la
+    // solicitud (MapearSede) -- gemelo deliberado, no una traduccion nueva.
     private static DetalleFranjaOrdinaria MapearFranja(FranjaProgramada franja) =>
         new(franja.HoraInicio, franja.HoraFin, franja.DiaOffsetFin,
             franja.Descansos.Select(MapearSubFranja).ToList().AsReadOnly(),
             franja.Extras.Select(MapearSubFranja).ToList().AsReadOnly(),
-            franja.Descripcion);
+            franja.Descripcion,
+            MapearSede(franja.Sede));
 
     private static DetalleSubFranja MapearSubFranja(SubFranjaProgramada subFranja) =>
         new(subFranja.HoraInicio, subFranja.HoraFin, subFranja.DiaOffsetInicio,

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/ProgramacionTurnoDiarioSolicitadaPortabilidadTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/ProgramacionTurnoDiarioSolicitadaPortabilidadTests.cs
@@ -113,6 +113,62 @@ public class ProgramacionTurnoDiarioSolicitadaPortabilidadTests
         return nodo.ToJsonString();
     }
 
+    // Issue #341 CA-5: la sede EFECTIVA de la franja (ya resuelta por la cascada del handler) es
+    // otro DTO plano de strings (DetalleSede, anidado dentro de DetalleFranjaOrdinaria) -- portable
+    // por el serializador por defecto del bus, igual que la sede a nivel del evento (arriba).
+    // Verifica ademas la igualdad por valor de DetalleFranjaOrdinaria completo (con Sede incluida
+    // en su Equals custom), no solo el campo Sede en aislado.
+    [Fact]
+    public void RoundTrip_PreservaLaSedeDeLaFranja_ConSerializadorPorDefectoDelBus()
+    {
+        var sedeFranja = new DetalleSede("SEDE-SUBA", "Suba");
+        var franja = new DetalleFranjaOrdinaria(
+            new TimeOnly(8, 0), new TimeOnly(16, 0), 0, [], [], "(08:00-16:00)[sede:Suba]", sedeFranja);
+        var detalleTurno = new DetalleTurno("Turno Manana", [franja], "Turno Manana (08:00-16:00)[sede:Suba]");
+        var evento = new ProgramacionTurnoDiarioSolicitada(SolicitudId, Empleado, Fecha, detalleTurno);
+
+        var json = JsonSerializer.Serialize(evento, CrearOpcionesProductor());
+
+        var body = BinaryData.FromString(json);
+        var restaurado = ServiceBusDeserializador.Deserializar<ProgramacionTurnoDiarioSolicitada>(body);
+
+        restaurado.Should().NotBeNull();
+        var franjaRestaurada = restaurado.DetalleTurno.FranjasOrdinarias[0];
+        franjaRestaurada.Sede.Should().Be(sedeFranja);
+        franjaRestaurada.Should().Be(franja);
+    }
+
+    // Issue #341 CA-4: retrocompatibilidad -- los mensajes publicados antes de este issue no llevan
+    // la clave "sede" dentro de cada franja. Se parte de un evento CON sede en la franja para que la
+    // asercion sobre Remove() delate un test vacuo si la clave cambiara de nombre (mismo patron que
+    // JsonSinLaClaveSede, arriba, para la sede a nivel del evento).
+    [Fact]
+    public void Deserializar_DejaSedeDeLaFranjaEnNull_CuandoElMensajeNoLlevaLaClaveSedeEnLaFranja()
+    {
+        var restaurado = ServiceBusDeserializador.Deserializar<ProgramacionTurnoDiarioSolicitada>(
+            BinaryData.FromString(JsonSinLaClaveSedeEnLaFranja()));
+
+        restaurado.Should().NotBeNull();
+        restaurado.DetalleTurno.FranjasOrdinarias[0].Sede.Should().BeNull();
+        restaurado.DetalleTurno.Nombre.Should().Be("Turno Manana");
+    }
+
+    private static string JsonSinLaClaveSedeEnLaFranja()
+    {
+        var franjaConSede = new DetalleFranjaOrdinaria(
+            new TimeOnly(8, 0), new TimeOnly(16, 0), 0, [], [], "(08:00-16:00)[sede:Suba]",
+            new DetalleSede("SEDE-SUBA", "Suba"));
+        var detalleTurno = new DetalleTurno("Turno Manana", [franjaConSede], "Turno Manana (08:00-16:00)[sede:Suba]");
+        var conSede = new ProgramacionTurnoDiarioSolicitada(SolicitudId, Empleado, Fecha, detalleTurno);
+
+        var nodo = JsonNode.Parse(JsonSerializer.Serialize(conSede, CrearOpcionesProductor()))!;
+        var franjaNodo = nodo["detalleTurno"]!["franjasOrdinarias"]![0]!.AsObject();
+        franjaNodo.Remove("sede").Should().BeTrue(
+            "el JSON del bus debe llevar la clave 'sede' en la franja para que quitarla represente la forma anterior a #341");
+
+        return nodo.ToJsonString();
+    }
+
     // Retro-compatibilidad: los eventos publicados antes de #288 no llevan el campo. STJ dejaria
     // null en un parametro posicional declarado como string no anulable, lo que seria una mina
     // para cualquier consumidor. Los DTOs lo normalizan a cadena vacia -- la consecuencia que el

--- a/tests/Bitakora.ControlAsistencia.PrivateEvents.Tests/Programacion/DetalleFranjaOrdinariaIgualdadTests.cs
+++ b/tests/Bitakora.ControlAsistencia.PrivateEvents.Tests/Programacion/DetalleFranjaOrdinariaIgualdadTests.cs
@@ -5,6 +5,8 @@
 // Issue #288: se agrego Descripcion (dato derivado, texto del formato tecnico) al constructor
 // primario. NO participa en Equals/GetHashCode (ver DetalleFranjaOrdinaria.cs); los construction
 // sites de este archivo pasan "" porque el valor es irrelevante para estos tests de igualdad.
+// Issue #341: se agrego Sede (dato de IDENTIDAD, la sede efectiva ya resuelta por la cascada) --
+// SI participa en Equals/GetHashCode, a diferencia de Descripcion.
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.PrivateEvents.Programacion;
 
@@ -18,24 +20,28 @@ public class DetalleFranjaOrdinariaIgualdadTests : IgualdadTestBase<DetalleFranj
     private static DetalleSubFranja Extra() =>
         new(new TimeOnly(17, 0), new TimeOnly(19, 0), 0, 0, "");
 
+    private static DetalleSede Sede() => new("SEDE-01", "Sede Principal");
+
     protected override DetalleFranjaOrdinaria CrearInstancia() =>
-        new(new TimeOnly(8, 0), new TimeOnly(17, 0), 0, [Descanso()], [Extra()], "");
+        new(new TimeOnly(8, 0), new TimeOnly(17, 0), 0, [Descanso()], [Extra()], "", Sede());
 
     protected override DetalleFranjaOrdinaria CrearInstanciaCopia() =>
-        new(new TimeOnly(8, 0), new TimeOnly(17, 0), 0, [Descanso()], [Extra()], "");
+        new(new TimeOnly(8, 0), new TimeOnly(17, 0), 0, [Descanso()], [Extra()], "", Sede());
 
     protected override IEnumerable<(string, DetalleFranjaOrdinaria)> CrearInstanciasDiferentes()
     {
         yield return ("HoraInicio",
-            new DetalleFranjaOrdinaria(new TimeOnly(7, 0), new TimeOnly(17, 0), 0, [Descanso()], [Extra()], ""));
+            new DetalleFranjaOrdinaria(new TimeOnly(7, 0), new TimeOnly(17, 0), 0, [Descanso()], [Extra()], "", Sede()));
         yield return ("HoraFin",
-            new DetalleFranjaOrdinaria(new TimeOnly(8, 0), new TimeOnly(18, 0), 0, [Descanso()], [Extra()], ""));
+            new DetalleFranjaOrdinaria(new TimeOnly(8, 0), new TimeOnly(18, 0), 0, [Descanso()], [Extra()], "", Sede()));
         yield return ("DiaOffsetFin",
-            new DetalleFranjaOrdinaria(new TimeOnly(8, 0), new TimeOnly(17, 0), 1, [Descanso()], [Extra()], ""));
+            new DetalleFranjaOrdinaria(new TimeOnly(8, 0), new TimeOnly(17, 0), 1, [Descanso()], [Extra()], "", Sede()));
         yield return ("Descansos",
-            new DetalleFranjaOrdinaria(new TimeOnly(8, 0), new TimeOnly(17, 0), 0, [], [Extra()], ""));
+            new DetalleFranjaOrdinaria(new TimeOnly(8, 0), new TimeOnly(17, 0), 0, [], [Extra()], "", Sede()));
         yield return ("Extras",
-            new DetalleFranjaOrdinaria(new TimeOnly(8, 0), new TimeOnly(17, 0), 0, [Descanso()], [], ""));
+            new DetalleFranjaOrdinaria(new TimeOnly(8, 0), new TimeOnly(17, 0), 0, [Descanso()], [], "", Sede()));
+        yield return ("Sede",
+            new DetalleFranjaOrdinaria(new TimeOnly(8, 0), new TimeOnly(17, 0), 0, [Descanso()], [Extra()], "", Sede: null));
     }
 
     // Cobertura especifica del override: las listas se comparan por valor, no por referencia.

--- a/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoSmokeTests.cs
@@ -189,6 +189,11 @@ public class SolicitarProgramacionTurnoSmokeTests(ApiFixture api, ServiceBusFixt
         var sedeEsperada = new DetalleSede(sedeId, sedeNombre);
         evento.Sede.Should().Be(sedeEsperada);
 
+        // Issue #341 CA-3: el turno del catalogo NO trae sedes prearmadas en sus franjas -> la
+        // cascada (franja.Sede ?? sedePorDefecto) aplica la sede de la solicitud a la UNICA franja.
+        evento.DetalleTurno.FranjasOrdinarias.Should().HaveCount(1);
+        evento.DetalleTurno.FranjasOrdinarias[0].Sede.Should().Be(sedeEsperada);
+
         // Assert: el campo nuevo es aditivo y TOLERANTE para el consumidor real -- ControlHoras
         // todavia no conoce "sede" (lo consumira en #336) y debe seguir procesando el mensaje sin
         // dead-letter. Es la unica evidencia end-to-end de esa tolerancia: el test de arriba
@@ -201,6 +206,161 @@ public class SolicitarProgramacionTurnoSmokeTests(ApiFixture api, ServiceBusFixt
         existeDeadLetter.Should().BeFalse(
             "el campo 'sede' es aditivo: ControlHoras debe ignorarlo sin fallar (SolicitudId {0}, suscripcion '{1}')",
             solicitudId, SuscripcionConsumidor);
+    }
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task SolicitarProgramacionTurno_ConservaLaSedeDeLaFranjaYAplicaLaSedePorDefecto_CuandoElTurnoTraeFranjasMixtas()
+    {
+        Assert.SkipWhen(!serviceBus.IsConfigured,
+            "ServiceBus no configurado. Usa appsettings.local.json o variable ServiceBus__ConnectionString.");
+
+        var ct = TestContext.Current.CancellationToken;
+
+        // Arrange: purgar mensajes preexistentes de ejecuciones anteriores
+        await serviceBus.PurgeAsync(TopicSalida, Suscripcion);
+
+        // Arrange: crear turno en catalogo con DOS franjas: la primera trae sede prearmada, la
+        // segunda no. Horarios sin solapamiento (TurnoCreado.Crear valida solapamiento).
+        var turnoId = Guid.CreateVersion7();
+        var turnoPayload = new
+        {
+            turnoId,
+            nombre = "[TEST] Turno Mixto Cascada",
+            ordinarias = new object[]
+            {
+                new
+                {
+                    inicio = "06:00:00",
+                    fin = "10:00:00",
+                    descansos = Array.Empty<object>(),
+                    extras = Array.Empty<object>(),
+                    sede = new { id = "SEDE-SUBA", nombre = "[TEST] Suba" }
+                },
+                new
+                {
+                    inicio = "14:00:00",
+                    fin = "18:00:00",
+                    descansos = Array.Empty<object>(),
+                    extras = Array.Empty<object>()
+                }
+            }
+        };
+        var crearTurnoResponse = await _client.PostAsJsonAsync("/api/programacion/turnos", turnoPayload, ct);
+        crearTurnoResponse.StatusCode.Should().Be(HttpStatusCode.Accepted);
+
+        // Arrange: solicitud CON sede -- issue #341 CA-1
+        var solicitudId = Guid.CreateVersion7();
+        var empleadoId = Guid.CreateVersion7().ToString();
+        var sedePrincipal = new DetalleSede("SEDE-01", "[TEST] Sede Principal");
+        var sedeSuba = new DetalleSede("SEDE-SUBA", "[TEST] Suba");
+        var payload = new
+        {
+            id = solicitudId,
+            turnoId,
+            empleado = new
+            {
+                empleadoId,
+                tipoIdentificacion = "CC",
+                numeroIdentificacion = "444555666",
+                nombres = "[TEST] Smoke Cascada",
+                apellidos = "[TEST] Publicacion"
+            },
+            fechas = new[] { "2026-06-01" },
+            sede = new { id = sedePrincipal.Id, nombre = sedePrincipal.Nombre }
+        };
+
+        // Act: enviar solicitud via HTTP
+        var response = await _client.PostAsJsonAsync("/api/programacion/solicitudes", payload, ct);
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+
+        // Assert: cada franja resuelve su cascada de forma independiente. La franja1 conserva su
+        // sede propia del catalogo (le gana al default); la franja2 (sin sede propia) adopta la
+        // sede de la solicitud.
+        var evento = await serviceBus.WaitForMessageAsync<ProgramacionTurnoDiarioSolicitada>(
+            TopicSalida, Suscripcion, e => e.SolicitudId == solicitudId, Timeout);
+
+        evento.Sede.Should().Be(sedePrincipal);
+        evento.DetalleTurno.FranjasOrdinarias.Should().HaveCount(2);
+        evento.DetalleTurno.FranjasOrdinarias[0].Sede.Should().Be(sedeSuba);
+        evento.DetalleTurno.FranjasOrdinarias[1].Sede.Should().Be(sedePrincipal);
+
+        // Assert: tolerancia del consumidor real ante el campo aditivo (sin dead letter de esta corrida)
+        await Task.Delay(TimeSpan.FromSeconds(5), ct);
+
+        var existeDeadLetter = await serviceBus.ExisteDeadLetterDeEstaCorridaAsync<ProgramacionTurnoDiarioSolicitadaMinimo>(
+            TopicSalida, SuscripcionConsumidor, e => e.SolicitudId == solicitudId);
+
+        existeDeadLetter.Should().BeFalse(
+            "no deberia haber un dead letter de esta corrida (SolicitudId {0}) en '{1}' - si lo hay, el consumidor fallo al procesar el evento",
+            solicitudId, SuscripcionConsumidor);
+    }
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task SolicitarProgramacionTurno_ConservaLaSedeDelCatalogo_CuandoLaSolicitudNoIncluyeSede()
+    {
+        Assert.SkipWhen(!serviceBus.IsConfigured,
+            "ServiceBus no configurado. Usa appsettings.local.json o variable ServiceBus__ConnectionString.");
+
+        var ct = TestContext.Current.CancellationToken;
+
+        // Arrange: purgar mensajes preexistentes de ejecuciones anteriores
+        await serviceBus.PurgeAsync(TopicSalida, Suscripcion);
+
+        // Arrange: crear turno en catalogo con sede PREARMADA en su unica franja.
+        var turnoId = Guid.CreateVersion7();
+        var sedeCatalogo = new DetalleSede("SEDE-CENTRO", "[TEST] Centro");
+        var turnoPayload = new
+        {
+            turnoId,
+            nombre = "[TEST] Turno Con Sede Prearmada",
+            ordinarias = new[]
+            {
+                new
+                {
+                    inicio = "08:00:00",
+                    fin = "16:00:00",
+                    descansos = Array.Empty<object>(),
+                    extras = Array.Empty<object>(),
+                    sede = new { id = sedeCatalogo.Id, nombre = sedeCatalogo.Nombre }
+                }
+            }
+        };
+        var crearTurnoResponse = await _client.PostAsJsonAsync("/api/programacion/turnos", turnoPayload, ct);
+        crearTurnoResponse.StatusCode.Should().Be(HttpStatusCode.Accepted);
+
+        // Arrange: solicitud SIN sede -- issue #341 CA-2: la franja con sede del catalogo la
+        // conserva (el catalogo le gana al "sin sede" de la solicitud tambien).
+        var solicitudId = Guid.CreateVersion7();
+        var empleadoId = Guid.CreateVersion7().ToString();
+        var payload = new
+        {
+            id = solicitudId,
+            turnoId,
+            empleado = new
+            {
+                empleadoId,
+                tipoIdentificacion = "CC",
+                numeroIdentificacion = "777888999",
+                nombres = "[TEST] Smoke Prearmada",
+                apellidos = "[TEST] Publicacion"
+            },
+            fechas = new[] { "2026-06-02" }
+        };
+
+        // Act: enviar solicitud via HTTP
+        var response = await _client.PostAsJsonAsync("/api/programacion/solicitudes", payload, ct);
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+
+        // Assert: el nivel de solicitud sigue siendo null (lo solicitado), pero la franja conserva
+        // la sede del catalogo (la verdad efectiva ya resuelta por la cascada).
+        var evento = await serviceBus.WaitForMessageAsync<ProgramacionTurnoDiarioSolicitada>(
+            TopicSalida, Suscripcion, e => e.SolicitudId == solicitudId, Timeout);
+
+        evento.Sede.Should().BeNull();
+        evento.DetalleTurno.FranjasOrdinarias.Should().HaveCount(1);
+        evento.DetalleTurno.FranjasOrdinarias[0].Sede.Should().Be(sedeCatalogo);
     }
 
     [Fact]

--- a/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoSmokeTests.cs
@@ -1,19 +1,65 @@
 using System.Net;
 using System.Net.Http.Json;
+using System.Text.Json;
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.PrivateEvents.Programacion;
 using Bitakora.ControlAsistencia.Programacion.SmokeTests.Fixtures;
 
 namespace Bitakora.ControlAsistencia.Programacion.SmokeTests.SolicitarProgramacionTurnoFunction;
 
-public class SolicitarProgramacionTurnoSmokeTests(ApiFixture api, ServiceBusFixture serviceBus)
+public class SolicitarProgramacionTurnoSmokeTests(
+    ApiFixture api, ServiceBusFixture serviceBus, PostgresFixture postgres)
 {
     private readonly HttpClient _client = api.Client;
 
     private const string TopicSalida = "programacion-turno-diario-solicitada";
     private const string Suscripcion = "smoke-tests";
     private const string SuscripcionConsumidor = "control-horas-escucha-programacion";
+    private const string SchemaProgramacion = "programacion";
+    private const string TipoEventoProgramacionSolicitada = "programacion_turno_solicitada";
     private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
+
+    // Formas minimas del evento persistido, para asertar sobre el JSON de mt_events sin referenciar
+    // Programacion.DomainEvents desde los smoke tests (mismo criterio que DeadLetterMinimos y que
+    // CrearTurnoSmokeTests). Solo declaran los campos que este test verifica; leerlas de forma
+    // case-insensitive deja la politica de nombres del serializador fuera de la asercion -- lo que
+    // se verifica es el DATO que quedo grabado, no como el host llama a la clave.
+    private sealed record SedeMinima(string Id, string Nombre);
+    private sealed record FranjaMinima(SedeMinima? Sede);
+    private sealed record TurnoMinimo(IReadOnlyList<FranjaMinima> FranjasOrdinarias);
+    private sealed record SolicitudMinima(TurnoMinimo DetalleTurno, SedeMinima? Sede);
+
+    private static readonly JsonSerializerOptions OpcionesLectura = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    // Turno de catalogo con DOS franjas: la primera trae sede prearmada, la segunda no -- el
+    // arrange que ejercita la cascada franja por franja (CA-1). Horarios sin solapamiento
+    // (TurnoCreado.Crear valida solapamiento entre ordinarias).
+    private static object TurnoConFranjasMixtasPayload(Guid turnoId, string sedeId, string sedeNombre) => new
+    {
+        turnoId,
+        nombre = "[TEST] Turno Mixto Cascada",
+        ordinarias = new object[]
+        {
+            new
+            {
+                inicio = "06:00:00",
+                fin = "10:00:00",
+                descansos = Array.Empty<object>(),
+                extras = Array.Empty<object>(),
+                sede = new { id = sedeId, nombre = sedeNombre }
+            },
+            new
+            {
+                inicio = "14:00:00",
+                fin = "18:00:00",
+                descansos = Array.Empty<object>(),
+                extras = Array.Empty<object>()
+            }
+        }
+    };
 
     private static object PayloadValido(Guid? id = null, Guid? turnoId = null) => new
     {
@@ -220,40 +266,18 @@ public class SolicitarProgramacionTurnoSmokeTests(ApiFixture api, ServiceBusFixt
         // Arrange: purgar mensajes preexistentes de ejecuciones anteriores
         await serviceBus.PurgeAsync(TopicSalida, Suscripcion);
 
-        // Arrange: crear turno en catalogo con DOS franjas: la primera trae sede prearmada, la
-        // segunda no. Horarios sin solapamiento (TurnoCreado.Crear valida solapamiento).
+        // Arrange: crear turno en catalogo con franjas mixtas (una con sede prearmada, otra sin)
         var turnoId = Guid.CreateVersion7();
-        var turnoPayload = new
-        {
-            turnoId,
-            nombre = "[TEST] Turno Mixto Cascada",
-            ordinarias = new object[]
-            {
-                new
-                {
-                    inicio = "06:00:00",
-                    fin = "10:00:00",
-                    descansos = Array.Empty<object>(),
-                    extras = Array.Empty<object>(),
-                    sede = new { id = "SEDE-SUBA", nombre = "[TEST] Suba" }
-                },
-                new
-                {
-                    inicio = "14:00:00",
-                    fin = "18:00:00",
-                    descansos = Array.Empty<object>(),
-                    extras = Array.Empty<object>()
-                }
-            }
-        };
-        var crearTurnoResponse = await _client.PostAsJsonAsync("/api/programacion/turnos", turnoPayload, ct);
+        var sedePrincipal = new DetalleSede("SEDE-01", "[TEST] Sede Principal");
+        var sedeSuba = new DetalleSede("SEDE-SUBA", "[TEST] Suba");
+        var crearTurnoResponse = await _client.PostAsJsonAsync(
+            "/api/programacion/turnos",
+            TurnoConFranjasMixtasPayload(turnoId, sedeSuba.Id, sedeSuba.Nombre), ct);
         crearTurnoResponse.StatusCode.Should().Be(HttpStatusCode.Accepted);
 
         // Arrange: solicitud CON sede -- issue #341 CA-1
         var solicitudId = Guid.CreateVersion7();
         var empleadoId = Guid.CreateVersion7().ToString();
-        var sedePrincipal = new DetalleSede("SEDE-01", "[TEST] Sede Principal");
-        var sedeSuba = new DetalleSede("SEDE-SUBA", "[TEST] Suba");
         var payload = new
         {
             id = solicitudId,
@@ -294,6 +318,71 @@ public class SolicitarProgramacionTurnoSmokeTests(ApiFixture api, ServiceBusFixt
         existeDeadLetter.Should().BeFalse(
             "no deberia haber un dead letter de esta corrida (SolicitudId {0}) en '{1}' - si lo hay, el consumidor fallo al procesar el evento",
             solicitudId, SuscripcionConsumidor);
+    }
+
+    // El handler tiene DOS efectos secundarios y los tests de arriba solo cubren uno (la
+    // publicacion al bus). Este cubre el otro: la persistencia en el event store
+    // (SolicitarProgramacionTurnoCommandHandler -> IEventStore.StartStream), que es lo que CA-1
+    // pide verificar "en el evento persistido" ademas de "en cada evento diario del bus".
+    // mt_events es la unica ventana black-box a lo que quedo grabado -- y cierra el riesgo real:
+    // que la sede efectiva llegue bien al bus pero se pierda en silencio en el JSON persistido,
+    // con un 202 igual de verde. Mismo patron que CrearTurnoSmokeTests para turno_creado (#335).
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task SolicitarProgramacionTurno_PersisteLaSedeEfectivaDeCadaFranja_CuandoElTurnoTraeFranjasMixtas()
+    {
+        Assert.SkipWhen(!postgres.IsConfigured, postgres.SkipReason ?? "Postgres no disponible.");
+
+        var ct = TestContext.Current.CancellationToken;
+
+        // Arrange: turno de catalogo con franjas mixtas (una con sede prearmada, otra sin)
+        var turnoId = Guid.CreateVersion7();
+        var sedeSuba = new SedeMinima("SEDE-SUBA", "[TEST] Suba");
+        var sedePrincipal = new SedeMinima("SEDE-01", "[TEST] Sede Principal");
+        var crearTurnoResponse = await _client.PostAsJsonAsync(
+            "/api/programacion/turnos",
+            TurnoConFranjasMixtasPayload(turnoId, sedeSuba.Id, sedeSuba.Nombre), ct);
+        crearTurnoResponse.StatusCode.Should().Be(HttpStatusCode.Accepted);
+
+        var solicitudId = Guid.CreateVersion7();
+        var payload = new
+        {
+            id = solicitudId,
+            turnoId,
+            empleado = new
+            {
+                empleadoId = Guid.CreateVersion7().ToString(),
+                tipoIdentificacion = "CC",
+                numeroIdentificacion = "888999000",
+                nombres = "[TEST] Smoke Persistencia",
+                apellidos = "[TEST] Cascada"
+            },
+            fechas = new[] { "2026-06-03" },
+            sede = new { id = sedePrincipal.Id, nombre = sedePrincipal.Nombre }
+        };
+
+        // Act
+        var response = await _client.PostAsJsonAsync("/api/programacion/solicitudes", payload, ct);
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+
+        // SolicitudProgramacionAggregateRoot.Apply asigna Id = evento.Id.ToString() -- el stream id
+        // es el guid canonico de la solicitud, sin formato explicito (MEF-ADR-0037).
+        var streamId = solicitudId.ToString();
+
+        var json = await postgres.ObtenerEventoAsync<JsonElement>(
+            SchemaProgramacion, streamId, TipoEventoProgramacionSolicitada,
+            campoJson: "Id", valorJson: streamId, Timeout);
+
+        var eventoPersistido = json.Deserialize<SolicitudMinima>(OpcionesLectura);
+        eventoPersistido.Should().NotBeNull();
+
+        // CA-1: cada franja quedo grabada con SU sede efectiva -- la prearmada le gana al default.
+        eventoPersistido!.DetalleTurno.FranjasOrdinarias.Should().HaveCount(2);
+        eventoPersistido.DetalleTurno.FranjasOrdinarias[0].Sede.Should().Be(sedeSuba);
+        eventoPersistido.DetalleTurno.FranjasOrdinarias[1].Sede.Should().Be(sedePrincipal);
+
+        // CA-3: la cascada NO altera el nivel de la solicitud -- ahi sigue LO SOLICITADO.
+        eventoPersistido.Sede.Should().Be(sedePrincipal);
     }
 
     [Fact]

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/Eventos/ProgramacionTurnoSolicitadaSerializacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/Eventos/ProgramacionTurnoSolicitadaSerializacionTests.cs
@@ -231,4 +231,12 @@ public class ProgramacionTurnoSolicitadaSerializacionTests
         restaurado.Should().NotBeNull();
         restaurado!.Sede.Should().Be(SedeEsperada);
     }
+
+    // Nota (issue #341): la retrocompatibilidad y el round-trip de la sede EFECTIVA a nivel de
+    // FranjaProgramada (dentro de este mismo evento persistido) ya quedan cubiertos por el issue
+    // #335 -- FranjaProgramada.Sede es un campo aditivo que STJ ya maneja correctamente sin
+    // resolver custom (ver FranjaOrdinariaSerializacionTests.RoundTrip_PreservaLaSede_...). Agregar
+    // aqui un test equivalente pasaria en verde de inmediato (no ejercita ningun comportamiento
+    // nuevo de este issue) -- lo nuevo de #341 en el eje de serializacion es exclusivamente
+    // DetalleFranjaOrdinaria.Sede, el DTO de BUS (ver ProgramacionTurnoDiarioSolicitadaPortabilidadTests).
 }

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/Eventos/ProgramacionTurnoSolicitadaSerializacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/Eventos/ProgramacionTurnoSolicitadaSerializacionTests.cs
@@ -232,11 +232,43 @@ public class ProgramacionTurnoSolicitadaSerializacionTests
         restaurado!.Sede.Should().Be(SedeEsperada);
     }
 
-    // Nota (issue #341): la retrocompatibilidad y el round-trip de la sede EFECTIVA a nivel de
-    // FranjaProgramada (dentro de este mismo evento persistido) ya quedan cubiertos por el issue
-    // #335 -- FranjaProgramada.Sede es un campo aditivo que STJ ya maneja correctamente sin
-    // resolver custom (ver FranjaOrdinariaSerializacionTests.RoundTrip_PreservaLaSede_...). Agregar
-    // aqui un test equivalente pasaria en verde de inmediato (no ejercita ningun comportamiento
-    // nuevo de este issue) -- lo nuevo de #341 en el eje de serializacion es exclusivamente
-    // DetalleFranjaOrdinaria.Sede, el DTO de BUS (ver ProgramacionTurnoDiarioSolicitadaPortabilidadTests).
+    // Issue #341 CA-4: los streams escritos antes de este issue no llevan la clave "Sede" DENTRO de
+    // cada franja. Es un eje distinto del test de arriba (la sede a nivel del evento, #331): la
+    // cascada escribe por primera vez una sede en franjas que el catalogo dejo sin ella, asi que el
+    // JSON viejo y el nuevo difieren tambien en ese nivel anidado.
+    [Fact]
+    public void Deserializar_DejaSedeDeCadaFranjaEnNull_CuandoElJsonPersistidoNoLlevaEseCampo()
+    {
+        var evento = Deserializar(JsonConFormaPersistidaAntesDelCambioDeTipos());
+
+        evento.DetalleTurno.FranjasOrdinarias.Single().Sede.Should().BeNull();
+    }
+
+    // Issue #341 CA-5, cara persistida: mt_events es el contrato mas longevo del sistema
+    // (CA-ADR-0029 decision #5), y desde este issue guarda la sede EFECTIVA de cada franja. La sede
+    // de la franja es deliberadamente DISTINTA de la del evento: son dos ejes independientes (lo
+    // efectivo por franja frente a lo solicitado a nivel del dia), y con la misma sede en ambos un
+    // round-trip que confundiera un nivel con el otro pasaria en verde.
+    [Fact]
+    public void RoundTrip_PreservaLaSedeDeCadaFranja_CuandoLaCascadaLaDejoResuelta()
+    {
+        var sedeDeLaFranja = new SedeProgramada("SEDE-SUBA", "Suba");
+        var turnoConSedePorFranja = new TurnoProgramado(
+            "Turno Manana",
+            new List<FranjaProgramada>
+            {
+                new(new TimeOnly(6, 0), new TimeOnly(14, 0), 0, [], [], DescripcionFranja, sedeDeLaFranja)
+            }.AsReadOnly(),
+            DescripcionTurno);
+        var evento = new ProgramacionTurnoSolicitada(
+            Id, EmpleadoEsperado, [Fecha1], turnoConSedePorFranja, SedeEsperada);
+        var opciones = ConfiguracionSerializacionProgramacion.CrearOpcionesMarten();
+
+        var json = JsonSerializer.Serialize(evento, opciones);
+        var restaurado = JsonSerializer.Deserialize<ProgramacionTurnoSolicitada>(json, opciones);
+
+        restaurado.Should().NotBeNull();
+        restaurado!.DetalleTurno.FranjasOrdinarias.Single().Sede.Should().Be(sedeDeLaFranja);
+        restaurado.Sede.Should().Be(SedeEsperada);
+    }
 }

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoCommandHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoCommandHandlerTests.cs
@@ -133,8 +133,9 @@ public class SolicitarProgramacionTurnoCommandHandlerTests
     // --- Issue #335: turno del catalogo con la sede PREARMADA por franja ---
     //
     // No la trae la solicitud (esa es la sede de #331, que aqui va en null): la trae el turno,
-    // desde que se creo. El handler no la conoce ni la mapea -- fluye sola por el snapshot
-    // existente (CatalogoTurnos.ObtenerDetalle -> FranjaOrdinaria.ToDetalle).
+    // desde que se creo, y llega por el snapshot existente (CatalogoTurnos.ObtenerDetalle ->
+    // FranjaOrdinaria.ToDetalle). Desde #341 la cascada la atraviesa -- con la solicitud sin sede
+    // es identidad -- y el handler la propaga tambien al payload de bus (MapearFranja).
     private static readonly SedeProgramada SedeSuba = new("SEDE-SUBA", "Suba");
     private static readonly DetalleSede SedeSubaDetalle = new("SEDE-SUBA", "Suba");
 
@@ -213,6 +214,27 @@ public class SolicitarProgramacionTurnoCommandHandlerTests
         }.AsReadOnly(),
         DescripcionTurnoMixto);
 
+    // --- Issue #341 CA-3: turno SIN sedes prearmadas + solicitud CON sede ---
+    //
+    // Es CrearEventoTurno(), la misma franja que usan los tests del camino feliz: la cascada
+    // (franja.Sede ?? sedePorDefecto) aplica SedePrincipal a la UNICA franja. La Descripcion NO
+    // cambia -- se congelo en el catalogo, ANTES de que la cascada conociera la sede de la solicitud.
+    private static readonly TurnoProgramado TurnoProgramadoConSedeAplicadaEsperado = new(
+        "Turno Manana",
+        new List<FranjaProgramada>
+        {
+            new(new TimeOnly(6, 0), new TimeOnly(14, 0), 0, [], [], "(06:00-14:00)", SedePrincipal)
+        }.AsReadOnly(),
+        "Turno Manana (06:00-14:00)");
+
+    private static readonly DetalleTurno DetalleConSedeAplicadaEsperado = new(
+        "Turno Manana",
+        new List<DetalleFranjaOrdinaria>
+        {
+            new(new TimeOnly(6, 0), new TimeOnly(14, 0), 0, [], [], "(06:00-14:00)", SedePrincipalDetalle)
+        }.AsReadOnly(),
+        "Turno Manana (06:00-14:00)");
+
     // --- Tests del camino feliz ---
 
     // CA-9, CA-10, CA-11, CA-12: emite evento de ES y publica evento publico por cada fecha
@@ -272,26 +294,6 @@ public class SolicitarProgramacionTurnoCommandHandlerTests
                 GuidAggregateId, EmpleadoDetalle, Fecha2, DetalleEsperado));
         And<SolicitudProgramacionAggregateRoot, int>(s => s.Fechas.Count, 2);
     }
-
-    // Issue #341 CA-3: turno SIN sedes prearmadas (CrearEventoTurno(), la misma franja que usan
-    // los tests del camino feliz) + solicitud CON sede -> la cascada (franja.Sede ?? sedePorDefecto)
-    // aplica SedePrincipal a la UNICA franja del turno. La Descripcion de la franja NO cambia (se
-    // congelo en el catalogo, ANTES de que la cascada conociera la sede de la solicitud).
-    private static readonly TurnoProgramado TurnoProgramadoConSedeAplicadaEsperado = new(
-        "Turno Manana",
-        new List<FranjaProgramada>
-        {
-            new(new TimeOnly(6, 0), new TimeOnly(14, 0), 0, [], [], "(06:00-14:00)", SedePrincipal)
-        }.AsReadOnly(),
-        "Turno Manana (06:00-14:00)");
-
-    private static readonly DetalleTurno DetalleConSedeAplicadaEsperado = new(
-        "Turno Manana",
-        new List<DetalleFranjaOrdinaria>
-        {
-            new(new TimeOnly(6, 0), new TimeOnly(14, 0), 0, [], [], "(06:00-14:00)", SedePrincipalDetalle)
-        }.AsReadOnly(),
-        "Turno Manana (06:00-14:00)");
 
     // Issue #331 CA-1 + Issue #341 CA-3: la sede viaja resuelta en el comando (el cliente la
     // resuelve, el servidor NUNCA consulta el maestro) y queda grabada en TRES lugares: el nivel
@@ -359,12 +361,12 @@ public class SolicitarProgramacionTurnoCommandHandlerTests
         And<SolicitudProgramacionAggregateRoot, SedeProgramada?>(s => s.Sede, null);
     }
 
-    // Issue #335: la sede PREARMADA en el catalogo llega al evento persistido sin que el flujo de
-    // solicitud la toque -- el handler no la lee ni la mapea, viaja dentro del snapshot del turno.
-    // Es el cimiento sobre el que #341 arma la cascada (sede de la franja ?? sede de la solicitud):
-    // si un refactor de ToDetalle/ObtenerDetalle dejara de copiarla, el defecto aparece aqui y no
-    // recien en #341. La solicitud va deliberadamente SIN sede propia para que el unico origen
-    // posible del dato sea el catalogo.
+    // Issue #335 + #341 CA-2: la sede PREARMADA en el catalogo llega intacta a AMBOS payloads
+    // cuando la solicitud no trae sede propia -- la cascada es identidad y el mapeo al bus la
+    // propaga. Si un refactor de ToDetalle/ObtenerDetalle dejara de copiarla, o si la cascada
+    // pisara la sede del catalogo con el null de la solicitud, el defecto aparece aqui. La
+    // solicitud va deliberadamente SIN sede propia para que el unico origen posible del dato sea
+    // el catalogo.
     [Fact]
     public async Task SolicitarProgramacionTurno_PersisteLaSedePrearmadaDelCatalogo_CuandoElTurnoLaTraePorFranja()
     {

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoCommandHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoCommandHandlerTests.cs
@@ -22,6 +22,8 @@ public class SolicitarProgramacionTurnoCommandHandlerTests
         Guid.Parse("018e4c1a-4f2b-7000-8000-112233445566");
     private static readonly Guid TurnoConSedePrearmadaId =
         Guid.Parse("018e4c1a-4f2b-7000-8000-778899aabbcc");
+    private static readonly Guid TurnoConFranjasMixtasId =
+        Guid.Parse("018e4c1a-4f2b-7000-8000-1a2b3c4d5e6f");
     private static readonly DateOnly Fecha1 = new(2026, 4, 7);
     private static readonly DateOnly Fecha2 = new(2026, 4, 8);
 
@@ -134,6 +136,7 @@ public class SolicitarProgramacionTurnoCommandHandlerTests
     // desde que se creo. El handler no la conoce ni la mapea -- fluye sola por el snapshot
     // existente (CatalogoTurnos.ObtenerDetalle -> FranjaOrdinaria.ToDetalle).
     private static readonly SedeProgramada SedeSuba = new("SEDE-SUBA", "Suba");
+    private static readonly DetalleSede SedeSubaDetalle = new("SEDE-SUBA", "Suba");
 
     private static TurnoCreado CrearEventoTurnoConSedePrearmada() =>
         TurnoCreado.Crear(
@@ -141,9 +144,7 @@ public class SolicitarProgramacionTurnoCommandHandlerTests
             "Turno Con Sede",
             [new DatosFranja(new TimeOnly(6, 0), new TimeOnly(14, 0), [], [], SedeSuba)]);
 
-    // La sede entra al ToString() de la franja, asi que la Descripcion derivada la incluye. Es la
-    // consecuencia aceptada en el issue (los turnos ya creados no cambian) y el UNICO rastro de la
-    // sede que hoy alcanza el payload de bus: DetalleFranjaOrdinaria no tiene campo Sede (#341).
+    // La sede entra al ToString() de la franja, asi que la Descripcion derivada la incluye.
     private static readonly string DescripcionFranjaConSede =
         $"(06:00-14:00)[{FranjaOrdinaria.Mensajes.LabelSede}:Suba]";
     private static readonly string DescripcionTurnoConSede =
@@ -157,13 +158,60 @@ public class SolicitarProgramacionTurnoCommandHandlerTests
         }.AsReadOnly(),
         DescripcionTurnoConSede);
 
+    // Issue #341 CA-2: la solicitud va sin sede (null), asi que la cascada (franja.Sede ??
+    // sedePorDefecto) deja la sede prearmada del catalogo intacta -- ahora tambien en el payload de
+    // bus, que gana su propio campo Sede (DetalleFranjaOrdinaria, #341). Antes de este issue
+    // DetalleFranjaOrdinaria no tenia campo Sede: el UNICO rastro de la sede en el bus era el texto
+    // de Descripcion.
     private static readonly DetalleTurno DetalleConSedePrearmadaEsperado = new(
         "Turno Con Sede",
         new List<DetalleFranjaOrdinaria>
         {
-            new(new TimeOnly(6, 0), new TimeOnly(14, 0), 0, [], [], DescripcionFranjaConSede)
+            new(new TimeOnly(6, 0), new TimeOnly(14, 0), 0, [], [], DescripcionFranjaConSede, SedeSubaDetalle)
         }.AsReadOnly(),
         DescripcionTurnoConSede);
+
+    // --- Issue #341: turno del catalogo con franjas MIXTAS (una con sede prearmada, otra sin) ---
+    //
+    // Ejercita CA-1: bajo una solicitud CON sede, cada franja resuelve su cascada de forma
+    // independiente -- la que ya trae sede del catalogo la conserva, la que no la recibe de la
+    // solicitud. Dos franjas en horarios distintos para no solapar (TurnoCreado.Crear valida
+    // solapamiento entre ordinarias).
+    private static TurnoCreado CrearEventoTurnoConFranjasMixtas() =>
+        TurnoCreado.Crear(
+            TurnoConFranjasMixtasId,
+            "Turno Mixto",
+            [
+                new DatosFranja(new TimeOnly(6, 0), new TimeOnly(10, 0), [], [], SedeSuba),
+                new DatosFranja(new TimeOnly(14, 0), new TimeOnly(18, 0), [], [])
+            ]);
+
+    private static readonly string DescripcionFranja1Mixta =
+        $"(06:00-10:00)[{FranjaOrdinaria.Mensajes.LabelSede}:Suba]";
+    private const string DescripcionFranja2Mixta = "(14:00-18:00)";
+    private static readonly string DescripcionTurnoMixto =
+        $"Turno Mixto {DescripcionFranja1Mixta}{DescripcionFranja2Mixta}";
+
+    // La cascada NUNCA reconstruye el ToString() ya congelado en el catalogo (Descripcion se
+    // calcula ANTES de conocer la sede de la solicitud): la franja2 queda con Sede = SedePrincipal
+    // pero su Descripcion sigue siendo "(14:00-18:00)", sin el label de sede.
+    private static readonly TurnoProgramado TurnoMixtoConCascadaEsperado = new(
+        "Turno Mixto",
+        new List<FranjaProgramada>
+        {
+            new(new TimeOnly(6, 0), new TimeOnly(10, 0), 0, [], [], DescripcionFranja1Mixta, SedeSuba),
+            new(new TimeOnly(14, 0), new TimeOnly(18, 0), 0, [], [], DescripcionFranja2Mixta, SedePrincipal)
+        }.AsReadOnly(),
+        DescripcionTurnoMixto);
+
+    private static readonly DetalleTurno DetalleMixtoConCascadaEsperado = new(
+        "Turno Mixto",
+        new List<DetalleFranjaOrdinaria>
+        {
+            new(new TimeOnly(6, 0), new TimeOnly(10, 0), 0, [], [], DescripcionFranja1Mixta, SedeSubaDetalle),
+            new(new TimeOnly(14, 0), new TimeOnly(18, 0), 0, [], [], DescripcionFranja2Mixta, SedePrincipalDetalle)
+        }.AsReadOnly(),
+        DescripcionTurnoMixto);
 
     // --- Tests del camino feliz ---
 
@@ -225,26 +273,73 @@ public class SolicitarProgramacionTurnoCommandHandlerTests
         And<SolicitudProgramacionAggregateRoot, int>(s => s.Fechas.Count, 2);
     }
 
-    // Issue #331 CA-1: la sede viaja resuelta en el comando (el cliente la resuelve, el servidor
-    // NUNCA consulta el maestro) y queda grabada tanto en el evento persistido (SedeProgramada,
-    // dominio) como en CADA evento diario publicado al bus interno (DetalleSede, gemelo deliberado).
-    // Dos fechas a proposito: CA-1 dice "cada ProgramacionTurnoDiarioSolicitada", asi que con una
-    // sola fecha una implementacion que solo poblara el primer evento pasaria en verde.
+    // Issue #341 CA-3: turno SIN sedes prearmadas (CrearEventoTurno(), la misma franja que usan
+    // los tests del camino feliz) + solicitud CON sede -> la cascada (franja.Sede ?? sedePorDefecto)
+    // aplica SedePrincipal a la UNICA franja del turno. La Descripcion de la franja NO cambia (se
+    // congelo en el catalogo, ANTES de que la cascada conociera la sede de la solicitud).
+    private static readonly TurnoProgramado TurnoProgramadoConSedeAplicadaEsperado = new(
+        "Turno Manana",
+        new List<FranjaProgramada>
+        {
+            new(new TimeOnly(6, 0), new TimeOnly(14, 0), 0, [], [], "(06:00-14:00)", SedePrincipal)
+        }.AsReadOnly(),
+        "Turno Manana (06:00-14:00)");
+
+    private static readonly DetalleTurno DetalleConSedeAplicadaEsperado = new(
+        "Turno Manana",
+        new List<DetalleFranjaOrdinaria>
+        {
+            new(new TimeOnly(6, 0), new TimeOnly(14, 0), 0, [], [], "(06:00-14:00)", SedePrincipalDetalle)
+        }.AsReadOnly(),
+        "Turno Manana (06:00-14:00)");
+
+    // Issue #331 CA-1 + Issue #341 CA-3: la sede viaja resuelta en el comando (el cliente la
+    // resuelve, el servidor NUNCA consulta el maestro) y queda grabada en TRES lugares: el nivel
+    // top del evento persistido (ProgramacionTurnoSolicitada.Sede -- lo SOLICITADO, trazabilidad),
+    // CADA evento diario publicado al bus interno (DetalleSede, gemelo deliberado) y, desde #341,
+    // la UNICA franja del turno (que no traia sede propia, asi que la cascada le aplica la de la
+    // solicitud) en AMBOS payloads (persistido y bus). Dos fechas a proposito: CA-1 de #331 dice
+    // "cada ProgramacionTurnoDiarioSolicitada", asi que con una sola fecha una implementacion que
+    // solo poblara el primer evento pasaria en verde.
     [Fact]
-    public async Task SolicitarProgramacionTurno_PersisteYPublicaLaSedeProgramada_CuandoLaSolicitudIncluyeSede()
+    public async Task SolicitarProgramacionTurno_AplicaLaSedeDeLaSolicitudATodasLasFranjas_CuandoElTurnoNoTraeSedesPrearmadas()
     {
         Given(TurnoId.ToString(), CrearEventoTurno());
         await WhenAsync(new SolicitarProgramacionTurno(
             GuidAggregateId, TurnoId, Empleado, [Fecha1, Fecha2], SedePrincipal));
 
         Then(new ProgramacionTurnoSolicitada(
-            GuidAggregateId, EmpleadoProgramado, [Fecha1, Fecha2], TurnoProgramadoEsperado, SedePrincipal));
+            GuidAggregateId, EmpleadoProgramado, [Fecha1, Fecha2], TurnoProgramadoConSedeAplicadaEsperado, SedePrincipal));
         ThenIsPublishedPrivately(
             new ProgramacionTurnoDiarioSolicitada(
-                GuidAggregateId, EmpleadoDetalle, Fecha1, DetalleEsperado, SedePrincipalDetalle),
+                GuidAggregateId, EmpleadoDetalle, Fecha1, DetalleConSedeAplicadaEsperado, SedePrincipalDetalle),
             new ProgramacionTurnoDiarioSolicitada(
-                GuidAggregateId, EmpleadoDetalle, Fecha2, DetalleEsperado, SedePrincipalDetalle));
+                GuidAggregateId, EmpleadoDetalle, Fecha2, DetalleConSedeAplicadaEsperado, SedePrincipalDetalle));
         And<SolicitudProgramacionAggregateRoot, SedeProgramada?>(s => s.Sede, SedePrincipal);
+        And<SolicitudProgramacionAggregateRoot, SedeProgramada?>(
+            s => s.DetalleTurno!.FranjasOrdinarias[0].Sede, SedePrincipal);
+    }
+
+    // Issue #341 CA-1: turno con franjas MIXTAS (una con sede prearmada del catalogo, otra sin) +
+    // solicitud CON sede -> cada franja resuelve su cascada de forma INDEPENDIENTE. La franja1
+    // conserva su sede propia (SedeSuba, el catalogo le gana al default); la franja2 (sin sede
+    // propia) adopta la de la solicitud (SedePrincipal). Se verifica en AMBOS payloads (evento
+    // persistido y evento diario publicado al bus).
+    [Fact]
+    public async Task SolicitarProgramacionTurno_ConservaLaSedeDeLaFranjaYAplicaLaSedePorDefecto_CuandoElTurnoTraeFranjasMixtas()
+    {
+        Given(TurnoConFranjasMixtasId.ToString(), CrearEventoTurnoConFranjasMixtas());
+        await WhenAsync(new SolicitarProgramacionTurno(
+            GuidAggregateId, TurnoConFranjasMixtasId, Empleado, [Fecha1], SedePrincipal));
+
+        Then(new ProgramacionTurnoSolicitada(
+            GuidAggregateId, EmpleadoProgramado, [Fecha1], TurnoMixtoConCascadaEsperado, SedePrincipal));
+        ThenIsPublishedPrivately(new ProgramacionTurnoDiarioSolicitada(
+            GuidAggregateId, EmpleadoDetalle, Fecha1, DetalleMixtoConCascadaEsperado, SedePrincipalDetalle));
+        And<SolicitudProgramacionAggregateRoot, SedeProgramada?>(
+            s => s.DetalleTurno!.FranjasOrdinarias[0].Sede, SedeSuba);
+        And<SolicitudProgramacionAggregateRoot, SedeProgramada?>(
+            s => s.DetalleTurno!.FranjasOrdinarias[1].Sede, SedePrincipal);
     }
 
     // Issue #331 CA-2: sede es opcional -- una solicitud sin sede (campo ausente) deja Sede en

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/ValueObjects/FranjaProgramadaParidadConDetalleFranjaOrdinariaTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/ValueObjects/FranjaProgramadaParidadConDetalleFranjaOrdinariaTests.cs
@@ -7,12 +7,10 @@
 // al tipo hijo correcto de cada lado (cuya propia paridad la cubre
 // SubFranjaProgramadaParidadConDetalleSubFranjaTests).
 //
-// Issue #335 (desviacion documentada, MEF-ADR-0012/CA-ADR-0029 decision #5): FranjaProgramada gana
-// el campo Sede (payload propio del dominio); el mapeo hacia el bus interno (DetalleFranjaOrdinaria)
-// queda explicitamente fuera de alcance de este issue -- ver
-// SolicitarProgramacionTurnoCommandHandler.MapearFranja, que no lo propaga todavia. El guardrail de
-// paridad exacta se relaja para permitir ESTA UNICA divergencia (Sede); cualquier otro campo nuevo
-// que no aparezca en ambos lados sigue rompiendo el test.
+// Issue #335 abrio una divergencia temporal deliberada (Sede solo en FranjaProgramada, el mapeo
+// hacia el bus interno quedaba fuera de alcance). Issue #341 la CIERRA: DetalleFranjaOrdinaria
+// gana su propio campo Sede (la sede EFECTIVA que resuelve la cascada) -- el guardrail vuelve a
+// exigir paridad EXACTA de nombres de campo en ambos lados, sin excepciones.
 
 using System.Reflection;
 using AwesomeAssertions;
@@ -27,14 +25,9 @@ public class FranjaProgramadaParidadConDetalleFranjaOrdinariaTests
         typeof(T).GetProperties(BindingFlags.Public | BindingFlags.Instance).Select(p => p.Name);
 
     [Fact]
-    public void FranjaProgramada_DeclaraLosMismosNombresDeCampoQueDetalleFranjaOrdinariaMasSedePropia()
+    public void FranjaProgramada_DeclaraLosMismosNombresDeCampoQueDetalleFranjaOrdinaria()
     {
-        var nombresProgramada = NombresDeCampos<FranjaProgramada>().ToList();
-        var nombresDetalle = NombresDeCampos<DetalleFranjaOrdinaria>().ToList();
-
-        nombresProgramada.Where(n => n != nameof(FranjaProgramada.Sede))
-            .Should().Equal(nombresDetalle);
-        nombresProgramada.Should().Contain(nameof(FranjaProgramada.Sede));
+        NombresDeCampos<FranjaProgramada>().Should().Equal(NombresDeCampos<DetalleFranjaOrdinaria>());
     }
 
     [Fact]
@@ -57,5 +50,17 @@ public class FranjaProgramadaParidadConDetalleFranjaOrdinariaTests
             .Should().Be(typeof(DetalleFranjaOrdinaria).GetProperty(nameof(DetalleFranjaOrdinaria.DiaOffsetFin))!.PropertyType);
         typeof(FranjaProgramada).GetProperty(nameof(FranjaProgramada.Descripcion))!.PropertyType
             .Should().Be(typeof(DetalleFranjaOrdinaria).GetProperty(nameof(DetalleFranjaOrdinaria.Descripcion))!.PropertyType);
+    }
+
+    // Issue #341: Sede tipa DELIBERADAMENTE distinto en cada lado (SedeProgramada vs DetalleSede,
+    // gemelos de payload por rol -- mismo criterio que Descansos/Extras con SubFranjaProgramada vs
+    // DetalleSubFranja).
+    [Fact]
+    public void FranjaProgramada_TipaSedeComoSedeProgramadaYDetalleFranjaOrdinariaComoDetalleSede()
+    {
+        typeof(FranjaProgramada).GetProperty(nameof(FranjaProgramada.Sede))!.PropertyType
+            .Should().Be(typeof(SedeProgramada));
+        typeof(DetalleFranjaOrdinaria).GetProperty(nameof(DetalleFranjaOrdinaria.Sede))!.PropertyType
+            .Should().Be(typeof(DetalleSede));
     }
 }

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/ValueObjects/TurnoProgramadoConSedePorDefectoTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/ValueObjects/TurnoProgramadoConSedePorDefectoTests.cs
@@ -1,0 +1,117 @@
+// Issue #341: cascada de sede al copiar el turno del catalogo en la solicitud de programacion.
+// Tests unitarios PUROS (sin harness) sobre TurnoProgramado.ConSedePorDefecto -- funcion pura
+// sobre records, tal como el precedente TurnoDiario.Segmentar (#327). Cubre la tabla de verdad
+// decidida en la sesion del planner (CA-1/CA-2/CA-3):
+//   franja con sede + solicitud con sede -> gana la franja
+//   franja con sede + solicitud sin sede -> franja
+//   franja sin sede + solicitud con sede -> solicitud
+//   ambas sin sede -> null ("sin sede asignada", estado valido)
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Programacion.DomainEvents;
+
+namespace Bitakora.ControlAsistencia.Programacion.Tests.ValueObjects;
+
+public class TurnoProgramadoConSedePorDefectoTests
+{
+    private static readonly SedeProgramada SedeCatalogo = new("SEDE-SUBA", "Suba");
+    private static readonly SedeProgramada SedeSolicitud = new("SEDE-CHAPINERO", "Chapinero");
+
+    private static FranjaProgramada CrearFranja(SedeProgramada? sede, string descripcion = "(06:00-14:00)") =>
+        new(new TimeOnly(6, 0), new TimeOnly(14, 0), 0, [], [], descripcion, sede);
+
+    private static TurnoProgramado CrearTurno(params FranjaProgramada[] franjas) =>
+        new("Turno Manana", franjas.ToList().AsReadOnly(), "Turno Manana (06:00-14:00)");
+
+    // Tabla de verdad, fila 1: franja con sede + solicitud con sede -> gana la franja.
+    [Fact]
+    public void ConSedePorDefecto_ConservaLaSedeDeLaFranja_CuandoLaFranjaYaTraeSedeDelCatalogo()
+    {
+        var turno = CrearTurno(CrearFranja(SedeCatalogo));
+
+        var resultado = turno.ConSedePorDefecto(SedeSolicitud);
+
+        resultado.FranjasOrdinarias[0].Sede.Should().Be(SedeCatalogo);
+    }
+
+    // Tabla de verdad, fila 2: franja con sede + solicitud sin sede -> franja (identidad).
+    [Fact]
+    public void ConSedePorDefecto_ConservaLaSedeDeLaFranja_CuandoLaSedePorDefectoEsNull()
+    {
+        var turno = CrearTurno(CrearFranja(SedeCatalogo));
+
+        var resultado = turno.ConSedePorDefecto(null);
+
+        resultado.Should().Be(turno);
+        resultado.FranjasOrdinarias[0].Sede.Should().Be(SedeCatalogo);
+    }
+
+    // Tabla de verdad, fila 3: franja sin sede + solicitud con sede -> solicitud.
+    [Fact]
+    public void ConSedePorDefecto_AplicaLaSedePorDefecto_CuandoLaFranjaNoTraeSede()
+    {
+        var turno = CrearTurno(CrearFranja(null));
+
+        var resultado = turno.ConSedePorDefecto(SedeSolicitud);
+
+        resultado.FranjasOrdinarias[0].Sede.Should().Be(SedeSolicitud);
+    }
+
+    // Tabla de verdad, fila 4: ambas sin sede -> null (sin sede asignada, estado valido).
+    [Fact]
+    public void ConSedePorDefecto_DejaLaFranjaSinSede_CuandoNingunoTraeSede()
+    {
+        var turno = CrearTurno(CrearFranja(null));
+
+        var resultado = turno.ConSedePorDefecto(null);
+
+        resultado.FranjasOrdinarias[0].Sede.Should().BeNull();
+    }
+
+    // CA-1: cada franja del turno resuelve su cascada de forma INDEPENDIENTE -- una implementacion
+    // que aplicara la sede por defecto a todo el turno de una sola vez (en lugar de franja por
+    // franja) pasaria las cuatro filas de la tabla de verdad de arriba (turnos de una sola franja)
+    // pero fallaria aqui.
+    [Fact]
+    public void ConSedePorDefecto_ResuelveCadaFranjaDeFormaIndependiente_CuandoElTurnoTieneFranjasMixtas()
+    {
+        var franjaConSede = new FranjaProgramada(
+            new TimeOnly(6, 0), new TimeOnly(10, 0), 0, [], [], "(06:00-10:00)[sede:Suba]", SedeCatalogo);
+        var franjaSinSede = new FranjaProgramada(
+            new TimeOnly(14, 0), new TimeOnly(18, 0), 0, [], [], "(14:00-18:00)");
+        var turno = CrearTurno(franjaConSede, franjaSinSede);
+
+        var resultado = turno.ConSedePorDefecto(SedeSolicitud);
+
+        resultado.FranjasOrdinarias[0].Sede.Should().Be(SedeCatalogo);
+        resultado.FranjasOrdinarias[1].Sede.Should().Be(SedeSolicitud);
+    }
+
+    // La cascada NUNCA reconstruye el ToString() ya congelado en el catalogo (Descripcion es dato
+    // derivado que se calculo ANTES de conocer la sede de la solicitud): solo el campo Sede cambia
+    // via `with`. Ademas de Descripcion, cubre que HoraInicio/HoraFin/Descansos/Extras/Nombre no se
+    // pierden -- si la implementacion reconstruyera la franja/turno a mano en lugar de usar `with`,
+    // este test lo delata.
+    [Fact]
+    public void ConSedePorDefecto_PreservaLosDemasCamposDeLaFranjaYDelTurno_CuandoAplicaLaSedePorDefecto()
+    {
+        var descanso = new SubFranjaProgramada(new TimeOnly(10, 0), new TimeOnly(10, 15), 0, 0, "(10:00-10:15)");
+        var franja = new FranjaProgramada(
+            new TimeOnly(6, 0), new TimeOnly(14, 0), 0, [descanso], [],
+            "(06:00-14:00)[Descansos:(10:00-10:15)]");
+        var turno = new TurnoProgramado(
+            "Turno Manana",
+            new List<FranjaProgramada> { franja }.AsReadOnly(),
+            "Turno Manana (06:00-14:00)[Descansos:(10:00-10:15)]");
+
+        var resultado = turno.ConSedePorDefecto(SedeSolicitud);
+
+        resultado.Nombre.Should().Be("Turno Manana");
+        resultado.Descripcion.Should().Be(turno.Descripcion);
+        resultado.FranjasOrdinarias[0].HoraInicio.Should().Be(new TimeOnly(6, 0));
+        resultado.FranjasOrdinarias[0].HoraFin.Should().Be(new TimeOnly(14, 0));
+        resultado.FranjasOrdinarias[0].Descripcion.Should().Be(franja.Descripcion);
+        resultado.FranjasOrdinarias[0].Descansos.Should().ContainSingle().Which.Should().Be(descanso);
+        resultado.FranjasOrdinarias[0].Sede.Should().Be(SedeSolicitud);
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/ValueObjects/TurnoProgramadoConSedePorDefectoTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/ValueObjects/TurnoProgramadoConSedePorDefectoTests.cs
@@ -17,8 +17,8 @@ public class TurnoProgramadoConSedePorDefectoTests
     private static readonly SedeProgramada SedeCatalogo = new("SEDE-SUBA", "Suba");
     private static readonly SedeProgramada SedeSolicitud = new("SEDE-CHAPINERO", "Chapinero");
 
-    private static FranjaProgramada CrearFranja(SedeProgramada? sede, string descripcion = "(06:00-14:00)") =>
-        new(new TimeOnly(6, 0), new TimeOnly(14, 0), 0, [], [], descripcion, sede);
+    private static FranjaProgramada CrearFranja(SedeProgramada? sede) =>
+        new(new TimeOnly(6, 0), new TimeOnly(14, 0), 0, [], [], "(06:00-14:00)", sede);
 
     private static TurnoProgramado CrearTurno(params FranjaProgramada[] franjas) =>
         new("Turno Manana", franjas.ToList().AsReadOnly(), "Turno Manana (06:00-14:00)");


### PR DESCRIPTION
## Resumen

Pipeline TDD completado:
- Fase roja: tests escritos con stubs
- Fase verde: implementación completa
- Smoke tests: escritos para endpoints detectados
- Fase refactor: revisión de calidad

## Decisiones del pipeline

<details>
<summary>Test Writer (fase roja) — 17m 0s</summary>

## ES Test Writer - Decisiones (issue #341)

### Tests creados

- `TurnoProgramadoConSedePorDefectoTests.cs` (NUEVO, Programacion.Tests/ValueObjects): 6 tests
  puros (sin harness) sobre `TurnoProgramado.ConSedePorDefecto`:
  - `ConSedePorDefecto_ConservaLaSedeDeLaFranja_CuandoLaFranjaYaTraeSedeDelCatalogo` - tabla de
    verdad fila 1 (CA-1)
  - `ConSedePorDefecto_ConservaLaSedeDeLaFranja_CuandoLaSedePorDefectoEsNull` - tabla de verdad
    fila 2 (CA-2) + identidad cuando el parametro es null
  - `ConSedePorDefecto_AplicaLaSedePorDefecto_CuandoLaFranjaNoTraeSede` - tabla de verdad fila 3
    (CA-3)
  - `ConSedePorDefecto_DejaLaFranjaSinSede_CuandoNingunoTraeSede` - tabla de verdad fila 4 (CA-2)
  - `ConSedePorDefecto_ResuelveCadaFranjaDeFormaIndependiente_CuandoElTurnoTieneFranjasMixtas` -
    CA-1, delata una implementacion que aplique la sede a nivel de turno en vez de por franja
  - `ConSedePorDefecto_PreservaLosDemasCamposDeLaFranjaYDelTurno_CuandoAplicaLaSedePorDefecto` -
    delata una reconstruccion manual (en vez de `with`) que pierda Descripcion/Descansos/etc.

- `SolicitarProgramacionTurnoCommandHandlerTests.cs` (MODIFICADO): 2 tests nuevos + 1 actualizado
  con expectativas nuevas:
  - `SolicitarProgramacionTurno_AplicaLaSedeDeLaSolicitudATodasLasFranjas_CuandoElTurnoNoTraeSedesPrearmadas`
    (renombrado desde `..._PersisteYPublicaLaSedeProgramada_...`, ahora cubre CA-3): turno sin
    sedes + solicitud con sede -> la unica franja adopta la sede de la solicitud, en el evento
    persistido y en cada evento de bus.
  - `SolicitarProgramacionTurno_ConservaLaSedeDeLaFranjaYAplicaLaSedePorDefecto_CuandoElTurnoTraeFranjasMixtas`
    (NUEVO, CA-1): turno con una franja con sede del catalogo y otra sin sede, bajo solicitud con
    sede -> cada franja resuelve su cascada de forma independiente.
  - `SolicitarProgramacionTurno_PersisteLaSedePrearmadaDelCatalogo_CuandoElTurnoLaTraePorFranja`
    (ya existia, de #335): actualizado `DetalleConSedePrearmadaEsperado` para exigir que la sede
    tambien llegue al evento de bus (antes de #341, `DetalleFranjaOrdinaria` no tenia campo Sede).

- `DetalleFranjaOrdinariaIgualdadTests.cs` (MODIFICADO): agregado el caso "Sede" a
  `CrearInstanciasDiferentes()` -- cubre que Sede participa en Equals/GetHashCode.

- `FranjaProgramadaParidadConDetalleFranjaOrdinariaTests.cs` (MODIFICADO): el guardrail vuelve a
  exigir paridad EXACTA de nombres de campo (ya no tolera la divergencia de Sede que #335 abrio
  temporalmente); se agrego un test que verifica que Sede tipa `SedeProgramada` en un lado y
  `DetalleSede` en el otro (mismo patron que Descansos/Extras).

- `ProgramacionTurnoDiarioSolicitadaPortabilidadTests.cs` (MODIFICADO, ControlHoras.Tests): 2
  tests nuevos para CA-4/CA-5 del lado del bus:
  - `RoundTrip_PreservaLaSedeDeLaFranja_ConSerializadorPorDefectoDelBus` (CA-5)
  - `Deserializar_DejaSedeDeLaFranjaEnNull_CuandoElMensajeNoLlevaLaClaveSedeEnLaFranja` (CA-4)

- `ProgramacionTurnoSolicitadaSerializacionTests.cs` (MODIFICADO): solo un comentario aclaratorio
  (ningun test nuevo) explicando por que la retrocompatibilidad/round-trip de `FranjaProgramada.Sede`
  a nivel de este evento persistido NO se duplica aqui (ver "Desviaciones del plan del planner").

### Stubs de produccion creados

- `TurnoProgramado.ConSedePorDefecto(SedeProgramada? sedePorDefecto): TurnoProgramado` -- stub con
  `throw new NotImplementedException()`. Es la unica pieza de LOGICA real de este issue.
- `DetalleFranjaOrdinaria.Sede` (campo posicional `DetalleSede? Sede = null`) -- agregado COMPLETO
  (no stub), con Equals/GetHashCode actualizados, siguiendo el precedente de #335
  (`FranjaProgramada.Sede`): es dato plano sin logica de negocio, no hay nada que posponer.
- El `SolicitarProgramacionTurnoCommandHandler` (HandleAsync, MapearFranja) NO se toco -- mismo
  patron que el test-writer de #331 aplico con el mapeo de `command.Sede`: el "wiring" del
  handler (invocar `ConSedePorDefecto` y propagar `Sede` en `MapearFranja`) queda pendiente para
  el implementer. Los 3 tests del handler fallan por esto (mas los 6 del VO puro, por el
  `NotImplementedException`), 9 en total.

### Estructura elegida

- El metodo de la cascada es un test unitario PURO (sin harness event-sourcing) porque
  `TurnoProgramado.ConSedePorDefecto` es una funcion pura sobre records -- mismo criterio que el
  precedente citado por el issue (`TurnoDiario.Segmentar`, #327).
- Los tests del handler siguen la clase existente (no nested classes): un solo comando/handler en
  este feature folder, coherente con el resto del archivo.

### Decisiones de diseno

- **Verificacion empirica de "los tests deben fallar" antes de comitear cualquier test de
  serializacion/igualdad**: para cada test de estructura de datos pura (Igualdad, Paridad,
  Portabilidad de `DetalleFranjaOrdinaria.Sede`) corri el test de forma aislada ANTES de aceptarlo
  en la fase roja. Confirme dos hechos:
  1. Los 2 tests que redactÉ inicialmente en `ProgramacionTurnoSolicitadaSerializacionTests.cs`
     (retrocompat/round-trip de `FranjaProgramada.Sede` DENTRO del evento persistido completo)
     PASABAN en verde de inmediato -- ese comportamiento ya lo cubrio #335 a nivel del VO aislado
     (`FranjaOrdinariaSerializacionTests`). Los removi (ver Desviaciones) porque no ejercitan
     ningun comportamiento nuevo de #341 y violarian el principio fundamental de este agente.
  2. Los tests de Igualdad/Portabilidad para el campo NUEVO `DetalleFranjaOrdinaria.Sede` tambien
     pasan en verde de inmediato -- pero por una razon legitima y distinta: es dato plano sin
     logica que posponer (mismo patron confirmado en el commit test-writer de #335 para
     `FranjaProgramada.Sede`, donde el Equals/GetHashCode se completo integro en la fase roja).
     Estos SI se mantienen: el "rojo" de la fase roja lo aportan los 9 tests de COMPORTAMIENTO
     (la cascada + el wiring del handler), no cada test individual de estructura de datos.
- La Descripcion de cada franja queda CONGELADA por el catalogo (calculada por
  `FranjaOrdinaria.ToString()` antes de que la cascada conozca la sede de la solicitud) -- los
  tests del handler lo documentan explicitamente: una franja que recibe sede por default via
  cascada NO gana el label `[sede:...]` en su Descripcion, solo en el campo `Sede`.

### Cobertura de criterios

| Criterio de aceptacion | Test(s) |
|---|---|
| CA-1: franja con sede se conserva, franja sin sede toma la de la solicitud (mixto) | `ConSedePorDefecto_ResuelveCadaFranjaDeFormaIndependiente_CuandoElTurnoTieneFranjasMixtas` (VO puro); `SolicitarProgramacionTurno_ConservaLaSedeDeLaFranjaYAplicaLaSedePorDefecto_CuandoElTurnoTraeFranjasMixtas` (handler, persistido + bus) |
| CA-2: solicitud sin sede, comportamiento actual intacto | `ConSedePorDefecto_ConservaLaSedeDeLaFranja_CuandoLaSedePorDefectoEsNull`, `ConSedePorDefecto_DejaLaFranjaSinSede_CuandoNingunoTraeSede` (VO puro); `SolicitarProgramacionTurno_PersisteLaSedePrearmadaDelCatalogo_CuandoElTurnoLaTraePorFranja` (handler, actualizado para exigir sede tambien en el bus) |
| CA-3: turno sin sedes + solicitud con sede -> todas las franjas con X, `Sede` de la solicitud intacta | `ConSedePorDefecto_AplicaLaSedePorDefecto_CuandoLaFranjaNoTraeSede` (VO puro); `SolicitarProgramacionTurno_AplicaLaSedeDeLaSolicitudATodasLasFranjas_CuandoElTurnoNoTraeSedesPrearmadas` (handler) |
| CA-4: retrocompatibilidad, JSON sin clave sede en franja | `Deserializar_DejaSedeDeLaFranjaEnNull_CuandoElMensajeNoLlevaLaClaveSedeEnLaFranja` (bus) |
| CA-5: round-trip con sedes pobladas en franjas, cruza el bus, incluida igualdad de `DetalleFranjaOrdinaria` | `RoundTrip_PreservaLaSedeDeLaFranja_ConSerializadorPorDefectoDelBus` (bus); `DetalleFranjaOrdinariaIgualdadTests` (caso "Sede") |
| CA-6: suite completa en verde | Verificado que solo los 9 tests de comportamiento nuevo fallan; el resto de la suite (216 en Programacion.Tests, 50 en PrivateEvents.Tests, 419 en ControlHoras.Tests, 13 en PublicEvents.Tests, 54 en Projections.Tests) sigue en verde |

### Desviaciones del plan del planner

| Sugerencia del issue | Desviacion aplicada | Razon tecnica | Consecuencia |
|---|---|---|---|
| CA-4 dice "el JSON ya persistido de AMBOS eventos... deserializa con sede null" | No se agrego un test de retrocompatibilidad/round-trip para `FranjaProgramada.Sede` dentro de `ProgramacionTurnoSolicitada` (evento persistido) | Ese comportamiento ya existe desde #335 (verificado empiricamente: el test pasaba en verde de inmediato, sin depender de ningun codigo de #341). Agregarlo violaria el principio fundamental de este agente ("los tests deben fallar"). Se dejo solo un comentario aclaratorio en `ProgramacionTurnoSolicitadaSerializacionTests.cs` documentando la decision | CA-4/CA-5 quedan cubiertos integramente por el lado que SI es nuevo en #341: `DetalleFranjaOrdinaria.Sede` (evento de bus), en `ProgramacionTurnoDiarioSolicitadaPortabilidadTests.cs`. Ningun CA queda sin cobertura -- se interpreta que "ambos eventos" del CA-4 se satisface con el evento persistido (ya cubierto por #335) + el evento de bus (cubierto aqui) |
| Interfaz publica propuesta: `ConSedePorDefecto(SedeProgramada? sedePorDefecto): TurnoProgramado` | Se implemento tal cual, sin cambios | La firma propuesta es correcta y suficiente | Ninguna |
| Interfaz publica propuesta: `DetalleFranjaOrdinaria` gana `+ DetalleSede? Sede`, posicional, en Equals/GetHashCode | Se implemento tal cual | Correcto, mismo patron que #335 | Ninguna |

### Nota sobre el orden de trabajo del implementer

El handler (`SolicitarProgramacionTurnoCommandHandler`) requiere DOS cambios para poner los 3
tests del handler en verde:
1. `HandleAsync`: aplicar `turnoProgramado.ConSedePorDefecto(command.Sede)` entre
   `catalogo.ObtenerDetalle()` y la construccion de `ProgramacionTurnoSolicitada`.
2. `MapearFranja`: agregar `Sede: MapearSede(franja.Sede)` (reutilizando el `MapearSede` que #331
   ya introdujo) para que la sede efectiva tambien llegue al evento de bus.

Y por supuesto, `TurnoProgramado.ConSedePorDefecto` debe implementarse con la logica real de la
cascada (`franja.Sede ?? sedePorDefecto` sobre cada franja, via `with`).

</details>

<details>
<summary>Implementer (fase verde) — 3m 34s</summary>

## ES Implementer - Decisiones

### Enfoque de implementacion

El test-writer ya habia dejado listos los tipos de datos (`DetalleFranjaOrdinaria.Sede` con
Equals/GetHashCode custom, incluida) y solo el metodo de comportamiento y su invocacion desde el
handler quedaban con `throw new NotImplementedException()`. El trabajo se redujo a dos puntos:

1. **`TurnoProgramado.ConSedePorDefecto(SedeProgramada? sedePorDefecto)`**: funcion pura sobre
   records. Usa `this with { FranjasOrdinarias = ... }` sobre el turno, y dentro del `Select`,
   `franja with { Sede = franja.Sede ?? sedePorDefecto }` por cada franja -- exactamente la tabla
   de verdad del issue (catalogo gana; sin sede en ninguno de los dos, queda null). Usar `with` en
   vez de reconstruir manualmente el record preserva `Descripcion` (dato derivado ya congelado en
   el catalogo, antes de conocer la sede de la solicitud) y el resto de campos sin tocarlos --
   los tests de "preserva los demas campos" y "resuelve cada franja de forma independiente" lo
   verifican directamente.

2. **`SolicitarProgramacionTurnoCommandHandler`**: se inserto `.ConSedePorDefecto(command.Sede)`
   inmediatamente despues de `catalogo.ObtenerDetalle()`, antes de que `turnoProgramado` alimente
   tanto el evento persistido (`ProgramacionTurnoSolicitada`) como el DTO de bus (`MapearTurno` /
   `MapearFranja`) -- un solo punto de resolucion, tal como pedia el issue. `MapearFranja` gano
   un quinto argumento posicional (`MapearSede(franja.Sede)`), reusando el mismo helper de mapeo
   `SedeProgramada -> DetalleSede` que ya existia para la sede de nivel solicitud (gemelo
   deliberado, no una traduccion nueva).

Con `command.Sede == null`, `ConSedePorDefecto(null)` es identidad para las franjas que ya
tenian sede y dejan en null a las que no -- permite invocarlo incondicionalmente sin ramificar el
handler por si la solicitud trae sede (Tell-don't-Ask, MEF-ADR-0012).

### Decisiones de diseno

- No se creo ningun tipo nuevo: `SedeProgramada`, `DetalleSede`, `FranjaProgramada.Sede` y
  `DetalleFranjaOrdinaria.Sede` ya existian (de #331/#335, este ultimo agregado por el
  test-writer en este mismo issue). El unico comportamiento nuevo es la cascada.
- La cascada vive en `TurnoProgramado` (dueno de las franjas), no en el handler ni en un servicio
  auxiliar -- sigue el precedente `TurnoDiario.Segmentar` (#327) citado en el issue.
- El mapeo de la sede efectiva hacia el bus reusa `MapearSede` (ya existente para la sede de la
  solicitud) en lugar de duplicar la logica de traduccion -- un solo punto de conversion
  `SedeProgramada -> DetalleSede` para todo el handler.

### ADRs consultados

- MEF-ADR-0012 (Tell-don't-Ask): la cascada vive en el objeto dueno de los datos (`TurnoProgramado`),
  el handler solo la invoca.
- CA-ADR-0029 / MEF-ADR-0039 (payload por rol, tres islas): el mapeo `FranjaProgramada ->
  DetalleFranjaOrdinaria` sigue viviendo unicamente en el FA (`SolicitarProgramacionTurnoCommandHandler`),
  unico proyecto que ve ambas islas.
- MEF-ADR-0023 / MEF-ADR-0024 (payload plano y portable): `DetalleSede` ya es record plano de
  strings (heredado de #331); no se agrego nada que rompa la portabilidad del evento de bus.
- CA-ADR-0029 decision #6 / MEF-ADR-0036 (campos aditivos, ningun tipo se mueve/renombra): el
  campo `Sede` se agrego como parametro posicional opcional con default `null` en
  `DetalleFranjaOrdinaria` (ya hecho por el test-writer); no se toco `IdentidadEventos{Dominio}`
  porque no se creo ningun tipo de evento nuevo, solo se le agrego un campo a uno existente.
- MEF-ADR-0002 / MEF-ADR-0016: la suite de tests ya seguia el DSL y la convencion de nombres; no
  se modifico ningun test.
- MEF-ADR-0018: no se genero ningun motor de "resolucion de defaults" generico -- un unico metodo
  con proposito concreto (`ConSedePorDefecto`), tal como pedia el issue explicitamente.

### Desviaciones de ADRs

Ninguna desviacion -- todos los ADRs aplicados al pie de la letra.

### Desviaciones del plan del planner

Ninguna desviacion -- la interfaz publica propuesta (`ConSedePorDefecto`, el punto de insercion en
el handler, la propagacion en `MapearFranja`) se implemento tal como la sugirio el issue.

### Precedentes consultados

- `TurnoDiario.Segmentar` (#327): confirmado como precedente valido de "comportamiento en el
  payload" (Tell-don't-Ask) -- se siguio la misma forma (funcion pura sobre records con `with`).
- El mapeo existente `MapearSede` en el propio handler (issue #331): reusado sin cambios para
  propagar la sede efectiva de la franja, evitando duplicar la traduccion
  `SedeProgramada -> DetalleSede`.

### Infraestructura modificada

Ninguna. El issue es explicito en que no hay eventos ni comandos nuevos -- solo un campo aditivo
en un tipo de evento que ya existia y que ya viaja por los topics existentes (`ProgramacionTurnoDiarioSolicitada`).
No se toco `infra/environments/dev/main.tf`.

### Complejidad encontrada

Ninguna significativa. El test-writer dejo el trabajo muy acotado: los tipos y su
Equals/GetHashCode ya estaban completos, solo faltaba la logica de negocio en dos puntos
puntuales. Unica friccion menor: el CLI de `dotnet test` en este repo usa el nuevo testing
platform de xunit v3 (requiere `--project` y `--filter-class`/`--filter-query` en vez del
`--filter` clasico de VSTest) -- no afecto la implementacion, solo la forma de invocar los tests
por filtro durante la verificacion.

### Resultado

- Tests pasando: 793/793 (14 omitidos por falta de infraestructura local -- ServiceBus/Postgres no
  configurados, esperado en este entorno).

</details>
<details>
<summary>Smoke Test Writer — 3m 54s</summary>

_(El agente no generó resumen)_

</details>
<details>
<summary>Reviewer (fase refactor) — 15m 18s</summary>

## ES Reviewer - Revision

### Evaluacion general
- Calidad: **buena**
- Cambios realizados: **si** (commit `9913221`)
- Suite: 812 tests, 0 errores, 795 correctos, 17 omitidos (smoke tests sin infra local). Baseline
  de entrada: 809/793/16 -- verde antes, durante y despues de cada cambio.

El diff llego solido: la cascada esta en el objeto dueno de los datos, es una funcion pura sobre
records, y el handler solo la invoca. El hallazgo de fondo no estuvo en el codigo de produccion
sino en la cobertura: el smoke test verificaba **un solo** efecto secundario del handler.

### Cumplimiento de ADRs aplicables

| ADR | Cumplimiento | Observacion |
|---|---|---|
| MEF-ADR-0012: Tell-don't-Ask / modelado | ok | `ConSedePorDefecto` vive en `TurnoProgramado` (dueno de las franjas), no en el handler ni en una clase estatica auxiliar. No se abrio ninguna propiedad nueva para que un externo opere. Precedente citado (`TurnoDiario.Segmentar`, #327) verificado y alineado. |
| MEF-ADR-0012: frontera de serializacion (bus) | ok | `DetalleFranjaOrdinaria.Sede` tipa `DetalleSede`, `record` plano de dos `string` -- portable por el serializador por defecto. Guardrail presente: `RoundTrip_PreservaLaSedeDeLaFranja_ConSerializadorPorDefectoDelBus` (sin resolver custom, camino real de `ServiceBusDeserializador`). |
| MEF-ADR-0012: `record` con `IReadOnlyList` | ok | Ambos records mantienen `Equals`/`GetHashCode` propios con `SequenceEqual`; `Sede` se sumo a ambos (identidad), a diferencia de `Descripcion` (derivado). Criterio consistente entre gemelos. |
| CA-ADR-0029 / MEF-ADR-0039: payload por rol | ok | El mapeo `FranjaProgramada -> DetalleFranjaOrdinaria` (y `SedeProgramada -> DetalleSede`) vive solo en el Function App, reusando el `MapearSede` que ya existia. Ningun tipo cruza ensamblados de eventos; no se agrego ninguna `ProjectReference`. |
| MEF-ADR-0023 / MEF-ADR-0024: payload plano | ok | Sin tipos ricos nuevos en el evento de bus. |
| CA-ADR-0029 decision #6 / MEF-ADR-0036: campos aditivos | ok | Ningun tipo se movio ni se renombro; `IdentidadEventosProgramacion.TiposPersistidos` intacto. `Sede` entra como parametro posicional opcional (`= null`), forma aditiva ya usada por `Descripcion` (#288) y por la sede de nivel solicitud (#331). Alias `programacion_turno_solicitada` sin cambios -- el guardrail de literales de `ComposicionServiciosTests` sigue verde. |
| MEF-ADR-0002 / MEF-ADR-0016: DSL y naming | ok | Tests del handler con `Given`/`WhenAsync`/`Then`/`And<>`; nombres `<Sujeto>_<LoQuePasa>_Cuando<Condicion>` con el comando como sujeto. Los tests del VO son unitarios puros (sin harness), tal como el issue pedia por ser funcion pura -- mismo criterio del precedente #327. |
| MEF-ADR-0018: no generalizar | ok | Un unico metodo con proposito concreto. Ningun "motor de resolucion de defaults". |

### Desviaciones de ADRs

**Desviaciones declaradas por el implementer**: ninguna (su resumen declara "todos los ADRs
aplicados al pie de la letra"; verificado contra el diff, la afirmacion se sostiene).

**Desviaciones del plan declaradas por el test-writer** (una, evaluada aqui):

#### Desviacion: CA-4 -- retrocompatibilidad del evento **persistido** sin test propio
- **Regla del issue**: CA-4 dice "el JSON ya persistido de **ambos** eventos (franjas sin clave
  `sede`) deserializa con sede null".
- **Desviacion aplicada**: el test-writer no agrego test para el evento persistido; dejo una nota
  en `ProgramacionTurnoSolicitadaSerializacionTests.cs` remitiendo a #335.
- **Razon del test-writer**: el test pasaria en verde de inmediato, lo que viola el principio de la
  fase roja.
- **Evaluacion del reviewer**: **la razon es correcta para la fase roja, pero la cobertura que
  invocaba no era exacta**. El test citado (`FranjaOrdinariaSerializacionTests`) cubre el VO rico
  `FranjaOrdinaria`, no `FranjaProgramada` dentro del evento persistido. La retrocompatibilidad si
  quedaba cubierta, pero solo de forma **implicita** (via `Should().Be(TurnoEsperado)`, porque
  `Sede` entra en el `Equals`); y el **round-trip con la sede poblada en la franja** no estaba
  cubierto en ningun lado -- `RoundTrip_PreservaLaSede_CuandoLaSedeEstaPoblada` (#331) usa un turno
  cuyas franjas van sin sede.
- **Accion tomada**: agregados dos tests de contrato en fase refactor (permitido: son contratos de
  serializacion, no comportamiento de negocio). Ver "Tests agregados".
- **Status**: resuelta en este PR.

**Desviaciones detectadas por el reviewer (NO declaradas)**: ninguna desviacion de ADR. Los
hallazgos que si aparecieron son de cobertura y de documentacion, listados abajo.

### Precedentes consultados por el implementer

| Precedente | ADR aplicable | Veredicto |
|---|---|---|
| `TurnoDiario.Segmentar` (#327) -- comportamiento en el payload | MEF-ADR-0012 | alineado |
| `MapearSede` del propio handler (#331) -- unico punto de traduccion `SedeProgramada -> DetalleSede` | CA-ADR-0029 #5 | alineado (reusarlo evita una segunda traduccion) |
| `FranjaProgramada.Sede` (#335) -- campo aditivo posicional en `Equals`/`GetHashCode` | MEF-ADR-0036 | alineado |

### Convenciones del pipeline (no ADRs)

| Convencion | Estado | Observacion |
|---|---|---|
| Cada test con `Then()` + `And<>()` | ok | Los dos tests nuevos del handler traen `Then` + `ThenIsPublishedPrivately` + dos `And<>` cada uno. |
| Overloads correctos para stream IDs compuestos | ok | `SolicitudProgramacionAggregateRoot.Id = e.Id.ToString()` (guid, no compuesto): `Then(evento)` es el overload correcto. El `Given(TurnoId.ToString(), ...)` del catalogo si lleva stream id explicito. |
| Fakes manuales (no NSubstitute) | n/a | El issue no agrega dependencias al handler. |
| Feature folders (produccion y tests) | ok | Espejo intacto; el test del VO puro en `ValueObjects/`. |
| Smoke tests: SkipWhen, secrets, cobertura | **falla -> corregido** | `SkipWhen` y filtro por `SolicitudId` correctos; **faltaba la cobertura del segundo efecto secundario** (persistencia). Ver "Criticas y hallazgos". |
| Proyecciones read-side | n/a | El diff no toca `ReadModels`/`Projections` ni ninguna Function GET. |
| Compatibilidad Marten write-side/read-side (#447) | n/a | El diff no toca versiones de `Cosmos.EventSourcing.*` ni `ComposicionServicios`/`ConfiguracionMartenProjections*`/`ConfiguracionSerializacion*`/`IdentidadEventos*`. Gate no disparado. |
| Identidad de stream (MEF-ADR-0037) | ok | Sin `ToString("N")` ni formato explicito; el smoke test nuevo usa `solicitudId.ToString()` canonico. No hay construccion manual de clave fuera de un `ComputarStreamId` (este aggregate no tiene clave compuesta) ni endpoints GET. |
| Control de volumen de telemetria (MEF-ADR-0038) | n/a | El diff no toca `ComposicionServicios*`, `ConfiguracionObservabilidad*` ni el callback de Wolverine. Gate no disparado. |
| Tests via ToString/comportamiento | ok | Sin getters expuestos para test. |
| Sin numeros magicos | ok | Sedes y descripciones como constantes con nombre. |
| Condiciones en positivo | ok | `franja.Sede ?? sedePorDefecto` -- sin guardas negativas nuevas. |
| Sin caracter U+2500 | ok | Verificado sobre todos los `.cs` del diff. |
| `dotnet format --verify-no-changes` | ok (para el diff) | Los 4 hallazgos `IDE0005` que reporta son de `ControlHoras.Tests` -- archivos preexistentes que este PR no toca. Deuda previa, no introducida aqui; no se corrige (fuera de alcance). |

### Elegancia del codigo

- **Compacto e idiomatico**: `ConSedePorDefecto` es una sola expresion (`this with { ... Select(f => f with { ... }) }`) -- funcion pura sobre records, sin ramificar por `null` en el llamador. No se agrego un early-return para el caso `null`: seria una rama extra sin cambiar la semantica observable.
- **Legible**: la insercion en el handler (`catalogo.ObtenerDetalle().ConSedePorDefecto(command.Sede)`) deja explicito el orden -- la cascada resuelve **antes** de que ningun evento se construya, que es la invariante que el issue pedia.
- **Robusto**: `MapearSede` reusado en vez de duplicar la traduccion; el `null` fluye igual por ambos payloads.
- **Limpieza**: build sin warnings propios; sin codigo muerto ni debug cruft. Se corrigieron tres puntos de documentacion que quedaron mintiendo (ver hallazgos).

### Criticas y hallazgos

1. **[mayor -- corregido] El smoke test cubria un solo efecto secundario del handler.**
   `SolicitarProgramacionTurnoCommandHandler` tiene dos: `IEventStore.StartStream` (persistencia) y
   `IPrivateEventSender.PublishAsync` (bus). Los tres smoke tests verificaban solo el bus, aun
   cuando CA-1 pide explicitamente "en el evento persistido **y** en cada evento diario del bus", y
   `PostgresFixture.ObtenerEventoAsync` ya existia con precedente directo (#335,
   `CrearTurno_PersisteLaSedePrearmadaDeCadaFranja_...`). El riesgo concreto que quedaba abierto: la
   sede efectiva llega bien al bus pero se pierde en silencio en `mt_events`, con un `202` igual de
   verde. **Corregido**: test nuevo (ver "Tests agregados").

2. **[menor -- corregido] Cobertura de CA-4/CA-5 incompleta del lado persistido.** Detalle en
   "Desviaciones". El round-trip con sede poblada **en la franja** del evento persistido no existia.

3. **[menor -- corregido] Documentacion desactualizada por el propio issue.** Tres puntos afirmaban
   un estado que #341 ya cambio:
   - `FranjaProgramada.cs` seguia declarando la divergencia con `DetalleFranjaOrdinaria` como
     abierta ("el mapeo hacia el bus interno queda fuera de alcance"), cuando este issue la cerro y
     el test de paridad ya volvio a exigir paridad exacta.
   - Dos comentarios en `SolicitarProgramacionTurnoCommandHandlerTests` afirmaban que "el handler no
     la conoce ni la mapea" -- `MapearFranja` ahora si la mapea.
   Un comentario que miente sobre el codigo es peor que ninguno: dirige mal la proxima lectura.

4. **[cosmetico -- corregido] Fixtures declarados dentro de la zona de tests.**
   `TurnoProgramadoConSedeAplicadaEsperado` y `DetalleConSedeAplicadaEsperado` estaban entre dos
   `[Fact]`, rompiendo la organizacion del archivo (todo lo demas vive arriba, agrupado por issue).

5. **[cosmetico -- corregido] Parametro opcional muerto** (`descripcion`) en el helper `CrearFranja`
   de `TurnoProgramadoConSedePorDefectoTests`: nunca se invocaba con valor distinto del default.

6. **[cosmetico -- corregido] Duplicacion del payload del turno mixto** entre dos smoke tests
   (bloque de ~20 lineas identico). Extraido a `TurnoConFranjasMixtasPayload(...)`.

7. **[observacion, no corregido]** Los smoke tests de este archivo repiten el arrange "crear turno
   en catalogo" en cuatro tests con payloads que si difieren entre si (con/sin sede, una/dos
   franjas). No se extrajo un helper comun: los payloads no son el mismo dato y forzar una firma
   generica los volveria menos legibles, no mas. Queda registrado por si un quinto caso aparece
   (Rule of Three, MEF-ADR-0018).

### Refactorings aplicados

- Extraccion de `TurnoConFranjasMixtasPayload(turnoId, sedeId, sedeNombre)` en los smoke tests.
- Reubicacion de los dos fixtures del handler test a la zona de fixtures, con su comentario de CA.
- Eliminacion del parametro opcional muerto en `CrearFranja`.
- Reescritura de tres bloques de documentacion desactualizada (`FranjaProgramada.cs` y dos
  comentarios del handler test).
- Aserciones del smoke test de persistencia via formas minimas (`SedeMinima`/`FranjaMinima`/
  `TurnoMinimo`/`SolicitudMinima`) leidas case-insensitive, en vez de navegar `JsonElement` por
  clave: mas legible y deja la politica de nombres del serializador fuera de la asercion -- lo que
  se verifica es el dato grabado. Mismo criterio que `DeadLetterMinimos`.

Cada cambio se verifico con `dotnet test` inmediatamente despues. Ninguno requirio revertirse.

### Cobertura de criterios de aceptacion

| Criterio | Estado | Test(s) |
|---|---|---|
| CA-1: franjas mixtas -- cada una resuelve su cascada, en evento persistido y en el bus | cubierto | `ConSedePorDefecto_ResuelveCadaFranjaDeFormaIndependiente_CuandoElTurnoTieneFranjasMixtas` (VO puro); `SolicitarProgramacionTurno_ConservaLaSedeDeLaFranjaYAplicaLaSedePorDefecto_CuandoElTurnoTraeFranjasMixtas` (handler, ambos payloads); mismo nombre en smoke tests (bus, e2e); **`SolicitarProgramacionTurno_PersisteLaSedeEfectivaDeCadaFranja_CuandoElTurnoTraeFranjasMixtas`** (smoke, mt_events -- agregado en esta fase) |
| CA-2: solicitud sin sede -- el catalogo se conserva, el resto queda null | cubierto | `ConSedePorDefecto_ConservaLaSedeDeLaFranja_CuandoLaSedePorDefectoEsNull`, `ConSedePorDefecto_DejaLaFranjaSinSede_CuandoNingunoTraeSede` (VO puro); `SolicitarProgramacionTurno_PersisteLaSedePrearmadaDelCatalogo_CuandoElTurnoLaTraePorFranja` (handler); `SolicitarProgramacionTurno_ConservaLaSedeDelCatalogo_CuandoLaSolicitudNoIncluyeSede` (smoke) |
| CA-3: turno sin sedes + solicitud con sede X -- todas con X, `ProgramacionTurnoSolicitada.Sede` sigue siendo X | cubierto | `ConSedePorDefecto_AplicaLaSedePorDefecto_CuandoLaFranjaNoTraeSede` (VO puro); `SolicitarProgramacionTurno_AplicaLaSedeDeLaSolicitudATodasLasFranjas_CuandoElTurnoNoTraeSedesPrearmadas` (handler, con `And<>` sobre `Sede` de la solicitud **y** de la franja); `SolicitarProgramacionTurno_PublicaElEventoDiarioConLaSede_...` (smoke) |
| CA-4: JSON ya persistido de **ambos** eventos deserializa con sede null | cubierto | Bus: `Deserializar_DejaSedeDeLaFranjaEnNull_CuandoElMensajeNoLlevaLaClaveSedeEnLaFranja`. Persistido: **`Deserializar_DejaSedeDeCadaFranjaEnNull_CuandoElJsonPersistidoNoLlevaEseCampo`** (agregado en esta fase; antes solo estaba implicito en el `Equals`) |
| CA-5: round-trip con serializador por defecto de `ProgramacionTurnoDiarioSolicitada` con sedes en las franjas, incluida la igualdad por valor | cubierto | `RoundTrip_PreservaLaSedeDeLaFranja_ConSerializadorPorDefectoDelBus` (afirma tambien `franjaRestaurada.Should().Be(franja)` completo); `DetalleFranjaOrdinariaIgualdadTests` (caso "Sede"); complemento persistido: **`RoundTrip_PreservaLaSedeDeCadaFranja_CuandoLaCascadaLaDejoResuelta`** |
| CA-6: suite completa en verde | cubierto | 812 tests, 0 errores |

Extra (fuera de los CAs, pero valioso): `FranjaProgramadaParidadConDetalleFranjaOrdinariaTests`
volvio a exigir **paridad exacta** de nombres de campo entre ambos gemelos y ademas congela que
`Sede` tipa distinto a cada lado (`SedeProgramada` vs `DetalleSede`). El guardrail que #335 habia
relajado quedo restaurado, no simplemente ampliado.

### Tests agregados

1. `SolicitarProgramacionTurno_PersisteLaSedeEfectivaDeCadaFranja_CuandoElTurnoTraeFranjasMixtas`
   (smoke, `Programacion.SmokeTests`): verifica el efecto secundario que faltaba -- lee el evento
   `programacion_turno_solicitada` de `mt_events` y afirma la sede efectiva de **cada** franja mas
   la sede de nivel solicitud. La clase gano `PostgresFixture` por constructor, con su propio
   `Assert.SkipWhen` (se omite limpio sin Postgres, verificado en local).
2. `Deserializar_DejaSedeDeCadaFranjaEnNull_CuandoElJsonPersistidoNoLlevaEseCampo`
   (`ProgramacionTurnoSolicitadaSerializacionTests`): CA-4 del lado persistido, explicito.
3. `RoundTrip_PreservaLaSedeDeCadaFranja_CuandoLaCascadaLaDejoResuelta` (idem): CA-5 del lado
   persistido, contra `CrearOpcionesMarten()`. La sede de la franja se eligio **distinta** de la del
   evento a proposito: con la misma en ambos niveles, un round-trip que confundiera un nivel con el
   otro pasaria en verde.

No se agregaron tests de igualdad ni de `ConfigurarSerializacion` nuevos: `DetalleSede` y
`SedeProgramada` son records planos sin resolver custom, ya cubiertos por sus propios
`*IgualdadTests` y `*ParidadTests` desde #331.

### Nota para el revisor humano

El smoke test agregado **no se puede ejecutar en local** (Postgres de dev no configurado en este
entorno: se omite). Corre por primera vez en el workflow de deploy. Dos decisiones tomadas para
minimizar el riesgo de un rojo espurio en CI:
- Las aserciones leen el JSON con formas minimas **case-insensitive**, asi que la politica de
  nombres del serializador de Marten no puede tumbar el test.
- El filtro de busqueda (`campoJson: "Id"`) usa PascalCase por consistencia con el precedente de
  #335 (`campoJson: "Nombre"` sobre `turno_creado`, cuyo resolver no renombra propiedades), que ya
  corre verde contra dev. Si CI mostrara un timeout en ese polling, la causa seria el casing del
  filtro y no el dato bajo prueba.

</details>

## Cobertura

| Archivo | Cobertura | Umbral | Estado |
|---|---|---|---|
| SolicitarProgramacionTurnoCommandHandler.cs | 100.0% | 95% | ok |
| DetalleFranjaOrdinaria.cs | - | no evaluado | - |
| FranjaProgramada.cs | - | no evaluado | - |
| TurnoProgramado.cs | - | no evaluado | - |
## Commits

9913221 refactor(issue-341): cerrar cobertura de persistencia y actualizar doctrina de la cascada
906dad9 test(issue-341): smoke tests para la cascada de sedes al copiar el turno
0f9105f feat(issue-341): aplicar cascada de sede al copiar el turno en la solicitud (fase verde)
2ced965 test(issue-341): tests para la cascada de sedes al copiar el turno (fase roja)

Closes #341