### PR TITLE
Esperar deploys ajenos antes de correr la suite de smoke

### DIFF
--- a/.github/workflows/deploy-colaboradores.yml
+++ b/.github/workflows/deploy-colaboradores.yml
@@ -186,6 +186,19 @@ jobs:
 
   smoke-tests:
     needs: deploy
+    # Un workflow LLAMADO no puede pedir mas permisos que su invocador: "the permissions for the
+    # GITHUB_TOKEN in the called workflow cannot be greater than those in the caller workflow"
+    # (GitHub Actions, reutilizacion de workflows). El default del repo es 'read'
+    # (default_workflow_permissions), que NO incluye el scope 'actions', asi que sin esta concesion
+    # el job de smoke-tests-dominio.yml -- que declara 'actions: read' para su paso 'Esperar deploys
+    # ajenos del mismo commit' -- tumba el run ENTERO con startup_failure, antes de crear un solo
+    # job y sin dejar annotation que lo explique. Verificado en el run 31516294884.
+    #
+    # Va a nivel de JOB y no de workflow para no tocar los permisos de 'determinar-alcance'
+    # (pull-requests: read) ni de 'deploy' (id-token: write), que declaran los suyos.
+    permissions:
+      contents: read
+      actions: read
     uses: ./.github/workflows/smoke-tests-dominio.yml
     with:
       base_url: https://func-asist-dev-colaboradores.azurewebsites.net

--- a/.github/workflows/deploy-control-horas.yml
+++ b/.github/workflows/deploy-control-horas.yml
@@ -201,6 +201,19 @@ jobs:
 
   smoke-tests:
     needs: deploy
+    # Un workflow LLAMADO no puede pedir mas permisos que su invocador: "the permissions for the
+    # GITHUB_TOKEN in the called workflow cannot be greater than those in the caller workflow"
+    # (GitHub Actions, reutilizacion de workflows). El default del repo es 'read'
+    # (default_workflow_permissions), que NO incluye el scope 'actions', asi que sin esta concesion
+    # el job de smoke-tests-dominio.yml -- que declara 'actions: read' para su paso 'Esperar deploys
+    # ajenos del mismo commit' -- tumba el run ENTERO con startup_failure, antes de crear un solo
+    # job y sin dejar annotation que lo explique. Verificado en el run 31516294884.
+    #
+    # Va a nivel de JOB y no de workflow para no tocar los permisos de 'determinar-alcance'
+    # (pull-requests: read) ni de 'deploy' (id-token: write), que declaran los suyos.
+    permissions:
+      contents: read
+      actions: read
     uses: ./.github/workflows/smoke-tests-dominio.yml
     with:
       base_url: https://func-asist-dev-control-horas.azurewebsites.net

--- a/.github/workflows/deploy-programacion.yml
+++ b/.github/workflows/deploy-programacion.yml
@@ -201,6 +201,19 @@ jobs:
 
   smoke-tests:
     needs: deploy
+    # Un workflow LLAMADO no puede pedir mas permisos que su invocador: "the permissions for the
+    # GITHUB_TOKEN in the called workflow cannot be greater than those in the caller workflow"
+    # (GitHub Actions, reutilizacion de workflows). El default del repo es 'read'
+    # (default_workflow_permissions), que NO incluye el scope 'actions', asi que sin esta concesion
+    # el job de smoke-tests-dominio.yml -- que declara 'actions: read' para su paso 'Esperar deploys
+    # ajenos del mismo commit' -- tumba el run ENTERO con startup_failure, antes de crear un solo
+    # job y sin dejar annotation que lo explique. Verificado en el run 31516294884.
+    #
+    # Va a nivel de JOB y no de workflow para no tocar los permisos de 'determinar-alcance'
+    # (pull-requests: read) ni de 'deploy' (id-token: write), que declaran los suyos.
+    permissions:
+      contents: read
+      actions: read
     uses: ./.github/workflows/smoke-tests-dominio.yml
     with:
       base_url: https://func-asist-dev-programacion.azurewebsites.net

--- a/.github/workflows/deploy-projections.yml
+++ b/.github/workflows/deploy-projections.yml
@@ -214,6 +214,19 @@ jobs:
     # deploy-control-horas.yml: aqui 'deploy' no tiene guarda 'if' propia. El push que no toca el
     # worker se filtra antes, en el 'paths' de arriba, y en ese caso no arranca el workflow entero.
     needs: deploy
+    # Un workflow LLAMADO no puede pedir mas permisos que su invocador: "the permissions for the
+    # GITHUB_TOKEN in the called workflow cannot be greater than those in the caller workflow"
+    # (GitHub Actions, reutilizacion de workflows). El default del repo es 'read'
+    # (default_workflow_permissions), que NO incluye el scope 'actions', asi que sin esta concesion
+    # el job de smoke-tests-dominio.yml -- que declara 'actions: read' para su paso 'Esperar deploys
+    # ajenos del mismo commit' -- tumba el run ENTERO con startup_failure, antes de crear un solo
+    # job y sin dejar annotation que lo explique. Verificado en el run 31516294884.
+    #
+    # Va a nivel de JOB y no de workflow para no tocar los permisos de 'determinar-alcance'
+    # (pull-requests: read) ni de 'deploy' (id-token: write), que declaran los suyos.
+    permissions:
+      contents: read
+      actions: read
     uses: ./.github/workflows/smoke-tests-dominio.yml
     with:
       # ControlHoras es hoy el unico dominio con proyecciones CONCRETAS: los unicos
@@ -242,8 +255,18 @@ jobs:
       # inmediato y no le da margen a la revision nueva del worker para tomar el advisory lock de
       # HotCold que la anterior esta liberando. El margen real lo pone el presupuesto de Polling de
       # los tests que consultan turnos -- 30s, el campo 'Timeout' de ObtenerTurnoVigenteSmokeTests
-      # y ListarTurnosVigentesSmokeTests. Si este job sale intermitente, ese es el primer numero a
-      # mirar, antes de sospechar de la suite o del deploy.
+      # y ListarTurnosVigentesSmokeTests.
+      #
+      # Corregido el 2026-08-11: la intermitencia observada en 3 runs NO venia de ese advisory lock
+      # ni de ese presupuesto de Polling. Venia de que este job corria la suite de ControlHoras
+      # mientras Deploy ControlHoras desplegaba en paralelo el Function App que la suite consulta,
+      # sin compuerta de version que lo detuviera -- precisamente porque este invocador no despliega
+      # ese FA y por eso no tiene un SHA propio que poner aca. El expected_sha vacio sigue siendo
+      # correcto y deliberado; lo que faltaba era la guarda, y vive en el paso 'Esperar deploys
+      # ajenos del mismo commit' de smoke-tests-dominio.yml, que se activa justamente cuando este
+      # input llega vacio. El diagnostico completo, la evidencia y el porque la guarda vive en el
+      # reusable estan en el comentario de ese paso. Si este job vuelve a salir intermitente, revisa
+      # esa guarda antes que los 30s de Polling.
       expected_sha: ''
     secrets:
       SERVICEBUS_CONNECTION_STRING: ${{ secrets.SERVICEBUS_CONNECTION_STRING }}

--- a/.github/workflows/smoke-tests-dominio.yml
+++ b/.github/workflows/smoke-tests-dominio.yml
@@ -80,12 +80,137 @@ concurrency:
 jobs:
   smoke-tests:
     runs-on: ubuntu-latest
+    permissions:
+      # Este workflow no declaraba 'permissions' y heredaba el default del repo. Al declararlo,
+      # todo scope no listado queda en 'none', asi que 'contents: read' es obligatorio para que
+      # actions/checkout siga clonando.
+      contents: read
+      # Lo necesita 'Esperar deploys ajenos del mismo commit': lista runs y jobs de OTROS
+      # workflows del repo, y ningun default concede ese scope.
+      actions: read
     steps:
       - uses: actions/checkout@v6
 
       - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
+
+      # Cierra la carrera diagnosticada el 2026-08-11 sobre los runs 31181921157 (sha 4eee1eb1),
+      # 31151821734 (4c4d8b38) y 31134226036 (f11a5971) de Deploy Projections. En los tres,
+      # 'build-and-test' y 'deploy' de ese workflow pasaron y lo unico que fallo fue este job; y en
+      # los tres el job 'deploy' de Deploy ControlHoras -- que despliega la Function App bajo
+      # prueba -- todavia estaba en vuelo cuando este arranco:
+      #
+      #   sha       | deploy del FA termina | este job arranca | resultado
+      #   4eee1eb1  | 13:19:51              | 13:19:20 (-31s)  | failure
+      #   4c4d8b38  | 05:51:23              | 05:51:02 (-21s)  | failure
+      #   f11a5971  | 00:22:03              | 00:21:56 (-7s)   | failure
+      #   1b6dbd69  | 16:36:36              | 16:36:18 (-18s)  | success  <- gano la carrera
+      #
+      # La MISMA suite, mismo commit y mismo entorno, paso 30-60s despues en el run de ControlHoras
+      # en los tres fallos. El cuarto caso importa igual: el solapamiento ocurre en 4 de 4, asi que
+      # la ventana es estructural y lo unico no determinista es quien la gana. Que en f11a5971 uno
+      # de los tests caidos fuera ObtenerTurnoVigente_Retorna400_CuandoLaFechaTieneFormatoInvalido
+      # -- validacion de formato, que no toca proyecciones ni read model -- descarta que el sintoma
+      # viniera del worker de proyecciones.
+      #
+      # Por que la guarda vive AQUI y no en el invocador: es el mismo argumento que ya puso el
+      # 'concurrency' de arriba en este archivo. Los invocadores se parten en dos clases, y la
+      # frontera no es el dominio sino quien despliega el Function App que se prueba:
+      #
+      #   deploy-control-horas.yml : expected_sha = SHA propio  -> despliega el FA que prueba
+      #   deploy-programacion.yml  : expected_sha = SHA propio  -> despliega el FA que prueba
+      #   deploy-colaboradores.yml : expected_sha = SHA propio  -> despliega el FA que prueba
+      #   deploy-projections.yml   : expected_sha = ''          -> prueba el FA de ControlHoras
+      #   smoke-tests.yml (matrix) : no lo pasa -> ''           -> prueba los FA de los 3 dominios
+      #
+      # Solo puede gatear por version quien despliega el FA que prueba: tiene un SHA propio que
+      # esperar en /api/version. Quien prueba un FA ajeno no lo tiene, degrada al HTTP 200 sobre
+      # /api/health que el binario VIEJO contesta al instante, y queda expuesto. Por eso la
+      # condicion de abajo es 'expected_sha == ""' y no una lista de dominios: identifica esa clase
+      # sin nombrar a nadie, cubre a los dos invocadores expuestos de hoy y a los que vengan.
+      # Un scaffold de dominio nuevo NO agranda la clase -- domain-scaffolder genera su
+      # deploy-*.yml con expected_sha propio, verificado en deploy-colaboradores.yml.
+      #
+      # Se espera el JOB 'deploy' de los runs ajenos y NO el run completo, a proposito: el run
+      # ajeno incluye su propio job de smoke, que pide el mismo grupo 'smoke-tests-dev' que este
+      # job ya tiene tomado. Esperar el run entero seria un deadlock -- el ajeno no puede terminar
+      # hasta que este libere el grupo, y este no continua hasta que el ajeno termine.
+      - name: Esperar deploys ajenos del mismo commit
+        if: inputs.expected_sha == ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+          # Un workflow llamado comparte el run del invocador, asi que este id ES el del run que
+          # invoca a este reusable y aparece en la consulta de abajo. Excluirlo evita esperarse a
+          # si mismo, que en deploy-projections.yml seria un deadlock inmediato: su propio job
+          # 'deploy' ya esta 'completed' cuando este corre, pero en un invocador que llamara a
+          # este reusable en paralelo con su deploy, no.
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          tmp=$(mktemp -d)
+          # 5s x 120 = 10 min. Los deploys observados tardan 1-2 min, asi que el limite deja
+          # margen de sobra; superarlo significa que algo esta mal de verdad y no que haya que
+          # seguir esperando. Se falla en vez de continuar: continuar es exactamente la carrera
+          # que este paso existe para cerrar, y un 'skip' silencioso reportaria verde una suite
+          # que nunca corrio.
+          limite=120
+
+          for intento in $(seq 1 "$limite"); do
+            if ! gh api "repos/${REPO}/actions/runs?head_sha=${SHA}&per_page=100" > "${tmp}/runs.json"; then
+              echo "::error::No se pudieron listar los runs de ${SHA}."
+              echo "Revisa que este job conserve 'actions: read' y que el endpoint acepte head_sha."
+              exit 1
+            fi
+
+            # Deploys ajenos de este commit que aun no terminaron. El prefijo 'Deploy ' es la
+            # convencion de nombre de todos los deploy-*.yml del repo (Deploy ControlHoras,
+            # Deploy Programacion, Deploy Colaboradores, Deploy Projections) y la que genera
+            # domain-scaffolder; si algun dia deja de serlo, este filtro deja de ver al ajeno y
+            # la carrera vuelve en silencio -- es el punto a revisar primero.
+            ajenos=$(jq -r --arg propio "$RUN_ID" '
+              .workflow_runs[]
+              | select((.id | tostring) != $propio)
+              | select(.name | startswith("Deploy "))
+              | select(.status != "completed")
+              | "\(.id)|\(.name)"' "${tmp}/runs.json")
+
+            bloqueantes=""
+            while IFS='|' read -r id nombre; do
+              if [ -z "$id" ]; then
+                continue
+              fi
+              # Se cuenta solo el job llamado 'deploy'. Si el run ajeno lo tiene 'skipped' -- el
+              # caso de determinar-alcance cuando el PR no toco ese dominio -- cuenta como
+              # completado y no bloquea.
+              en_vuelo=$(gh api "repos/${REPO}/actions/runs/${id}/jobs" \
+                --jq '[.jobs[] | select(.name == "deploy") | select(.status != "completed")] | length') || en_vuelo=""
+
+              if ! [[ "$en_vuelo" =~ ^[0-9]+$ ]]; then
+                echo "::error::No se pudieron leer los jobs del run ${id} (${nombre})."
+                exit 1
+              fi
+
+              if [ "$en_vuelo" -gt 0 ]; then
+                bloqueantes="${bloqueantes}${nombre} (run ${id})"$'\n'
+              fi
+            done <<< "$ajenos"
+
+            if [ -z "$bloqueantes" ]; then
+              echo "Ningun deploy ajeno de ${SHA} tiene su job 'deploy' en vuelo. Se continua."
+              exit 0
+            fi
+
+            echo "Intento ${intento}/${limite}: esperando el job 'deploy' de:"
+            printf '%s' "$bloqueantes" | sed 's/^/  - /'
+            sleep 5
+          done
+
+          echo "::error::Timeout: tras 10 min sigue habiendo un deploy ajeno de ${SHA} en vuelo."
+          printf '%s' "$bloqueantes" | sed 's/^/  - /'
+          echo "Correr la suite ahora la ejercitaria contra un Function App a medio desplegar."
+          exit 1
 
       - name: Warmup Function App
         run: |

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -25,6 +25,21 @@ jobs:
       max-parallel: 1
       matrix:
         include: ${{ fromJson(needs.discovery.outputs.matrix) }}
+    # Un workflow LLAMADO no puede pedir mas permisos que su invocador: "the permissions for the
+    # GITHUB_TOKEN in the called workflow cannot be greater than those in the caller workflow"
+    # (GitHub Actions, reutilizacion de workflows). El default del repo es 'read'
+    # (default_workflow_permissions), que NO incluye el scope 'actions', asi que sin esta concesion
+    # el job de smoke-tests-dominio.yml -- que declara 'actions: read' para su paso 'Esperar deploys
+    # ajenos del mismo commit' -- tumba el run ENTERO con startup_failure, antes de crear un solo
+    # job y sin dejar annotation que lo explique. Verificado: el run 31516294884 murio asi, y el
+    # 31516470612 arranco y paso al conceder esto.
+    #
+    # Va a nivel de JOB y no de workflow para no alterar los permisos de 'discovery', que solo
+    # necesita el default para su checkout. Los cuatro deploy-*.yml que invocan este mismo reusable
+    # llevan la concesion en su job de smoke por la misma razon.
+    permissions:
+      contents: read
+      actions: read
     uses: ./.github/workflows/smoke-tests-dominio.yml
     with:
       base_url: ${{ matrix.base_url }}


### PR DESCRIPTION
## Sintoma

`Deploy Projections` venia rojo en `main` desde el 2026-08-07. Sus jobs propios (`build-and-test`, `deploy`, verificacion de la revision activa) pasaban: lo unico que fallaba era el job de smoke que corre despues, con `SedeId`/`NombreSede` en `null`.

## Causa raiz

No es un bug de producto. Ese job corre la suite de **ControlHoras**, y `Deploy ControlHoras` estaba desplegando en paralelo el Function App que la suite consulta.

| SHA | `deploy` del FA termina | smoke de Projections arranca | Δ | Resultado |
|---|---|---|---|---|
| `4eee1eb1` | 13:19:51 | 13:19:20 | −31s | ❌ |
| `4c4d8b38` | 05:51:23 | 05:51:02 | −21s | ❌ |
| `f11a5971` | 00:22:03 | 00:21:56 | −7s | ❌ |
| `1b6dbd69` | 16:36:36 | 16:36:18 | −18s | ✅ gano la carrera |

4 de 4 se solapan: la ventana es estructural y lo unico no determinista es quien la gana. En los tres fallos la **misma suite paso 30-60s despues** en el run de ControlHoras, que si tiene compuerta de version.

Prueba de que no venia del worker: en `f11a5971` uno de los tests caidos fue `ObtenerTurnoVigente_Retorna400_CuandoLaFechaTieneFormatoInvalido` — validacion de formato de fecha, que no toca proyecciones ni read model.

## La asimetria

> Solo puede gatear por version quien despliega el Function App que prueba, porque tiene un SHA propio que esperar en `/api/version`.

| Invocador | `expected_sha` | ¿Despliega el FA que prueba? |
|---|---|---|
| `deploy-control-horas.yml` | SHA propio | Si |
| `deploy-programacion.yml` | SHA propio | Si |
| `deploy-colaboradores.yml` | SHA propio | Si |
| `deploy-projections.yml` | `''` | **No** — prueba el FA de ControlHoras |
| `smoke-tests.yml` | no lo pasa | **No** — matriz sobre los 3 dominios |

Los dos ultimos degradan al HTTP 200 sobre `/api/health` que el binario viejo contesta al instante. Poner `expected_sha` ahi **no** es la solucion: un push que solo toque `Projections/**` no dispara `deploy-control-horas.yml`, asi que `/api/version` reportaria un SHA anterior y la compuerta agotaria sus 120s sin que nada este mal.

## La correccion

Guarda en el reusable `smoke-tests-dominio.yml`, activada por `inputs.expected_sha == ''` — identifica esa clase sin enumerar dominios. Un scaffold nuevo no la agranda: `domain-scaffolder` genera su `deploy-*.yml` con `expected_sha` propio.

Dos restricciones de diseno, documentadas en el codigo:

- **Espera el job `deploy` de los runs ajenos, no el run completo.** El ajeno incluye su propio job de smoke, que pide el mismo grupo `smoke-tests-dev` que el job que espera ya tiene tomado. Esperar el run entero seria un deadlock.
- **Los cinco invocadores conceden `actions: read` a nivel de job.** Sin eso el run muere con `startup_failure` antes de crear un solo job y sin annotation: un workflow llamado no puede pedir mas permisos que su invocador, y el default del repo (`default_workflow_permissions: read`) no incluye ese scope.

## Verificacion

| Prueba | Resultado |
|---|---|
| 9 casos con fixtures (espera y avanza, 3 dominios ajenos, `deploy` skipped, timeout, 2 fallos de API) | ✅ |
| Consulta contra la API real de GitHub | ✅ |
| `actionlint` sobre los 6 workflows — solo hallazgos preexistentes | ✅ |
| `shellcheck` del paso | ✅ |
| Asuncion del job llamado `deploy`, contra datos reales de los 4 deploys | ✅ 4/4 |
| Run real [31516294884](../../actions/runs/31516294884) — reprodujo el `startup_failure` | ✅ diagnostico |
| Run real [31516470612](../../actions/runs/31516470612) — `permissions` a nivel workflow, 3 legs | ✅ |
| Run real [31516948045](../../actions/runs/31516948045) — `permissions` a nivel job, 3 legs | ✅ |

En los dos runs verdes la guarda ejecuto con el token restringido en las tres legs:

```
Ningun deploy ajeno de ff0bf418... tiene su job 'deploy' en vuelo. Se continua.
```

## Lo que NO esta verificado

- **La rama que bloquea.** Los dos runs reales encontraron cero deploys ajenos, porque un dispatch sobre una rama no dispara deploys. Solo la reproduce un push a `main` que dispare dos o mas deploys: el primero despues del merge la ejercita.
- **El camino de timeout** en runner real (si por fixture).
- **Dependencia de nombres:** el prefijo `Deploy ` y el job llamado `deploy`. Es la convencion de los cuatro workflows y la que genera el scaffolder, pero si cambia, la guarda deja de ver al ajeno **en silencio**. Documentado en el codigo como el primer punto a revisar; el blindaje va en el issue del harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)