### PR TITLE
Asignar la sede por franja al turno diario en ControlHoras

### DIFF
--- a/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/BloqueTurno.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/BloqueTurno.cs
@@ -10,5 +10,11 @@ namespace Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 /// No se persiste en <c>mt_events</c> ni requiere <c>ConfigurarSerializacion</c>: es el resultado de
 /// un metodo de lectura pura, no el payload de un evento. Su serializacion como parte del documento
 /// del read model es alcance del issue sucesor (TurnoVigente).
+///
+/// Issue #336: Sede es campo aditivo y opcional -- el bloque conoce donde rige. Los bloques de
+/// descanso y extra heredan la sede de la franja madre que los contiene (no tienen sede propia);
+/// una franja sin sede asignada (turno prearmado multi-sede sin resolver) produce bloques con
+/// sede null. La plomeria que estampa el valor vive en <see cref="TurnoDiario.Segmentar"/> y su
+/// cadena de recorte (MEF-ADR-0012, Tell-don't-Ask).
 /// </remarks>
-public record BloqueTurno(TipoBloque Tipo, DateTime Inicio, DateTime Fin);
+public record BloqueTurno(TipoBloque Tipo, DateTime Inicio, DateTime Fin, SedeProgramada? Sede = null);

--- a/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/FranjaProgramada.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/FranjaProgramada.cs
@@ -69,6 +69,10 @@ public record FranjaProgramada(
     /// La hora de inicio de la franja pertenece siempre al dia de asignacion (offset 0); solo su
     /// hora de fin lleva <see cref="DiaOffsetFin"/>. Cada sub-franja resuelve sus dos offsets
     /// propios (<see cref="SubFranjaProgramada.ATramo"/>).
+    ///
+    /// Issue #336: la franja madre es la unica duena de la sede -- estampa <see cref="Sede"/> en
+    /// TODOS los tramos que produce, tipados o no (los descansos y extras no tienen sede propia,
+    /// la heredan de aqui).
     /// </remarks>
     internal IEnumerable<Tramo> Segmentar()
     {
@@ -82,12 +86,12 @@ public record FranjaProgramada(
         foreach (var sub in subFranjas)
         {
             if (sub.Inicio > cursor)
-                yield return new Tramo(TipoBloque.Ordinaria, cursor, sub.Inicio);
-            yield return sub;
+                yield return new Tramo(TipoBloque.Ordinaria, cursor, sub.Inicio, Sede);
+            yield return sub with { Sede = Sede };
             cursor = sub.Fin;
         }
 
         if (cursor < finFranja)
-            yield return new Tramo(TipoBloque.Ordinaria, cursor, finFranja);
+            yield return new Tramo(TipoBloque.Ordinaria, cursor, finFranja, Sede);
     }
 }

--- a/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/FranjaProgramada.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/FranjaProgramada.cs
@@ -72,9 +72,18 @@ public record FranjaProgramada(
     ///
     /// Issue #336: la franja madre es la unica duena de la sede -- estampa <see cref="Sede"/> en
     /// TODOS los tramos que produce, tipados o no (los descansos y extras no tienen sede propia,
-    /// la heredan de aqui).
+    /// la heredan de aqui). El estampado es un unico paso al final de la tuberia, no un argumento
+    /// repetido en cada <c>new Tramo(...)</c>: asi un tramo nuevo que se agregue al recorte hereda
+    /// la sede por construccion, sin poder olvidarla.
     /// </remarks>
-    internal IEnumerable<Tramo> Segmentar()
+    internal IEnumerable<Tramo> Segmentar() =>
+        Recortar().Select(tramo => tramo with { Sede = Sede });
+
+    /// <summary>
+    /// Aritmetica pura del recorte, sin sede: produce los tramos en minutos absolutos que
+    /// <see cref="Segmentar"/> despues estampa.
+    /// </summary>
+    private IEnumerable<Tramo> Recortar()
     {
         var subFranjas = Descansos
             .Select(descanso => descanso.ATramo(TipoBloque.Descanso))
@@ -86,12 +95,12 @@ public record FranjaProgramada(
         foreach (var sub in subFranjas)
         {
             if (sub.Inicio > cursor)
-                yield return new Tramo(TipoBloque.Ordinaria, cursor, sub.Inicio, Sede);
-            yield return sub with { Sede = Sede };
+                yield return new Tramo(TipoBloque.Ordinaria, cursor, sub.Inicio);
+            yield return sub;
             cursor = sub.Fin;
         }
 
         if (cursor < finFranja)
-            yield return new Tramo(TipoBloque.Ordinaria, cursor, finFranja, Sede);
+            yield return new Tramo(TipoBloque.Ordinaria, cursor, finFranja);
     }
 }

--- a/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/FranjaProgramada.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/FranjaProgramada.cs
@@ -11,6 +11,12 @@ namespace Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 /// defecto compararia por referencia -- ADR-0015) y EXCLUYEN Descripcion (dato derivado, no
 /// identidad de la franja) -- mismo criterio que DetalleFranjaOrdinaria (issues #129 y #288) y
 /// que FranjaProgramada (Programacion.DomainEvents, issue #319).
+///
+/// Issue #336: Sede es campo aditivo y opcional (null = sin sede asignada) -- gemelo deliberado de
+/// DetalleFranjaOrdinaria.Sede (PrivateEvents.Programacion, issue #341), tipado con el
+/// SedeProgramada propio de este ensamblado (payload por rol). A diferencia de Descripcion, SI
+/// entra en Equals/GetHashCode -- es dato de identidad de la franja, no un derivado (mismo
+/// criterio que FranjaProgramada.Sede en Programacion.DomainEvents, issue #335).
 /// </remarks>
 public record FranjaProgramada(
     TimeOnly HoraInicio,
@@ -18,7 +24,8 @@ public record FranjaProgramada(
     int DiaOffsetFin,
     IReadOnlyList<SubFranjaProgramada> Descansos,
     IReadOnlyList<SubFranjaProgramada> Extras,
-    string Descripcion)
+    string Descripcion,
+    SedeProgramada? Sede = null)
 {
     /// <summary>
     /// Los eventos anteriores a este record no llevan el campo: STJ deja null en el parametro
@@ -35,7 +42,8 @@ public record FranjaProgramada(
             && HoraFin == other.HoraFin
             && DiaOffsetFin == other.DiaOffsetFin
             && Descansos.SequenceEqual(other.Descansos)
-            && Extras.SequenceEqual(other.Extras);
+            && Extras.SequenceEqual(other.Extras)
+            && Sede == other.Sede;
     }
 
     public override int GetHashCode()
@@ -46,6 +54,7 @@ public record FranjaProgramada(
         hash.Add(DiaOffsetFin);
         foreach (var d in Descansos) hash.Add(d);
         foreach (var e in Extras) hash.Add(e);
+        hash.Add(Sede);
         return hash.ToHashCode();
     }
 

--- a/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/SedeProgramada.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/SedeProgramada.cs
@@ -1,0 +1,18 @@
+namespace Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
+
+/// <summary>
+/// Sede efectiva donde rige, para una franja del turno diario, el control persistido por este
+/// dominio.
+/// </summary>
+/// <remarks>
+/// Issue #336: gemelo deliberado de SedeProgramada (Programacion.DomainEvents, issue #331) y de
+/// DetalleSede (PrivateEvents.Programacion, issue #331) -- payload por rol, tres islas sin
+/// referencias entre si (CA-ADR-0029 decision #5 / MEF-ADR-0039 decision #6). ControlHoras solo
+/// persiste la sede EFECTIVA ya resuelta por la cascada del lado de Programacion (#341); nunca la
+/// valida ni la deriva -- por eso, a diferencia del gemelo de Programacion, no expone
+/// EstaCompleta() (esa regla de completitud pertenece a quien COMPONE la sede, no a quien
+/// solamente la transporta y persiste).
+/// Sin Equals custom: todos los campos son string, la igualdad por valor del record por defecto ya
+/// es correcta (mismo criterio que Empleado, issue #319, y SedeProgramada de Programacion, #331).
+/// </remarks>
+public record SedeProgramada(string Id, string Nombre);

--- a/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/Tramo.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/Tramo.cs
@@ -12,8 +12,12 @@ namespace Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 /// La aritmetica replica la de <c>MomentoDelDia</c> (ControlHoras/ValueObjects) en vez de reusarla:
 /// aquel vive en el Function App, que referencia este ensamblado y no al reves (isla de eventos,
 /// CA-ADR-0029 decision #2 / MEF-ADR-0039 decisiones 2 y 4).
+///
+/// Issue #336: Sede viaja como dato inerte a traves de toda la cadena (Segmentar ->
+/// RomperEnMedianoche -> ResolverA): el tramo la transporta sin interpretarla, la franja madre es
+/// quien la estampa al construir cada Tramo (Tell-don't-Ask -- MEF-ADR-0012).
 /// </remarks>
-internal readonly record struct Tramo(TipoBloque Tipo, int Inicio, int Fin)
+internal readonly record struct Tramo(TipoBloque Tipo, int Inicio, int Fin, SedeProgramada? Sede = null)
 {
     private const int MinutosPorHora = 60;
     private const int MinutosPorDia = 1440;
@@ -46,6 +50,6 @@ internal readonly record struct Tramo(TipoBloque Tipo, int Inicio, int Fin)
     internal BloqueTurno ResolverA(DateOnly fecha)
     {
         var medianoche = fecha.ToDateTime(TimeOnly.MinValue);
-        return new BloqueTurno(Tipo, medianoche.AddMinutes(Inicio), medianoche.AddMinutes(Fin));
+        return new BloqueTurno(Tipo, medianoche.AddMinutes(Inicio), medianoche.AddMinutes(Fin), Sede);
     }
 }

--- a/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/Tramo.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/Tramo.cs
@@ -14,8 +14,10 @@ namespace Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 /// CA-ADR-0029 decision #2 / MEF-ADR-0039 decisiones 2 y 4).
 ///
 /// Issue #336: Sede viaja como dato inerte a traves de toda la cadena (Segmentar ->
-/// RomperEnMedianoche -> ResolverA): el tramo la transporta sin interpretarla, la franja madre es
-/// quien la estampa al construir cada Tramo (Tell-don't-Ask -- MEF-ADR-0012).
+/// RomperEnMedianoche -> ResolverA): el tramo la transporta sin interpretarla ni decidir nada
+/// sobre ella. Quien la estampa es la franja madre, duena del dato, en un unico paso al cierre de
+/// <see cref="FranjaProgramada.Segmentar"/> (Tell-don't-Ask -- MEF-ADR-0012); por eso ningun
+/// <c>new Tramo(...)</c> de la aritmetica de recorte necesita pasarla.
 /// </remarks>
 internal readonly record struct Tramo(TipoBloque Tipo, int Inicio, int Fin, SedeProgramada? Sede = null)
 {

--- a/src/Bitakora.ControlAsistencia.ControlHoras/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/EventHandler/ProgramacionTurnoDiarioSolicitadaEventHandler.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/EventHandler/ProgramacionTurnoDiarioSolicitadaEventHandler.cs
@@ -75,11 +75,18 @@ public partial class ProgramacionTurnoDiarioSolicitadaEventHandler
     private static TurnoDiario MapearTurnoDiario(DetalleTurno turno) =>
         new(turno.Nombre, turno.FranjasOrdinarias.Select(MapearFranja).ToList(), turno.Descripcion);
 
+    // Issue #336: propaga la sede EFECTIVA ya resuelta por la cascada del lado de Programacion
+    // (#341) -- mapeo mecanico DetalleSede -> SedeProgramada, tolerante a null (no toda franja de
+    // un turno multi-sede trae sede resuelta).
     private static FranjaProgramada MapearFranja(DetalleFranjaOrdinaria franja) =>
         new(franja.HoraInicio, franja.HoraFin, franja.DiaOffsetFin,
             franja.Descansos.Select(MapearSubFranja).ToList(),
             franja.Extras.Select(MapearSubFranja).ToList(),
-            franja.Descripcion);
+            franja.Descripcion,
+            MapearSede(franja.Sede));
+
+    private static SedeProgramada? MapearSede(DetalleSede? sede) =>
+        sede is null ? null : new SedeProgramada(sede.Id, sede.Nombre);
 
     private static SubFranjaProgramada MapearSubFranja(DetalleSubFranja sub) =>
         new(sub.HoraInicio, sub.HoraFin, sub.DiaOffsetInicio, sub.DiaOffsetFin, sub.Descripcion);

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/AsignarTurnoViaSbSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/AsignarTurnoViaSbSmokeTests.cs
@@ -142,6 +142,130 @@ public class AsignarTurnoViaSbSmokeTests(ServiceBusFixture serviceBus, PostgresF
             empleadoId, SuscripcionSmokeTests, TopicDiaCalculado);
     }
 
+    // Issue #336 CA-1/CA-3: el evento de bus trae la sede EFECTIVA ya resuelta por la cascada del
+    // lado de Programacion (#341) en cada franja -- el handler la propaga (DetalleSede ->
+    // SedeProgramada, mapeo mecanico) al persistir TurnoDiarioAsignado. La primera franja trae
+    // sede, la segunda no: mismo escenario "Turno Partido" que
+    // ProgramacionTurnoDiarioSolicitadaEventHandlerTests, verificado aqui contra el entorno real
+    // (persistencia en Postgres + cadena de eventos de Service Bus intacta).
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task DebeAsignarTurnoDiario_ConSedePorFranja_CuandoElEventoTraeSedesEfectivas()
+    {
+        Assert.SkipWhen(!serviceBus.IsConfigured,
+            "ServiceBus no configurado. Usa appsettings.local.json o variable ServiceBus__ConnectionString.");
+        Assert.SkipWhen(!postgres.IsConfigured,
+            postgres.SkipReason ?? "Postgres no disponible.");
+
+        // Arrange
+        var correlationId = Guid.CreateVersion7().ToString();
+        var solicitudId = Guid.CreateVersion7();
+        var empleadoId = Guid.CreateVersion7().ToString();
+        var fecha = new DateOnly(2026, 4, 11);
+
+        var evento = new
+        {
+            SolicitudId = solicitudId,
+            Empleado = new
+            {
+                EmpleadoId = empleadoId,
+                TipoIdentificacion = "CC",
+                NumeroIdentificacion = "222333444",
+                Nombres = "[TEST] Smoke Sede",
+                Apellidos = "[TEST] Por Franja"
+            },
+            Fecha = fecha.ToString("yyyy-MM-dd"),
+            DetalleTurno = new
+            {
+                Nombre = "[TEST] Turno Partido Sede",
+                // Primera franja con sede efectiva resuelta; segunda sin sede (turno multi-sede
+                // parcialmente resuelto) -- distingue "una franja con sede" de "todas comparten
+                // la misma sede a nivel turno".
+                FranjasOrdinarias = new object[]
+                {
+                    new
+                    {
+                        HoraInicio = "06:00:00",
+                        HoraFin = "10:00:00",
+                        DiaOffsetFin = 0,
+                        Descansos = Array.Empty<object>(),
+                        Extras = Array.Empty<object>(),
+                        Sede = new { Id = "SEDE-SUBA-TEST", Nombre = "[TEST] Suba" }
+                    },
+                    new
+                    {
+                        HoraInicio = "14:00:00",
+                        HoraFin = "18:00:00",
+                        DiaOffsetFin = 0,
+                        Descansos = Array.Empty<object>(),
+                        Extras = Array.Empty<object>()
+                    }
+                }
+            }
+        };
+
+        // Arrange: purgar suscripcion smoke-tests de dia-calculado para evitar falsos positivos
+        // de ejecuciones anteriores (patron purge-before-act, ADR-0016).
+        await serviceBus.PurgeAsync(TopicDiaCalculado, SuscripcionSmokeTests);
+
+        // Act: publicar al topic de Service Bus
+        await serviceBus.PublishAsync(TopicEntrada, evento, correlationId);
+
+        // Assert: verificar que el evento TurnoDiarioAsignado fue persistido en PostgreSQL
+        var streamId = $"{empleadoId}:{fecha:yyyy-MM-dd}";
+        var tipoEvento = "turno_diario_asignado";
+
+        var existe = await postgres.ExisteEventoAsync(
+            SchemaControlHoras, streamId, tipoEvento, Timeout,
+            campoJson: "SolicitudId", valorJson: solicitudId.ToString());
+
+        existe.Should().BeTrue(
+            $"el evento {tipoEvento} con SolicitudId {solicitudId} deberia existir en el stream {streamId}");
+
+        var eventoPersistido = await postgres.ObtenerEventoAsync<JsonElement>(
+            SchemaControlHoras, streamId, tipoEvento,
+            "SolicitudId", solicitudId.ToString(), TimeSpan.FromSeconds(5));
+
+        // CA-1: la primera franja persiste con la sede efectiva mapeada a SedeProgramada; CA-3 (a
+        // nivel de bloque, cubierto por unit tests de Segmentar) parte de este mismo campo. La
+        // segunda franja (sin sede en el evento) queda null -- CA-2 de regresion, ya cubierto por
+        // el test anterior de esta clase, se reafirma aqui dentro de un mismo turno multi-sede.
+        var sedeSubaEsperada = new SedeProgramada("SEDE-SUBA-TEST", "[TEST] Suba");
+        var turnoDiarioEsperado = new TurnoDiario("[TEST] Turno Partido Sede", [
+            new FranjaProgramada(
+                new TimeOnly(6, 0), new TimeOnly(10, 0), 0,
+                Array.Empty<SubFranjaProgramada>(), Array.Empty<SubFranjaProgramada>(), "",
+                sedeSubaEsperada),
+            new FranjaProgramada(
+                new TimeOnly(14, 0), new TimeOnly(18, 0), 0,
+                Array.Empty<SubFranjaProgramada>(), Array.Empty<SubFranjaProgramada>(), "")
+        ], "");
+        var turnoDiarioPersistido = eventoPersistido
+            .GetProperty("DetalleTurno").Deserialize<TurnoDiario>();
+        turnoDiarioPersistido.Should().BeEquivalentTo(turnoDiarioEsperado,
+            opciones => opciones.ExcludingMembersNamed("Descripcion"));
+
+        // Efecto secundario (HU-131): DiaCalculado se sigue publicando con normalidad cuando las
+        // franjas traen sede -- el mapeo nuevo no interrumpe la cadena reactiva existente.
+        var diaCalculado = await serviceBus.WaitForMessageAsync<DiaCalculado>(
+            TopicDiaCalculado, SuscripcionSmokeTests,
+            e => e.InformacionEmpleado != null && e.InformacionEmpleado.EmpleadoId == empleadoId,
+            Timeout);
+
+        diaCalculado.Fecha.Should().Be(fecha);
+        diaCalculado.InformacionEmpleado!.EmpleadoId.Should().Be(empleadoId);
+
+        // Assert: ausencia de dead letter de ESTA corrida en la suscripcion del consumidor de
+        // entrada -- confirma que el mapeo DetalleSede -> SedeProgramada no rompe el handler
+        // cuando el evento trae sedes efectivas por franja.
+        var existeDeadLetterProgramacion = await serviceBus.ExisteDeadLetterDeEstaCorridaAsync<ProgramacionTurnoDiarioSolicitadaMinimo>(
+            TopicEntrada, SuscripcionConsumidor, e => e.SolicitudId == solicitudId);
+
+        existeDeadLetterProgramacion.Should().BeFalse(
+            "no deberia haber un dead letter de esta corrida (SolicitudId {0}) en '{1}' - si lo hay, el mapeo de sede fallo al procesar el evento",
+            solicitudId, SuscripcionConsumidor);
+    }
+
     /// <summary>
     /// Regression test para el bug del issue #29.
     /// Wolverine serializa con camelCase. El endpoint consumidor usaba ToObjectFromJson

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/AsignarTurnoViaSbSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/AsignarTurnoViaSbSmokeTests.cs
@@ -148,9 +148,15 @@ public class AsignarTurnoViaSbSmokeTests(ServiceBusFixture serviceBus, PostgresF
     // sede, la segunda no: mismo escenario "Turno Partido" que
     // ProgramacionTurnoDiarioSolicitadaEventHandlerTests, verificado aqui contra el entorno real
     // (persistencia en Postgres + cadena de eventos de Service Bus intacta).
+    //
+    // Nombre segun MEF-ADR-0016 (<Sujeto>_<LoQuePasa>_Cuando<Condicion>, que el ADR aplica tambien
+    // a los smoke tests): el sujeto es el evento de bus que dispara el flujo, igual que en los unit
+    // tests del handler. Los dos tests hermanos de esta clase conservan el patron "Debe..." previo
+    // al ADR -- son parte de los 60 casos que el ADR deja para un refactor dedicado, no un
+    // precedente a replicar en tests nuevos.
     [Fact]
     [Trait("Category", "Smoke")]
-    public async Task DebeAsignarTurnoDiario_ConSedePorFranja_CuandoElEventoTraeSedesEfectivas()
+    public async Task ProgramacionTurnoDiarioSolicitada_PersisteElTurnoConSedePorFranja_CuandoElEventoTraeSedesEfectivas()
     {
         Assert.SkipWhen(!serviceBus.IsConfigured,
             "ServiceBus no configurado. Usa appsettings.local.json o variable ServiceBus__ConnectionString.");

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/FranjaProgramadaIgualdadTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/FranjaProgramadaIgualdadTests.cs
@@ -4,6 +4,9 @@
 // (IReadOnlyList) se comparan POR VALOR (SequenceEqual), no por referencia (MEF-ADR-0012). Mismo
 // patron que DetalleFranjaOrdinariaIgualdadTests (PrivateEvents.Tests), del cual este archivo es
 // espejo deliberado.
+//
+// Issue #336: Sede se agrega al caso "instancias diferentes" -- a diferencia de Descripcion, SI
+// entra en la identidad de la franja (Equals/GetHashCode custom).
 
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
@@ -37,6 +40,9 @@ public class FranjaProgramadaIgualdadTests : IgualdadTestBase<FranjaProgramada>
             new FranjaProgramada(new TimeOnly(8, 0), new TimeOnly(17, 0), 0, [], [Extra()], ""));
         yield return ("Extras",
             new FranjaProgramada(new TimeOnly(8, 0), new TimeOnly(17, 0), 0, [Descanso()], [], ""));
+        yield return ("Sede",
+            new FranjaProgramada(new TimeOnly(8, 0), new TimeOnly(17, 0), 0, [Descanso()], [Extra()], "",
+                new SedeProgramada("SEDE-SUBA", "Suba")));
     }
 
     // Cobertura especifica del override: las listas se comparan por valor, no por referencia.

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/FranjaProgramadaParidadConDetalleFranjaOrdinariaTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/FranjaProgramadaParidadConDetalleFranjaOrdinariaTests.cs
@@ -1,0 +1,64 @@
+// Issue #336 (agregado en revision): guardrail de la duplicacion deliberada de payload por rol
+// (tres islas, CA-ADR-0029 decisiones #2 y #5): FranjaProgramada (ControlHoras.DomainEvents) y
+// DetalleFranjaOrdinaria (PrivateEvents.Programacion) declaran el mismo dato en dos ensamblados
+// que no se referencian entre si. Sin este guardrail, agregar un campo a uno de los dos no rompe
+// nada y el dato se pierde en silencio en MapearFranja (el modo de fallo que CA-ADR-0029 decision
+// #5 documenta como silencioso). Este par es justamente el que el issue #336 extiende con Sede.
+//
+// Espejo del guardrail equivalente del lado de Programacion
+// (FranjaProgramadaParidadConDetalleFranjaOrdinariaTests, Programacion.Tests, issues #319/#341):
+// la paridad se verifica en varios pasos porque las hijas (Descansos/Extras) y la sede tipan
+// DELIBERADAMENTE distinto en cada isla -- son gemelos de payload por rol, no el mismo tipo.
+
+using System.Reflection;
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
+using Bitakora.ControlAsistencia.PrivateEvents.Programacion;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Tests.AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction.Eventos;
+
+public class FranjaProgramadaParidadConDetalleFranjaOrdinariaTests
+{
+    private static IEnumerable<string> NombresDeCampos<T>() =>
+        typeof(T).GetProperties(BindingFlags.Public | BindingFlags.Instance).Select(p => p.Name);
+
+    [Fact]
+    public void FranjaProgramada_DeclaraLosMismosNombresDeCampoQueDetalleFranjaOrdinaria()
+    {
+        NombresDeCampos<FranjaProgramada>().Should().Equal(NombresDeCampos<DetalleFranjaOrdinaria>());
+    }
+
+    [Fact]
+    public void FranjaProgramada_TipaDescansosYExtrasComoListasDeSubFranjaProgramada()
+    {
+        typeof(FranjaProgramada).GetProperty(nameof(FranjaProgramada.Descansos))!.PropertyType
+            .Should().Be(typeof(IReadOnlyList<SubFranjaProgramada>));
+        typeof(FranjaProgramada).GetProperty(nameof(FranjaProgramada.Extras))!.PropertyType
+            .Should().Be(typeof(IReadOnlyList<SubFranjaProgramada>));
+    }
+
+    [Fact]
+    public void FranjaProgramada_TipaLosCamposEscalaresIgualQueDetalleFranjaOrdinaria()
+    {
+        typeof(FranjaProgramada).GetProperty(nameof(FranjaProgramada.HoraInicio))!.PropertyType
+            .Should().Be(typeof(DetalleFranjaOrdinaria).GetProperty(nameof(DetalleFranjaOrdinaria.HoraInicio))!.PropertyType);
+        typeof(FranjaProgramada).GetProperty(nameof(FranjaProgramada.HoraFin))!.PropertyType
+            .Should().Be(typeof(DetalleFranjaOrdinaria).GetProperty(nameof(DetalleFranjaOrdinaria.HoraFin))!.PropertyType);
+        typeof(FranjaProgramada).GetProperty(nameof(FranjaProgramada.DiaOffsetFin))!.PropertyType
+            .Should().Be(typeof(DetalleFranjaOrdinaria).GetProperty(nameof(DetalleFranjaOrdinaria.DiaOffsetFin))!.PropertyType);
+        typeof(FranjaProgramada).GetProperty(nameof(FranjaProgramada.Descripcion))!.PropertyType
+            .Should().Be(typeof(DetalleFranjaOrdinaria).GetProperty(nameof(DetalleFranjaOrdinaria.Descripcion))!.PropertyType);
+    }
+
+    // Issue #336: Sede tipa DELIBERADAMENTE distinto en cada lado (SedeProgramada propia de esta
+    // isla vs DetalleSede del bus interno) -- mismo criterio que Descansos/Extras. Su paridad de
+    // campos la cubre SedeProgramadaParidadConDetalleSedeTests.
+    [Fact]
+    public void FranjaProgramada_TipaSedeComoSedeProgramadaYDetalleFranjaOrdinariaComoDetalleSede()
+    {
+        typeof(FranjaProgramada).GetProperty(nameof(FranjaProgramada.Sede))!.PropertyType
+            .Should().Be(typeof(SedeProgramada));
+        typeof(DetalleFranjaOrdinaria).GetProperty(nameof(DetalleFranjaOrdinaria.Sede))!.PropertyType
+            .Should().Be(typeof(DetalleSede));
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/SedeProgramadaIgualdadTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/SedeProgramadaIgualdadTests.cs
@@ -1,0 +1,24 @@
+// Issue #336: Tests de contrato IEquatable para SedeProgramada (record propio de
+// ControlHoras.DomainEvents). Todos los campos son string: la igualdad por valor del record por
+// defecto ya es correcta, sin Equals/GetHashCode custom -- mismo criterio que SedeProgramada
+// (Programacion.DomainEvents, issue #331) y Empleado (issue #319).
+
+using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
+using Bitakora.ControlAsistencia.ControlHoras.Tests.ValueObjects;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Tests.AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction.Eventos;
+
+public class SedeProgramadaIgualdadTests : IgualdadTestBase<SedeProgramada>
+{
+    protected override SedeProgramada CrearInstancia() =>
+        new("SEDE-SUBA", "Suba");
+
+    protected override SedeProgramada CrearInstanciaCopia() =>
+        new("SEDE-SUBA", "Suba");
+
+    protected override IEnumerable<(string, SedeProgramada)> CrearInstanciasDiferentes()
+    {
+        yield return ("Id", new SedeProgramada("SEDE-CHAPINERO", "Suba"));
+        yield return ("Nombre", new SedeProgramada("SEDE-SUBA", "Chapinero"));
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/SedeProgramadaParidadConDetalleSedeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/SedeProgramadaParidadConDetalleSedeTests.cs
@@ -2,10 +2,13 @@
 // CA-ADR-0029 decisiones #2 y #5): SedeProgramada (ControlHoras.DomainEvents) y DetalleSede
 // (PrivateEvents.Programacion) declaran el mismo dato en dos ensamblados que no se referencian
 // entre si. Sin este guardrail, agregar un campo a uno de los dos no rompe nada y el dato se
-// pierde en silencio en MapearFranja -- el mismo modo de fallo que ya cubren los pares de gemelos
-// analogos de este ensamblado (Empleado/DetalleEmpleado, TurnoDiario/DetalleTurno,
-// FranjaProgramada/DetalleFranjaOrdinaria, SubFranjaProgramada/DetalleSubFranja) y el gemelo
-// equivalente del lado de Programacion (SedeProgramadaParidadConDetalleSedeTests, issue #331).
+// pierde en silencio en MapearFranja -- el mismo modo de fallo que cubre el gemelo equivalente del
+// lado de Programacion (SedeProgramadaParidadConDetalleSedeTests, Programacion.Tests, issue #331).
+//
+// Su par contenedor lo cubre FranjaProgramadaParidadConDetalleFranjaOrdinariaTests (agregado en la
+// revision de este issue). Los otros gemelos de esta isla -- Empleado/DetalleEmpleado,
+// TurnoDiario/DetalleTurno, SubFranjaProgramada/DetalleSubFranja (issue #322) -- todavia NO tienen
+// guardrail de paridad de este lado, a diferencia de Programacion.Tests, que los tiene los cuatro.
 
 using System.Reflection;
 using AwesomeAssertions;

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/SedeProgramadaParidadConDetalleSedeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/SedeProgramadaParidadConDetalleSedeTests.cs
@@ -1,0 +1,30 @@
+// Issue #336: guardrail de la duplicacion deliberada de payload por rol (tres islas,
+// CA-ADR-0029 decisiones #2 y #5): SedeProgramada (ControlHoras.DomainEvents) y DetalleSede
+// (PrivateEvents.Programacion) declaran el mismo dato en dos ensamblados que no se referencian
+// entre si. Sin este guardrail, agregar un campo a uno de los dos no rompe nada y el dato se
+// pierde en silencio en MapearFranja -- el mismo modo de fallo que ya cubren los pares de gemelos
+// analogos de este ensamblado (Empleado/DetalleEmpleado, TurnoDiario/DetalleTurno,
+// FranjaProgramada/DetalleFranjaOrdinaria, SubFranjaProgramada/DetalleSubFranja) y el gemelo
+// equivalente del lado de Programacion (SedeProgramadaParidadConDetalleSedeTests, issue #331).
+
+using System.Reflection;
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
+using Bitakora.ControlAsistencia.PrivateEvents.Programacion;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Tests.AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction.Eventos;
+
+public class SedeProgramadaParidadConDetalleSedeTests
+{
+    private static IEnumerable<(string Nombre, Type Tipo)> Campos<T>() =>
+        typeof(T).GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Select(p => (p.Name, p.PropertyType));
+
+    [Fact]
+    public void SedeProgramada_DeclaraLosMismosCamposQueDetalleSede()
+    {
+        var campos = Campos<SedeProgramada>();
+
+        campos.Should().Equal(Campos<DetalleSede>());
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/TurnoDiarioAsignadoSerializacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/TurnoDiarioAsignadoSerializacionTests.cs
@@ -263,4 +263,76 @@ public class TurnoDiarioAsignadoSerializacionTests
             ],
             ""));
     }
+
+    // Issue #336 CA-4: JSON persistido antes de este issue no lleva la clave "Sede" en ninguna
+    // franja (ultimo parametro posicional, aditivo y opcional). A diferencia de Descripcion, aqui
+    // null ES el valor correcto de retrocompatibilidad -- no hay normalizacion especial, "sin sede
+    // asignada" es una franja real y valida (turno prearmado multi-sede sin resolver).
+    [Fact]
+    public void Deserializar_DejaLaSedeEnNull_CuandoElJsonPersistidoNoLlevaLaClaveSede()
+    {
+        const string jsonPersistidoSinSede = """
+            {
+              "Id": "EMP-001:2026-03-15",
+              "InformacionEmpleado": {
+                "EmpleadoId": "EMP-001",
+                "TipoIdentificacion": "CC",
+                "NumeroIdentificacion": "1234567890",
+                "Nombres": "Luis Augusto",
+                "Apellidos": "Barreto"
+              },
+              "Fecha": "2026-03-15",
+              "DetalleTurno": {
+                "Nombre": "Turno Manana",
+                "FranjasOrdinarias": [
+                  {
+                    "HoraInicio": "08:00:00",
+                    "HoraFin": "16:00:00",
+                    "DiaOffsetFin": 0,
+                    "Descansos": [],
+                    "Extras": [],
+                    "Descripcion": "(08:00-16:00)"
+                  }
+                ],
+                "Descripcion": "Turno Manana (08:00-16:00)"
+              },
+              "SolicitudId": "019600b0-0000-7000-8000-000000000001"
+            }
+            """;
+        var opciones = ConfiguracionSerializacionControlHoras.CrearOpcionesMarten();
+
+        var deserializado = JsonSerializer.Deserialize<TurnoDiarioAsignado>(jsonPersistidoSinSede, opciones);
+
+        deserializado.Should().NotBeNull();
+        deserializado!.DetalleTurno.FranjasOrdinarias.Should().ContainSingle()
+            .Which.Sede.Should().BeNull();
+    }
+
+    // Issue #336 CA-5: round-trip Marten con sedes pobladas en las franjas de un turno partido --
+    // incluye igualdad por valor de FranjaProgramada con sede (Equals custom ahora la compara).
+    [Fact]
+    public void Deserializar_ReconstruyeIdentico_ConSedesPobladasEnLasFranjas()
+    {
+        var sedeSuba = new SedeProgramada("SEDE-SUBA", "Suba");
+        var sedeChapinero = new SedeProgramada("SEDE-CHAPINERO", "Chapinero");
+        var turnoConSedes = new TurnoDiario(
+            "Turno Partido",
+            [
+                new FranjaProgramada(
+                    new TimeOnly(6, 0), new TimeOnly(10, 0), 0, [], [], "(06:00-10:00)", sedeSuba),
+                new FranjaProgramada(
+                    new TimeOnly(14, 0), new TimeOnly(18, 0), 0, [], [], "(14:00-18:00)", sedeChapinero)
+            ],
+            "Turno Partido");
+        var evento = new TurnoDiarioAsignado(StreamId, EmpleadoDePrueba, Fecha, turnoConSedes, SolicitudId);
+        var opciones = ConfiguracionSerializacionControlHoras.CrearOpcionesMarten();
+
+        var json = JsonSerializer.Serialize(evento, opciones);
+        var deserializado = JsonSerializer.Deserialize<TurnoDiarioAsignado>(json, opciones);
+
+        deserializado.Should().NotBeNull();
+        deserializado!.DetalleTurno.Should().Be(turnoConSedes);
+        deserializado.DetalleTurno.FranjasOrdinarias[0].Sede.Should().Be(sedeSuba);
+        deserializado.DetalleTurno.FranjasOrdinarias[1].Sede.Should().Be(sedeChapinero);
+    }
 }

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/TurnoDiarioSegmentarTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/TurnoDiarioSegmentarTests.cs
@@ -324,4 +324,27 @@ public class TurnoDiarioSegmentarTests
         resultado[0].Sede.Should().Be(sedeSuba);
         resultado[1].Sede.Should().Be(sedeChapinero);
     }
+
+    [Fact]
+    public void Segmentar_ConservaLaSedeEnLosDosBloquesPartidos_CuandoLaFranjaConSedeCruzaMedianoche()
+    {
+        // CA-3 x CA-4 (agregado en revision): la sede se estampa antes del corte en medianoche, asi
+        // que el corte debe preservarla en AMBOS lados. Sin este test, romper la copia de Sede en
+        // Tramo.RomperEnMedianoche dejaria sin sede a todo turno nocturno -- la mitad del dominio --
+        // y ningun otro test lo delataria: los demas casos de sede no cruzan el limite del dia.
+        var sedeSuba = new SedeProgramada("SEDE-SUBA", "Suba");
+        var franja = Franja(22, 0, 6, 0, diaOffsetFin: 1, sede: sedeSuba);
+        var turno = Turno(franja);
+
+        var resultado = turno.Segmentar(Fecha);
+
+        var esperado = new[]
+        {
+            new BloqueTurno(TipoBloque.Ordinaria,
+                new DateTime(2026, 8, 10, 22, 0, 0), new DateTime(2026, 8, 11, 0, 0, 0), sedeSuba),
+            new BloqueTurno(TipoBloque.Ordinaria,
+                new DateTime(2026, 8, 11, 0, 0, 0), new DateTime(2026, 8, 11, 6, 0, 0), sedeSuba),
+        };
+        resultado.Should().Equal(esperado);
+    }
 }

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/TurnoDiarioSegmentarTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/TurnoDiarioSegmentarTests.cs
@@ -11,6 +11,11 @@
 // usa DiaOffsetFin; cada SubFranjaProgramada (descanso/extra) usa su propio DiaOffsetInicio/Fin.
 // Todos los offsets son relativos a la MISMA fecha ancla (la fecha de asignacion del turno), no al
 // inicio de la franja individual.
+//
+// Issue #336 CA-3: Segmentar estampa en cada BloqueTurno la sede de su franja madre. Los
+// descansos y extras NO tienen sede propia -- heredan la de la franja que los contiene (el
+// glosario los define como contenidos en la ordinaria). Una franja sin sede asignada (turno
+// prearmado multi-sede sin resolver) produce bloques con sede null.
 
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
@@ -30,9 +35,10 @@ public class TurnoDiarioSegmentarTests
     private static FranjaProgramada Franja(
         int horaInicio, int minutoInicio, int horaFin, int minutoFin, int diaOffsetFin = 0,
         IReadOnlyList<SubFranjaProgramada>? descansos = null,
-        IReadOnlyList<SubFranjaProgramada>? extras = null) =>
+        IReadOnlyList<SubFranjaProgramada>? extras = null,
+        SedeProgramada? sede = null) =>
         new(new TimeOnly(horaInicio, minutoInicio), new TimeOnly(horaFin, minutoFin), diaOffsetFin,
-            descansos ?? [], extras ?? [], "");
+            descansos ?? [], extras ?? [], "", sede);
 
     private static TurnoDiario Turno(params FranjaProgramada[] franjas) =>
         new("Turno", franjas, "");
@@ -250,5 +256,72 @@ public class TurnoDiarioSegmentarTests
                 new DateTime(2026, 8, 10, 14, 0, 0), new DateTime(2026, 8, 10, 18, 0, 0)),
         };
         resultado.Should().Equal(esperado);
+    }
+
+    [Fact]
+    public void Segmentar_EstampaLaSedeDeLaFranjaEnElBloqueOrdinario_CuandoLaFranjaTraeSede()
+    {
+        // CA-3: franja simple 06:00-14:00 con sede -> el unico bloque ordinario hereda esa sede.
+        var sedeSuba = new SedeProgramada("SEDE-SUBA", "Suba");
+        var franja = Franja(6, 0, 14, 0, sede: sedeSuba);
+        var turno = Turno(franja);
+
+        var resultado = turno.Segmentar(Fecha);
+
+        var esperado = new[]
+        {
+            new BloqueTurno(TipoBloque.Ordinaria,
+                new DateTime(2026, 8, 10, 6, 0, 0), new DateTime(2026, 8, 10, 14, 0, 0), sedeSuba),
+        };
+        resultado.Should().Equal(esperado);
+    }
+
+    [Fact]
+    public void Segmentar_PropagaLaSedeDeLaFranjaATodosLosBloques_CuandoHayDescansoYExtra()
+    {
+        // CA-3: los descansos y extras no tienen sede propia -- heredan la de la franja madre que
+        // los contiene (mismo criterio del glosario que ya aplica Segmentar para los tramos).
+        var sedeChapinero = new SedeProgramada("SEDE-CHAPINERO", "Chapinero");
+        var descanso = SubFranja(10, 0, 11, 0);
+        var extra = SubFranja(12, 0, 13, 0);
+        var franja = Franja(6, 0, 14, 0, descansos: [descanso], extras: [extra], sede: sedeChapinero);
+        var turno = Turno(franja);
+
+        var resultado = turno.Segmentar(Fecha);
+
+        resultado.Should().HaveCount(5);
+        resultado.Should().OnlyContain(b => b.Sede == sedeChapinero);
+    }
+
+    [Fact]
+    public void Segmentar_DejaLaSedeEnNullEnTodosLosBloques_CuandoLaFranjaNoTraeSede()
+    {
+        // CA-3 (borde documentado en el issue): turno prearmado multi-sede asignado sin sede en la
+        // solicitud -> la franja llega sin sede y esa ausencia se propaga tal cual a los bloques.
+        var descanso = SubFranja(10, 0, 11, 0);
+        var franja = Franja(6, 0, 14, 0, descansos: [descanso]);
+        var turno = Turno(franja);
+
+        var resultado = turno.Segmentar(Fecha);
+
+        resultado.Should().OnlyContain(b => b.Sede == null);
+    }
+
+    [Fact]
+    public void Segmentar_AsignaACadaBloqueLaSedeDeSuPropiaFranja_CuandoElTurnoTieneVariasFranjasConSedesDistintas()
+    {
+        // CA-3: turno partido con sedes distintas por franja (escenario que fija la semantica del
+        // issue) -- cada bloque lleva la sede de SU franja madre, nunca una sede global del turno.
+        var sedeSuba = new SedeProgramada("SEDE-SUBA", "Suba");
+        var sedeChapinero = new SedeProgramada("SEDE-CHAPINERO", "Chapinero");
+        var franjaManana = Franja(6, 0, 10, 0, sede: sedeSuba);
+        var franjaTarde = Franja(14, 0, 18, 0, sede: sedeChapinero);
+        var turno = Turno(franjaManana, franjaTarde);
+
+        var resultado = turno.Segmentar(Fecha);
+
+        resultado.Should().HaveCount(2);
+        resultado[0].Sede.Should().Be(sedeSuba);
+        resultado[1].Sede.Should().Be(sedeChapinero);
     }
 }

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/ProgramacionTurnoDiarioSolicitadaEventHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/ProgramacionTurnoDiarioSolicitadaEventHandlerTests.cs
@@ -129,4 +129,57 @@ public class ProgramacionTurnoDiarioSolicitadaEventHandlerTests
         And<ControlDiarioAggregateRoot, TurnoDiario?>(
             StreamId, c => c.DetalleTurno, turnoPersistidoEsperado);
     }
+
+    // Issue #336 CA-1: el evento de bus trae la sede EFECTIVA ya resuelta por la cascada del lado
+    // de Programacion (#341) en cada franja -- el handler la propaga (DetalleSede -> SedeProgramada,
+    // mapeo mecanico) al persistir TurnoDiarioAsignado. La segunda franja llega sin sede y el mapeo
+    // tolerante la deja null: no todas las franjas de un turno multi-sede tienen que traerla.
+    [Fact]
+    public async Task ProgramacionTurnoDiarioSolicitada_PropagaLaSedeDeCadaFranja_CuandoElEventoTraeSedesEfectivas()
+    {
+        var sedeSubaDetalle = new DetalleSede("SEDE-SUBA", "Suba");
+        var turnoEntrante = new DetalleTurno(
+            "Turno Partido",
+            [
+                new DetalleFranjaOrdinaria(
+                    new TimeOnly(6, 0), new TimeOnly(10, 0), 0, [], [], "(06:00-10:00)", sedeSubaDetalle),
+                new DetalleFranjaOrdinaria(
+                    new TimeOnly(14, 0), new TimeOnly(18, 0), 0, [], [], "(14:00-18:00)")
+            ],
+            "Turno Partido");
+
+        await WhenAsync(new ProgramacionTurnoDiarioSolicitada(
+            SolicitudId, EmpleadoDetalle, Fecha, turnoEntrante));
+
+        // Oraculo construido a mano, no derivado del mapeo bajo prueba (MEF-ADR-0002).
+        var sedeSubaEsperada = new SedeProgramada("SEDE-SUBA", "Suba");
+        var turnoPersistidoEsperado = new TurnoDiario(
+            "Turno Partido",
+            [
+                new FranjaProgramada(
+                    new TimeOnly(6, 0), new TimeOnly(10, 0), 0, [], [], "(06:00-10:00)", sedeSubaEsperada),
+                new FranjaProgramada(
+                    new TimeOnly(14, 0), new TimeOnly(18, 0), 0, [], [], "(14:00-18:00)")
+            ],
+            "Turno Partido");
+
+        Then(StreamId, new TurnoDiarioAsignado(
+            StreamId, Empleado, Fecha, turnoPersistidoEsperado, SolicitudId));
+        And<ControlDiarioAggregateRoot, SedeProgramada?>(
+            StreamId, c => c.DetalleTurno!.FranjasOrdinarias[0].Sede, sedeSubaEsperada);
+        And<ControlDiarioAggregateRoot, SedeProgramada?>(
+            StreamId, c => c.DetalleTurno!.FranjasOrdinarias[1].Sede, null);
+    }
+
+    // Issue #336 CA-2: evento de bus sin sedes en las franjas -> comportamiento actual intacto,
+    // todas las franjas persisten con Sede null (regresion explicita, en verde).
+    [Fact]
+    public async Task ProgramacionTurnoDiarioSolicitada_DejaLaSedeEnNull_CuandoElEventoNoTraeSedesEnLasFranjas()
+    {
+        await WhenAsync(CrearEvento());
+
+        Then(StreamId, CrearTurnoDiarioAsignado());
+        And<ControlDiarioAggregateRoot, SedeProgramada?>(
+            StreamId, c => c.DetalleTurno!.FranjasOrdinarias[0].Sede, null);
+    }
 }


### PR DESCRIPTION
## Resumen

Pipeline TDD completado:
- Fase roja: tests escritos con stubs
- Fase verde: implementación completa
- Smoke tests: escritos para endpoints detectados
- Fase refactor: revisión de calidad

## Decisiones del pipeline

<details>
<summary>Test Writer (fase roja) — 10m 33s</summary>

## ES Test Writer - Decisiones (issue #336)

### Tests creados / extendidos

- `SedeProgramadaIgualdadTests.cs` (nuevo): 8 tests heredados de `IgualdadTestBase<SedeProgramada>`
  - Contrato `IEquatable` completo para el nuevo record `SedeProgramada` (ControlHoras.DomainEvents)
- `SedeProgramadaParidadConDetalleSedeTests.cs` (nuevo): 1 test
  - `SedeProgramada_DeclaraLosMismosCamposQueDetalleSede` - guardrail de paridad de payload por rol
    frente a `DetalleSede` (PrivateEvents.Programacion)
- `FranjaProgramadaIgualdadTests.cs` (extendido, listado en Impacto/Modifica del issue): +1 caso
  - `CrearInstanciasDiferentes()` gana la entrada `"Sede"` - Sede entra en Equals/GetHashCode
- `TurnoDiarioSegmentarTests.cs` (extendido, listado en Impacto/Modifica): +4 tests (CA-3)
  - `Segmentar_EstampaLaSedeDeLaFranjaEnElBloqueOrdinario_CuandoLaFranjaTraeSede`
  - `Segmentar_PropagaLaSedeDeLaFranjaATodosLosBloques_CuandoHayDescansoYExtra` - descansos/extras
    heredan la sede de su franja madre, no tienen sede propia
  - `Segmentar_DejaLaSedeEnNullEnTodosLosBloques_CuandoLaFranjaNoTraeSede` - borde documentado en
    el issue (turno prearmado multi-sede sin resolver)
  - `Segmentar_AsignaACadaBloqueLaSedeDeSuPropiaFranja_CuandoElTurnoTieneVariasFranjasConSedesDistintas`
    - escenario que fija la semantica: cada bloque lleva la sede de SU franja, no una global
- `ProgramacionTurnoDiarioSolicitadaEventHandlerTests.cs` (extendido): +2 tests (CA-1, CA-2)
  - `ProgramacionTurnoDiarioSolicitada_PropagaLaSedeDeCadaFranja_CuandoElEventoTraeSedesEfectivas`
    (CA-1): dos franjas, una con `DetalleSede` y otra sin - verifica mapeo tolerante
  - `ProgramacionTurnoDiarioSolicitada_DejaLaSedeEnNull_CuandoElEventoNoTraeSedesEnLasFranjas`
    (CA-2): regresion explicita
- `TurnoDiarioAsignadoSerializacionTests.cs` (extendido): +2 tests (CA-4, CA-5)
  - `Deserializar_DejaLaSedeEnNull_CuandoElJsonPersistidoNoLlevaLaClaveSede` (CA-4):
    retrocompatibilidad - JSON persistido antes de este issue no lleva la clave `Sede`
  - `Deserializar_ReconstruyeIdentico_ConSedesPobladasEnLasFranjas` (CA-5): round-trip Marten con
    dos franjas con sedes distintas, incluida igualdad por valor completa de `TurnoDiario`

### Estructura elegida

- Una clase de test por responsabilidad, siguiendo el patron ya establecido en el dominio
  (paridad con `EmpleadoIgualdadTests`, `SubFranjaProgramadaIgualdadTests`,
  `FranjaProgramadaParidadConDetalleFranjaOrdinariaTests` de Programacion.Tests).
- `SedeProgramadaParidadConDetalleSedeTests` reusa el patron exacto de
  `SedeProgramadaParidadConDetalleSedeTests` (Programacion.Tests, issue #331): cada isla de
  eventos tiene su propio gemelo de `DetalleSede`, con su propio guardrail de paridad.
- No se creo un guardrail de paridad completo `FranjaProgramadaParidadConDetalleFranjaOrdinariaTests`
  para ControlHoras (analogo al de Programacion.Tests): no estaba en el alcance de los 6 CAs del
  issue y ya existe cobertura equivalente via `FranjaProgramadaIgualdadTests` (Equals custom) +
  el nuevo `SedeProgramadaParidadConDetalleSedeTests`. Se documenta como decision consciente por si
  el reviewer prefiere agregarlo.

### Stubs creados (aditivos, sin logica nueva)

- `SedeProgramada.cs` (ControlHoras.DomainEvents): record `(string Id, string Nombre)`, gemelo de
  `SedeProgramada` (Programacion.DomainEvents) y `DetalleSede` (PrivateEvents). Sin `EstaCompleta()`
  a proposito: esa regla de completitud pertenece a quien COMPONE la sede (Programacion), no a
  quien la transporta/persiste (ControlHoras) - desviacion respecto al gemelo de Programacion,
  documentada en el remarks del tipo.
- `FranjaProgramada.Sede` (ControlHoras.DomainEvents): parametro posicional aditivo
  `SedeProgramada? Sede = null` al final del record, incluido en `Equals`/`GetHashCode` custom.
- `BloqueTurno.Sede` (ControlHoras.DomainEvents): parametro posicional aditivo
  `SedeProgramada? Sede = null` al final del record. Sin Equals custom (no lo tenia antes; el
  Equals por defecto del record ya compara por valor porque `SedeProgramada` tiene igualdad por
  valor).

**No se toco ninguna logica de produccion existente** (`MapearFranja` en el handler, `Tramo`,
`SubFranjaProgramada.ATramo`, `FranjaProgramada.Segmentar`, `TurnoDiario.Segmentar`,
`Tramo.ResolverA`): al agregar `Sede` con valor por defecto `null` al final de los records, todo
el codigo de produccion existente sigue compilando sin cambios y sigue construyendo instancias con
`Sede = null` siempre. Esto es justo el comportamiento esperado en fase roja: los tests que
esperan una sede poblada (CA-1, CA-3 con sede) FALLAN; los tests de regresion/retrocompatibilidad
(CA-2, CA-4, forma de serializacion en CA-5) pasan porque son comportamiento mecanico que no
depende de logica de negocio nueva.

### Decisiones de diseno

- Se opto por NO modificar la plomeria interna (`Tramo`, `SubFranjaProgramada.ATramo`,
  `Tramo.ResolverA`) porque el issue explicitamente deja esa decision (si `Tramo` transporta la
  sede o el pipeline de `Segmentar` se recompone) como "propuesta revisable -- decision del
  pipeline" -- responsabilidad del implementer, preservando Tell-don't-Ask.
- Los factory methods de `TurnoDiarioSegmentarTests` (`Franja(...)`) ganaron un parametro opcional
  `sede` al final, sin romper ninguna llamada existente.
- El escenario de CA-1 replica textualmente el ejemplo del issue (turno prearmado multi-sede,
  franja con sede y franja sin sede) para fijar la semantica de mapeo tolerante.

### Cobertura de criterios

| Criterio de aceptacion | Test(s) |
|---|---|
| CA-1: TurnoDiarioAsignado persiste con sede en franjas correspondientes | `ProgramacionTurnoDiarioSolicitada_PropagaLaSedeDeCadaFranja_CuandoElEventoTraeSedesEfectivas` |
| CA-2: evento sin sedes -> comportamiento actual intacto | `ProgramacionTurnoDiarioSolicitada_DejaLaSedeEnNull_CuandoElEventoNoTraeSedesEnLasFranjas` |
| CA-3: Segmentar estampa sede en bloques, descansos/extras heredan, sin sede -> null | 4 tests en `TurnoDiarioSegmentarTests.cs` (ver arriba) |
| CA-4: retrocompatibilidad JSON sin clave "sede" | `Deserializar_DejaLaSedeEnNull_CuandoElJsonPersistidoNoLlevaLaClaveSede` |
| CA-5: round-trip Marten con sedes pobladas + igualdad por valor | `Deserializar_ReconstruyeIdentico_ConSedesPobladasEnLasFranjas` |
| CA-6: suite completa en verde | Verificado por el implementer/reviewer, no por un test individual |

### Desviaciones del plan del planner

| Sugerencia del issue | Desviacion aplicada | Razon tecnica | Consecuencia |
|---|---|---|---|
| "SedeProgramada gemelo propio de ControlHoras.DomainEvents" (sin mas detalle de metodos) | Se documenta explicitamente en el remarks que NO expone `EstaCompleta()` (a diferencia del gemelo de Programacion) | ControlHoras nunca compone ni valida la sede, solo la transporta/persiste - `EstaCompleta()` es una regla de quien COMPONE (MEF-ADR-0012, Tell-don't-Ask: la regla vive donde nace el dato) | Ninguna: el issue no pedia ese metodo, la interfaz publica propuesta solo listaba `record SedeProgramada(string Id, string Nombre)` |
| Ninguna otra desviacion - la interfaz publica propuesta y el modelo de eventos se aplicaron tal cual. | | | |

</details>

<details>
<summary>Implementer (fase verde) — 5m 58s</summary>

## ES Implementer - Decisiones

### Enfoque de implementacion

El test-writer ya habia dejado en verde (compilando) la forma publica completa del cambio:
`SedeProgramada` (nuevo record en `ControlHoras.DomainEvents`), el campo `Sede` en
`FranjaProgramada` (con Equals/GetHashCode custom que ya lo incluia) y el campo `Sede` en
`BloqueTurno`. Lo que faltaba era exclusivamente la plomeria interna que hace que ese dato
realmente fluya de punta a punta:

1. **`ProgramacionTurnoDiarioSolicitadaEventHandler.MapearFranja`**: se agrego el mapeo mecanico
   `DetalleSede -> SedeProgramada` (nuevo metodo privado `MapearSede`, tolerante a null) y se paso
   como ultimo argumento posicional al construir `FranjaProgramada`. Sigue el mismo patron ya
   usado por `MapearEmpleado`/`MapearTurnoDiario`/`MapearSubFranja` en el mismo archivo.
2. **`Tramo` (struct interno, no persistido)**: se le agrego el campo opcional `SedeProgramada?
   Sede = null`. `RomperEnMedianoche` no requirio cambios porque usa `this with { ... }`, que ya
   preserva el campo nuevo automaticamente. `ResolverA` se actualizo para copiar `Sede` al
   `BloqueTurno` resultante.
3. **`FranjaProgramada.Segmentar()`**: es el unico punto donde se construyen instancias de
   `Tramo` a partir de la franja -- por eso es el unico lugar que necesita estampar `Sede`: se
   paso `Sede` en los dos `new Tramo(...)` que generan el tramo Ordinaria de los huecos, y se
   sobreescribio con `sub with { Sede = Sede }` el tramo que ya viene de
   `SubFranjaProgramada.ATramo()` (que nunca fija sede propia, siempre null por diseno -- los
   descansos/extras no tienen sede propia, la heredan de la franja madre).

No hizo falta tocar `TurnoDiario.Segmentar` (el pipeline `SelectMany -> SelectMany -> Select` ya
propaga cualquier campo que traiga el `Tramo`) ni `SubFranjaProgramada.ATramo` (deliberadamente no
fija sede: es la franja madre la unica duena del dato, Tell-don't-Ask).

### Decisiones de diseno

- **Punto unico de estampado**: se eligio que `FranjaProgramada.Segmentar()` sea el unico lugar
  que lee `this.Sede` y la propaga -- ni `Tramo` ni `SubFranjaProgramada` conocen o deciden nada
  sobre la sede, solo la transportan (`Tramo`) o la ignoran deliberadamente (`SubFranjaProgramada`,
  que nunca tiene sede propia). Esto respeta MEF-ADR-0012 (Tell-don't-Ask): el objeto dueno del
  dato (la franja) es quien lo estampa, no un calculo externo.
- **`Tramo.Sede` como parametro posicional opcional con default `null`**: mantiene consistencia
  con el resto del ensamblado (`FranjaProgramada.Sede`, `BloqueTurno.Sede`) y no rompe ningun
  call-site existente de `new Tramo(tipo, inicio, fin)` (los de `ATramo`, `RomperEnMedianoche`).
- **`MapearSede` como metodo privado separado** en el handler, en vez de inline: sigue el patron
  ya establecido de un metodo de mapeo por tipo (`MapearEmpleado`, `MapearSubFranja`), legible y
  consistente con el resto del archivo.

### ADRs consultados

- CA-ADR-0029 / MEF-ADR-0039: tres islas y payload por rol -- verificado que `SedeProgramada`
  (ControlHoras.DomainEvents) es un gemelo deliberado de `DetalleSede` (PrivateEvents.Programacion)
  sin referenciarlo, y que el mapeo mecanico vive en el Function App (unico proyecto que ve ambas
  islas). Ya estaba resuelto por el test-writer; el implementer solo completo el mapeo que faltaba
  en `MapearFranja`.
- MEF-ADR-0012: Tell-don't-Ask -- el estampado de sede vive en `FranjaProgramada.Segmentar()` (el
  objeto dueno del dato), no como calculo externo sobre los tramos.
- CA-ADR-0029 decision #6 / MEF-ADR-0036: campos aditivos -- `Sede` se agrego como ultimo
  parametro posicional opcional en `FranjaProgramada`/`BloqueTurno`/`Tramo`; ningun tipo de evento
  se movio ni renombro. `TurnoDiarioAsignado` no cambio de forma (su lista de tipos persistidos en
  `IdentidadEventosControlHoras` no requirio modificacion: `SedeProgramada`/`FranjaProgramada`/
  `BloqueTurno` no son eventos en si mismos, son payload/resultado de lectura pura).
- MEF-ADR-0002 / MEF-ADR-0016: DSL de tests y convencion de nombres -- no aplico cambios de
  produccion relacionados, solo se verifico que los tests ya seguian la convencion.

### Desviaciones de ADRs

Ninguna desviacion -- todos los ADRs aplicados al pie de la letra.

### Desviaciones del plan del planner

Ninguna desviacion -- el planner ya anticipaba correctamente que la plomeria de `Tramo.cs` era
"revisable" y quedaba a decision del pipeline; se opto por la forma mas simple (campo opcional
transportado sin logica) porque es exactamente lo que la doctrina Tell-don't-Ask pide: `Tramo` no
interpreta la sede, solo la lleva.

### Precedentes consultados

- `DetalleFranjaOrdinaria.Sede` (PrivateEvents.Programacion, issue #341) y `FranjaProgramada.Sede`
  (Programacion.DomainEvents, issue #335): usados como referencia de forma (campo aditivo opcional,
  entra en Equals/GetHashCode). Alineados con MEF-ADR-0012/CA-ADR-0029; no se detecto ninguna
  violacion que reportar.

### Infraestructura modificada

Ninguna. Este issue no agrega ni modifica eventos de bus (`IPrivateEvent`/`IPublicEvent`): extiende
el consumo existente de `ProgramacionTurnoDiarioSolicitada` (sin cambios en su contrato) y el
payload de un evento de event-sourcing (`TurnoDiarioAsignado`) que nunca cruza el bus. No hay
topics ni subscriptions que agregar en `infra/environments/dev/main.tf`.

### Complejidad encontrada

Ninguna significativa. El test-writer ya habia dejado la forma publica (records, campos,
Equals/GetHashCode) completamente resuelta y compilando; el trabajo del implementer se redujo a
tres ediciones puntuales y mecanicas (mapeo en el handler + dos structs internos de la cadena de
segmentacion). Los 4 tests que fallaban al arrancar (todos en `TurnoDiarioSegmentarTests` y uno en
`ProgramacionTurnoDiarioSolicitadaEventHandlerTests`) pasaron en el primer intento tras estas
ediciones.

### Resultado

- Tests pasando: 812/812 ejecutados (17 omitidos son smoke tests que requieren infraestructura
  externa -- ServiceBus/Postgres no configurados en este entorno, comportamiento esperado y
  preexistente, no relacionado con este issue).
- Suite completa del repo en verde.

</details>
<details>
<summary>Smoke Test Writer — 3m 17s</summary>

_(El agente no generó resumen)_

</details>
<details>
<summary>Reviewer (fase refactor) — 12m 26s</summary>

## ES Reviewer - Revision (issue #336)

### Evaluacion general
- Calidad: **buena**
- Cambios realizados: **si** (commit `b932b3d`, refactor + 5 tests agregados)
- Suite: 817 correctos / 0 errores / 18 omitidos (smoke tests sin infra local). Baseline al
  arrancar la revision: 812 correctos, ya en verde -- no hubo bloqueo heredado.

### Cumplimiento de ADRs aplicables

| ADR | Cumplimiento | Observacion |
|---|---|---|
| CA-ADR-0029 / MEF-ADR-0039: tres islas y payload por rol | ok | `SedeProgramada` es gemelo propio de `ControlHoras.DomainEvents`, cero `ProjectReference` nuevos (el `.csproj` de la isla sigue sin ninguno). El mapeo `DetalleSede -> SedeProgramada` vive en el Function App (`MapearSede`), unico proyecto que ve ambas islas. Verifique ademas que `SedeProgramada` no se filtra a `PublicEvents`/`PrivateEvents`/`ReadModels`. |
| MEF-ADR-0012: Tell-don't-Ask y frontera de serializacion | ok (reforzado en refactor) | El estampado vive en la cadena de la franja, no en un calculo externo. Recorri el checklist completo de antipatrones (7 items) sin hallazgos: no hay clase estatica operando sobre datos crudos, no hay getter solo-para-test, no hay `[JsonConstructor]`, no hay `record` con `IReadOnlyList` sin `Equals` custom, y ningun evento con marker de bus gana payload rico (`TurnoDiarioAsignado` no tiene marker; `DiaCalculado` no se toca). |
| CA-ADR-0029 decision #6 / MEF-ADR-0036: campos aditivos | ok | Ningun tipo de evento se movio ni renombro; `IdentidadEventosControlHoras.TiposPersistidos` no requiere cambio (`SedeProgramada` es payload, no evento). El alias `turno_diario_asignado` intacto. `Sede` entra como ultimo parametro posicional opcional -- CA-4 lo prueba contra JSON ya persistido. |
| MEF-ADR-0002 / MEF-ADR-0016: DSL de tests y naming | **desviacion NO declarada, corregida** | Ver seccion "Desviaciones". El smoke test nuevo nacio con el patron `Debe...`, que MEF-ADR-0016 declara superado y aplica explicitamente tambien a smoke tests. |

### Desviaciones de ADRs

**Desviaciones declaradas por el implementer**: ninguna (su resumen declara "todos los ADRs
aplicados al pie de la letra"). Verifique esa afirmacion contra el diff y la confirmo para los tres
ADRs de produccion.

**Desviaciones detectadas por el reviewer (NO declaradas)**:

#### Desviacion: MEF-ADR-0016
- **Regla del ADR**: patron unico `<Sujeto>_<LoQuePasa>[_Cuando<Condicion>]`, que el ADR aplica
  explicitamente a **todos** los tests del proyecto, smoke tests incluidos (tiene una fila propia en
  la tabla de ejemplos). El patron `Debe[Resultado]_Cuando[Condicion]` queda fuera de la convencion.
- **Desviacion encontrada en el diff**: `AsignarTurnoViaSbSmokeTests.cs` -- el test nuevo nacio como
  `DebeAsignarTurnoDiario_ConSedePorFranja_CuandoElEventoTraeSedesEfectivas`, replicando el patron
  de los dos tests hermanos de la clase. Esos dos hermanos son legacy (parte de los ~60 casos que el
  ADR deja para un refactor dedicado); un test **nuevo** no debe sumar a esa deuda.
- **Accion tomada**: corregida en refactor ->
  `ProgramacionTurnoDiarioSolicitada_PersisteElTurnoConSedePorFranja_CuandoElEventoTraeSedesEfectivas`
  (sujeto = el evento de bus que dispara el flujo, igual que en los unit tests del handler). Se
  documento en el propio archivo por que los hermanos conservan el patron viejo.
- **Status**: pendiente de evaluacion del usuario

#### Hallazgo de documentacion: comentario factualmente falso
- **Regla**: no es un ADR, pero un comentario que afirma cobertura inexistente es peor que la
  ausencia de comentario -- induce al proximo lector a no agregar el guardrail que falta.
- **Encontrado en el diff**: `SedeProgramadaParidadConDetalleSedeTests.cs` (ControlHoras.Tests)
  afirmaba que el modo de fallo "ya lo cubren los pares de gemelos analogos **de este ensamblado**
  (Empleado/DetalleEmpleado, TurnoDiario/DetalleTurno, FranjaProgramada/DetalleFranjaOrdinaria,
  SubFranjaProgramada/DetalleSubFranja)". Verificado por inspeccion: en `ControlHoras.Tests` **no
  existia ningun** test de paridad antes de este PR. Los cuatro que el comentario nombra existen
  solo en `Programacion.Tests`.
- **Accion tomada**: corregido el comentario **y** cerrada la brecha para el par que este issue
  toca (ver "Tests agregados").
- **Status**: pendiente de evaluacion del usuario

### Precedentes consultados por el implementer

| Precedente | ADR aplicable | Veredicto |
|---|---|---|
| `DetalleFranjaOrdinaria.Sede` (PrivateEvents, #341) | MEF-ADR-0012 (portabilidad por bus) / CA-ADR-0029 #5 | alineado -- DTO plano de strings, con su round-trip por serializador por defecto ya cubierto (`ProgramacionTurnoDiarioSolicitadaPortabilidadTests.RoundTrip_PreservaLaSedeDeLaFranja_...`) |
| `FranjaProgramada.Sede` (Programacion.DomainEvents, #335) | CA-ADR-0029 #5 | alineado -- mismo criterio de campo aditivo dentro de `Equals`/`GetHashCode` |
| `SedeProgramadaParidadConDetalleSedeTests` (Programacion.Tests, #331) | CA-ADR-0029 #5 | alineado, y **mas completo que su copia**: del lado de Programacion el par contenedor tiene su propio guardrail (`FranjaProgramadaParidadConDetalleFranjaOrdinariaTests`); del lado de ControlHoras no existia. El precedente estaba bien; lo que faltaba era copiar tambien esa pieza. |

### Convenciones del pipeline (no ADRs)

| Convencion | Estado | Observacion |
|---|---|---|
| Cada test con `Then()` + `And<>()` | ok | Los dos tests nuevos del handler usan `Then(StreamId, ...)` + dos/un `And<T,P>(StreamId, ...)`. |
| Overloads correctos para stream IDs compuestos | ok | `ControlDiarioAggregateRoot` tiene `ComputarStreamId(empleadoId, fecha)`; todos los tests usan los overloads con `aggregateId`. |
| Fakes manuales (no NSubstitute) | n/a | El handler solo depende de `IEventStore` e `IPublicEventSender`, ambos provistos por el harness. |
| Feature folders (produccion y tests) | ok | Espejo exacto: `AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/`, un archivo por responsabilidad. |
| Smoke tests: SkipWhen, secrets, cobertura | ok | `Assert.SkipWhen` (xUnit v3) en ambos fixtures; filtro por `SolicitudId`/`EmpleadoId`, nunca por posicion; purge-before-act; ambos efectos secundarios cubiertos (persistencia en Postgres **y** publicacion de `DiaCalculado`); un solo archivo por comando. Sin topics nuevos -> nada que agregar en `infra/`. |
| Proyecciones read-side | n/a | El diff no toca proyecciones ni read models. Ver "Criticas" sobre `TurnoVigenteProjection`. |
| Compatibilidad Marten write-side/read-side | n/a | El diff no toca version de `Cosmos.EventSourcing.*` ni ninguna linea de configuracion de Marten. La lista de serializacion es unica (`ConfiguracionSerializacionControlHoras`, en el ensamblado de eventos) y la consumen ambos lados, asi que un campo aditivo no puede divergir. |
| Identidad de stream (MEF-ADR-0037) | ok | Gate corrido (el archivo del handler, con `StartStream`/`ExistsAsync`/`GetAggregateRootAsync`, esta en el diff). Sin `ToString("N")` ni formatos explicitos sobre `Guid`; `ComputarStreamId` sigue siendo el punto unico en produccion; no hay GET de read-side en el diff. |
| Control de volumen de telemetria (MEF-ADR-0038) | n/a | El diff no toca `ComposicionServicios*`, `ConfiguracionObservabilidad*` ni el callback de Wolverine. |
| Tests via ToString/comportamiento | ok | La sede se verifica por el resultado publico de `Segmentar` y por el evento persistido, no por getters abiertos para el test. |
| Sin numeros magicos | ok | Las constantes de tiempo siguen en `Tramo` (`MinutosPorHora`, `MinutosPorDia`); los ids de sede en tests son literales de datos de prueba. |
| Condiciones en positivo | ok | `MapearSede` usa `sede is null ? null : ...` (guard de mapeo, no bifurcacion invertida). |

### Elegancia del codigo

- **Compacidad / robustez (corregido)**: el estampado de la sede estaba repetido en **tres** sitios
  dentro de `FranjaProgramada.Segmentar()` (dos `new Tramo(..., Sede)` y un `sub with { Sede = Sede }`).
  Funcionaba, pero dejaba una trampa: cualquier tramo que se agregue manana al recorte nace sin sede
  y ningun compilador lo delata. Se extrajo la aritmetica pura a `Recortar()` y el estampado quedo
  como **un unico paso al cierre** (`Recortar().Select(tramo => tramo with { Sede = Sede })`). Efectos:
  el iterador de recorte vuelve exactamente a su forma previa al issue (diff neto cero sobre la
  aritmetica), el comentario XML ("estampa Sede en TODOS los tramos que produce") pasa a ser
  literalmente lo que el codigo hace, y la herencia de sede es por construccion.
- **Idiomatico**: buen uso de `with` sobre `readonly record struct` para transportar el campo por la
  cadena sin escribir plomeria; `MapearSede` sigue el patron de un metodo de mapeo por tipo ya
  establecido en el handler.
- **Limpieza**: cero warnings del compilador en el codigo nuevo. `dotnet format --verify-no-changes`
  reporta 4 `IDE0005` (usings innecesarios), **todos en archivos ajenos a este diff** y preexistentes
  desde el issue #270 -- no se tocan aqui (deuda para un refactor propio).
- **Documentacion**: los remarks son densos pero justificados (explican el *por que* de la
  duplicacion por rol). Se actualizo el de `Tramo` porque el refactor invalido su descripcion
  ("la estampa al construir cada Tramo" ya no era cierto).

### Criticas y hallazgos

1. **[mayor -- corregido]** Faltaba el guardrail de paridad `FranjaProgramada` /
   `DetalleFranjaOrdinaria` en `ControlHoras.Tests`. Es precisamente el par que este issue extiende
   con `Sede`, y su ausencia deja abierto el modo de fallo que CA-ADR-0029 decision #5 documenta como
   **silencioso**: si manana un lado gana un campo y el otro no, `MapearFranja` pierde el dato sin
   que nada falle. El test-writer lo dejo anotado como decision consciente "por si el reviewer
   prefiere agregarlo"; lo agregue (4 casos, espejo del de Programacion). No cubro los otros tres
   pares de esta isla (Empleado, TurnoDiario, SubFranjaProgramada): quedan fuera del alcance de este
   issue y anotados en el comentario del archivo para que se vean.
2. **[mayor -- corregido]** Hueco de cobertura en CA-3: ningun test verificaba que la sede sobreviva
   el **corte en medianoche**. El estampado ocurre antes de `Tramo.RomperEnMedianoche`, que preserva
   la sede solo porque usa `this with { ... }`; sustituirlo por `new Tramo(Tipo, cursor, limite)`
   dejaria sin sede a **todo turno nocturno** -- la mitad del dominio -- y la suite seguiria verde.
   Agregue el test y **verifique empiricamente que no es vacuo** mutando esa linea en produccion: el
   test nuevo fue el unico de los 441 que fallo. Produccion restaurada.
3. **[menor -- corregido]** Naming del smoke test nuevo fuera de MEF-ADR-0016 (ver "Desviaciones").
4. **[menor -- corregido]** Comentario factualmente falso sobre guardrails existentes (ver
   "Desviaciones").
5. **[observacion, no corregido -- fuera de alcance]** `TurnoVigenteProjection.MapearBloque` no
   propaga `BloqueTurno.Sede` al read model `Bloque` (`ReadModels`), que sigue siendo
   `(Tipo, Inicio, Fin)`. Esto es **correcto para este PR**: el issue declara explicitamente que el
   consumidor de produccion de `BloqueTurno.Sede` es **#337** y que #336 solo lo bloquea. Lo dejo
   anotado para que #337 no asuma que el read-side ya lo trae.
6. **[observacion, no corregido]** Los smoke tests arman el stream id a mano
   (`$"{empleadoId}:{fecha:yyyy-MM-dd}"`) en vez de llamar a `ComputarStreamId`. No lo flageo bajo
   MEF-ADR-0037: es patron preexistente de los tres tests de la clase, el proyecto de smoke tests no
   referencia el Function App donde vive el aggregate, y el ADR acota el punto unico de conversion a
   CommandHandlers/EventHandlers/endpoints de produccion.
7. **[verificado, sin hallazgo]** La ruta real bus -> deserializacion -> `MapearFranja` ya tiene
   guardrail: `ProgramacionTurnoDiarioSolicitadaPortabilidadTests.RoundTrip_PreservaLaSedeDeLaFranja_ConSerializadorPorDefectoDelBus`
   (de #341) prueba que `DetalleFranjaOrdinaria.Sede` sobrevive el serializador por defecto tal como
   lo ve ControlHoras. Sin el, CA-1 seria verde en unit test y perderia el dato en produccion.

### Refactorings aplicados

1. `FranjaProgramada.Segmentar()` -> `Segmentar()` (estampado unico) + `Recortar()` (aritmetica
   pura). Justificacion: elimina tres puntos de repeticion, vuelve la herencia de sede imposible de
   olvidar, y realinea el comentario con el codigo.
2. Remark de `Tramo` actualizado: describia un estampado "al construir cada Tramo" que el refactor
   dejo de ser cierto.
3. Renombre del smoke test nuevo a MEF-ADR-0016.
4. Comentario de `SedeProgramadaParidadConDetalleSedeTests` corregido a la realidad de la cobertura.

Cada cambio se verifico con `dotnet test` inmediatamente despues; ninguno requirio revert.

### Cobertura de criterios de aceptacion

| Criterio | Estado | Test(s) |
|---|---|---|
| CA-1: `TurnoDiarioAsignado` persiste la sede en las franjas que la traen (las demas null) | cubierto | `ProgramacionTurnoDiarioSolicitada_PropagaLaSedeDeCadaFranja_CuandoElEventoTraeSedesEfectivas` + smoke `ProgramacionTurnoDiarioSolicitada_PersisteElTurnoConSedePorFranja_CuandoElEventoTraeSedesEfectivas` |
| CA-2: evento sin sedes -> comportamiento intacto | cubierto | `ProgramacionTurnoDiarioSolicitada_DejaLaSedeEnNull_CuandoElEventoNoTraeSedesEnLasFranjas` (+ los dos tests preexistentes de la clase, en verde) |
| CA-3: `Segmentar` estampa la sede de la franja madre; descansos/extras heredan; sin sede -> null | cubierto | `Segmentar_EstampaLaSedeDeLaFranjaEnElBloqueOrdinario_...`, `Segmentar_PropagaLaSedeDeLaFranjaATodosLosBloques_CuandoHayDescansoYExtra`, `Segmentar_DejaLaSedeEnNullEnTodosLosBloques_...`, `Segmentar_AsignaACadaBloqueLaSedeDeSuPropiaFranja_...`, **+ `Segmentar_ConservaLaSedeEnLosDosBloquesPartidos_CuandoLaFranjaConSedeCruzaMedianoche` (agregado)** |
| CA-4: JSON persistido sin clave `sede` deserializa con null | cubierto | `Deserializar_DejaLaSedeEnNull_CuandoElJsonPersistidoNoLlevaLaClaveSede` |
| CA-5: round-trip Marten con sedes + igualdad por valor de `FranjaProgramada` | cubierto | `Deserializar_ReconstruyeIdentico_ConSedesPobladasEnLasFranjas` + `FranjaProgramadaIgualdadTests` (caso "Sede") + `SedeProgramadaIgualdadTests` |
| CA-6: suite completa en verde | cubierto | 817 correctos / 0 errores / 18 omitidos |

### Tests agregados

- `FranjaProgramadaParidadConDetalleFranjaOrdinariaTests` (nuevo, 4 casos): guardrail de paridad del
  par de gemelos que este issue extiende -- nombres de campo iguales, tipos escalares iguales, y las
  tres propiedades que tipan deliberadamente distinto (`Descansos`/`Extras`/`Sede`) apuntando al
  gemelo correcto de cada isla. Es un test de contrato, no de comportamiento.
- `Segmentar_ConservaLaSedeEnLosDosBloquesPartidos_CuandoLaFranjaConSedeCruzaMedianoche` (caso borde
  CA-3 x CA-4), validado por mutacion para descartar que sea vacuo.
- Tests de igualdad y serializacion: **ya existian y son correctos** -- el test-writer cubrio
  `IgualdadTestBase<SedeProgramada>`, la entrada `Sede` en `FranjaProgramadaIgualdadTests`, el
  round-trip Marten y la retrocompatibilidad del JSON. No hizo falta agregar nada ahi.

</details>

## Cobertura

| Archivo | Cobertura | Umbral | Estado |
|---|---|---|---|
| BloqueTurno.cs | - | excluido | - |
| SedeProgramada.cs | - | excluido | - |
| FranjaProgramada.cs | - | no evaluado | - |
| Tramo.cs | - | no evaluado | - |
| ProgramacionTurnoDiarioSolicitadaEventHandler.cs | - | no evaluado | - |
## Commits

b932b3d refactor(issue-336): unico punto de estampado de sede y guardrail de paridad de franja
be3e619 test(hu-336): smoke tests para endpoints
96b2dba feat(issue-336): asignar la sede por franja al turno diario en ControlHoras (fase verde)
6942673 test(issue-336): tests para asignar la sede por franja al turno diario (fase roja)

Closes #336