### PR TITLE
Filtrar el panorama de turnos vigentes por sede

### DIFF
--- a/src/Bitakora.ControlAsistencia.ControlHoras/ListarTurnosVigentes/FunctionEndpoint.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ListarTurnosVigentes/FunctionEndpoint.cs
@@ -30,6 +30,14 @@ namespace Bitakora.ControlAsistencia.ControlHoras.ListarTurnosVigentes;
 // rechazado con 400, empleadoId opcional filtra a un solo empleado (CA-2), recorte de rango con
 // RangoConsulta.Recortar (CA-3) y 200 con lista vacia cuando no hay datos en el rango (CA-4)
 // -- nunca 404: un rango sin turnos asignados no es un error.
+//
+// Issue #337 (CA-2/CA-3/CA-4): sedeId es un tercer filtro opcional, combinable con empleadoId y el
+// rango -- "dias donde AL MENOS un bloque rige en esa sede" (issue #337, "Contexto"), por eso el
+// predicado es Bloques.Any(b => b.SedeId == sedeId) y no un campo a nivel de TurnoVigente (la sede
+// va por bloque, nunca por dia). Marten traduce Any() sobre la coleccion anidada a una consulta
+// JSONB (MEF-ADR-0035). Los bloques con SedeId null (CA-4/CA-5, franjas sin sede o documentos
+// proyectados antes de #336/#337) nunca igualan un sedeId no nulo, asi que quedan fuera de
+// cualquier filtro por sede sin necesitar una rama explicita.
 public class FunctionEndpoint(IDocumentStore store, ITenantResolver tenantResolver)
 {
     private const string FormatoFecha = "yyyy-MM-dd";
@@ -60,6 +68,11 @@ public class FunctionEndpoint(IDocumentStore store, ITenantResolver tenantResolv
         // ausente y vacio se tratan igual -- sin filtro por empleado.
         var empleadoId = req.Query["empleadoId"].ToString();
 
+        // Issue #337, CA-2/CA-3: sedeId es opcional -- ausente = sin filtro por sede (regresion de
+        // #329 intacta, CA-3). Mismo tratamiento de StringValues.ToString() que empleadoId: ausente
+        // y vacio se comportan igual.
+        var sedeId = req.Query["sedeId"].ToString();
+
         // CA-3: recorte de la cota de 31 dias, siempre hacia adelante desde `desde`.
         var rangoAplicado = RangoConsulta.Recortar(desde, hasta);
 
@@ -77,6 +90,11 @@ public class FunctionEndpoint(IDocumentStore store, ITenantResolver tenantResolv
 
         if (!string.IsNullOrEmpty(empleadoId))
             query = query.Where(v => v.EmpleadoId == empleadoId);
+
+        // CA-2 (issue #337): "dias donde al menos un bloque rige en esa sede" -- un dia multi-sede
+        // (turno partido Suba/Chapinero) aparece bajo cualquiera de las sedes de sus bloques.
+        if (!string.IsNullOrEmpty(sedeId))
+            query = query.Where(v => v.Bloques.Any(b => b.SedeId == sedeId));
 
         // Orden sugerido por la investigacion del planner: por EmpleadoId y luego por Fecha --
         // estable para pintar grillas multi-empleado x rango de fechas.

--- a/src/Bitakora.ControlAsistencia.ControlHoras/ListarTurnosVigentes/FunctionEndpoint.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ListarTurnosVigentes/FunctionEndpoint.cs
@@ -34,10 +34,12 @@ namespace Bitakora.ControlAsistencia.ControlHoras.ListarTurnosVigentes;
 // Issue #337 (CA-2/CA-3/CA-4): sedeId es un tercer filtro opcional, combinable con empleadoId y el
 // rango -- "dias donde AL MENOS un bloque rige en esa sede" (issue #337, "Contexto"), por eso el
 // predicado es Bloques.Any(b => b.SedeId == sedeId) y no un campo a nivel de TurnoVigente (la sede
-// va por bloque, nunca por dia). Marten traduce Any() sobre la coleccion anidada a una consulta
-// JSONB (MEF-ADR-0035). Los bloques con SedeId null (CA-4/CA-5, franjas sin sede o documentos
-// proyectados antes de #336/#337) nunca igualan un sedeId no nulo, asi que quedan fuera de
-// cualquier filtro por sede sin necesitar una rama explicita.
+// va por bloque, nunca por dia). Sigue siendo la via de consulta (a') de MEF-ADR-0035 (LINQ sobre
+// session.Query<TView>()): Marten soporta Any() dentro de colecciones hijas y traduce una igualdad
+// como esta a containment JSONB -- data -> 'Bloques' @> '[{"SedeId": ...}]' --, la unica forma
+// elegible para indice GIN (martendb.io/documents/querying/linq/child-collections.html). Esa misma
+// semantica de containment resuelve CA-4/CA-5 sin rama explicita: un bloque sin la clave SedeId
+// (franja sin sede, o documento proyectado antes de #336/#337) nunca contiene un sedeId no nulo.
 public class FunctionEndpoint(IDocumentStore store, ITenantResolver tenantResolver)
 {
     private const string FormatoFecha = "yyyy-MM-dd";

--- a/src/Bitakora.ControlAsistencia.Projections/ControlHoras/TurnoVigenteProjection.cs
+++ b/src/Bitakora.ControlAsistencia.Projections/ControlHoras/TurnoVigenteProjection.cs
@@ -71,8 +71,11 @@ public sealed partial class TurnoVigenteProjection : SingleStreamProjection<Turn
     private static IReadOnlyList<Bloque> MapearBloques(TurnoDiarioAsignado evento) =>
         evento.DetalleTurno.Segmentar(evento.Fecha).Select(MapearBloque).ToList();
 
+    // Issue #337: SedeId/NombreSede se propagan tal cual desde BloqueTurno.Sede (ya estampada por
+    // TurnoDiario.Segmentar, issue #336) -- ambos quedan null cuando la franja de origen no trae
+    // sede (turno prearmado sin resolver o evento anterior a #336).
     private static Bloque MapearBloque(BloqueTurno bloque) =>
-        new(MapearTipo(bloque.Tipo), bloque.Inicio, bloque.Fin);
+        new(MapearTipo(bloque.Tipo), bloque.Inicio, bloque.Fin, bloque.Sede?.Id, bloque.Sede?.Nombre);
 
     private static TipoBloqueVigente MapearTipo(TipoBloqueEvento tipo) => tipo switch
     {

--- a/src/Bitakora.ControlAsistencia.ReadModels/ControlHoras/Bloque.cs
+++ b/src/Bitakora.ControlAsistencia.ReadModels/ControlHoras/Bloque.cs
@@ -7,4 +7,18 @@ namespace Bitakora.ControlAsistencia.ReadModels.ControlHoras;
 /// planner"). Record plano, sin comportamiento: la clase de proyeccion companion es quien mapea
 /// cada <c>BloqueTurno</c> que produce <c>TurnoDiario.Segmentar</c> a este tipo.
 /// </summary>
-public sealed record Bloque(TipoBloque Tipo, DateTime Inicio, DateTime Fin);
+/// <remarks>
+/// Issue #337: SedeId/NombreSede son campos aditivos y opcionales (strings anulables, planos --
+/// sin record <c>Sede</c> anidado: el nombre puro sigue reservado al concepto rico del futuro
+/// maestro de sedes, #338). Espejo de <c>BloqueTurno.Sede</c> (ControlHoras.DomainEvents, issue
+/// #336) desagregado en sus dos campos primitivos -- la sede va POR BLOQUE, nunca a nivel de dia
+/// (un dia multi-sede no tiene "una" sede). Ambos quedan null cuando el bloque proviene de una
+/// franja sin sede asignada (turno prearmado sin resolver) o de un evento anterior a #336 que
+/// nunca trajo el campo.
+/// </remarks>
+public sealed record Bloque(
+    TipoBloque Tipo,
+    DateTime Inicio,
+    DateTime Fin,
+    string? SedeId = null,
+    string? NombreSede = null);

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/ListarTurnosVigentes/ListarTurnosVigentesSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/ListarTurnosVigentes/ListarTurnosVigentesSmokeTests.cs
@@ -34,6 +34,22 @@ namespace Bitakora.ControlAsistencia.ControlHoras.SmokeTests.ListarTurnosVigente
 // Sin PostgresFixture: la verificacion de persistencia del evento turno_diario_asignado ya la cubre
 // AsignarTurnoViaSbSmokeTests (issue #322); aqui solo interesa que la vista materializada llegue al
 // endpoint HTTP -- mismo alcance que ObtenerTurnoVigenteSmokeTests.
+//
+// Issue #337 (CA-2/CA-3/CA-4): sedeId es un tercer filtro opcional sobre la MISMA Function -- ningun
+// endpoint nuevo. Para sembrar bloques con sede se publica ProgramacionTurnoDiarioSolicitada con la
+// clave "Sede" DENTRO de cada franja ordinaria (PrivateEvents.Programacion.DetalleFranjaOrdinaria.
+// Sede, issue #341) -- nunca a nivel del evento completo: la sede rige por bloque, nunca por dia
+// (issue #337, "Contexto"). El mapeo real hasta el bloque de la vista es
+// ProgramacionTurnoDiarioSolicitadaEventHandler.MapearFranja -> TurnoDiario.Segmentar (#336) ->
+// TurnoVigenteProjection.MapearBloque (#337); este smoke test no lo referencia, solo publica el JSON
+// con la forma que ese mapeo espera. CA-1 (el mapeo de sede en si) y el detalle de "el ultimo gana"
+// ya los cubre el unit test de la proyeccion (projection-test-writer) -- aqui solo se verifica que el
+// filtro sedeId del endpoint HTTP responde con el contrato correcto.
+//
+// ObtenerTurnoVigente (#328) NO se toca en este archivo ni en su propia suite: su Function.cs no
+// cambio (issue #337, "Endpoints / rutas" -- "sin cambio de firma ni ruta"), aunque su respuesta
+// tambien ganaria los campos de sede en los bloques por compartir la misma vista TurnoVigente. El
+// alcance de esta tarea son los endpoints modificados, y el unico modificado es este.
 public class ListarTurnosVigentesSmokeTests(ApiFixture api, ServiceBusFixture serviceBus)
 {
     private readonly HttpClient _client = api.Client;
@@ -72,11 +88,14 @@ public class ListarTurnosVigentesSmokeTests(ApiFixture api, ServiceBusFixture se
         bool RangoRecortado,
         IReadOnlyList<TurnoVigenteRespuestaSmoke> Turnos);
 
-    private static string Ruta(DateOnly desde, DateOnly hasta, string? empleadoId = null)
+    private static string Ruta(
+        DateOnly desde, DateOnly hasta, string? empleadoId = null, string? sedeId = null)
     {
         var query = $"desde={desde:yyyy-MM-dd}&hasta={hasta:yyyy-MM-dd}";
         if (empleadoId is not null)
             query += $"&empleadoId={Uri.EscapeDataString(empleadoId)}";
+        if (sedeId is not null)
+            query += $"&sedeId={Uri.EscapeDataString(sedeId)}";
 
         return $"/api/control-horas/turnos-vigentes?{query}";
     }
@@ -112,6 +131,102 @@ public class ListarTurnosVigentesSmokeTests(ApiFixture api, ServiceBusFixture se
                     }
                 },
                 Descripcion = "[TEST] Turno Vigente Listar 08:00-16:00"
+            }
+        };
+
+        await serviceBus.PublishAsync(TopicEntrada, evento, solicitudId.ToString());
+    }
+
+    // Issue #337: variante de PublicarTurnoAsync con UNA franja que SI trae sede -- la clave "Sede"
+    // va dentro de la franja (DetalleFranjaOrdinaria.Sede, issue #341), nunca a nivel del evento
+    // completo. Usada por el escenario de combinacion sedeId + empleadoId (CA-3).
+    private async Task PublicarTurnoConSedeAsync(
+        Guid solicitudId, string empleadoId, DateOnly fecha, string nombreTurno,
+        string sedeId, string nombreSede)
+    {
+        var evento = new
+        {
+            SolicitudId = solicitudId,
+            Empleado = new
+            {
+                EmpleadoId = empleadoId,
+                TipoIdentificacion = "CC",
+                NumeroIdentificacion = "444555666",
+                Nombres = "[TEST] Smoke Listar",
+                Apellidos = "[TEST] TurnosVigentes"
+            },
+            Fecha = fecha.ToString("yyyy-MM-dd"),
+            DetalleTurno = new
+            {
+                Nombre = nombreTurno,
+                FranjasOrdinarias = new[]
+                {
+                    new
+                    {
+                        HoraInicio = "08:00:00",
+                        HoraFin = "16:00:00",
+                        DiaOffsetFin = 0,
+                        Descansos = Array.Empty<object>(),
+                        Extras = Array.Empty<object>(),
+                        Descripcion = (string?)null,
+                        Sede = new { Id = sedeId, Nombre = nombreSede }
+                    }
+                },
+                Descripcion = $"[TEST] {nombreTurno}"
+            }
+        };
+
+        await serviceBus.PublishAsync(TopicEntrada, evento, solicitudId.ToString());
+    }
+
+    // Issue #337: turno partido en DOS franjas, cada una en su propia sede -- el escenario del
+    // "Contexto" del issue (Carlos manana-Suba/tarde-Chapinero). Ambas franjas producen un bloque
+    // Ordinaria cada una (sin cruce de horario, sin solape) para que la vista materialice un dia
+    // multi-sede real.
+    private async Task PublicarTurnoMultiSedeAsync(
+        Guid solicitudId, string empleadoId, DateOnly fecha, string nombreTurno,
+        string sedeIdManana, string nombreSedeManana,
+        string sedeIdTarde, string nombreSedeTarde)
+    {
+        var evento = new
+        {
+            SolicitudId = solicitudId,
+            Empleado = new
+            {
+                EmpleadoId = empleadoId,
+                TipoIdentificacion = "CC",
+                NumeroIdentificacion = "444555666",
+                Nombres = "[TEST] Smoke Listar",
+                Apellidos = "[TEST] TurnosVigentes"
+            },
+            Fecha = fecha.ToString("yyyy-MM-dd"),
+            DetalleTurno = new
+            {
+                Nombre = nombreTurno,
+                FranjasOrdinarias = new[]
+                {
+                    new
+                    {
+                        HoraInicio = "08:00:00",
+                        HoraFin = "12:00:00",
+                        DiaOffsetFin = 0,
+                        Descansos = Array.Empty<object>(),
+                        Extras = Array.Empty<object>(),
+                        Descripcion = (string?)null,
+                        Sede = new { Id = sedeIdManana, Nombre = nombreSedeManana }
+                    },
+                    new
+                    {
+                        HoraInicio = "14:00:00",
+                        HoraFin = "18:00:00",
+                        DiaOffsetFin = 0,
+                        Descansos = Array.Empty<object>(),
+                        Extras = Array.Empty<object>(),
+                        Descripcion = (string?)null,
+                        Sede = new { Id = sedeIdTarde, Nombre = nombreSedeTarde }
+                    }
+                },
+                Descripcion = $"[TEST] {nombreTurno}"
             }
         };
 
@@ -382,5 +497,140 @@ public class ListarTurnosVigentesSmokeTests(ApiFixture api, ServiceBusFixture se
         // este materializada (verificado arriba) -- prueba que el recorte restringe la consulta.
         respuesta.Turnos.Should().Contain(t => t.Fecha == fechaDentro);
         respuesta.Turnos.Should().NotContain(t => t.Fecha == fechaFuera);
+    }
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarTurnosVigentes_IncluyeElDiaBajoCualquieraDeSusSedes_CuandoElTurnoEsMultiSede()
+    {
+        // CA-2 (issue #337): escenario del "Contexto" -- Carlos con manana-Suba/tarde-Chapinero
+        // aparece en el panorama de AMBOS jefes de sede, porque el filtro es "al menos un bloque
+        // rige en esa sede", no "el dia entero pertenece a una sola sede".
+        Assert.SkipWhen(!serviceBus.IsConfigured,
+            "ServiceBus no configurado. Usa appsettings.local.json o variable ServiceBus__ConnectionString.");
+
+        var ct = TestContext.Current.CancellationToken;
+
+        var solicitudId = Guid.CreateVersion7();
+        var empleadoId = Guid.CreateVersion7().ToString();
+        var fecha = new DateOnly(2026, 6, 5);
+        var sedeIdManana = Guid.CreateVersion7().ToString();
+        var sedeIdTarde = Guid.CreateVersion7().ToString();
+        var sedeIdSinTurnosDeEsteEmpleado = Guid.CreateVersion7().ToString();
+
+        await PublicarTurnoMultiSedeAsync(
+            solicitudId, empleadoId, fecha, "[TEST] Turno Multi Sede",
+            sedeIdManana, "[TEST] Sede Suba", sedeIdTarde, "[TEST] Sede Chapinero");
+
+        var materializado = await EsperarTurnoEnLaListaAsync(empleadoId, fecha, ct);
+        materializado.Should().BeTrue(
+            $"la vista de {empleadoId} en {fecha} deberia materializarse dentro del timeout");
+
+        // Assert: aparece filtrando por la sede de la franja de la manana...
+        var responseManana = await _client.GetAsync(Ruta(fecha, fecha, empleadoId, sedeIdManana), ct);
+        responseManana.StatusCode.Should().Be(HttpStatusCode.OK);
+        var respuestaManana = await responseManana.Content.ReadFromJsonAsync<ListaTurnosVigentesSmoke>(
+            JsonOptions, cancellationToken: ct);
+        respuestaManana!.Turnos.Should().Contain(t => t.EmpleadoId == empleadoId && t.Fecha == fecha);
+
+        // ...y TAMBIEN filtrando por la sede de la franja de la tarde -- mismo dia, dos sedes.
+        var responseTarde = await _client.GetAsync(Ruta(fecha, fecha, empleadoId, sedeIdTarde), ct);
+        responseTarde.StatusCode.Should().Be(HttpStatusCode.OK);
+        var respuestaTarde = await responseTarde.Content.ReadFromJsonAsync<ListaTurnosVigentesSmoke>(
+            JsonOptions, cancellationToken: ct);
+        respuestaTarde!.Turnos.Should().Contain(t => t.EmpleadoId == empleadoId && t.Fecha == fecha);
+
+        // Assert: NO aparece bajo una sede que ningun bloque de este turno tiene.
+        var responseOtraSede = await _client.GetAsync(
+            Ruta(fecha, fecha, empleadoId, sedeIdSinTurnosDeEsteEmpleado), ct);
+        responseOtraSede.StatusCode.Should().Be(HttpStatusCode.OK);
+        var respuestaOtraSede = await responseOtraSede.Content.ReadFromJsonAsync<ListaTurnosVigentesSmoke>(
+            JsonOptions, cancellationToken: ct);
+        respuestaOtraSede!.Turnos.Should().NotContain(t => t.EmpleadoId == empleadoId && t.Fecha == fecha);
+    }
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarTurnosVigentes_ExcluyeElDiaSinSede_CuandoSeFiltraPorSedeId()
+    {
+        // CA-4 (issue #337): un dia cuyos bloques no tienen sede (franja sin sede asignada, o
+        // documento proyectado antes de #336/#337 -- CA-5) no aparece bajo NINGUN sedeId, pero SI
+        // en la consulta sin filtro. Regresion de #329 verificada explicitamente en el mismo test.
+        Assert.SkipWhen(!serviceBus.IsConfigured,
+            "ServiceBus no configurado. Usa appsettings.local.json o variable ServiceBus__ConnectionString.");
+
+        var ct = TestContext.Current.CancellationToken;
+
+        var solicitudId = Guid.CreateVersion7();
+        var empleadoId = Guid.CreateVersion7().ToString();
+        var fecha = new DateOnly(2026, 6, 6);
+        var sedeIdCualquiera = Guid.CreateVersion7().ToString();
+
+        // PublicarTurnoAsync (helper de #329) nunca incluye la clave "Sede" en la franja --
+        // equivalente comportamental a un bloque con SedeId/NombreSede null (CA-4/CA-5).
+        await PublicarTurnoAsync(solicitudId, empleadoId, fecha, "[TEST] Turno Sin Sede");
+
+        var materializado = await EsperarTurnoEnLaListaAsync(empleadoId, fecha, ct);
+        materializado.Should().BeTrue(
+            $"la vista de {empleadoId} en {fecha} deberia materializarse dentro del timeout");
+
+        // Assert: filtrando por CUALQUIER sedeId, el dia sin sede queda fuera.
+        var responseFiltrada = await _client.GetAsync(
+            Ruta(fecha, fecha, empleadoId, sedeIdCualquiera), ct);
+        responseFiltrada.StatusCode.Should().Be(HttpStatusCode.OK);
+        var respuestaFiltrada = await responseFiltrada.Content.ReadFromJsonAsync<ListaTurnosVigentesSmoke>(
+            JsonOptions, cancellationToken: ct);
+        respuestaFiltrada!.Turnos.Should().NotContain(t => t.EmpleadoId == empleadoId && t.Fecha == fecha);
+
+        // Assert: sin filtro de sede, el dia SI aparece -- regresion de #329 intacta.
+        var responseSinFiltro = await _client.GetAsync(Ruta(fecha, fecha, empleadoId), ct);
+        responseSinFiltro.StatusCode.Should().Be(HttpStatusCode.OK);
+        var respuestaSinFiltro = await responseSinFiltro.Content.ReadFromJsonAsync<ListaTurnosVigentesSmoke>(
+            JsonOptions, cancellationToken: ct);
+        respuestaSinFiltro!.Turnos.Should().Contain(t => t.EmpleadoId == empleadoId && t.Fecha == fecha);
+    }
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarTurnosVigentes_CombinaSedeIdConEmpleadoId_CuandoAmbosFiltrosSeAplican()
+    {
+        // CA-3 (issue #337): sedeId es combinable con empleadoId -- misma sede, dos empleados
+        // distintos, el filtro compuesto (AND) devuelve solo al empleado pedido.
+        Assert.SkipWhen(!serviceBus.IsConfigured,
+            "ServiceBus no configurado. Usa appsettings.local.json o variable ServiceBus__ConnectionString.");
+
+        var ct = TestContext.Current.CancellationToken;
+
+        var fecha = new DateOnly(2026, 6, 7);
+        var sedeId = Guid.CreateVersion7().ToString();
+        var solicitudA = Guid.CreateVersion7();
+        var solicitudB = Guid.CreateVersion7();
+        var empleadoIdA = Guid.CreateVersion7().ToString();
+        var empleadoIdB = Guid.CreateVersion7().ToString();
+
+        await PublicarTurnoConSedeAsync(
+            solicitudA, empleadoIdA, fecha, "[TEST] Turno Combinado A", sedeId, "[TEST] Sede Combinada");
+        await PublicarTurnoConSedeAsync(
+            solicitudB, empleadoIdB, fecha, "[TEST] Turno Combinado B", sedeId, "[TEST] Sede Combinada");
+
+        var aMaterializado = await EsperarTurnoEnLaListaAsync(empleadoIdA, fecha, ct);
+        aMaterializado.Should().BeTrue(
+            $"la vista de {empleadoIdA} en {fecha} deberia materializarse dentro del timeout");
+
+        var bMaterializado = await EsperarTurnoEnLaListaAsync(empleadoIdB, fecha, ct);
+        bMaterializado.Should().BeTrue(
+            $"la vista de {empleadoIdB} en {fecha} deberia materializarse dentro del timeout");
+
+        // Act: combinar sedeId (compartido por A y B) + empleadoId=A.
+        var response = await _client.GetAsync(Ruta(fecha, fecha, empleadoIdA, sedeId), ct);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var respuesta = await response.Content.ReadFromJsonAsync<ListaTurnosVigentesSmoke>(
+            JsonOptions, cancellationToken: ct);
+        respuesta.Should().NotBeNull();
+
+        // Assert: solo el turno de A -- el filtro compuesto excluye a B aunque comparta la sede.
+        respuesta!.Turnos.Should().ContainSingle(t => t.EmpleadoId == empleadoIdA && t.Fecha == fecha);
+        respuesta.Turnos.Should().NotContain(t => t.EmpleadoId == empleadoIdB);
     }
 }

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/ListarTurnosVigentes/ListarTurnosVigentesSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/ListarTurnosVigentes/ListarTurnosVigentesSmokeTests.cs
@@ -42,9 +42,10 @@ namespace Bitakora.ControlAsistencia.ControlHoras.SmokeTests.ListarTurnosVigente
 // (issue #337, "Contexto"). El mapeo real hasta el bloque de la vista es
 // ProgramacionTurnoDiarioSolicitadaEventHandler.MapearFranja -> TurnoDiario.Segmentar (#336) ->
 // TurnoVigenteProjection.MapearBloque (#337); este smoke test no lo referencia, solo publica el JSON
-// con la forma que ese mapeo espera. CA-1 (el mapeo de sede en si) y el detalle de "el ultimo gana"
-// ya los cubre el unit test de la proyeccion (projection-test-writer) -- aqui solo se verifica que el
-// filtro sedeId del endpoint HTTP responde con el contrato correcto.
+// con la forma que ese mapeo espera. El detalle de "el ultimo gana" lo cubre el unit test de la
+// proyeccion (projection-test-writer); aqui se verifica el filtro sedeId del endpoint HTTP y, sobre
+// esa misma respuesta, que los campos de sede efectivamente VIAJEN al cliente en cada bloque (CA-1
+// de punta a punta: la cadena completa, no solo la funcion pura de mapeo).
 //
 // ObtenerTurnoVigente (#328) NO se toca en este archivo ni en su propia suite: su Function.cs no
 // cambio (issue #337, "Endpoints / rutas" -- "sin cambio de firma ni ruta"), aunque su respuesta
@@ -55,6 +56,11 @@ public class ListarTurnosVigentesSmokeTests(ApiFixture api, ServiceBusFixture se
     private readonly HttpClient _client = api.Client;
 
     private const string TopicEntrada = "programacion-turno-diario-solicitada";
+
+    // Descripcion del turno sembrado por PublicarTurnoAsync: es el dato que la vista devuelve como
+    // HorarioResumido, asi que se afirma contra esta misma constante (eco del payload publicado).
+    private const string DescripcionTurnoSinSede = "[TEST] Turno Vigente Listar 08:00-16:00";
+
     private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
 
     // Case-insensitive: la respuesta viaja en camelCase (ComposicionServicios configura
@@ -71,7 +77,15 @@ public class ListarTurnosVigentesSmokeTests(ApiFixture api, ServiceBusFixture se
         Extra
     }
 
-    private sealed record BloqueSmoke(TipoBloqueSmoke Tipo, DateTime Inicio, DateTime Fin);
+    // Issue #337: SedeId/NombreSede son aditivos y opcionales en la vista, asi que tambien lo son en
+    // esta forma local -- un bloque sin sede (turno sembrado sin la clave "Sede", o documento
+    // proyectado antes de #336/#337) los trae null.
+    private sealed record BloqueSmoke(
+        TipoBloqueSmoke Tipo,
+        DateTime Inicio,
+        DateTime Fin,
+        string? SedeId = null,
+        string? NombreSede = null);
 
     private sealed record TurnoVigenteRespuestaSmoke(
         string Id,
@@ -100,49 +114,15 @@ public class ListarTurnosVigentesSmokeTests(ApiFixture api, ServiceBusFixture se
         return $"/api/control-horas/turnos-vigentes?{query}";
     }
 
-    private async Task PublicarTurnoAsync(
-        Guid solicitudId, string empleadoId, DateOnly fecha, string nombreTurno)
-    {
-        var evento = new
-        {
-            SolicitudId = solicitudId,
-            Empleado = new
-            {
-                EmpleadoId = empleadoId,
-                TipoIdentificacion = "CC",
-                NumeroIdentificacion = "444555666",
-                Nombres = "[TEST] Smoke Listar",
-                Apellidos = "[TEST] TurnosVigentes"
-            },
-            Fecha = fecha.ToString("yyyy-MM-dd"),
-            DetalleTurno = new
-            {
-                Nombre = nombreTurno,
-                FranjasOrdinarias = new[]
-                {
-                    new
-                    {
-                        HoraInicio = "08:00:00",
-                        HoraFin = "16:00:00",
-                        DiaOffsetFin = 0,
-                        Descansos = Array.Empty<object>(),
-                        Extras = Array.Empty<object>(),
-                        Descripcion = (string?)null
-                    }
-                },
-                Descripcion = "[TEST] Turno Vigente Listar 08:00-16:00"
-            }
-        };
-
-        await serviceBus.PublishAsync(TopicEntrada, evento, solicitudId.ToString());
-    }
-
-    // Issue #337: variante de PublicarTurnoAsync con UNA franja que SI trae sede -- la clave "Sede"
-    // va dentro de la franja (DetalleFranjaOrdinaria.Sede, issue #341), nunca a nivel del evento
-    // completo. Usada por el escenario de combinacion sedeId + empleadoId (CA-3).
-    private async Task PublicarTurnoConSedeAsync(
+    // Envelope UNICO de ProgramacionTurnoDiarioSolicitada para toda la suite: entre escenarios solo
+    // cambian las franjas y la descripcion del turno, nunca el empleado ni la forma del evento
+    // (antes del issue #337 esta misma forma vivia triplicada -- MEF-ADR-0018, Rule of Three).
+    // FranjasOrdinarias viaja como object[] porque las franjas con y sin la clave "Sede" son tipos
+    // anonimos distintos; STJ serializa cada elemento por su tipo en tiempo de ejecucion, asi que
+    // ninguna pierde campos al convivir en el mismo arreglo.
+    private async Task PublicarProgramacionAsync(
         Guid solicitudId, string empleadoId, DateOnly fecha, string nombreTurno,
-        string sedeId, string nombreSede)
+        string descripcionTurno, params object[] franjasOrdinarias)
     {
         var evento = new
         {
@@ -159,79 +139,70 @@ public class ListarTurnosVigentesSmokeTests(ApiFixture api, ServiceBusFixture se
             DetalleTurno = new
             {
                 Nombre = nombreTurno,
-                FranjasOrdinarias = new[]
-                {
-                    new
-                    {
-                        HoraInicio = "08:00:00",
-                        HoraFin = "16:00:00",
-                        DiaOffsetFin = 0,
-                        Descansos = Array.Empty<object>(),
-                        Extras = Array.Empty<object>(),
-                        Descripcion = (string?)null,
-                        Sede = new { Id = sedeId, Nombre = nombreSede }
-                    }
-                },
-                Descripcion = $"[TEST] {nombreTurno}"
+                FranjasOrdinarias = franjasOrdinarias,
+                Descripcion = descripcionTurno
             }
         };
 
         await serviceBus.PublishAsync(TopicEntrada, evento, solicitudId.ToString());
     }
+
+    // Franja ordinaria SIN la clave "Sede" -- forma exacta que ya publicaba #329: sus bloques quedan
+    // con SedeId/NombreSede null, el equivalente comportamental de un documento proyectado antes de
+    // #336/#337 (CA-4/CA-5).
+    private static object FranjaOrdinaria(string horaInicio, string horaFin) =>
+        new
+        {
+            HoraInicio = horaInicio,
+            HoraFin = horaFin,
+            DiaOffsetFin = 0,
+            Descansos = Array.Empty<object>(),
+            Extras = Array.Empty<object>(),
+            Descripcion = (string?)null
+        };
+
+    // Issue #337/#341: la clave "Sede" va DENTRO de la franja (DetalleFranjaOrdinaria.Sede), nunca a
+    // nivel del evento completo -- la sede rige por bloque, nunca por dia (issue #337, "Contexto").
+    private static object FranjaOrdinaria(
+        string horaInicio, string horaFin, string sedeId, string nombreSede) =>
+        new
+        {
+            HoraInicio = horaInicio,
+            HoraFin = horaFin,
+            DiaOffsetFin = 0,
+            Descansos = Array.Empty<object>(),
+            Extras = Array.Empty<object>(),
+            Descripcion = (string?)null,
+            Sede = new { Id = sedeId, Nombre = nombreSede }
+        };
+
+    private Task PublicarTurnoAsync(
+        Guid solicitudId, string empleadoId, DateOnly fecha, string nombreTurno) =>
+        PublicarProgramacionAsync(
+            solicitudId, empleadoId, fecha, nombreTurno, DescripcionTurnoSinSede,
+            FranjaOrdinaria("08:00:00", "16:00:00"));
+
+    // Issue #337: una sola franja que SI trae sede -- escenario de combinacion sedeId + empleadoId
+    // (CA-3).
+    private Task PublicarTurnoConSedeAsync(
+        Guid solicitudId, string empleadoId, DateOnly fecha, string nombreTurno,
+        string sedeId, string nombreSede) =>
+        PublicarProgramacionAsync(
+            solicitudId, empleadoId, fecha, nombreTurno, $"[TEST] {nombreTurno}",
+            FranjaOrdinaria("08:00:00", "16:00:00", sedeId, nombreSede));
 
     // Issue #337: turno partido en DOS franjas, cada una en su propia sede -- el escenario del
     // "Contexto" del issue (Carlos manana-Suba/tarde-Chapinero). Ambas franjas producen un bloque
     // Ordinaria cada una (sin cruce de horario, sin solape) para que la vista materialice un dia
     // multi-sede real.
-    private async Task PublicarTurnoMultiSedeAsync(
+    private Task PublicarTurnoMultiSedeAsync(
         Guid solicitudId, string empleadoId, DateOnly fecha, string nombreTurno,
         string sedeIdManana, string nombreSedeManana,
-        string sedeIdTarde, string nombreSedeTarde)
-    {
-        var evento = new
-        {
-            SolicitudId = solicitudId,
-            Empleado = new
-            {
-                EmpleadoId = empleadoId,
-                TipoIdentificacion = "CC",
-                NumeroIdentificacion = "444555666",
-                Nombres = "[TEST] Smoke Listar",
-                Apellidos = "[TEST] TurnosVigentes"
-            },
-            Fecha = fecha.ToString("yyyy-MM-dd"),
-            DetalleTurno = new
-            {
-                Nombre = nombreTurno,
-                FranjasOrdinarias = new[]
-                {
-                    new
-                    {
-                        HoraInicio = "08:00:00",
-                        HoraFin = "12:00:00",
-                        DiaOffsetFin = 0,
-                        Descansos = Array.Empty<object>(),
-                        Extras = Array.Empty<object>(),
-                        Descripcion = (string?)null,
-                        Sede = new { Id = sedeIdManana, Nombre = nombreSedeManana }
-                    },
-                    new
-                    {
-                        HoraInicio = "14:00:00",
-                        HoraFin = "18:00:00",
-                        DiaOffsetFin = 0,
-                        Descansos = Array.Empty<object>(),
-                        Extras = Array.Empty<object>(),
-                        Descripcion = (string?)null,
-                        Sede = new { Id = sedeIdTarde, Nombre = nombreSedeTarde }
-                    }
-                },
-                Descripcion = $"[TEST] {nombreTurno}"
-            }
-        };
-
-        await serviceBus.PublishAsync(TopicEntrada, evento, solicitudId.ToString());
-    }
+        string sedeIdTarde, string nombreSedeTarde) =>
+        PublicarProgramacionAsync(
+            solicitudId, empleadoId, fecha, nombreTurno, $"[TEST] {nombreTurno}",
+            FranjaOrdinaria("08:00:00", "12:00:00", sedeIdManana, nombreSedeManana),
+            FranjaOrdinaria("14:00:00", "18:00:00", sedeIdTarde, nombreSedeTarde));
 
     // Sensa la materializacion asincrona consultando ESTE mismo endpoint sobre un rango de un solo
     // dia (desde == hasta) filtrado por empleadoId, que nunca activa el recorte -- no via
@@ -384,8 +355,10 @@ public class ListarTurnosVigentesSmokeTests(ApiFixture api, ServiceBusFixture se
         turno.NombreCompleto.Should().Be("[TEST] Smoke Listar [TEST] TurnosVigentes");
         turno.Fecha.Should().Be(fechaTurno);
         turno.NombreTurno.Should().Be("[TEST] Turno Vigente Trabajador");
-        turno.HorarioResumido.Should().Be("[TEST] Turno Vigente Listar 08:00-16:00");
+        turno.HorarioResumido.Should().Be(DescripcionTurnoSinSede);
 
+        // Issue #337: el turno sembrado no trae sede, asi que el bloque llega con SedeId/NombreSede
+        // null (valores por defecto de BloqueSmoke) -- regresion de #329 intacta.
         var bloqueEsperado = new BloqueSmoke(
             TipoBloqueSmoke.Ordinaria,
             fechaTurno.ToDateTime(new TimeOnly(8, 0)),
@@ -517,10 +490,12 @@ public class ListarTurnosVigentesSmokeTests(ApiFixture api, ServiceBusFixture se
         var sedeIdManana = Guid.CreateVersion7().ToString();
         var sedeIdTarde = Guid.CreateVersion7().ToString();
         var sedeIdSinTurnosDeEsteEmpleado = Guid.CreateVersion7().ToString();
+        const string nombreSedeManana = "[TEST] Sede Suba";
+        const string nombreSedeTarde = "[TEST] Sede Chapinero";
 
         await PublicarTurnoMultiSedeAsync(
             solicitudId, empleadoId, fecha, "[TEST] Turno Multi Sede",
-            sedeIdManana, "[TEST] Sede Suba", sedeIdTarde, "[TEST] Sede Chapinero");
+            sedeIdManana, nombreSedeManana, sedeIdTarde, nombreSedeTarde);
 
         var materializado = await EsperarTurnoEnLaListaAsync(empleadoId, fecha, ct);
         materializado.Should().BeTrue(
@@ -532,6 +507,25 @@ public class ListarTurnosVigentesSmokeTests(ApiFixture api, ServiceBusFixture se
         var respuestaManana = await responseManana.Content.ReadFromJsonAsync<ListaTurnosVigentesSmoke>(
             JsonOptions, cancellationToken: ct);
         respuestaManana!.Turnos.Should().Contain(t => t.EmpleadoId == empleadoId && t.Fecha == fecha);
+
+        // Assert (CA-1 de punta a punta): la sede no solo filtra, tambien VIAJA al cliente en cada
+        // bloque -- cada uno con la sede de SU PROPIA franja, no la del dia. Filtrar por la sede de
+        // la manana devuelve el dia COMPLETO (incluido el bloque de la tarde en otra sede): es la
+        // evidencia de que el predicado es "al menos un bloque rige en esa sede", no un recorte de
+        // los bloques devueltos.
+        var turnoMultiSede = respuestaManana.Turnos.Single(
+            t => t.EmpleadoId == empleadoId && t.Fecha == fecha);
+        turnoMultiSede.Bloques.Should().BeEquivalentTo(new[]
+        {
+            new BloqueSmoke(
+                TipoBloqueSmoke.Ordinaria,
+                fecha.ToDateTime(new TimeOnly(8, 0)), fecha.ToDateTime(new TimeOnly(12, 0)),
+                sedeIdManana, nombreSedeManana),
+            new BloqueSmoke(
+                TipoBloqueSmoke.Ordinaria,
+                fecha.ToDateTime(new TimeOnly(14, 0)), fecha.ToDateTime(new TimeOnly(18, 0)),
+                sedeIdTarde, nombreSedeTarde)
+        });
 
         // ...y TAMBIEN filtrando por la sede de la franja de la tarde -- mismo dia, dos sedes.
         var responseTarde = await _client.GetAsync(Ruta(fecha, fecha, empleadoId, sedeIdTarde), ct);
@@ -588,6 +582,12 @@ public class ListarTurnosVigentesSmokeTests(ApiFixture api, ServiceBusFixture se
         var respuestaSinFiltro = await responseSinFiltro.Content.ReadFromJsonAsync<ListaTurnosVigentesSmoke>(
             JsonOptions, cancellationToken: ct);
         respuestaSinFiltro!.Turnos.Should().Contain(t => t.EmpleadoId == empleadoId && t.Fecha == fecha);
+
+        // Assert (CA-5): el dia se consulta SIN ERROR y sus bloques llegan con ambos campos de sede
+        // en null -- el mismo contrato que devuelve un documento proyectado antes de #336/#337.
+        var turnoSinSede = respuestaSinFiltro.Turnos.Single(
+            t => t.EmpleadoId == empleadoId && t.Fecha == fecha);
+        turnoSinSede.Bloques.Should().OnlyContain(b => b.SedeId == null && b.NombreSede == null);
     }
 
     [Fact]

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ListarTurnosVigentes/FunctionEndpointTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ListarTurnosVigentes/FunctionEndpointTests.cs
@@ -93,4 +93,18 @@ public class FunctionEndpointTests
 
         resultado.Value.Should().BeOfType<string>().Which.Should().Contain("anterior");
     }
+
+    [Fact]
+    public async Task ListarTurnosVigentes_Retorna400_CuandoSedeIdEsValidoPeroElRangoNoLoEs()
+    {
+        // Issue #337 CA-3: el tercer filtro opcional (sedeId, combinable con empleadoId) tampoco
+        // relaja la validacion del rango -- la consulta del jefe de sede pasa por el mismo borde.
+        // Es la unica rama del filtro por sede ejercitable sin Postgres: el predicado
+        // Bloques.Any(...) lo resuelve Marten contra la base real y queda cubierto por el smoke test
+        // contra dev (MEF-ADR-0013), no por este archivo -- que corre con store nulo a proposito.
+        var resultado = await EjecutarEsperandoBadRequest(
+            "?desde=2026-05-10&hasta=2026-05-05&empleadoId=EMP-001&sedeId=SD-SUBA");
+
+        resultado.Value.Should().BeOfType<string>().Which.Should().Contain("anterior");
+    }
 }

--- a/tests/Bitakora.ControlAsistencia.Projections.Tests/ControlHoras/TurnoVigenteProjectionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Projections.Tests/ControlHoras/TurnoVigenteProjectionTests.cs
@@ -16,6 +16,12 @@
 // vista) comparten nombre a proposito, mismo criterio de "tres islas" que ya aplican Empleado/
 // TurnoDiario/FranjaProgramada entre los ensamblados de eventos. Con ambos "using" activos el
 // simbolo corto "TipoBloque" queda ambiguo (CS0104); el alias resuelve solo el lado ReadModels.
+//
+// Issue #337 (fase roja): extension de este archivo -- CA-1, mapeo de SedeId/NombreSede en cada
+// Bloque desde la SedeProgramada que #336 ya estampa en cada BloqueTurno. MapearBloque (produccion
+// actual) ignora bloque.Sede por completo, asi que estos tests quedan en rojo hasta que
+// projection-implementer lo propague; ninguno reusa el algoritmo de Segmentar como oraculo, se
+// arma a mano igual que los tests de arriba (MEF-ADR-0002).
 
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
@@ -159,5 +165,170 @@ public class TurnoVigenteProjectionTests
         vista.Id.Should().Be(streamKey);
         vista.EmpleadoId.Should().Be("EMP-001");
         vista.Fecha.Should().Be(fecha);
+    }
+
+    // --- Issue #337: mapeo de sede por bloque (CA-1) ---
+
+    // CA-1: una franja sin descansos ni extras con Sede asignada produce un unico Bloque Ordinaria
+    // con SedeId/NombreSede tomados de esa SedeProgramada. Hoy MapearBloque ignora bloque.Sede por
+    // completo (produccion actual: "new(MapearTipo(bloque.Tipo), bloque.Inicio, bloque.Fin)"), asi
+    // que este test queda en rojo hasta que projection-implementer propague el dato.
+    [Fact]
+    public void Create_MapeaSedeIdYNombreSede_DesdeLaSedeDeLaFranja()
+    {
+        var empleado = EmpleadoDePrueba();
+        var fecha = new DateOnly(2026, 8, 3);
+        var streamKey = "EMP-001:2026-08-03";
+        var sede = new SedeProgramada("SD-SUBA", "Suba");
+
+        var franja = new FranjaProgramada(
+            new TimeOnly(6, 0), new TimeOnly(14, 0), DiaOffsetFin: 0,
+            Descansos: [], Extras: [], Descripcion: "(06:00-14:00)", Sede: sede);
+        var turnoDiario = new TurnoDiario("Turno Manana", [franja], "Turno Manana: (06:00-14:00)");
+        var evento = new TurnoDiarioAsignado(streamKey, empleado, fecha, turnoDiario, Guid.NewGuid());
+
+        var vista = TurnoVigenteProjection.Create(evento);
+
+        var medianoche = fecha.ToDateTime(TimeOnly.MinValue);
+        vista.Bloques.Should().Equal(
+            new Bloque(
+                TipoBloqueVigente.Ordinaria, medianoche.AddHours(6), medianoche.AddHours(14),
+                SedeId: "SD-SUBA", NombreSede: "Suba"));
+    }
+
+    // CA-1 (issue #336, "Los bloques de descanso y extra heredan la sede de la franja madre que
+    // los contiene"): los CUATRO bloques que produce Segmentar sobre una franja con descanso y
+    // extra (mismo turno del test CA-1 de #328, arriba) heredan la MISMA sede de la franja madre --
+    // ninguno tiene sede propia.
+    [Fact]
+    public void Create_HeredaLaSedeDeLaFranjaEnBloquesDeDescansoYExtra()
+    {
+        var empleado = EmpleadoDePrueba();
+        var fecha = new DateOnly(2026, 8, 3);
+        var streamKey = "EMP-001:2026-08-03";
+        var sede = new SedeProgramada("SD-SUBA", "Suba");
+
+        var franja = new FranjaProgramada(
+            new TimeOnly(6, 0),
+            new TimeOnly(14, 0),
+            DiaOffsetFin: 0,
+            Descansos: [new SubFranjaProgramada(new TimeOnly(10, 0), new TimeOnly(10, 15), 0, 0, "(10:00-10:15)")],
+            Extras: [new SubFranjaProgramada(new TimeOnly(5, 0), new TimeOnly(6, 0), 0, 0, "(05:00-06:00)")],
+            Descripcion: "(06:00-14:00)[Descansos:(10:00-10:15)][Extras:(05:00-06:00)]",
+            Sede: sede);
+        var turnoDiario = new TurnoDiario(
+            "Turno Manana",
+            [franja],
+            "Turno Manana: (06:00-14:00)[Descansos:(10:00-10:15)][Extras:(05:00-06:00)]");
+        var evento = new TurnoDiarioAsignado(streamKey, empleado, fecha, turnoDiario, Guid.NewGuid());
+
+        var vista = TurnoVigenteProjection.Create(evento);
+
+        var medianoche = fecha.ToDateTime(TimeOnly.MinValue);
+        var bloquesEsperados = new[]
+        {
+            new Bloque(TipoBloqueVigente.Extra, medianoche.AddHours(5), medianoche.AddHours(6), "SD-SUBA", "Suba"),
+            new Bloque(TipoBloqueVigente.Ordinaria, medianoche.AddHours(6), medianoche.AddHours(10), "SD-SUBA", "Suba"),
+            new Bloque(TipoBloqueVigente.Descanso, medianoche.AddHours(10), medianoche.AddHours(10).AddMinutes(15), "SD-SUBA", "Suba"),
+            new Bloque(TipoBloqueVigente.Ordinaria, medianoche.AddHours(10).AddMinutes(15), medianoche.AddHours(14), "SD-SUBA", "Suba"),
+        };
+        vista.Bloques.Should().Equal(bloquesEsperados);
+    }
+
+    // CA-1, segunda mitad: "los bloques de franjas sin sede quedan con ambos campos null" -- una
+    // franja sin Sede (default, turno prearmado multi-sede sin resolver o evento anterior a #336)
+    // no inventa sede en ninguno de sus bloques. Oraculo explicito para que una implementacion
+    // futura no pueda "adivinar" un valor no-null y seguir pasando por casualidad.
+    [Fact]
+    public void Create_DejaSedeIdYNombreSedeNulos_CuandoLaFranjaNoTraeSede()
+    {
+        var empleado = EmpleadoDePrueba();
+        var fecha = new DateOnly(2026, 8, 3);
+        var streamKey = "EMP-001:2026-08-03";
+
+        var franja = new FranjaProgramada(
+            new TimeOnly(6, 0), new TimeOnly(14, 0), DiaOffsetFin: 0,
+            Descansos: [], Extras: [], Descripcion: "(06:00-14:00)");
+        var turnoDiario = new TurnoDiario("Turno Manana", [franja], "Turno Manana: (06:00-14:00)");
+        var evento = new TurnoDiarioAsignado(streamKey, empleado, fecha, turnoDiario, Guid.NewGuid());
+
+        var vista = TurnoVigenteProjection.Create(evento);
+
+        var medianoche = fecha.ToDateTime(TimeOnly.MinValue);
+        vista.Bloques.Should().Equal(
+            new Bloque(TipoBloqueVigente.Ordinaria, medianoche.AddHours(6), medianoche.AddHours(14)));
+    }
+
+    // CA-2 (semantica del filtro fijada por el escenario de la conversacion del issue): un turno
+    // partido con dos franjas contiguas en sedes DISTINTAS (Suba en la manana, Chapinero en la
+    // tarde) produce bloques con la sede de SU PROPIA franja, no la del turno completo -- la razon
+    // de ser de "sede por bloque, nunca por dia" (issue #337, "Contexto").
+    [Fact]
+    public void Create_MapeaSedesDistintasPorBloque_CuandoElTurnoTieneFranjasEnSedesDistintas()
+    {
+        var empleado = EmpleadoDePrueba();
+        var fecha = new DateOnly(2026, 8, 3);
+        var streamKey = "EMP-001:2026-08-03";
+        var suba = new SedeProgramada("SD-SUBA", "Suba");
+        var chapinero = new SedeProgramada("SD-CHAPINERO", "Chapinero");
+
+        var franjaManana = new FranjaProgramada(
+            new TimeOnly(6, 0), new TimeOnly(14, 0), DiaOffsetFin: 0,
+            Descansos: [], Extras: [], Descripcion: "(06:00-14:00)", Sede: suba);
+        var franjaTarde = new FranjaProgramada(
+            new TimeOnly(14, 0), new TimeOnly(22, 0), DiaOffsetFin: 0,
+            Descansos: [], Extras: [], Descripcion: "(14:00-22:00)", Sede: chapinero);
+        var turnoDiario = new TurnoDiario(
+            "Turno Partido", [franjaManana, franjaTarde], "Turno Partido: (06:00-14:00)/(14:00-22:00)");
+        var evento = new TurnoDiarioAsignado(streamKey, empleado, fecha, turnoDiario, Guid.NewGuid());
+
+        var vista = TurnoVigenteProjection.Create(evento);
+
+        var medianoche = fecha.ToDateTime(TimeOnly.MinValue);
+        var bloquesEsperados = new[]
+        {
+            new Bloque(TipoBloqueVigente.Ordinaria, medianoche.AddHours(6), medianoche.AddHours(14), "SD-SUBA", "Suba"),
+            new Bloque(TipoBloqueVigente.Ordinaria, medianoche.AddHours(14), medianoche.AddHours(22), "SD-CHAPINERO", "Chapinero"),
+        };
+        vista.Bloques.Should().Equal(bloquesEsperados);
+    }
+
+    // CA-2/CA-1: "el ultimo gana" (semantica ya fijada por #328) aplica igual a la sede -- una
+    // reasignacion que cambia de sede no deja bloques con la sede VIEJA mezclada con datos nuevos.
+    // vistaPrevia simula un documento materializado antes de esta reasignacion, ya con sede (no el
+    // caso null de CA-5 -- ese es un dato persistido sin este issue desplegado, no ejercitable
+    // desde Apply).
+    [Fact]
+    public void Apply_SobrescribeLaSedeDeLosBloques_CuandoLaReasignacionCambiaDeSede()
+    {
+        var fecha = new DateOnly(2026, 8, 3);
+        var streamKey = "EMP-001:2026-08-03";
+        var medianoche = fecha.ToDateTime(TimeOnly.MinValue);
+
+        var vistaPrevia = new TurnoVigente(
+            streamKey,
+            "EMP-001",
+            "Ana Ramirez",
+            fecha,
+            "Turno Manana",
+            "Turno Manana: (06:00-14:00)",
+            [new Bloque(
+                TipoBloqueVigente.Ordinaria, medianoche.AddHours(6), medianoche.AddHours(14),
+                "SD-SUBA", "Suba")]);
+
+        var chapinero = new SedeProgramada("SD-CHAPINERO", "Chapinero");
+        var franjaTarde = new FranjaProgramada(
+            new TimeOnly(14, 0), new TimeOnly(22, 0), DiaOffsetFin: 0,
+            Descansos: [], Extras: [], Descripcion: "(14:00-22:00)", Sede: chapinero);
+        var turnoTarde = new TurnoDiario("Turno Tarde", [franjaTarde], "Turno Tarde: (14:00-22:00)");
+        var segundoEvento = new TurnoDiarioAsignado(
+            streamKey, EmpleadoDePrueba(), fecha, turnoTarde, Guid.NewGuid());
+
+        var vista = TurnoVigenteProjection.Apply(segundoEvento, vistaPrevia);
+
+        vista.Bloques.Should().Equal(
+            new Bloque(
+                TipoBloqueVigente.Ordinaria, medianoche.AddHours(14), medianoche.AddHours(22),
+                "SD-CHAPINERO", "Chapinero"));
     }
 }


### PR DESCRIPTION
## Resumen

Pipeline TDD completado:
- Fase roja: tests escritos con stubs
- Fase verde: implementación completa
- Smoke tests: escritos para endpoints detectados
- Fase refactor: revisión de calidad

## Decisiones del pipeline

<details>
<summary>Projection Test Writer (fase roja) — 8m 43s</summary>

# projection-test-writer -- issue #337 (fase roja read-side)

## Tests creados

`tests/Bitakora.ControlAsistencia.Projections.Tests/ControlHoras/TurnoVigenteProjectionTests.cs`
(extension del archivo existente de #328, invocacion directa de `TurnoVigenteProjection.Create`/
`Apply` -- N1, sin DSL Given/When/Then). Seccion nueva "Issue #337: mapeo de sede por bloque
(CA-1)", cinco tests:

- `Create_MapeaSedeIdYNombreSede_DesdeLaSedeDeLaFranja` -- una franja simple con
  `Sede: new SedeProgramada("SD-SUBA", "Suba")` debe producir un `Bloque` con `SedeId`/
  `NombreSede` poblados. **Rojo hoy**: `TurnoVigenteProjection.MapearBloque` ignora
  `bloque.Sede` por completo (`new(MapearTipo(bloque.Tipo), bloque.Inicio, bloque.Fin)`).
- `Create_HeredaLaSedeDeLaFranjaEnBloquesDeDescansoYExtra` -- mismo turno del test CA-1 original
  de #328 (franja con descanso+extra, tres `TipoBloque` representados), ahora con `Sede` en la
  franja: los CUATRO bloques resultantes deben heredar la MISMA sede (issue #336, "los bloques de
  descanso y extra heredan la sede de la franja madre"). **Rojo hoy**, mismo motivo.
- `Create_DejaSedeIdYNombreSedeNulos_CuandoLaFranjaNoTraeSede` -- franja sin `Sede` (default):
  oraculo explicito de que ambos campos quedan null. Pasa hoy en verde (default ya es null) --
  se deja como guarda de regresion explicita, no como el disparador del rojo de este archivo.
- `Create_MapeaSedesDistintasPorBloque_CuandoElTurnoTieneFranjasEnSedesDistintas` -- turno partido
  con dos franjas contiguas en sedes distintas (Suba/Chapinero, el escenario de la conversacion
  del issue): cada bloque debe llevar la sede de SU PROPIA franja. **Rojo hoy**.
- `Apply_SobrescribeLaSedeDeLosBloques_CuandoLaReasignacionCambiaDeSede` -- "el ultimo gana"
  (semantica ya fijada por #328) aplicado a la sede: una reasignacion a otra sede no debe dejar
  bloques mezclando la sede vieja. **Rojo hoy**.

Cada oraculo se arma a mano (MEF-ADR-0002): ninguno reusa `TurnoDiario.Segmentar` ni
`MapearBloque` para calcular el valor esperado.

## Stub de compilacion creado

`src/Bitakora.ControlAsistencia.ReadModels/ControlHoras/Bloque.cs`: se agregan `SedeId`/
`NombreSede` (`string?`, default `null`) como parametros posicionales adicionales del record --
puramente forma de datos (sin logica, sin `partial`), necesaria para que los tests nuevos
compilen. Las tres llamadas existentes con 3 argumentos posicionales (`Create_Proyecta...` y
`Apply_...` de #328) siguen compilando igual, sin tocarlas. No se modifico
`TurnoVigenteProjection.cs` (`MapearBloque`): esa propagacion es responsabilidad de
projection-implementer.

## Cobertura de "Capas de test esperadas" del issue

- **Unit tests de la proyeccion**: hecho (arriba), CA-1 completo.
- **Config-test del worker**: sin cambios -- confirmado leyendo
  `ConfiguracionMartenProjectionsControlHoras.cs` (no registra proyeccion nueva, el seam no
  cambia) y `ConfiguracionMartenProjectionsTests.cs` (no referencia `Bloque`). Tal como el issue
  lo declara, no aplica.
- **Test de composicion de la Function GET**: **no se agrego ningun test nuevo** -- ver
  "Desviaciones del plan del planner" abajo.
- **Smoke test**: fuera de mi alcance (agente `smoke-test-writer`).

## Desviaciones del plan del planner

El issue lista en "Capas de test esperadas": *"Test de composicion de la Function GET: filtro
sedeId en ListarTurnosVigentes (extension del de #329)"*. Decidi NO agregar ningun test nuevo en
`ComposicionServiciosTests.cs` (ControlHoras.Tests), por lo siguiente:

- Mi mandato (agents/projection-test-writer.md) acota el "test de composicion" estrictamente a
  verificar que el `FunctionEndpoint` resuelve `IDocumentStore`/`ITenantResolver` desde el
  contenedor DI, sin excepcion -- nunca el comportamiento de un `Where` LINQ.
- `ListarTurnosVigentes.FunctionEndpoint` **no cambia su constructor** con este issue (sigue
  siendo `(IDocumentStore store, ITenantResolver tenantResolver)`): el test de composicion que
  #329 ya dejo
  (`AgregarServiciosControlHoras_ResuelveElEndpointDeListarTurnosVigentes_CuandoElContenedorEstaCompuesto`)
  sigue cubriendo exactamente el mismo grafo de DI sin ningun cambio. Agregar una copia idéntica
  no produciria ningun rojo nuevo -- violaria la regla 1 ("los tests que escribas DEBEN fallar").
- El comportamiento real del filtro `Bloques.Any(b => b.SedeId == sedeId)` es una consulta LINQ de
  Marten contra Postgres (`session.Query<TurnoVigente>().Where(...).ToListAsync()`): no hay forma
  de ejercitarlo sin una base real. El proyecto no usa Testcontainers (MEF-ADR-0013 fija smoke
  tests contra dev como la via para este tipo de comportamiento, precedente ya visible en
  `FunctionEndpointTests.cs` de #329, que solo prueba el borde HTTP -- fechas invalidas -- con
  `store: null!`, nunca el filtrado real). Escribir un test de borde HTTP que solo agregue
  `&sedeId=...` a la query string, sin tocar la validacion existente, pasaria en verde hoy sin
  necesitar ningun cambio de produccion -- de nuevo, no es un test valido bajo la regla 1.
- Conclusion: esa casilla del issue queda satisfecha por el test heredado de #329 (sin cambios
  necesarios) y por el smoke test que corresponde a otro agente. Documento esta decision para que
  el reviewer no espere un archivo nuevo en `ComposicionServiciosTests.cs` de mi parte.

## Verificacion

`dotnet build ControlAsistencias.slnx` -- compilacion correcta, 0 errores (5 warnings
preexistentes, ninguno de mis archivos). No se corrio `dotnet test` (ya se sabe que los 4 tests
marcados "Rojo hoy" van a fallar).

## Commit

`b8050bf` -- `test(issue-337): tests de proyeccion para sede por bloque en TurnoVigente (fase roja)`

</details>

<details>
<summary>Projection Implementer (fase verde) — 4m 34s</summary>

# Resumen -- projection-implementer (issue #337)

## Enfoque

`projection-test-writer` dejo dos archivos: el read model `Bloque` ya con
`SedeId`/`NombreSede` (forma de datos, sin logica) y la extension de
`TurnoVigenteProjectionTests` con seis casos rojos sobre el mapeo de sede.
Mi trabajo se limito a:

1. **Proyeccion (N1, companion en el worker)**: `TurnoVigenteProjection.MapearBloque`
   ahora propaga `bloque.Sede?.Id` / `bloque.Sede?.Nombre` desde el `BloqueTurno`
   que produce `TurnoDiario.Segmentar` (issue #336) al record `Bloque` de
   ReadModels. Cambio de una linea; sin logica condicional -- el operador `?.`
   ya resuelve el caso "franja sin sede -> ambos campos null" (CA-1 segunda
   mitad) sin rama explicita.
2. **Registro en el named store**: sin cambios. `ConfigurarControlHoras` ya
   registraba `TurnoVigenteProjection` con `ProjectionLifecycle.Async` desde
   el issue #328; el issue #337 lo declara explicitamente como "sin cambios
   de registro" y lo verifique en
   `ConfiguracionMartenProjectionsControlHoras.cs:111`.
3. **Function GET**: `ListarTurnosVigentes/FunctionEndpoint.cs` gana el filtro
   opcional `sedeId`, leido del query string igual que `empleadoId` y aplicado
   como `query.Where(v => v.Bloques.Any(b => b.SedeId == sedeId))` -- la
   semantica "dias donde AL MENOS un bloque rige en esa sede" (CA-2) que el
   issue fija con el escenario del turno partido Suba/Chapinero. `sedeId`
   ausente deja el comportamiento de #329 intacto (CA-3); los bloques con
   `SedeId` null (franjas sin sede o documentos pre-#336/#337, CA-4/CA-5)
   nunca igualan un `sedeId` no nulo, asi que quedan fuera de cualquier
   filtro por sede sin codigo adicional. `ObtenerTurnoVigente` no se toco:
   su respuesta gana los campos de sede automaticamente porque reusa la
   misma vista `TurnoVigente`.

## Decisiones de diseno

- No cree ningun tipo `Sede` anidado en ReadModels ni en el DTO de respuesta:
  el issue es explicito en que la sede va por bloque, plana, sin recorte de
  presentacion a nivel de dia (Rule of Three, MEF-ADR-0018) -- coherente con
  lo que ya dejo `Bloque.cs`.
- El filtro `sedeId` se compone igual que `empleadoId` (un `if` que agrega un
  `.Where` extra sobre el mismo `IQueryable<TurnoVigente>`), no un unico
  `Where` con ternarios anidados -- mismo estilo que ya establecio #329 para
  mantener la Function legible.

## ADRs / recursos consultados

- MEF-ADR-0035 (via el Skill `projections`, `read-apis.md`): consulta LINQ
  `Any()` sobre coleccion anidada es la via de consulta correcta para un
  filtro "al menos un elemento cumple" sobre un documento materializado (via
  (a), sin proyeccion nueva).
- MEF-ADR-0034: lifecycle `Async`, sin cambios de registro -- verificado, no
  solo asumido, leyendo `ConfiguracionMartenProjectionsControlHoras.cs`.
- MEF-ADR-0028: la `QuerySession` sigue abierta solo con `tenantResolver.TenantId`;
  `sedeId` es filtro de recurso, nunca tenant -- sin cambios respecto a #329.
- MEF-ADR-0012 (Tell-don't-Ask): el mapeo de sede no reimplementa nada de
  `TurnoDiario.Segmentar`, solo propaga el campo que #336 ya estampa en
  `BloqueTurno`.

## Desviaciones

- **Filtro `sedeId` en la Function sin test de composicion dedicado.** El
  issue lista en "Capas de test esperadas" un "Test de composicion de la
  Function GET: filtro sedeId ... (extension del de #329)", pero
  `projection-test-writer` solo entrego los dos archivos de proyeccion (ver
  tarea recibida) -- no toco `FunctionEndpointTests.cs`. Revise ese archivo:
  cubre unicamente las tres ramas de validacion HTTP que cortocircuitan
  ANTES de abrir la `QuerySession` (carve-out de coverage de Functions GET
  que solo delegan a `LoadAsync`/`Query`, MEF-ADR-0035 issue #371); el filtro
  `sedeId` cae del lado que Marten resuelve via LINQ sobre Postgres real, no
  ejercitable con ese doble nulo (`store: null!, tenantResolver: null!`).
  Implemente el filtro de todos modos porque el issue lo especifica de forma
  explicita en "Endpoints/rutas" y en los CA-2/CA-3/CA-4 -- mi rol tambien
  cubre "Functions HTTP GET" como parte de produccion, no solo lo que un test
  concreto exige. Consecuencia: la cobertura automatizada de esta rama queda
  en manos del smoke test que el issue prevé como "si el pipeline lo juzga
  viable contra dev" (etapa posterior del pipeline, fuera de mi alcance).
  No agregue ni modifique ningun test -- ninguna regla de "no tocar tests"
  se violo.

## Resultado

- `dotnet build`: compilacion correcta, sin errores.
- `dotnet test --project tests/Bitakora.ControlAsistencia.Projections.Tests/...`:
  59/59 en verde (incluye los 6 casos nuevos de sede por bloque).
- `dotnet test --project tests/Bitakora.ControlAsistencia.ControlHoras.Tests/...`:
  441/441 en verde (sin regresion en `FunctionEndpointTests`,
  `ComposicionServiciosTests` ni `RangoConsultaTests`).
- `dotnet test --solution ControlAsistencias.slnx`: 822 correctos, 0 errores,
  18 omitidos (smoke tests que requieren Postgres/ServiceBus reales, no
  disponibles en este entorno local) -- CA-6 cumplido.
- `dotnet format --include <archivos tocados>`: sin cambios adicionales de
  formato.

</details>
<details>
<summary>Smoke Test Writer — 6m 15s</summary>

_(El agente no generó resumen)_

</details>
<details>
<summary>Reviewer (fase refactor) — 11m 31s</summary>

# ES Reviewer - Revision (issue #337)

### Evaluacion general
- Calidad: **buena**
- Cambios realizados: **si** (commit `04eea8c`, solo tests + un comentario de produccion)
- Baseline al iniciar: verde (822 correctos / 0 errores / 21 omitidos). Sin `blockage-report.md`.
- Baseline al terminar: verde (**823 correctos / 0 errores / 21 omitidos**), `dotnet format
  --verify-no-changes` limpio sobre los archivos del diff.

### Cumplimiento de ADRs aplicables

| ADR | Cumplimiento | Observacion |
|---|---|---|
| MEF-ADR-0035: doctrina proyeccion / query read-side | ok | Read model `Bloque` sigue siendo `record` plano sin `partial`; el comportamiento vive en la companion `TurnoVigenteProjection` (`partial`, `Create`/`Apply` estaticos, `view with {}`). Consulta por via **(a')** `session.Query<TurnoVigente>()` con LINQ, sobre `QuerySession`. Sin `FetchLatest`, sin `IDocumentSession`, sin time-travel. |
| MEF-ADR-0034: worker de proyecciones | ok | Sin proyeccion nueva ni cambio de lifecycle: `TurnoVigenteProjection` ya estaba registrada `Async` en `ConfiguracionMartenProjectionsControlHoras` desde #328. Config-test sin cambios, tal como el issue lo declara. Verificado, no asumido. |
| MEF-ADR-0028: tenancy | ok | `store.QuerySession(tenantResolver.TenantId)` intacto. `sedeId` entra por query string como **filtro de recurso**, nunca como tenant -- sin superficie BOLA/IDOR nueva. |
| MEF-ADR-0006: naming de Functions | ok | Ninguna Function nueva; `ListarTurnosVigentes` conserva nombre y ruta. `ObtenerTurnoVigente` sin tocar. |
| MEF-ADR-0018: Rule of Three | ok (con correccion aplicada) | El codigo de produccion respeta la decision del issue: **sin** resumen de sedes a nivel de dia, sin record `Sede` anidado en ReadModels. En los smoke tests si habia una violacion (ver "Desviaciones detectadas por el reviewer"). |
| Issue #317 CA-2 / #328: sin sufijos arquitectonicos en el read-side | ok | `Bloque`/`TurnoVigente` sin sufijo `View`, coherente con la divergencia ya documentada. |
| MEF-ADR-0012 (transversal, checklist de antipatrones) | ok | Recorrido completo: (1) no hay propiedad publica nueva de VO consumida solo por un servicio externo -- `SedeId`/`NombreSede` son campos de un read model plano, que es su naturaleza; (2) no hay clase estatica operando sobre datos crudos de un VO -- la companion de proyeccion es la receta canonica de MEF-ADR-0035, no una salida facil; (3) ningun getter existe solo para tests; (4) sin `InternalsVisibleTo`; (5) sin `[JsonConstructor]`; (6) `record` con `IReadOnlyList<T>`: `TurnoVigente.Bloques` preexiste de #328 y es un documento Marten cuya igualdad estructural no se usa en produccion -- `Bloque` (el tipo que si se compara en tests) es un record de escalares, igualdad por valor correcta; (7) **no aplica**: el diff no introduce ni modifica ningun evento con marker de bus (`IPrivateEvent`/`IPublicEvent`) -- solo un read model y una vista. |
| MEF-ADR-0002 / MEF-ADR-0016 (testing y naming) | ok | Oraculos armados a mano, sin reusar `MapearBloque` ni `Segmentar` para calcular lo esperado. Nombres `Create_...`/`Apply_...` siguen el precedente ya mergeado de #328 para proyecciones N1. Solo `[Fact]`. |

### Desviaciones de ADRs

**Desviaciones declaradas por el implementer**:

#### Desviacion: plan del issue ("Capas de test esperadas") -- no un ADR
- **Regla**: el issue lista "Test de composicion de la Function GET: filtro `sedeId` en
  `ListarTurnosVigentes` (extension del de #329)".
- **Desviacion aplicada**: no se agrego ningun test nuevo de composicion; el implementer implemento
  el filtro sin cobertura automatizada propia.
- **Razon del implementer**: el filtro `Bloques.Any(...)` lo resuelve Marten contra Postgres; el
  test heredado de #329 (`...ResuelveElEndpointDeListarTurnosVigentes...`) ya cubre el mismo grafo
  de DI porque el constructor no cambio; el proyecto proscribe Testcontainers (MEF-ADR-0013).
- **Consecuencia conocida**: la cobertura real del filtro queda en el smoke test contra dev.
- **Evaluacion del reviewer**: **aceptable**, con matiz. La razon es tecnicamente correcta y
  verificada (`FunctionEndpointTests` corre con `store: null!` a proposito; el test de composicion
  de #329 no cambia porque el ctor no cambio). Pero la desviacion era **parcialmente evitable**: si
  existe una rama del nuevo parametro ejercitable sin Postgres -- que la presencia de `sedeId` no
  relaje la validacion del rango --, y el precedente de `empleadoId` (#329) ya la habia establecido.
  La agregue en esta fase (ver "Tests agregados"). El resto de la casilla queda legitimamente en el
  smoke test.
- **Status**: pendiente de evaluacion del usuario.

**Desviaciones detectadas por el reviewer (NO declaradas por el implementer/smoke-test-writer)**:

#### Desviacion: MEF-ADR-0018 (Rule of Three) en los smoke tests
- **Regla del ADR**: no duplicar sin necesidad; a la tercera repeticion, extraer.
- **Desviacion encontrada en el diff**: `ListarTurnosVigentesSmokeTests.cs` quedo con **tres**
  metodos casi identicos (`PublicarTurnoAsync`, `PublicarTurnoConSedeAsync`,
  `PublicarTurnoMultiSedeAsync`, ~32 lineas cada uno) que solo difieren en el arreglo de franjas y
  la descripcion del turno: el envelope completo del evento y el bloque `Empleado` estaban
  triplicados literalmente.
- **Accion tomada**: **corregida en refactor** -- un envelope unico (`PublicarProgramacionAsync`)
  mas dos factories `FranjaOrdinaria` (con y sin la clave `"Sede"`); los tres metodos publicos
  quedan como expresiones de una linea y ningun call site cambio.
- **Riesgo controlado**: el JSON publicado **no cambia**. `FranjasOrdinarias` pasa de `T[]` a
  `object[]`; verifique por ejecucion propia (.NET 10, `dotnet run` file-based) que STJ serializa
  cada elemento de un `object[]` por su tipo en tiempo de ejecucion, produciendo el mismo documento
  campo por campo -- incluida la ausencia total de la clave `"Sede"` en la franja sin sede (no un
  `"Sede": null`). Esto importaba porque estos tests estan `Skip` en local y no dan senal propia.
- **Status**: pendiente de evaluacion del usuario.

#### Desviacion: cobertura del contrato de respuesta (convencion de smoke tests del pipeline)
- **Regla**: los smoke tests deben cubrir **todos** los efectos observables del endpoint modificado,
  no solo el codigo de estado o un subconjunto del contrato.
- **Desviacion encontrada en el diff**: `BloqueSmoke` (forma local de la respuesta) **no** incluia
  `SedeId`/`NombreSede`, asi que ningun test -- de ninguna capa -- verificaba que los campos nuevos
  efectivamente llegaran al cliente. Los tres smoke tests nuevos afirmaban solo la **pertenencia**
  del dia a la lista filtrada. El unit test de la proyeccion cubre la funcion pura evento -> vista,
  pero no la cadena serializacion Marten -> documento -> respuesta HTTP, que es justo donde un
  campo aditivo nuevo puede perderse en silencio.
- **Accion tomada**: **corregida en refactor** -- `BloqueSmoke` gana ambos campos (opcionales) y se
  agregaron dos aserciones sobre respuestas que los tests ya obtenian: en el dia multi-sede, que
  cada bloque llega con la sede de **su propia** franja (y que filtrar por la sede de la manana
  devuelve el dia **completo**, incluido el bloque de la tarde -- evidencia de que el predicado es
  "al menos un bloque", no un recorte de bloques); en el dia sin sede, que ambos campos llegan
  nulos (CA-5).
- **Status**: pendiente de evaluacion del usuario.

#### Observacion menor: cita imprecisa en un comentario de produccion
- **Encontrado**: el comentario de cabecera de `FunctionEndpoint.cs` atribuia a MEF-ADR-0035 la
  afirmacion "Marten traduce `Any()` sobre la coleccion anidada a una consulta JSONB". Ese ADR fija
  la **via de consulta** (LINQ sobre `QuerySession`), no la estrategia de traduccion SQL.
- **Accion tomada**: corregido -- la traduccion se cita contra su fuente real, la documentacion de
  Marten ("Querying within Child Collections"), verificada en esta revision: una igualdad dentro de
  `Any()` produce containment JSONB (`data -> 'Bloques' @> '[{"SedeId": ...}]'`), la unica forma
  elegible para indice GIN. Confirma ademas que el patron elegido por el implementer es el
  **mas** index-friendly de la tabla de estrategias de Marten, y que la semantica de containment
  resuelve CA-4/CA-5 por construccion (un bloque sin la clave nunca contiene un `sedeId` no nulo).

### Precedentes consultados por el implementer

| Precedente | ADR aplicable | Veredicto |
|---|---|---|
| `ConfiguracionMartenProjectionsControlHoras.cs:111` (registro `Async` de #328) | MEF-ADR-0034 | alineado -- verificado en codigo, no asumido |
| Composicion del filtro `empleadoId` de #329 (`if` + `.Where` encadenado) | MEF-ADR-0035 | alineado -- el nuevo filtro replica exactamente esa forma |
| `TurnoDiario.Segmentar` como unico dueno de la segmentacion (#327/#336) | MEF-ADR-0012 | alineado -- la proyeccion propaga, no reimplementa |
| `FunctionEndpointTests.cs` de #329 (borde HTTP con `store: null!`) | MEF-ADR-0035 (carve-out #371) | alineado -- y su ultimo test era el precedente exacto que faltaba extender a `sedeId` |

### Convenciones del pipeline (no ADRs)

| Convencion | Estado | Observacion |
|---|---|---|
| Cada test con `Then()` + `And<>()` | n/a | No hay tests de command handler en el diff. Los de proyeccion N1 invocan `Create`/`Apply` directo (precedente #328, MEF-ADR-0035); los del endpoint son de borde HTTP. |
| Overloads correctos para stream IDs compuestos | n/a | Sin DSL de aggregate en el diff. |
| Fakes manuales (no NSubstitute) | ok | Cero mocks: `store: null!` deliberado en el borde HTTP, fixtures reales en smoke. |
| Feature folders (produccion y tests) | ok | `ListarTurnosVigentes/` espejado en `ControlHoras.Tests` y `ControlHoras.SmokeTests`; proyeccion y read model en sus ensamblados (`Projections`/`ReadModels`). |
| Smoke tests: SkipWhen, secrets, cobertura | ok (tras correccion) | `Assert.SkipWhen` (xUnit v3) en los tres tests nuevos; `appsettings.json` con connection strings vacios; filtrado siempre por `empleadoId`/`sedeId` unicos por corrida, nunca por posicion; una sola clase por query, sin archivo duplicado. Cobertura por efecto: el endpoint GET no publica ni persiste (sin efectos secundarios que verificar contra Postgres/Service Bus); el efecto observable es el cuerpo de la respuesta, que ahora si se afirma completo. Sin topic nuevo -> sin suscripcion `smoke-tests` que dar de alta. |
| Proyecciones read-side: partial, inmutabilidad, read APIs, naming | ok | `partial` solo en la companion (worker), read model plano; `Create`/`Apply` estaticos y `with {}`; via (a') canonica; `TId = string` coherente con `StreamIdentity.AsString`. |
| Compatibilidad Marten write-side/read-side (#447) | n/a | El gate no dispara: el diff no toca version de `Cosmos.EventSourcing.*` ni `ComposicionServicios*`/`ConfiguracionMartenProjections*`/serializacion/`AddEventTypes`. Nota de despliegue (no hallazgo): el **par 2** (worker -> query-side) converge por construccion porque ambos procesos comparten el ensamblado `ReadModels`, y los dos ordenes de despliegue son seguros -- Function App primero: el containment JSONB no matchea documentos viejos (comportamiento CA-5); worker primero: el Function App viejo ignora campos que no conoce. |
| Identidad de stream (MEF-ADR-0037) | n/a | El diff no toca `StartStream`/`ExistsAsync`/`GetAggregateRootAsync`/`GroupId`/`ComputarStreamId`. La Function GET no recibe id de ruta: filtra por campos de dominio del documento (`EmpleadoId`, `Fecha`, `Bloques.SedeId`) via `Query<TView>()`, nunca por clave de stream. |
| Control de volumen de telemetria (MEF-ADR-0038) | n/a | El diff no toca `ComposicionServicios*`, `ConfiguracionObservabilidad*`, `AddOpenTelemetry`, `SetSampler` ni el callback de Wolverine. |
| Tests via ToString/comportamiento | ok | Ningun getter agregado para satisfacer un test; los campos nuevos existen porque el cliente del panorama los necesita. |
| Sin numeros magicos | ok | La descripcion repetida del turno sembrado paso a constante (`DescripcionTurnoSinSede`). Las horas de los escenarios son datos del caso, no constantes de dominio. |
| Condiciones en positivo (guardas if/else afirmativas) | ok | `if (!string.IsNullOrEmpty(sedeId))` es una guarda de "aplicar filtro si viene", sin rama `else` -- no es una bifurcacion en negativo; ademas replica textualmente la forma del filtro `empleadoId` de #329. |

### Elegancia del codigo
- **Produccion: ya era elegante.** El cambio de `MapearBloque` es de una linea y el operador `?.`
  resuelve el caso "franja sin sede -> ambos campos null" sin rama explicita -- exactamente lo que
  CA-1 pide, sin `if`. El filtro del endpoint compone un `.Where` mas sobre el `IQueryable`, en el
  mismo estilo que #329, en vez de anidar ternarios dentro de la expresion LINQ.
- El predicado elegido (`Any()` con igualdad simple) resulta ser, ademas, la forma **mas eficiente**
  de las que Marten documenta para colecciones hijas: containment JSONB, la unica elegible para
  indice GIN. No hubo trade-off entre legibilidad y eficiencia.
- **Tests: habia deuda.** Los smoke tests traian ~96 lineas de payload triplicado (compacidad) y
  afirmaban solo la mitad del contrato observable del endpoint (robustez del oraculo). Ambas
  corregidas.
- Sin `Console.WriteLine`, sin codigo comentado, sin imports innecesarios, sin `─` (U+2500) en
  ningun archivo. Los 4 warnings del build (`NU1902`) y los `IDE0005` de `dotnet format` son
  **preexistentes** y viven en archivos ajenos al diff (`Programacion`, tests de serializacion de
  #183): no se tocan (regla de no refactorizar codigo no relacionado con la HU).

### Criticas y hallazgos
1. **Envelope de smoke triplicado** -- severidad **menor**. Corregido (ver desviaciones).
2. **Campos de sede sin oraculo en la respuesta HTTP** -- severidad **mayor** (el unico defecto de
   fondo del diff): el issue agrega dos campos al contrato de un endpoint y ningun test verificaba
   que llegaran al cliente. Corregido.
3. **Rama del borde HTTP con `sedeId` sin cubrir** -- severidad **menor**. Corregido con el test que
   extiende el precedente de `empleadoId`.
4. **Cita imprecisa de MEF-ADR-0035 en un comentario** -- severidad **cosmetica**. Corregido con la
   fuente verificable real (doc de Marten).
5. **No es hallazgo, queda anotado**: el veredicto real del filtro `Bloques.Any(...)` solo se lee
   despues del deploy a dev (Marten resuelve la traduccion contra Postgres). Verifique contra la
   documentacion oficial de Marten que la forma es soportada y canonica, pero eso es evidencia
   documental, no ejecucion. Los tres smoke tests nuevos son quienes lo confirman en dev.
6. **Discrepancia trivial entre resumenes**: el implementer reporta "6 casos nuevos" de sede y el
   diff/test-writer traen 5. Sin impacto en el codigo.

### Refactorings aplicados
- `ListarTurnosVigentesSmokeTests.cs`: extraccion de `PublicarProgramacionAsync` (envelope unico) y
  de las dos sobrecargas `FranjaOrdinaria` (con/sin sede); los tres `Publicar*Async` quedan como
  delegaciones de una linea. Justificacion: MEF-ADR-0018 (tercera repeticion). Equivalencia del JSON
  verificada empiricamente antes de aplicar.
- `ListarTurnosVigentesSmokeTests.cs`: `DescripcionTurnoSinSede` como constante, usada tanto al
  publicar como al afirmar el `HorarioResumido` (una sola fuente para el eco del payload).
- `FunctionEndpoint.cs`: reescritura del comentario del filtro para citar la fuente correcta de cada
  afirmacion (MEF-ADR-0035 para la via de consulta; doc de Marten para la traduccion a containment
  JSONB) y explicar por que CA-4/CA-5 no necesitan rama explicita.
- `dotnet test` corrido despues de los cambios: 823/0. Ningun refactor requirio revertirse.

### Cobertura de criterios de aceptacion
| Criterio | Estado | Test(s) |
|---|---|---|
| CA-1: la proyeccion materializa `SedeId`/`NombreSede` por bloque; franjas sin sede -> null | cubierto | `Create_MapeaSedeIdYNombreSede_DesdeLaSedeDeLaFranja`, `Create_HeredaLaSedeDeLaFranjaEnBloquesDeDescansoYExtra`, `Create_DejaSedeIdYNombreSedeNulos_CuandoLaFranjaNoTraeSede`, `Apply_SobrescribeLaSedeDeLosBloques_CuandoLaReasignacionCambiaDeSede` + (agregado) la asercion de bloques en `ListarTurnosVigentes_IncluyeElDiaBajoCualquieraDeSusSedes_CuandoElTurnoEsMultiSede` (cadena completa hasta la respuesta HTTP) |
| CA-2: `sedeId` devuelve los dias con AL MENOS un bloque en esa sede (dia multi-sede bajo cualquiera) | cubierto | `Create_MapeaSedesDistintasPorBloque_CuandoElTurnoTieneFranjasEnSedesDistintas` (unit) + `ListarTurnosVigentes_IncluyeElDiaBajoCualquieraDeSusSedes_CuandoElTurnoEsMultiSede` (smoke: manana, tarde y una tercera sede que NO debe traerlo) |
| CA-3: `sedeId` combinable con `empleadoId` y el rango; sin `sedeId`, #329 intacto | cubierto | `ListarTurnosVigentes_CombinaSedeIdConEmpleadoId_CuandoAmbosFiltrosSeAplican` (smoke), `ListarTurnosVigentes_Retorna400_CuandoSedeIdEsValidoPeroElRangoNoLoEs` (agregado) y la suite completa de #329 sin cambios (regresion) |
| CA-4: dias sin sede fuera de todo `sedeId`, presentes sin filtro | cubierto | `ListarTurnosVigentes_ExcluyeElDiaSinSede_CuandoSeFiltraPorSedeId` (smoke, ambas mitades en el mismo test) |
| CA-5: documentos ya proyectados sin sede se consultan sin error | cubierto por equivalencia | Irreproducible literalmente (exige datos escritos antes del deploy). Cubierto por: la asercion agregada de bloques con ambos campos nulos en `...ExcluyeElDiaSinSede...`, el default `null` del record `Bloque`, y la semantica de containment JSONB (un bloque sin la clave nunca matchea un `sedeId` no nulo). |
| CA-6: suite completa en verde | cubierto | `dotnet test`: 823 correctos, 0 errores, 21 omitidos (smoke sin credenciales locales) |

### Tests agregados
- `FunctionEndpointTests.ListarTurnosVigentes_Retorna400_CuandoSedeIdEsValidoPeroElRangoNoLoEs`
  (ControlHoras.Tests) -- unica rama del nuevo parametro ejercitable sin Postgres; extiende el
  precedente exacto de `empleadoId` que dejo #329. Cierra parcialmente la casilla "Test de
  composicion de la Function GET" que ambos agentes anteriores declararon como desviacion.
- Aserciones agregadas a smoke tests existentes (no tests nuevos): contrato de sede por bloque en la
  respuesta del dia multi-sede (CA-1 de punta a punta) y campos nulos en el dia sin sede (CA-5).
- Tests de contrato de igualdad/serializacion (`IgualdadTestBase<T>`, round-trip JSON): **no
  aplican** -- el diff no introduce ningun `IEquatable<T>` ni `ConfigurarSerializacion`, ni ningun
  evento con marker de bus. `Bloque` es un record plano de escalares en `ReadModels` (cuarta isla,
  sin Marten): su igualdad por valor es la del compilador y su serializacion es la del serializador
  por defecto.

</details>

## Cobertura

| Archivo | Cobertura | Umbral | Estado |
|---|---|---|---|
| TurnoVigenteProjection.cs | 96.0% | 95% | ok |
| FunctionEndpoint.cs | - | excluido | - |
| Bloque.cs | - | excluido | - |
## Commits

04eea8c refactor(hu-337): dedup del envelope de smoke y cobertura del contrato de sede
51e6894 test(hu-337): smoke tests para endpoints
f8fe553 feat(issue-337): propaga sede por bloque en TurnoVigente y filtro sedeId (fase verde)
b8050bf test(issue-337): tests de proyeccion para sede por bloque en TurnoVigente (fase roja)

Closes #337