### PR TITLE
#360 scaffold(colaboradores): nuevo dominio Colaboradores

### DIFF
--- a/.github/smoke-tests-dominios.json
+++ b/.github/smoke-tests-dominios.json
@@ -8,5 +8,10 @@
     "dominio": "ControlHoras",
     "base_url": "https://func-asist-dev-control-horas.azurewebsites.net",
     "test_project": "tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/"
+  },
+  {
+    "dominio": "Colaboradores",
+    "base_url": "https://func-asist-dev-colaboradores.azurewebsites.net",
+    "test_project": "tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/"
   }
 ]

--- a/.github/workflows/deploy-colaboradores.yml
+++ b/.github/workflows/deploy-colaboradores.yml
@@ -1,0 +1,196 @@
+name: Deploy Colaboradores
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/Bitakora.ControlAsistencia.Colaboradores/**'
+      # Issue #237: sin estas rutas el modo de fallo es el mismo que describe global.json mas
+      # abajo: staleness silenciosa. Cambiar un evento persistido o el payload que viaja al bus
+      # no dispararia el deploy del dominio que lo emite, y la Function App seguiria sirviendo el
+      # binario anterior sin aviso.
+      - 'src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/**'
+      - 'src/Bitakora.ControlAsistencia.PrivateEvents/**'
+      - 'src/Bitakora.ControlAsistencia.PublicEvents/**'
+      # global.json (issue #454 del harness): quien lo lee NO es actions/setup-dotnet -- los
+      # jobs de abajo le pasan 'dotnet-version' explicito, no 'global-json-file', asi que la
+      # action solo instala el SDK del canal pedido. Lo leen el muxer del CLI y el resolver
+      # de SDK de MSBuild al correr 'dotnet restore/build', y por eso su 'version' +
+      # 'rollForward' deciden con cual de los SDK instalados se compila este dominio. El modo
+      # de fallo no es rotura -- eso lo atrapa el CI del PR antes del merge -- sino staleness
+      # silenciosa: sin esta ruta, un push a main que solo toque global.json no dispara nada
+      # y la Function App sigue sirviendo el binario construido con el SDK anterior, sin aviso.
+      - 'global.json'
+      # Este propio workflow (issue #454 del harness): sin esta ruta, un cambio en como se
+      # construye/despliega este dominio nunca dispara solo -- hay que lanzarlo a mano con
+      # workflow_dispatch cada vez.
+      - '.github/workflows/deploy-colaboradores.yml'
+      # Exclusiones deliberadas de esta lista -- no las agregues buscando simetria:
+      # - ControlAsistencias.slnx: lo usa build-and-test (el gate de test), no el job deploy,
+      #   que compila el .csproj de este dominio directo. Un cambio al .slnx por ESTE dominio
+      #   ya viene acompanado de cambios en src/.../Colaboradores/** (que disparan igual), y
+      #   uno por OTRO dominio no altera el binario de este.
+      # - infra/**: su trigger vive en infra-cd.yml y este workflow se encadena detras via el
+      #   workflow_run de abajo, para que el codigo nunca se despliegue antes del apply de
+      #   infra (MEF-ADR-0022). Devolverlo aqui rompe ese orden.
+      # - tests/**: un cambio de tests no altera el binario publicado de este dominio.
+  workflow_run:
+    # 'Infra CD - Terraform Apply' es el nombre real del workflow en este repo
+    # (.github/workflows/infra-cd.yml), verificado contra el resto de workflows de deploy.
+    workflows: ['Infra CD - Terraform Apply']
+    types: [completed]
+  workflow_dispatch:
+
+jobs:
+  # El apply de infra (infra-cd.yml, MEF-ADR-0022) y el deploy de codigo pueden correr en
+  # el mismo push a main. Encadenar por workflow_run (en vez de un 'push' que dispare
+  # ambos) garantiza el orden infra -> deploy (MEF-ADR-0022, "Orden: infra antes que deploy
+  # de codigo"). Pero workflow_run por si solo redesplegaria el dominio tras CADA apply de
+  # infra (seguro por idempotencia, pero costoso); este job filtra por si el PR que se acaba
+  # de mergear toco este dominio (src/Bitakora.ControlAsistencia.Colaboradores/**) y salta el
+  # redeploy si no. Se resuelve via la API de PRs asociados al commit (no depende de la
+  # estrategia de merge: squash, merge o rebase).
+  determinar-alcance:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      debe_desplegar: ${{ steps.check.outputs.debe_desplegar }}
+    steps:
+      - id: check
+        name: Decidir si corresponde desplegar este dominio
+        # Los datos del evento entran por 'env' y NO interpolados como ${{ }} dentro del
+        # 'run'. Un ${{ }} en el cuerpo del script se sustituye como TEXTO antes de que bash
+        # lo parsee, asi que un dato controlable por quien dispara la corrida se vuelve
+        # codigo. Pasarlo por 'env' lo mantiene siempre como valor, nunca como sintaxis; es
+        # la mitigacion que prescribe el hardening de GitHub Actions para datos del evento.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENTO: ${{ github.event_name }}
+          RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          RUN_RAMA: ${{ github.event.workflow_run.head_branch }}
+          RUN_SHA: ${{ github.event.workflow_run.head_sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          # push directo (src/**) o workflow_dispatch: siempre despliega.
+          if [ "$EVENTO" != "workflow_run" ]; then
+            echo "debe_desplegar=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # 'Infra CD - Terraform Apply' solo corre en push a main (el plan de PR vive en
+          # infra-ci.yml, otro workflow), pero se filtra igual por conclusion y rama por
+          # defensividad.
+          if [ "$RUN_CONCLUSION" != "success" ] || [ "$RUN_RAMA" != "main" ]; then
+            echo "debe_desplegar=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # ...y el PR mergeado toco este dominio.
+          PR_NUM=$(gh api "repos/${REPO}/commits/${RUN_SHA}/pulls" --jq '.[0].number // empty')
+          if [ -z "$PR_NUM" ]; then
+            echo "debe_desplegar=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if gh api "repos/${REPO}/pulls/${PR_NUM}/files" --paginate --jq '.[].filename' | grep -qE '^src/Bitakora\.ControlAsistencia\.Colaboradores/'; then
+            echo "debe_desplegar=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "debe_desplegar=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  build-and-test:
+    needs: determinar-alcance
+    if: needs.determinar-alcance.outputs.debe_desplegar == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Restore
+        run: dotnet restore ControlAsistencias.slnx
+
+      - name: Build
+        run: dotnet build ControlAsistencias.slnx --no-restore --configuration Release
+
+      - name: Test
+        run: |
+          for proj in tests/Bitakora.ControlAsistencia.*.Tests/; do
+            dotnet test --project "$proj" --no-build --configuration Release --ignore-exit-code 8
+          done
+
+  deploy:
+    needs: [determinar-alcance, build-and-test]
+    if: needs.determinar-alcance.outputs.debe_desplegar == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      # Declarar 'permissions' a nivel de job pone en 'none' todo scope que no se liste, asi
+      # que 'contents: read' es obligatorio para que actions/checkout siga clonando.
+      contents: read
+      # Emite el token federado que azure/login canjea por OIDC, sin client secret
+      # (MEF-ADR-0022). El bloque va por JOB y no a nivel de workflow a proposito: el job
+      # 'determinar-alcance' necesita 'pull-requests: read', que este reparto no le quita.
+      id-token: write
+    outputs:
+      sha: ${{ github.event.workflow_run.head_sha || github.sha }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Restore
+        run: dotnet restore src/Bitakora.ControlAsistencia.Colaboradores/ -r linux-x64
+
+      - name: Build
+        run: |
+          dotnet build src/Bitakora.ControlAsistencia.Colaboradores/ \
+            --configuration Release \
+            --no-restore \
+            -r linux-x64 \
+            -p:SourceRevisionId=${{ github.event.workflow_run.head_sha || github.sha }}
+
+      - name: Publish
+        run: |
+          dotnet publish src/Bitakora.ControlAsistencia.Colaboradores/ \
+            --configuration Release \
+            --no-build \
+            -r linux-x64 \
+            --self-contained false \
+            --output ./publish
+
+      - name: Validar artefacto de publicacion
+        run: |
+          test -f ./publish/host.json
+          test -f ./publish/functions.metadata
+          test -f ./publish/Bitakora.ControlAsistencia.Colaboradores.dll
+
+      - name: Azure Authentication
+        uses: azure/login@v3
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Deploy to Azure Functions
+        uses: Azure/functions-action@v1
+        with:
+          app-name: func-asist-dev-colaboradores
+          package: ./publish
+
+  smoke-tests:
+    needs: deploy
+    uses: ./.github/workflows/smoke-tests-dominio.yml
+    with:
+      base_url: https://func-asist-dev-colaboradores.azurewebsites.net
+      test_project: tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/
+      expected_sha: ${{ needs.deploy.outputs.sha }}
+    secrets:
+      SERVICEBUS_CONNECTION_STRING: ${{ secrets.SERVICEBUS_CONNECTION_STRING }}
+      POSTGRES_CONNECTION_STRING: ${{ secrets.POSTGRES_CONNECTION_STRING }}

--- a/ControlAsistencias.slnx
+++ b/ControlAsistencias.slnx
@@ -1,6 +1,8 @@
 <Solution>
   <Folder Name="/src/">
     <Project Path="src/Bitakora.ControlAsistencia.ControlHoras/Bitakora.ControlAsistencia.ControlHoras.csproj" />
+    <Project Path="src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/Bitakora.ControlAsistencia.Colaboradores.DomainEvents.csproj" />
+    <Project Path="src/Bitakora.ControlAsistencia.Colaboradores/Bitakora.ControlAsistencia.Colaboradores.csproj" />
     <Project Path="src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/Bitakora.ControlAsistencia.ControlHoras.DomainEvents.csproj" />
     <Project Path="src/Bitakora.ControlAsistencia.PrivateEvents/Bitakora.ControlAsistencia.PrivateEvents.csproj" />
     <Project Path="src/Bitakora.ControlAsistencia.Programacion/Bitakora.ControlAsistencia.Programacion.csproj" />
@@ -12,6 +14,8 @@
   <Folder Name="/tests/">
     <Project Path="tests/Bitakora.ControlAsistencia.PrivateEvents.Tests/Bitakora.ControlAsistencia.PrivateEvents.Tests.csproj" />
     <Project Path="tests/Bitakora.ControlAsistencia.Programacion.Tests/Bitakora.ControlAsistencia.Programacion.Tests.csproj" />
+    <Project Path="tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests.csproj" />
+    <Project Path="tests/Bitakora.ControlAsistencia.Colaboradores.Tests/Bitakora.ControlAsistencia.Colaboradores.Tests.csproj" />
     <Project Path="tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests.csproj" />
     <Project Path="tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Bitakora.ControlAsistencia.ControlHoras.Tests.csproj" />
     <Project Path="tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/Bitakora.ControlAsistencia.Programacion.SmokeTests.csproj" />

--- a/infra/environments/dev/dominio-colaboradores.tf
+++ b/infra/environments/dev/dominio-colaboradores.tf
@@ -1,0 +1,77 @@
+# Terraform del dominio Colaboradores (issue #360).
+#
+# Archivo propio y no main.tf: los demas bloques de dominio (Programacion, ControlHoras) siguen
+# viviendo en main.tf porque asi se scaffoldearon originalmente, pero un archivo aparte por
+# dominio nuevo evita que dos scaffolds concurrentes choquen editando el mismo archivo. Terraform
+# evalua todos los .tf del directorio del entorno como un unico root module (no hay
+# subdirectorios que recorrer), asi que este archivo comparte sin cambios las referencias a
+# locals/modules ya declarados en main.tf (module.resource_group, module.key_vault,
+# module.monitoring, local.prefix_short, local.tags, local.storage_data_roles,
+# local.service_bus_connection_kv_ref, local.marten_connection_kv_ref).
+#
+# Divergencias deliberadas frente a la plantilla generica del harness (documentadas en
+# CA-ADR-0026, "Custodia de secretos"): este proyecto usa un UNICO namespace de Service Bus y un
+# UNICO app setting SERVICE_BUS_CONNECTION (sin la topologia interno/externo de MEF-ADR-0024 del
+# harness), y Application Insights se configura con el valor directo de
+# module.monitoring.connection_string (no una referencia de Key Vault, decision #7 de ese ADR).
+# El modulo local infra/modules/service-plan tampoco acepta os_type/worker_count/always_on --
+# solo sku_name (default B1, hardcodea os_type = "Linux").
+
+resource "random_string" "storage_suffix_colaboradores" {
+  length  = 6
+  special = false
+  upper   = false
+}
+
+module "storage_colaboradores" {
+  source              = "../../modules/storage"
+  name                = "stcolaboradores${var.environment}${random_string.storage_suffix_colaboradores.result}"
+  resource_group_name = module.resource_group.name
+  location            = module.resource_group.location
+  tags                = local.tags
+}
+
+# Un Service Plan por dominio (ADR-0020): aisla el computo de cada dominio. Mismo patron que
+# Programacion/ControlHoras (Linux, SKU B1 -- el default del modulo).
+module "service_plan_colaboradores" {
+  source              = "../../modules/service-plan"
+  name                = "asp-${local.prefix_short}-colaboradores"
+  resource_group_name = module.resource_group.name
+  location            = module.resource_group.location
+  sku_name            = "B1"
+  tags                = local.tags
+}
+
+module "function_app_colaboradores" {
+  source                         = "../../modules/function-app"
+  name                           = "func-${local.prefix_short}-colaboradores"
+  resource_group_name            = module.resource_group.name
+  location                       = module.resource_group.location
+  service_plan_id                = module.service_plan_colaboradores.id
+  storage_account_name           = module.storage_colaboradores.name
+  app_insights_connection_string = module.monitoring.connection_string
+  app_settings = {
+    SERVICE_BUS_CONNECTION = local.service_bus_connection_kv_ref
+    DOMINIO                = "colaboradores"
+    MartenConnectionString = local.marten_connection_kv_ref
+  }
+  tags = local.tags
+}
+
+# RBAC data-plane (ADR-0024 decision #6 / CA-ADR-0026): la managed identity necesita
+# "Key Vault Secrets User" para resolver las referencias @Microsoft.KeyVault(...) de sus app
+# settings.
+resource "azurerm_role_assignment" "kv_secrets_user_colaboradores" {
+  scope                = module.key_vault.id
+  role_definition_name = "Key Vault Secrets User"
+  principal_id         = module.function_app_colaboradores.principal_id
+}
+
+# Storage por identidad administrada (ADR-0025 decision #3 / CA-ADR-0026 decision #5):
+# AzureWebJobsStorage se resuelve por identidad, no por Key Vault.
+resource "azurerm_role_assignment" "storage_data_colaboradores" {
+  for_each             = local.storage_data_roles
+  scope                = module.storage_colaboradores.id
+  role_definition_name = each.value
+  principal_id         = module.function_app_colaboradores.principal_id
+}

--- a/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/Bitakora.ControlAsistencia.Colaboradores.DomainEvents.csproj
+++ b/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/Bitakora.ControlAsistencia.Colaboradores.DomainEvents.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <!-- Isla de eventos (CA-ADR-0029 decision #2, canon MEF-ADR-0039): ninguna dependencia de
+       proyecto, tampoco hacia PublicEvents/PrivateEvents, y ningun paquete. El dominio nace sin
+       ningun tipo persistido; los payloads ricos de sus eventos (si los necesita) se agregan a
+       este ensamblado cuando ColaboradorAggregateRoot los aplique (issue #360). -->
+
+</Project>

--- a/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/IdentidadEventosColaboradores.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/IdentidadEventosColaboradores.cs
@@ -1,0 +1,17 @@
+namespace Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+
+// Issue #360: gemela de IdentidadEventosProgramacion/IdentidadEventosControlHoras. Lista de los
+// tipos de evento que SE PERSISTEN en el event store de Colaboradores -- el mismo criterio de
+// inclusion de este ensamblado (CA-ADR-0029). El dominio nace sin aggregate ni evento propio: la
+// lista se llena a medida que ColaboradorAggregateRoot (issue #348 y el desglose #349-#357)
+// aplique sus primeros eventos. Los eventos que solo cruzan el bus (PublicEvents/PrivateEvents) no
+// entran aqui: nunca pasan por el EventGraph de Marten.
+//
+// Registrar estos tipos via Events.AddEventTypes NO declara su alias -- Marten lo sigue derivando
+// del nombre de clase (JasperFx.Events.EventTypeExtensions.GetSmarterEventTypeName /
+// GetEventTypeName). Lo unico que AddEventTypes garantiza es que el mapping exista antes de la
+// primera lectura del proceso, en vez de depender de que un append lo haya poblado.
+public static class IdentidadEventosColaboradores
+{
+    public static IReadOnlyList<Type> TiposPersistidos { get; } = [];
+}

--- a/src/Bitakora.ControlAsistencia.Colaboradores/Bitakora.ControlAsistencia.Colaboradores.csproj
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/Bitakora.ControlAsistencia.Colaboradores.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>Bitakora.ControlAsistencia.Colaboradores</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.8.1" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.52.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.OpenTelemetry" Version="1.2.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.*" />
+    <PackageReference Include="Cosmos.EventDriven.Abstractions" Version="2.3.1" />
+    <PackageReference Include="Cosmos.EventDriven.CritterStack" Version="2.3.1" />
+    <PackageReference Include="Cosmos.EventDriven.CritterStack.AzureServiceBus" Version="2.3.1" />
+    <PackageReference Include="Cosmos.EventSourcing.Abstractions" Version="2.3.1" />
+    <PackageReference Include="Cosmos.EventSourcing.CritterStack" Version="2.3.1" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.*" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Bitakora.ControlAsistencia.PublicEvents\Bitakora.ControlAsistencia.PublicEvents.csproj" />
+    <ProjectReference Include="..\Bitakora.ControlAsistencia.PrivateEvents\Bitakora.ControlAsistencia.PrivateEvents.csproj" />
+    <ProjectReference Include="..\Bitakora.ControlAsistencia.Colaboradores.DomainEvents\Bitakora.ControlAsistencia.Colaboradores.DomainEvents.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Bitakora.ControlAsistencia.Colaboradores/HealthCheck.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/HealthCheck.cs
@@ -1,0 +1,13 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+
+namespace Bitakora.ControlAsistencia.Colaboradores;
+
+public class HealthCheck
+{
+    [Function("health")]
+    public IActionResult Run(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "health")]
+        HttpRequest req) => new OkObjectResult("OK");
+}

--- a/src/Bitakora.ControlAsistencia.Colaboradores/IColaboradoresAssemblyMarker.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/IColaboradoresAssemblyMarker.cs
@@ -1,0 +1,6 @@
+namespace Bitakora.ControlAsistencia.Colaboradores;
+
+/// <summary>
+/// Marker interface para assembly scanning de Wolverine.
+/// </summary>
+public interface IColaboradoresAssemblyMarker;

--- a/src/Bitakora.ControlAsistencia.Colaboradores/Infraestructura/ComposicionServicios.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/Infraestructura/ComposicionServicios.cs
@@ -1,0 +1,138 @@
+using System.Globalization;
+using System.Text.Json;
+using Azure.Monitor.OpenTelemetry.Exporter;
+using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+using Cosmos.EventDriven.CritterStack;
+using Cosmos.EventDriven.CritterStack.AzureServiceBus;
+using Cosmos.EventSourcing.CritterStack;
+using Cosmos.EventSourcing.CritterStack.Commands;
+using Cosmos.MultiTenancy;
+using FluentValidation;
+using Marten;
+using Microsoft.Azure.Functions.Worker.OpenTelemetry;
+using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry;
+using OpenTelemetry.Trace;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Infraestructura;
+
+// Issue #360: composicion del contenedor DI del dominio Colaboradores, extraida de Program.cs a un
+// metodo testeable. Unica fuente de verdad: Program.cs y el test de composicion
+// (Colaboradores.Tests) invocan este mismo metodo -- mismo patron que ComposicionServicios de
+// Programacion/ControlHoras (issue #221), asi que un wiring roto (p.ej. el hueco de
+// ITenantResolver de #219) no puede desincronizarse entre el host real y el guardrail de CI.
+public static class ComposicionServicios
+{
+    public static IServiceCollection AgregarServiciosColaboradores(
+        this IServiceCollection services,
+        string martenConnectionString,
+        string serviceBusConnectionString,
+        bool isDev)
+    {
+        services.AgregarWolverineParaComandosServerless(
+            typeof(IColaboradoresAssemblyMarker).Assembly,
+            martenConnectionString,
+            "colaboradores",
+            isDev,
+            options =>
+            {
+                // Issue #309 (replicado desde el scaffold del dominio -- Programacion/ControlHoras
+                // ya lo aplican): apaga el polling de metricas de profundidad de cola de Wolverine
+                // (PersistenceMetrics.StartPolling, PeriodicTimer de 5s que llama
+                // store.Admin.FetchCountsAsync()). Nadie las consume hoy (sin dashboard ni alerta)
+                // y CheckHealthAsync llama FetchCountsAsync por su cuenta, asi que el health check
+                // no depende de este polling.
+                //
+                // Se conserva la durabilidad real -- recovery, scheduled jobs y dead letters, que
+                // corren en el mismo DurabilityAgent: DurabilityAgentEnabled y Mode no se tocan.
+                //
+                // Va en el callback de AgregarWolverineParaComandosServerless, y no despues de esa
+                // llamada, porque es el hook que el paquete expone sobre WolverineOptions:
+                // Cosmos.EventSourcing.CritterStack 2.3.1 lo corre PRIMERO y despues solo reasigna
+                // Durability.Mode = Solo -- esa reasignacion pisaria en silencio cualquier intento
+                // de tocar Mode desde aqui, pero no toca DurabilityMetricsEnabled (verificado
+                // descompilando el paquete en ControlHoras/ComposicionServicios). Que sobreviva no
+                // es contrato del paquete: lo sostiene el guardrail de ComposicionServiciosTests
+                // sobre el contenedor real.
+                options.Durability.DurabilityMetricsEnabled = false;
+
+                options.HabilitarAzureServiceBusParaServerLess(serviceBusConnectionString);
+
+                // El dominio nace sin ningun evento de bus (issue #360: solo se genera el andamiaje
+                // sobre el que se implementan los cortes #348/#353 y el resto del desglose). Cuando
+                // Colaboradores publique su primer evento (privado o publico), se registra aqui con
+                // options.PublicarEventoServerless<TEvento>("<topic>") -- ADR-0024 decision #3.
+            });
+
+        services.AgregarMartenEventStore();
+        // Issue #219: Cosmos.Event* 2.x dejo de auto-registrar un ITenantResolver por defecto (se
+        // movio a Cosmos.MultiTenancy.CritterStack), pero los routers/senders de Wolverine lo
+        // siguen exigiendo por constructor. La infraestructura de este proyecto es multi-tenant
+        // conjoined (CA-ADR-0027) pero opera con un unico tenant logico: se registra un resolver de
+        // valores fijos en vez de los resolvers header-based de 2.x.
+        // Ver docs/adr/ca-adr-0027-tenancy-conjoined-con-tenant-unico.md.
+        services.AddScoped<ITenantResolver, TenantResolverFijo>();
+        services.AgregarWolverineCommandRouter();
+        services.AgregarWolverineEventSender();
+        // Nota: AgregarWolverinePrivateEventRouter() no se registra todavia -- el dominio no
+        // consume ningun evento privado por ahora (mismo criterio que Programacion). Se agrega
+        // junto con el primer FunctionEndpoint de ServiceBus que este dominio necesite.
+
+        services.ConfigureMarten(options =>
+        {
+            // Issue #277 (replicado desde el scaffold): registra los tipos de evento persistidos en
+            // el EventGraph. Lista vacia al nacer -- se llena a medida que ColaboradorAggregateRoot
+            // aplique sus primeros eventos.
+            options.Events.AddEventTypes(IdentidadEventosColaboradores.TiposPersistidos);
+
+            // Cuando aparezca un value object rico que necesite ConfigurarSerializacion (ctor
+            // privado), se invoca AQUI DENTRO junto a AddEventTypes -- nunca en un ConfigureMarten
+            // separado (issue #232 CA-5: ComposicionServiciosTests lo verifica sobre el store real
+            // del contenedor, y un segundo ConfigureMarten corre el riesgo de que el resolver de
+            // serializacion custom quede sin efecto en silencio si el orden de callbacks cambia).
+        });
+
+        // Observabilidad (issue #308, CA-ADR-0009 Capa 2): mismo wiring que ControlHoras -- el
+        // dominio de referencia mas reciente en adoptar el exporter completo (a diferencia de
+        // Programacion, que todavia no lo tiene). Ratio configurable via TELEMETRY_SAMPLING_RATIO
+        // (default 0.2, igual que los otros dos dominios); el daily cap (Capa 3) y la alerta de
+        // spike (Capa 4) siguen siendo el respaldo si el sampling deja pasar demasiado.
+        var samplingRatio = double.TryParse(
+            Environment.GetEnvironmentVariable("TELEMETRY_SAMPLING_RATIO"),
+            NumberStyles.Float,
+            CultureInfo.InvariantCulture,
+            out var ratio) && ratio is >= 0.0 and <= 1.0
+                ? ratio
+                : 0.2;
+
+        // Issue #308 hallazgo 1: UseAzureMonitorExporter() llama SetSampler internamente
+        // (Azure.Monitor.OpenTelemetry.Exporter 1.8.1) con RateLimitedSampler porque
+        // AzureMonitorExporterOptions.TracesPerSecond tiene default 5.0. El SetSampler propio DEBE
+        // ir en un segundo .WithTracing(...) DESPUES de .UseAzureMonitorExporter() o ese
+        // SetSampler interno lo pisa y el sampler configurado aqui nunca se instala (verificado en
+        // runtime sobre ControlHoras).
+        services.AddOpenTelemetry()
+            .WithTracing(tracing => tracing
+                .AddSource("Wolverine")
+                .AddSource("Marten")
+                .AddSource("Npgsql")
+                .AddSource("Bitakora.ControlAsistencia.Colaboradores.*"))
+            .UseFunctionsWorkerDefaults()
+            .UseAzureMonitorExporter()
+            .WithTracing(tracing => tracing
+                .SetSampler(new ParentBasedSampler(new TraceIdRatioBasedSampler(samplingRatio))));
+
+        // Serializacion JSON global: camelCase hacia el cliente, case-insensitive en lectura
+        services.Configure<JsonSerializerOptions>(options =>
+        {
+            options.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
+            options.PropertyNameCaseInsensitive = true;
+        });
+
+        // Validacion de requests
+        services.AddScoped<IRequestValidator, RequestValidator>();
+        services.AddValidatorsFromAssemblyContaining<IColaboradoresAssemblyMarker>();
+
+        return services;
+    }
+}

--- a/src/Bitakora.ControlAsistencia.Colaboradores/Infraestructura/RequestValidator.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/Infraestructura/RequestValidator.cs
@@ -1,0 +1,45 @@
+using System.Text.Json;
+using FluentValidation;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Infraestructura;
+
+public interface IRequestValidator
+{
+    Task<(T? Comando, IActionResult? Error)> ValidarAsync<T>(
+        HttpRequest req, CancellationToken ct);
+}
+
+public class RequestValidator(IServiceProvider serviceProvider) : IRequestValidator
+{
+    public async Task<(T? Comando, IActionResult? Error)> ValidarAsync<T>(
+        HttpRequest req, CancellationToken ct)
+    {
+        T? comando;
+        try
+        {
+            comando = await req.ReadFromJsonAsync<T>(ct);
+        }
+        catch (JsonException)
+        {
+            return (default, new BadRequestObjectResult(
+                "El body es invalido o esta malformado"));
+        }
+
+        if (comando is null)
+            return (default, new BadRequestObjectResult("El body es requerido"));
+
+        var validator = serviceProvider.GetService<IValidator<T>>();
+        if (validator is null)
+            return (comando, null);
+
+        var resultado = await validator.ValidateAsync(comando, ct);
+        if (!resultado.IsValid)
+            return (default, new BadRequestObjectResult(
+                new ValidationProblemDetails(resultado.ToDictionary())));
+
+        return (comando, null);
+    }
+}

--- a/src/Bitakora.ControlAsistencia.Colaboradores/Infraestructura/TenantResolverFijo.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/Infraestructura/TenantResolverFijo.cs
@@ -1,0 +1,24 @@
+using Cosmos.MultiTenancy;
+using JasperFx;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Infraestructura;
+
+// Issue #360 (replica del patron fijado en issue #219 para Programacion/ControlHoras):
+// ITenantResolver de tenant unico. Cosmos.Event* 2.x dejo de auto-registrar un ITenantResolver por
+// defecto en AgregarWolverineCommandRouter/AgregarWolverinePrivateEventRouter, pero
+// WolverineCommandRouter/WolverineQueryRouter/WolverinePrivateEventRouter/
+// WolverinePublicEventSender/WolverinePrivateEventSender lo siguen exigiendo por constructor.
+// La infraestructura de este proyecto es multi-tenant conjoined (CA-ADR-0027) pero opera con un
+// unico tenant logico: se registra un ITenantResolver con valores fijos en vez de los resolvers
+// header-based de 2.x (AgregarTenantResolverHibrido/ProxyTenantResolver), que exigirian headers
+// TenantId/user_id inexistentes en este flujo HTTP.
+// Ver docs/adr/ca-adr-0027-tenancy-conjoined-con-tenant-unico.md.
+public sealed class TenantResolverFijo : ITenantResolver
+{
+    private const string TenantIdFijo = StorageConstants.DefaultTenantId;
+    private const string UserIdFijo = "sin-identificar";
+
+    public string TenantId => TenantIdFijo;
+
+    public string UserId => UserIdFijo;
+}

--- a/src/Bitakora.ControlAsistencia.Colaboradores/Program.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/Program.cs
@@ -1,0 +1,16 @@
+using Bitakora.ControlAsistencia.Colaboradores.Infraestructura;
+using Microsoft.Azure.Functions.Worker.Builder;
+using Microsoft.Extensions.Hosting;
+
+var builder = FunctionsApplication.CreateBuilder(args);
+builder.ConfigureFunctionsWebApplication();
+
+var martenConnectionString = Environment.GetEnvironmentVariable("MartenConnectionString")!;
+var serviceBusConnectionString = Environment.GetEnvironmentVariable("SERVICE_BUS_CONNECTION")!;
+
+builder.Services.AgregarServiciosColaboradores(
+    martenConnectionString,
+    serviceBusConnectionString,
+    builder.Environment.IsDevelopment());
+
+await builder.Build().RunAsync();

--- a/src/Bitakora.ControlAsistencia.Colaboradores/VersionCheck.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/VersionCheck.cs
@@ -1,0 +1,24 @@
+using System.Reflection;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+
+namespace Bitakora.ControlAsistencia.Colaboradores;
+
+public class VersionCheck
+{
+    [Function("version")]
+    public IActionResult Run(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "version")]
+        HttpRequest req)
+    {
+        var informationalVersion = Assembly.GetExecutingAssembly()
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+            .InformationalVersion;
+
+        var separatorIndex = informationalVersion?.IndexOf('+') ?? -1;
+        var sha = separatorIndex >= 0 ? informationalVersion![(separatorIndex + 1)..] : string.Empty;
+
+        return new OkObjectResult(sha);
+    }
+}

--- a/src/Bitakora.ControlAsistencia.Colaboradores/host.json
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/host.json
@@ -1,0 +1,27 @@
+{
+    "version": "2.0",
+    "telemetryMode": "OpenTelemetry",
+    "logging": {
+        "logLevel": {
+            "default": "Warning",
+            "Function": "Information",
+            "Host.Results": "Information",
+            "Host.Aggregator": "Information",
+            "Marten": "Warning",
+            "Wolverine": "Warning"
+        },
+        "applicationInsights": {
+            "enableLiveMetricsFilters": true
+        }
+    },
+    "extensions": {
+        "serviceBus": {
+            "autoCompleteMessages": false,
+            "maxAutoLockRenewalDuration": "00:05:00",
+            "maxConcurrentCalls": 1,
+            "maxConcurrentSessions": 16,
+            "prefetchCount": 0,
+            "sessionIdleTimeout": "00:00:01"
+        }
+    }
+}

--- a/src/Bitakora.ControlAsistencia.Projections/Bitakora.ControlAsistencia.Projections.csproj
+++ b/src/Bitakora.ControlAsistencia.Projections/Bitakora.ControlAsistencia.Projections.csproj
@@ -26,6 +26,7 @@
     <ProjectReference Include="..\Bitakora.ControlAsistencia.ReadModels\Bitakora.ControlAsistencia.ReadModels.csproj" />
     <ProjectReference Include="..\Bitakora.ControlAsistencia.Programacion.DomainEvents\Bitakora.ControlAsistencia.Programacion.DomainEvents.csproj" />
     <ProjectReference Include="..\Bitakora.ControlAsistencia.ControlHoras.DomainEvents\Bitakora.ControlAsistencia.ControlHoras.DomainEvents.csproj" />
+    <ProjectReference Include="..\Bitakora.ControlAsistencia.Colaboradores.DomainEvents\Bitakora.ControlAsistencia.Colaboradores.DomainEvents.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Bitakora.ControlAsistencia.Projections/Infraestructura/ConfiguracionMartenProjections.cs
+++ b/src/Bitakora.ControlAsistencia.Projections/Infraestructura/ConfiguracionMartenProjections.cs
@@ -15,6 +15,7 @@ public static class ConfiguracionMartenProjections
         // remover las anteriores (MEF-ADR-0006/MEF-ADR-0034 seccion 2).
         services.ConfigurarProgramacion(martenConnectionString);
         services.ConfigurarControlHoras(martenConnectionString);
+        services.ConfigurarColaboradores(martenConnectionString);
 
         return services;
     }

--- a/src/Bitakora.ControlAsistencia.Projections/Infraestructura/ConfiguracionMartenProjectionsColaboradores.cs
+++ b/src/Bitakora.ControlAsistencia.Projections/Infraestructura/ConfiguracionMartenProjectionsColaboradores.cs
@@ -1,0 +1,93 @@
+using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+using JasperFx.Events; // StreamIdentity, EventNamingStyle (NO Marten.Events, mismo gotcha que DaemonMode)
+using JasperFx.Events.Daemon; // DaemonMode (NO Marten.Events.Daemon: compila pero deja DaemonMode sin resolver)
+using JasperFx.MultiTenancy; // TenancyStyle (NO Marten.*, mismo gotcha que StreamIdentity/DaemonMode)
+using Marten;
+
+namespace Bitakora.ControlAsistencia.Projections.Infraestructura;
+
+/// <summary>
+/// Marker del named store de proyecciones del dominio Colaboradores (MEF-ADR-0034 seccion 2).
+/// </summary>
+public interface IColaboradoresProjectionStore : IDocumentStore;
+
+/// <summary>
+/// Seam de composicion de proyecciones del dominio Colaboradores (issue #360;
+/// MEF-ADR-0006/MEF-ADR-0034 secciones 2 y 6) -- hermano read-side de ComposicionServicios
+/// (write-side, MEF-ADR-0029): fuente unica que comparten Program.cs del worker y el config-test.
+///
+/// Registra el named store sobre la misma conexion y el mismo schema "colaboradores" que ya usa
+/// (o usara) el write-side (ComposicionServicios.AgregarServiciosColaboradores) -- el read-side no
+/// crea base ni schema nuevos. El dominio nace sin ninguna proyeccion concreta: se suman
+/// aditivamente dentro de este mismo AddMartenStore cuando el desglose de issues (#348, #349-#357)
+/// materialice el primer read model.
+///
+/// El seam se declara con modificadores de acceso y sin partial: un metodo partial sin
+/// modificadores desaparece en silencio al compilar si nadie lo implementa, y ademas seria
+/// implicitamente privado e inalcanzable desde el ensamblado de tests.
+/// </summary>
+public static class ConfiguracionMartenProjectionsColaboradores
+{
+    private const string SchemaDelDominio = "colaboradores";
+
+    public static IServiceCollection ConfigurarColaboradores(
+        this IServiceCollection services, string martenConnectionString)
+    {
+        services.AddMartenStore<IColaboradoresProjectionStore>(opts =>
+            {
+                opts.Connection(martenConnectionString);
+                opts.DatabaseSchemaName = SchemaDelDominio; // mismo schema que el write-side (MEF-ADR-0003)
+
+                // Replica de la identidad de stream que el write-side declara por defecto via
+                // Cosmos.EventSourcing.CritterStack (AgregarConfiguracionMartenComandos: Events.
+                // StreamIdentity = AsString): el issue #360 describe el stream de
+                // ColaboradorAggregateRoot como "stream por Identificacion" -- un valor de texto
+                // (cedula), nunca un Guid. Sin esta linea Marten aplica su default AsGuid y el
+                // daemon leeria el event store (stream_id varchar) como uuid, sin encontrar ningun
+                // stream (mismo sintoma que el issue #253 de ControlHoras/Programacion).
+                opts.Events.StreamIdentity = StreamIdentity.AsString;
+
+                // El event store se escribe con tenancy conjoined (AgregarConfiguracionMartenComandos,
+                // Cosmos.EventSourcing.CritterStack 2.3.1) y Marten documenta TenancyStyle.Conjoined
+                // como un modelo opt-in que el lado que lee debe declarar igual que el que escribio
+                // ("Event Store Multi-Tenancy": https://martendb.io/events/multitenancy.html).
+                opts.Events.TenancyStyle = TenancyStyle.Conjoined;
+
+                // Replica de Events.EventNamingStyle = SmarterTypeName (idem ControlHoras/Programacion):
+                // hoy inocua (eventos top-level, sin anidar), pero sin esta linea un futuro evento
+                // anidado calcularia un alias distinto entre write-side y worker, sin ninguna senal
+                // en el build.
+                opts.Events.EventNamingStyle = EventNamingStyle.SmarterTypeName;
+
+                // Policies.AllDocumentsAreMultiTenanted() gobierna la forma de la tabla de cualquier
+                // read model que este worker llegue a materializar para Colaboradores.
+                opts.Policies.AllDocumentsAreMultiTenanted();
+
+                // Replica de la configuracion de metadata del write-side (MEF-ADR-0034 seccion 6
+                // punto 3, seccion 7): el config-test verifica exactamente estas tres. La
+                // habilitacion real de las columnas es responsabilidad del write-side de este
+                // dominio (issue #360, ComposicionServicios.AgregarServiciosColaboradores).
+                opts.Events.MetadataConfig.CorrelationIdEnabled = true;
+                opts.Events.MetadataConfig.CausationIdEnabled = true;
+                opts.Events.MetadataConfig.HeadersEnabled = true;
+
+                // Defensa en profundidad read-side: registra los tipos de evento persistidos de
+                // Colaboradores en el EventGraph de este named store, para que el daemon no dependa
+                // del fallback por mt_dotnet_type al leer streams preexistentes. Lista vacia al
+                // nacer -- se llena junto con IdentidadEventosColaboradores.TiposPersistidos.
+                opts.Events.AddEventTypes(IdentidadEventosColaboradores.TiposPersistidos);
+
+                // Cuando ColaboradorAggregateRoot aplique su primer evento y aparezca la primera
+                // proyeccion, se agrega aqui con opts.Projections.Add<TProjection>(ProjectionLifecycle.Async)
+                // -- lifecycle Async es el canonico del worker (MEF-ADR-0034 seccion 3); Inline solo
+                // seria valido con justificacion explicita en el issue correspondiente.
+            })
+            // Registrar el store no basta: sin esta llamada el daemon queda apagado y ninguna
+            // proyeccion se materializa. HotCold elige lider sobre advisory locks de PostgreSQL,
+            // lo correcto para un Container App que Azure puede correr momentaneamente con mas de
+            // una replica (MEF-ADR-0034 seccion 2).
+            .AddAsyncDaemon(DaemonMode.HotCold);
+
+        return services;
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests.csproj
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AwesomeAssertions" Version="*" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.*" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.*" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.*" />
+    <PackageReference Include="Npgsql" Version="9.*" />
+    <PackageReference Include="xunit.v3.mtp-v2" Version="3.*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Bitakora.ControlAsistencia.PublicEvents\Bitakora.ControlAsistencia.PublicEvents.csproj" />
+    <ProjectReference Include="..\..\src\Bitakora.ControlAsistencia.PrivateEvents\Bitakora.ControlAsistencia.PrivateEvents.csproj" />
+    <ProjectReference Include="..\..\src\Bitakora.ControlAsistencia.Colaboradores.DomainEvents\Bitakora.ControlAsistencia.Colaboradores.DomainEvents.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="appsettings.json" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="appsettings.local.json" CopyToOutputDirectory="PreserveNewest" Condition="Exists('appsettings.local.json')" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/Fixtures/ApiFixture.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/Fixtures/ApiFixture.cs
@@ -1,0 +1,36 @@
+using System.Net;
+using Microsoft.Extensions.Configuration;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.SmokeTests.Fixtures;
+
+public class ApiFixture : IAsyncLifetime
+{
+    public HttpClient Client { get; private set; } = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        var configuration = new ConfigurationBuilder()
+            .SetBasePath(AppContext.BaseDirectory)
+            .AddJsonFile("appsettings.json", optional: false)
+            .AddJsonFile("appsettings.local.json", optional: true)
+            .AddEnvironmentVariables()
+            .Build();
+
+        var baseUrl = configuration["Api:BaseUrl"]
+            ?? throw new InvalidOperationException(
+                "Api:BaseUrl no esta configurado. Usa appsettings.json, appsettings.local.json o la variable de entorno Api__BaseUrl.");
+
+        Client = new HttpClient { BaseAddress = new Uri(baseUrl) };
+
+        var response = await Client.GetAsync("/api/health");
+        if (response.StatusCode != HttpStatusCode.OK)
+            throw new InvalidOperationException(
+                $"El entorno {baseUrl} no esta disponible. Health check retorno {response.StatusCode}.");
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        Client.Dispose();
+        return ValueTask.CompletedTask;
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/Fixtures/AssemblyFixture.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/Fixtures/AssemblyFixture.cs
@@ -1,0 +1,6 @@
+using Bitakora.ControlAsistencia.Colaboradores.SmokeTests.Fixtures;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]
+[assembly: AssemblyFixture(typeof(ApiFixture))]
+[assembly: AssemblyFixture(typeof(ServiceBusFixture))]
+[assembly: AssemblyFixture(typeof(PostgresFixture))]

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/Fixtures/Polling.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/Fixtures/Polling.cs
@@ -1,0 +1,85 @@
+namespace Bitakora.ControlAsistencia.Colaboradores.SmokeTests.Fixtures;
+
+public static class Polling
+{
+    public static async Task<T> WaitUntilAsync<T>(
+        Func<Task<T?>> probe,
+        TimeSpan timeout,
+        TimeSpan? interval = null) where T : class
+    {
+        var delay = interval ?? TimeSpan.FromSeconds(1);
+        var deadline = DateTime.UtcNow + timeout;
+        Exception? lastException = null;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            try
+            {
+                var result = await probe();
+                if (result is not null)
+                    return result;
+            }
+            catch (Exception ex)
+            {
+                lastException = ex;
+            }
+
+            var remaining = deadline - DateTime.UtcNow;
+            if (remaining <= TimeSpan.Zero)
+                break;
+
+            await Task.Delay(remaining < delay ? remaining : delay);
+
+            // Backoff simple: incrementar 50% hasta max 5s
+            if (delay < TimeSpan.FromSeconds(5))
+                delay = TimeSpan.FromMilliseconds(delay.TotalMilliseconds * 1.5);
+        }
+
+        if (lastException is not null)
+            throw new TimeoutException(
+                $"Polling agoto el timeout de {timeout.TotalSeconds}s. Ultima excepcion: {lastException.Message}",
+                lastException);
+
+        throw new TimeoutException(
+            $"Polling agoto el timeout de {timeout.TotalSeconds}s sin obtener resultado.");
+    }
+
+    public static async Task<bool> WaitUntilTrueAsync(
+        Func<Task<bool>> condition,
+        TimeSpan timeout,
+        TimeSpan? interval = null)
+    {
+        var delay = interval ?? TimeSpan.FromSeconds(1);
+        var deadline = DateTime.UtcNow + timeout;
+        Exception? lastException = null;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            try
+            {
+                if (await condition())
+                    return true;
+            }
+            catch (Exception ex)
+            {
+                lastException = ex;
+            }
+
+            var remaining = deadline - DateTime.UtcNow;
+            if (remaining <= TimeSpan.Zero)
+                break;
+
+            await Task.Delay(remaining < delay ? remaining : delay);
+
+            if (delay < TimeSpan.FromSeconds(5))
+                delay = TimeSpan.FromMilliseconds(delay.TotalMilliseconds * 1.5);
+        }
+
+        if (lastException is not null)
+            throw new TimeoutException(
+                $"Polling agoto el timeout de {timeout.TotalSeconds}s. Ultima excepcion: {lastException.Message}",
+                lastException);
+
+        return false;
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/Fixtures/PostgresFixture.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/Fixtures/PostgresFixture.cs
@@ -1,0 +1,125 @@
+using System.Net.Sockets;
+using System.Text.Json;
+using Microsoft.Extensions.Configuration;
+using Npgsql;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.SmokeTests.Fixtures;
+
+public class PostgresFixture : IAsyncLifetime
+{
+    private string _connectionString = null!;
+
+    public bool IsConfigured { get; private set; }
+
+    public string? SkipReason { get; private set; }
+
+    public async ValueTask InitializeAsync()
+    {
+        var configuration = new ConfigurationBuilder()
+            .SetBasePath(AppContext.BaseDirectory)
+            .AddJsonFile("appsettings.json", optional: false)
+            .AddJsonFile("appsettings.local.json", optional: true)
+            .AddEnvironmentVariables()
+            .Build();
+
+        var connectionString = configuration["Postgres:ConnectionString"];
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            IsConfigured = false;
+            SkipReason = "Postgres no configurado. Usa appsettings.local.json o variable Postgres__ConnectionString.";
+            return;
+        }
+
+        try
+        {
+            await using var conn = new NpgsqlConnection(connectionString);
+            await conn.OpenAsync();
+        }
+        catch (NpgsqlException ex) when (ex.InnerException is SocketException or TimeoutException)
+        {
+            IsConfigured = false;
+            SkipReason = $"No se pudo conectar a Postgres. Verifica que tu IP este en el firewall de Azure (psql-asist-dev). Detalle: {ex.InnerException.Message}";
+            return;
+        }
+
+        IsConfigured = true;
+        _connectionString = connectionString;
+    }
+
+    public Task<bool> ExisteEventoAsync(
+        string schema, string streamId, string tipoEvento, TimeSpan timeout,
+        string? campoJson = null, string? valorJson = null)
+    {
+        return Polling.WaitUntilTrueAsync(async () =>
+        {
+            var eventos = await ObtenerEventosInternoAsync(schema, streamId, tipoEvento);
+
+            if (campoJson is null || valorJson is null)
+                return eventos.Count > 0;
+
+            return eventos.Any(e =>
+                e.TryGetProperty(campoJson, out var prop) &&
+                prop.ToString() == valorJson);
+        }, timeout);
+    }
+
+    public async Task<T> ObtenerEventoAsync<T>(
+        string schema, string streamId, string tipoEvento,
+        string campoJson, string valorJson, TimeSpan timeout)
+    {
+        var json = await Polling.WaitUntilAsync(async () =>
+        {
+            var eventos = await ObtenerEventosInternoAsync(schema, streamId, tipoEvento);
+
+            var match = eventos.FirstOrDefault(e =>
+                e.TryGetProperty(campoJson, out var prop) &&
+                prop.ToString() == valorJson);
+
+            if (match.ValueKind == JsonValueKind.Undefined)
+                return null;
+
+            return JsonSerializer.Serialize(match);
+        }, timeout);
+
+        return JsonSerializer.Deserialize<T>(json)!;
+    }
+
+    private async Task<List<JsonElement>> ObtenerEventosInternoAsync(
+        string schema, string streamId, string tipoEvento)
+    {
+        await using var conn = new NpgsqlConnection(_connectionString);
+        await conn.OpenAsync();
+
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"""
+            SELECT data
+            FROM {EscaparSchema(schema)}.mt_events
+            WHERE stream_id = @streamId
+              AND type = @tipoEvento
+            ORDER BY seq_id
+            """;
+        cmd.Parameters.AddWithValue("streamId", streamId);
+        cmd.Parameters.AddWithValue("tipoEvento", tipoEvento);
+
+        var eventos = new List<JsonElement>();
+        await using var reader = await cmd.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            var json = reader.GetString(0);
+            var elemento = JsonSerializer.Deserialize<JsonElement>(json);
+            eventos.Add(elemento);
+        }
+
+        return eventos;
+    }
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    private static string EscaparSchema(string schema)
+    {
+        // Solo permitir caracteres alfanumericos y guion bajo para prevenir SQL injection
+        if (!System.Text.RegularExpressions.Regex.IsMatch(schema, @"^[a-zA-Z_][a-zA-Z0-9_]*$"))
+            throw new ArgumentException($"Nombre de schema invalido: {schema}");
+        return schema;
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/Fixtures/ServiceBusFixture.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/Fixtures/ServiceBusFixture.cs
@@ -1,0 +1,188 @@
+using System.Text.Json;
+using Azure.Messaging.ServiceBus;
+using Microsoft.Extensions.Configuration;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.SmokeTests.Fixtures;
+
+public class ServiceBusFixture : IAsyncLifetime
+{
+    private ServiceBusClient? _client;
+    private JsonSerializerOptions _jsonOptions = null!;
+
+    public bool IsConfigured { get; private set; }
+
+    public ValueTask InitializeAsync()
+    {
+        // PropertyNameCaseInsensitive: Wolverine publica en camelCase.
+        _jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        };
+
+        var configuration = new ConfigurationBuilder()
+            .SetBasePath(AppContext.BaseDirectory)
+            .AddJsonFile("appsettings.json", optional: false)
+            .AddJsonFile("appsettings.local.json", optional: true)
+            .AddEnvironmentVariables()
+            .Build();
+
+        var connectionString = configuration["ServiceBus:ConnectionString"];
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            IsConfigured = false;
+            return ValueTask.CompletedTask;
+        }
+
+        IsConfigured = true;
+        _client = new ServiceBusClient(connectionString);
+
+        return ValueTask.CompletedTask;
+    }
+
+    public async Task PurgeAsync(string topicName, string subscriptionName)
+    {
+        await using var receiver = _client!.CreateReceiver(topicName, subscriptionName);
+        var maxWait = TimeSpan.FromSeconds(2);
+
+        while (true)
+        {
+            var message = await receiver.ReceiveMessageAsync(maxWait);
+            if (message is null)
+                break;
+
+            await receiver.CompleteMessageAsync(message);
+        }
+    }
+
+    public async Task PublishAsync<T>(string topicName, T message, string? correlationId = null)
+    {
+        await using var sender = _client!.CreateSender(topicName);
+
+        var json = JsonSerializer.Serialize(message);
+        var sbMessage = new ServiceBusMessage(json)
+        {
+            ContentType = "application/json"
+        };
+
+        if (correlationId is not null)
+            sbMessage.CorrelationId = correlationId;
+
+        await sender.SendMessageAsync(sbMessage);
+    }
+
+    public async Task<T> WaitForMessageAsync<T>(
+        string topicName,
+        string subscriptionName,
+        Func<T, bool> match,
+        TimeSpan timeout)
+    {
+        await using var receiver = _client!.CreateReceiver(topicName, subscriptionName);
+
+        var deadline = DateTime.UtcNow + timeout;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            var remaining = deadline - DateTime.UtcNow;
+            if (remaining <= TimeSpan.Zero)
+                break;
+
+            var maxWait = remaining < TimeSpan.FromSeconds(5) ? remaining : TimeSpan.FromSeconds(5);
+            var received = await receiver.ReceiveMessageAsync(maxWait);
+
+            if (received is null)
+                continue;
+
+            try
+            {
+                var deserialized = JsonSerializer.Deserialize<T>(received.Body.ToString(), _jsonOptions);
+                if (deserialized is null)
+                {
+                    await receiver.CompleteMessageAsync(received);
+                    continue;
+                }
+
+                if (match(deserialized))
+                {
+                    await receiver.CompleteMessageAsync(received);
+                    return deserialized;
+                }
+
+                await receiver.CompleteMessageAsync(received);
+                throw new InvalidOperationException(
+                    $"Llego mensaje de tipo {typeof(T).Name} pero no cumplio el predicado. " +
+                    $"Contenido: {received.Body}");
+            }
+            catch (JsonException)
+            {
+                await receiver.CompleteMessageAsync(received);
+                continue;
+            }
+        }
+
+        throw new TimeoutException(
+            $"No se recibio ningun mensaje en la suscripcion {subscriptionName} " +
+            $"del topic {topicName} en {timeout.TotalSeconds}s");
+    }
+
+    private const int TamanoPaginaDeadLetter = 100;
+
+    // Recorre el DLQ completo con peek iterativo (patron oficial de Microsoft Learn,
+    // "message-browsing#maximum-number-of-messages"). El peek no completa mensajes, asi que
+    // iterar el DLQ entero es no destructivo.
+    public async Task<IReadOnlyList<ServiceBusReceivedMessage>> PeekDeadLetterMessagesAsync(
+        string topicName,
+        string subscriptionName)
+    {
+        var options = new ServiceBusReceiverOptions { SubQueue = SubQueue.DeadLetter };
+        await using var receiver = _client!.CreateReceiver(topicName, subscriptionName, options);
+
+        var mensajes = new List<ServiceBusReceivedMessage>();
+        long? desdeSecuencia = null;
+
+        while (true)
+        {
+            var pagina = await receiver.PeekMessagesAsync(
+                maxMessages: TamanoPaginaDeadLetter, fromSequenceNumber: desdeSecuencia);
+            if (pagina.Count == 0)
+                break;
+
+            mensajes.AddRange(pagina);
+            desdeSecuencia = pagina[^1].SequenceNumber + 1;
+        }
+
+        return mensajes;
+    }
+
+    // Acota el assert a "hay un dead letter de ESTA corrida" en vez de "el DLQ esta globalmente
+    // vacio". T es una forma minima plana que solo declara el identificador de correlacion, sin
+    // depender de la deserializacion custom de los value objects ricos del contrato.
+    public async Task<bool> ExisteDeadLetterDeEstaCorridaAsync<T>(
+        string topicName,
+        string subscriptionName,
+        Func<T, bool> match)
+    {
+        var mensajes = await PeekDeadLetterMessagesAsync(topicName, subscriptionName);
+
+        foreach (var mensaje in mensajes)
+        {
+            try
+            {
+                var deserializado = JsonSerializer.Deserialize<T>(mensaje.Body.ToString(), _jsonOptions);
+                if (deserializado is not null && match(deserializado))
+                    return true;
+            }
+            catch (JsonException)
+            {
+                continue;
+            }
+        }
+
+        return false;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_client is not null)
+            await _client.DisposeAsync();
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/Health/HealthSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/Health/HealthSmokeTests.cs
@@ -1,0 +1,19 @@
+using System.Net;
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.SmokeTests.Fixtures;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.SmokeTests.Health;
+
+public class HealthSmokeTests(ApiFixture api)
+{
+    private readonly HttpClient _client = api.Client;
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task DebeEstarDisponible_CuandoSeConsultaHealthCheck()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var response = await _client.GetAsync("/api/health", ct);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/appsettings.json
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/appsettings.json
@@ -1,0 +1,11 @@
+{
+  "Api": {
+    "BaseUrl": "https://func-asist-dev-colaboradores.azurewebsites.net"
+  },
+  "ServiceBus": {
+    "ConnectionString": ""
+  },
+  "Postgres": {
+    "ConnectionString": ""
+  }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/Bitakora.ControlAsistencia.Colaboradores.Tests.csproj
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/Bitakora.ControlAsistencia.Colaboradores.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Cosmos.EventSourcing.Testing.Utilities" Version="2.3.1" />
+    <PackageReference Include="xunit.v3.mtp-v2" Version="3.*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Bitakora.ControlAsistencia.Colaboradores\Bitakora.ControlAsistencia.Colaboradores.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/Infraestructura/ComposicionServiciosTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/Infraestructura/ComposicionServiciosTests.cs
@@ -1,0 +1,203 @@
+// Issue #360 (replica del patron fijado en issue #221 para Programacion/ControlHoras): guardrail
+// de CI que compone el contenedor DI real del dominio (el mismo metodo que invoca Program.cs, ver
+// ComposicionServicios.AgregarServiciosColaboradores) y valida que el grafo completo es resoluble,
+// sin infra desplegada (connection strings dummy).
+//
+// Root cause que este guardrail atrapa (issue #219): un ITenantResolver sin registrar compila y
+// pasa los tests unitarios existentes -- ni "dotnet build" ni un test que no construya el grafo de
+// DI del host detectan el hueco -- y solo aparece DESPUES del deploy, en los smoke tests contra
+// dev (HTTP 500 en toda funcion).
+//
+// Limite conocido: BuildServiceProvider(ValidateOnBuild) no valida registros por factory-lambda
+// (Wolverine/Marten registran varios), solo los de tipo mapeado -- de ahi la resolucion explicita
+// de ICommandRouter en un scope, ademas del build general.
+
+using System.Globalization;
+using System.Reflection;
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.Infraestructura;
+using Cosmos.EventSourcing.Abstractions.Commands;
+using Marten;
+using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry.Trace;
+using Wolverine;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Tests.Infraestructura;
+
+public class ComposicionServiciosTests
+{
+    private const string MartenConnectionStringDummy =
+        "Host=dummy;Port=5432;Database=dummy;Username=dummy;Password=dummy";
+
+    private const string ServiceBusConnectionStringDummy =
+        "Endpoint=sb://dummy.servicebus.windows.net/;SharedAccessKeyName=dummy;SharedAccessKey=dummy";
+
+    // Issue #308 (replicado): nombre de la variable de entorno y default del ratio de sampling
+    // (CA-ADR-0009 Capa 2). Se repite como literal inline en ComposicionServicios.cs -- a
+    // diferencia de Projections, este dominio no declara InternalsVisibleTo hacia su proyecto de
+    // tests -- por eso se fijan aqui una sola vez para no repetirlos en cada test.
+    private const string VariableRatioSampling = "TELEMETRY_SAMPLING_RATIO";
+    private const double RatioSamplingPorDefecto = 0.2;
+
+    private static ServiceProvider ComponerServiceProvider()
+    {
+        var services = new ServiceCollection();
+
+        services.AgregarServiciosColaboradores(
+            MartenConnectionStringDummy,
+            ServiceBusConnectionStringDummy,
+            isDev: true);
+
+        return services.BuildServiceProvider(
+            new ServiceProviderOptions { ValidateOnBuild = true, ValidateScopes = true });
+    }
+
+    // Fija el valor de la variable de entorno mientras corre la accion y lo restaura despues (null
+    // la elimina). Necesario para que el escenario de ratio configurado sea determinista frente a
+    // tests corriendo en paralelo.
+    private static void ConVariableDeEntorno(string nombre, string? valor, Action accion)
+    {
+        var original = Environment.GetEnvironmentVariable(nombre);
+        Environment.SetEnvironmentVariable(nombre, valor);
+        try
+        {
+            accion();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(nombre, original);
+        }
+    }
+
+    // Issue #308 (replicado): lee la propiedad interna `Sampler` de TracerProviderSdk
+    // (OpenTelemetry.dll no la expone publicamente). Determinista -- compara tipos y lee
+    // Sampler.Description (publica) --, no requiere muestrear actividades reales contra un ratio
+    // fraccionario.
+    private static Sampler ObtenerSamplerEfectivo(TracerProvider tracerProvider)
+    {
+        var propiedad = tracerProvider.GetType()
+            .GetProperty("Sampler", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException(
+                "TracerProviderSdk ya no expone la propiedad interna 'Sampler' " +
+                "(OpenTelemetry 1.16.0) -- actualizar este helper de reflection.");
+
+        return (Sampler)propiedad.GetValue(tracerProvider)!;
+    }
+
+    [Fact]
+    public void AgregarServiciosColaboradores_ComponeElGrafoCompleto_CuandoLasConnectionStringsSonDummy()
+    {
+        var act = () => ComponerServiceProvider().Dispose();
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public async Task AgregarServiciosColaboradores_ResuelveICommandRouter_CuandoElContenedorEstaCompuesto()
+    {
+        // Wolverine registra dependencias scoped que solo implementan IAsyncDisposable
+        // (Wolverine.Persistence.MessageStoreCollection); el scope se libera con DisposeAsync.
+        await using var provider = ComponerServiceProvider();
+        await using var scope = provider.CreateAsyncScope();
+
+        var act = () => scope.ServiceProvider.GetRequiredService<ICommandRouter>();
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public async Task AgregarServiciosColaboradores_HabilitaColumnasDeMetadataDeEvento_CuandoElContenedorEstaCompuesto()
+    {
+        await using var provider = ComponerServiceProvider();
+        await using var scope = provider.CreateAsyncScope();
+
+        var store = scope.ServiceProvider.GetRequiredService<IDocumentStore>();
+        var metadataConfig = store.Options.Events.MetadataConfig;
+
+        metadataConfig.CorrelationIdEnabled.Should().BeTrue();
+        metadataConfig.CausationIdEnabled.Should().BeTrue();
+        metadataConfig.HeadersEnabled.Should().BeTrue();
+    }
+
+    // --- Sampler efectivo del TracerProvider (issue #308, replicado) ---
+    [Fact]
+    public void AgregarServiciosColaboradores_ResuelveElSamplerConfiguradoPorElProyecto_EnVezDeRateLimitedSampler()
+    {
+        // TracerProvider se registra Singleton (default de OpenTelemetry): no requiere un scope
+        // Wolverine (IAsyncDisposable) para resolverse, a diferencia de ICommandRouter arriba --
+        // Dispose() sincrono del ServiceProvider raiz basta.
+        using var provider = ComponerServiceProvider();
+        var tracerProvider = provider.GetRequiredService<TracerProvider>();
+
+        var samplerEfectivo = ObtenerSamplerEfectivo(tracerProvider);
+
+        // Oraculo por nombre completo, no por referencia al tipo (es internal en otro ensamblado:
+        // Azure.Monitor.OpenTelemetry.Exporter.Internals.RateLimitedSampler no se puede nombrar
+        // desde este proyecto).
+        samplerEfectivo.GetType().FullName.Should().NotBe(
+            "Azure.Monitor.OpenTelemetry.Exporter.Internals.RateLimitedSampler");
+        samplerEfectivo.Should().BeOfType<ParentBasedSampler>();
+    }
+
+    [Fact]
+    public void AgregarServiciosColaboradores_PropagaElRatioDeSamplingConfigurado_AlSamplerEfectivo()
+    {
+        ConVariableDeEntorno(VariableRatioSampling, "0.5", () =>
+        {
+            using var provider = ComponerServiceProvider();
+            var tracerProvider = provider.GetRequiredService<TracerProvider>();
+
+            var samplerEfectivo = ObtenerSamplerEfectivo(tracerProvider);
+
+            samplerEfectivo.Description.Should().Contain(FormatearRatio(0.5));
+        });
+    }
+
+    [Fact]
+    public void AgregarServiciosColaboradores_PropagaElRatioPorDefecto_AlSamplerEfectivo_CuandoLaVariableEstaAusente()
+    {
+        ConVariableDeEntorno(VariableRatioSampling, null, () =>
+        {
+            using var provider = ComponerServiceProvider();
+            var tracerProvider = provider.GetRequiredService<TracerProvider>();
+
+            var samplerEfectivo = ObtenerSamplerEfectivo(tracerProvider);
+
+            samplerEfectivo.Description.Should().Contain(FormatearRatio(RatioSamplingPorDefecto));
+        });
+    }
+
+    // TraceIdRatioBasedSampler embebe el ratio en su Description con formato F6 invariante
+    // ("TraceIdRatioBasedSampler{0.200000}"), verificado contra OpenTelemetry 1.16.0.
+    private static string FormatearRatio(double ratio) =>
+        ratio.ToString("F6", CultureInfo.InvariantCulture);
+
+    // --- Issue #309 (replicado): apagar la recoleccion de metricas de durabilidad de Wolverine ---
+    [Fact]
+    public async Task AgregarServiciosColaboradores_ApagaLaRecoleccionDeMetricasDeDurabilidad_CuandoElContenedorEstaCompuesto()
+    {
+        // El provider se libera con await using porque WolverineOptions se registra Singleton via
+        // factory-lambda -- el contenedor lo trackea para disposal -- y solo implementa
+        // IAsyncDisposable.
+        await using var provider = ComponerServiceProvider();
+
+        var opciones = provider.GetRequiredService<WolverineOptions>();
+
+        opciones.Durability.DurabilityMetricsEnabled.Should().BeFalse();
+    }
+
+    // Este issue apaga la recoleccion de METRICAS de cola, no la durabilidad real -- recovery,
+    // scheduled jobs y dead letters (procesados por el mismo DurabilityAgent) siguen activos. Mode
+    // sigue siendo Solo, el valor que AgregarWolverineParaComandosServerless fija
+    // incondicionalmente DESPUES del callback del consumidor.
+    [Fact]
+    public async Task AgregarServiciosColaboradores_ConservaLaDurabilidadReal_CuandoApagaLasMetricasDeCola()
+    {
+        await using var provider = ComponerServiceProvider();
+
+        var opciones = provider.GetRequiredService<WolverineOptions>();
+
+        opciones.Durability.DurabilityAgentEnabled.Should().BeTrue();
+        opciones.Durability.Mode.Should().Be(DurabilityMode.Solo);
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/Infraestructura/TenantResolverFijoTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/Infraestructura/TenantResolverFijoTests.cs
@@ -1,0 +1,35 @@
+// Issue #360 (replica del patron fijado en issue #219): ITenantResolver de tenant unico para
+// Colaboradores (CA-ADR-0027: infraestructura multi-tenant conjoined operando con un unico tenant
+// logico).
+// Sin este resolver registrado en el DI, WolverineCommandRouter no puede construirse (breaking
+// change de Cosmos.Event* 2.x). Ver docs/bitacora/field-notes/2026-07-18-1905-bug-investigation.md.
+//
+// TenantId debe resolver al tenant por defecto de Marten (JasperFx.StorageConstants.DefaultTenantId,
+// valor "*DEFAULT*"), que Marten mapea a Tenancy.Default aun con AllDocumentsAreMultiTenanted().
+// UserId es un valor fijo ("sin-identificar") porque el proyecto no distingue usuarios.
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.Infraestructura;
+using Cosmos.MultiTenancy;
+using JasperFx;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Tests.Infraestructura;
+
+public class TenantResolverFijoTests
+{
+    [Fact]
+    public void TenantId_RetornaElTenantPorDefectoDeMarten()
+    {
+        ITenantResolver resolver = new TenantResolverFijo();
+
+        resolver.TenantId.Should().Be(StorageConstants.DefaultTenantId);
+    }
+
+    [Fact]
+    public void UserId_RetornaSinIdentificar()
+    {
+        ITenantResolver resolver = new TenantResolverFijo();
+
+        resolver.UserId.Should().Be("sin-identificar");
+    }
+}


### PR DESCRIPTION
## Resumen

Scaffold del dominio **Colaboradores** (`colaboradores`) creado con domain-scaffolder.

### Incluye
- Function App: `src/Bitakora.ControlAsistencia.Colaboradores/`
- Tests: `tests/Bitakora.ControlAsistencia.Colaboradores.Tests/`
- Smoke Tests: `tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/`
- Terraform: storage account + function app en `infra/environments/dev/dominio-colaboradores.tf`
- GitHub Actions: `.github/workflows/deploy-colaboradores.yml` (+ workflows `smoke-tests-dominio.yml` y `smoke-tests.yml` la primera vez en el repo)
- Smoke tests: registro del dominio en `.github/smoke-tests/colaboradores.json`

## Commits

688cce0 scaffold(colaboradores): nuevo dominio Colaboradores - Function App, tests, Terraform y deploy workflow
4eee1eb Merge pull request #347 from augusto-romero-arango/worktree-issue-337-filtrar-el-panorama-de-turnos-vigentes-p
04eea8c refactor(hu-337): dedup del envelope de smoke y cobertura del contrato de sede
51e6894 test(hu-337): smoke tests para endpoints
f8fe553 feat(issue-337): propaga sede por bloque en TurnoVigente y filtro sedeId (fase verde)
b8050bf test(issue-337): tests de proyeccion para sede por bloque en TurnoVigente (fase roja)

Closes #360