### PR TITLE
Crear los value objects de identidad del colaborador

### DIFF
--- a/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/Identificacion.Mensajes.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/Identificacion.Mensajes.cs
@@ -1,0 +1,16 @@
+using System.Resources;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+
+public sealed partial class Identificacion
+{
+    private static readonly ResourceManager ResourceManager = new(
+        "Bitakora.ControlAsistencia.Colaboradores.DomainEvents.IdentificacionMensajes",
+        typeof(Identificacion).Assembly);
+
+    public static class Mensajes
+    {
+        public static string NumeroVacio =>
+            ResourceManager.GetString(nameof(NumeroVacio))!;
+    }
+}

--- a/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/Identificacion.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/Identificacion.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using System.Text.Json.Serialization.Metadata;
 
 namespace Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
@@ -39,20 +40,54 @@ public sealed partial class Identificacion : IEquatable<Identificacion>
     }
 
     // CA-1, CA-2: normaliza (trim + MAYUSCULAS) y valida que el numero no sea vacio ni whitespace.
-    public static Identificacion Crear(TipoIdentificacion tipo, string numero) =>
-        throw new NotImplementedException();
+    public static Identificacion Crear(TipoIdentificacion tipo, string numero)
+    {
+        if (string.IsNullOrWhiteSpace(numero))
+            throw new ArgumentException(Mensajes.NumeroVacio, nameof(numero));
+
+        return new Identificacion(tipo, numero.Trim().ToUpperInvariant());
+    }
 
     // Contrato: clave del stream de Colaborador.
-    public override string ToString() => throw new NotImplementedException();
+    public override string ToString() => $"{_tipo}:{_numero}";
 
-    // Igualdad por valor
-    public bool Equals(Identificacion? other) => throw new NotImplementedException();
+    // Igualdad por valor. _tipo se compara por referencia (deliberado, ver remarks de
+    // TipoIdentificacion): Desde() siempre retorna la instancia canonica de la lista cerrada.
+    public bool Equals(Identificacion? other) =>
+        other is not null && _tipo == other._tipo && _numero == other._numero;
 
     public override bool Equals(object? obj) => Equals(obj as Identificacion);
 
-    public override int GetHashCode() => throw new NotImplementedException();
+    public override int GetHashCode() => HashCode.Combine(_tipo, _numero);
 
     // Mapping de serializacion -- vive aqui porque cambia con la clase (patron SubFranja).
-    public static void ConfigurarSerializacion(DefaultJsonTypeInfoResolver resolver) =>
-        throw new NotImplementedException();
+    // _tipo se persiste como su codigo literal ("CC") y se rehidrata via TipoIdentificacion.Desde --
+    // el codigo, no una sombra numerica, es el contrato de identidad (MEF-ADR-0012).
+    public static void ConfigurarSerializacion(DefaultJsonTypeInfoResolver resolver)
+    {
+        var ctor = typeof(Identificacion)
+            .GetConstructor(BindingFlags.NonPublic | BindingFlags.Instance, Type.EmptyTypes)!;
+        var tipoField = typeof(Identificacion)
+            .GetField("_tipo", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var numeroField = typeof(Identificacion)
+            .GetField("_numero", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        resolver.Modifiers.Add(typeInfo =>
+        {
+            if (typeInfo.Type != typeof(Identificacion)) return;
+            if (typeInfo.Kind != JsonTypeInfoKind.Object) return;
+
+            typeInfo.CreateObject = () => ctor.Invoke(null);
+
+            var tipoProp = typeInfo.CreateJsonPropertyInfo(typeof(string), "tipo");
+            tipoProp.Get = obj => ((Identificacion)obj)._tipo.ToString();
+            tipoProp.Set = (obj, val) => tipoField.SetValue(obj, TipoIdentificacion.Desde((string)val!));
+            typeInfo.Properties.Add(tipoProp);
+
+            var numeroProp = typeInfo.CreateJsonPropertyInfo(typeof(string), "numero");
+            numeroProp.Get = obj => numeroField.GetValue(obj);
+            numeroProp.Set = (obj, val) => numeroField.SetValue(obj, val);
+            typeInfo.Properties.Add(numeroProp);
+        });
+    }
 }

--- a/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/Identificacion.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/Identificacion.cs
@@ -23,6 +23,11 @@ public sealed partial class Identificacion : IEquatable<Identificacion>
     private readonly TipoIdentificacion _tipo;
     private readonly string _numero;
 
+    // Observables de solo lectura (interfaz publica fijada por el issue #348). Son insumo del
+    // mapeo rico->plano de #349+, NO la via para armar la clave del stream: esa clave sale
+    // unicamente de ToString(). Recomponerla a mano -- $"{id.Tipo}:{id.Numero}" -- duplicaria el
+    // punto de conversion y dejaria el separador y el orden en manos del llamador
+    // (MEF-ADR-0037: punto unico de conversion de la identidad de stream).
     public TipoIdentificacion Tipo => _tipo;
     public string Numero => _numero;
 
@@ -65,27 +70,28 @@ public sealed partial class Identificacion : IEquatable<Identificacion>
     // el codigo, no una sombra numerica, es el contrato de identidad (MEF-ADR-0012).
     public static void ConfigurarSerializacion(DefaultJsonTypeInfoResolver resolver)
     {
-        var ctor = typeof(Identificacion)
-            .GetConstructor(BindingFlags.NonPublic | BindingFlags.Instance, Type.EmptyTypes)!;
-        var tipoField = typeof(Identificacion)
-            .GetField("_tipo", BindingFlags.NonPublic | BindingFlags.Instance)!;
-        var numeroField = typeof(Identificacion)
-            .GetField("_numero", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var tipoClase = typeof(Identificacion);
+        var ctor = tipoClase.GetConstructor(BindingFlags.NonPublic | BindingFlags.Instance, Type.EmptyTypes)!;
+        var tipoField = tipoClase.GetField("_tipo", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var numeroField = tipoClase.GetField("_numero", BindingFlags.NonPublic | BindingFlags.Instance)!;
 
         resolver.Modifiers.Add(typeInfo =>
         {
-            if (typeInfo.Type != typeof(Identificacion)) return;
+            if (typeInfo.Type != tipoClase) return;
             if (typeInfo.Kind != JsonTypeInfoKind.Object) return;
 
             typeInfo.CreateObject = () => ctor.Invoke(null);
 
+            // Los Get leen los campos directamente (este codigo vive dentro de la propia clase);
+            // solo los Set necesitan reflexion, porque los campos son readonly y C# no permite
+            // asignarlos fuera del constructor.
             var tipoProp = typeInfo.CreateJsonPropertyInfo(typeof(string), "tipo");
             tipoProp.Get = obj => ((Identificacion)obj)._tipo.ToString();
             tipoProp.Set = (obj, val) => tipoField.SetValue(obj, TipoIdentificacion.Desde((string)val!));
             typeInfo.Properties.Add(tipoProp);
 
             var numeroProp = typeInfo.CreateJsonPropertyInfo(typeof(string), "numero");
-            numeroProp.Get = obj => numeroField.GetValue(obj);
+            numeroProp.Get = obj => ((Identificacion)obj)._numero;
             numeroProp.Set = (obj, val) => numeroField.SetValue(obj, val);
             typeInfo.Properties.Add(numeroProp);
         });

--- a/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/Identificacion.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/Identificacion.cs
@@ -1,0 +1,58 @@
+using System.Text.Json.Serialization.Metadata;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+
+/// <summary>
+/// Identidad de un colaborador: tipo de documento (lista cerrada PILA) + numero.
+/// </summary>
+/// <remarks>
+/// Issue #348: compone la clave del stream del futuro ColaboradorAggregateRoot (#349+) --
+/// ToString() -> "{Tipo}:{Numero}" es CONTRATO, no detalle de presentacion. El numero es
+/// alfanumerico (los pasaportes traen letras), se normaliza trim + MAYUSCULAS para que
+/// " ab-123 " y "AB-123" produzcan el mismo stream (CA-1).
+/// MEF-ADR-0012: sealed class, constructor privado real + constructor vacio para STJ/Marten,
+/// factory Crear() con validacion, ConfigurarSerializacion registrando campos privados (patron
+/// SubFranja) -- proscrito [JsonConstructor].
+/// Tipo y Numero son observables de solo lectura: son la identidad misma (no datos intermedios de
+/// calculo), los DTOs planos de bus del futuro evento persistido (#349+) los necesitaran para el
+/// mapeo rico->plano.
+/// </remarks>
+public sealed partial class Identificacion : IEquatable<Identificacion>
+{
+    private readonly TipoIdentificacion _tipo;
+    private readonly string _numero;
+
+    public TipoIdentificacion Tipo => _tipo;
+    public string Numero => _numero;
+
+    private Identificacion(TipoIdentificacion tipo, string numero)
+    {
+        _tipo = tipo;
+        _numero = numero;
+    }
+
+    // Constructor vacio para STJ/Marten
+    private Identificacion()
+    {
+        _tipo = TipoIdentificacion.CC;
+        _numero = string.Empty;
+    }
+
+    // CA-1, CA-2: normaliza (trim + MAYUSCULAS) y valida que el numero no sea vacio ni whitespace.
+    public static Identificacion Crear(TipoIdentificacion tipo, string numero) =>
+        throw new NotImplementedException();
+
+    // Contrato: clave del stream de Colaborador.
+    public override string ToString() => throw new NotImplementedException();
+
+    // Igualdad por valor
+    public bool Equals(Identificacion? other) => throw new NotImplementedException();
+
+    public override bool Equals(object? obj) => Equals(obj as Identificacion);
+
+    public override int GetHashCode() => throw new NotImplementedException();
+
+    // Mapping de serializacion -- vive aqui porque cambia con la clase (patron SubFranja).
+    public static void ConfigurarSerializacion(DefaultJsonTypeInfoResolver resolver) =>
+        throw new NotImplementedException();
+}

--- a/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/IdentificacionMensajes.resx
+++ b/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/IdentificacionMensajes.resx
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" msdata:Ordinal="0" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter</value></resheader>
+  <data name="NumeroVacio" xml:space="preserve">
+    <value>El numero de identificacion no puede estar vacio ni contener solo espacios</value>
+  </data>
+</root>

--- a/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/NombreColaborador.Mensajes.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/NombreColaborador.Mensajes.cs
@@ -1,0 +1,19 @@
+using System.Resources;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+
+public sealed partial class NombreColaborador
+{
+    private static readonly ResourceManager ResourceManager = new(
+        "Bitakora.ControlAsistencia.Colaboradores.DomainEvents.NombreColaboradorMensajes",
+        typeof(NombreColaborador).Assembly);
+
+    public static class Mensajes
+    {
+        public static string PrimerNombreRequerido =>
+            ResourceManager.GetString(nameof(PrimerNombreRequerido))!;
+
+        public static string PrimerApellidoRequerido =>
+            ResourceManager.GetString(nameof(PrimerApellidoRequerido))!;
+    }
+}

--- a/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/NombreColaborador.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/NombreColaborador.cs
@@ -1,0 +1,59 @@
+using System.Text.Json.Serialization.Metadata;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+
+/// <summary>
+/// Nombre completo del colaborador -- dueno unico de la composicion del nombre completo.
+/// </summary>
+/// <remarks>
+/// Issue #348: primer nombre y primer apellido son obligatorios (minimo colombiano); los segundos
+/// son opcionales (null, vacio o whitespace se normalizan a ausente, con trim en los presentes).
+/// NombreCompleto es la unica composicion canonica -- ningun consumidor concatena por su cuenta
+/// (Tell-don't-Ask, MEF-ADR-0012).
+/// Los 4 componentes NO son publicos: cuando el futuro evento persistido (#349+) necesite mapear a
+/// un DTO plano de bus, ese issue decidira la via de conversion (ej. ToContrato()), no este.
+/// </remarks>
+public sealed partial class NombreColaborador : IEquatable<NombreColaborador>
+{
+    private readonly string _primerNombre;
+    private readonly string? _segundoNombre;
+    private readonly string _primerApellido;
+    private readonly string? _segundoApellido;
+
+    private NombreColaborador(
+        string primerNombre, string? segundoNombre, string primerApellido, string? segundoApellido)
+    {
+        _primerNombre = primerNombre;
+        _segundoNombre = segundoNombre;
+        _primerApellido = primerApellido;
+        _segundoApellido = segundoApellido;
+    }
+
+    // Constructor vacio para STJ/Marten
+    private NombreColaborador()
+    {
+        _primerNombre = string.Empty;
+        _primerApellido = string.Empty;
+    }
+
+    // CA-3: primer nombre y primer apellido obligatorios (no vacios ni whitespace, con trim). Los
+    // segundos se normalizan a ausente cuando llegan null, vacios o whitespace.
+    public static NombreColaborador Crear(
+        string primerNombre, string? segundoNombre, string primerApellido, string? segundoApellido) =>
+        throw new NotImplementedException();
+
+    // CA-4: composicion canonica unica -- espacios simples, omite opcionales ausentes.
+    public string NombreCompleto => throw new NotImplementedException();
+
+    public override string ToString() => throw new NotImplementedException();
+
+    // Igualdad por valor
+    public bool Equals(NombreColaborador? other) => throw new NotImplementedException();
+
+    public override bool Equals(object? obj) => Equals(obj as NombreColaborador);
+
+    public override int GetHashCode() => throw new NotImplementedException();
+
+    public static void ConfigurarSerializacion(DefaultJsonTypeInfoResolver resolver) =>
+        throw new NotImplementedException();
+}

--- a/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/NombreColaborador.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/NombreColaborador.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using System.Text.Json.Serialization.Metadata;
 
 namespace Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
@@ -39,21 +40,69 @@ public sealed partial class NombreColaborador : IEquatable<NombreColaborador>
     // CA-3: primer nombre y primer apellido obligatorios (no vacios ni whitespace, con trim). Los
     // segundos se normalizan a ausente cuando llegan null, vacios o whitespace.
     public static NombreColaborador Crear(
-        string primerNombre, string? segundoNombre, string primerApellido, string? segundoApellido) =>
-        throw new NotImplementedException();
+        string primerNombre, string? segundoNombre, string primerApellido, string? segundoApellido)
+    {
+        if (string.IsNullOrWhiteSpace(primerNombre))
+            throw new ArgumentException(Mensajes.PrimerNombreRequerido, nameof(primerNombre));
+        if (string.IsNullOrWhiteSpace(primerApellido))
+            throw new ArgumentException(Mensajes.PrimerApellidoRequerido, nameof(primerApellido));
+
+        return new NombreColaborador(
+            primerNombre.Trim(), NormalizarOpcional(segundoNombre),
+            primerApellido.Trim(), NormalizarOpcional(segundoApellido));
+    }
 
     // CA-4: composicion canonica unica -- espacios simples, omite opcionales ausentes.
-    public string NombreCompleto => throw new NotImplementedException();
+    public string NombreCompleto =>
+        string.Join(" ", new[] { _primerNombre, _segundoNombre, _primerApellido, _segundoApellido }
+            .Where(componente => !string.IsNullOrWhiteSpace(componente)));
 
-    public override string ToString() => throw new NotImplementedException();
+    public override string ToString() => NombreCompleto;
 
     // Igualdad por valor
-    public bool Equals(NombreColaborador? other) => throw new NotImplementedException();
+    public bool Equals(NombreColaborador? other) =>
+        other is not null
+        && _primerNombre == other._primerNombre
+        && _segundoNombre == other._segundoNombre
+        && _primerApellido == other._primerApellido
+        && _segundoApellido == other._segundoApellido;
 
     public override bool Equals(object? obj) => Equals(obj as NombreColaborador);
 
-    public override int GetHashCode() => throw new NotImplementedException();
+    public override int GetHashCode() =>
+        HashCode.Combine(_primerNombre, _segundoNombre, _primerApellido, _segundoApellido);
 
-    public static void ConfigurarSerializacion(DefaultJsonTypeInfoResolver resolver) =>
-        throw new NotImplementedException();
+    private static string? NormalizarOpcional(string? valor) =>
+        string.IsNullOrWhiteSpace(valor) ? null : valor.Trim();
+
+    public static void ConfigurarSerializacion(DefaultJsonTypeInfoResolver resolver)
+    {
+        var tipoClase = typeof(NombreColaborador);
+        var ctor = tipoClase.GetConstructor(BindingFlags.NonPublic | BindingFlags.Instance, Type.EmptyTypes)!;
+        var primerNombreField = tipoClase.GetField("_primerNombre", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var segundoNombreField = tipoClase.GetField("_segundoNombre", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var primerApellidoField = tipoClase.GetField("_primerApellido", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var segundoApellidoField = tipoClase.GetField("_segundoApellido", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        resolver.Modifiers.Add(typeInfo =>
+        {
+            if (typeInfo.Type != tipoClase) return;
+            if (typeInfo.Kind != JsonTypeInfoKind.Object) return;
+
+            typeInfo.CreateObject = () => ctor.Invoke(null);
+
+            RegistrarCampo(typeInfo, primerNombreField, "primerNombre");
+            RegistrarCampo(typeInfo, segundoNombreField, "segundoNombre");
+            RegistrarCampo(typeInfo, primerApellidoField, "primerApellido");
+            RegistrarCampo(typeInfo, segundoApellidoField, "segundoApellido");
+        });
+    }
+
+    private static void RegistrarCampo(JsonTypeInfo typeInfo, FieldInfo field, string nombreJson)
+    {
+        var prop = typeInfo.CreateJsonPropertyInfo(typeof(string), nombreJson);
+        prop.Get = obj => field.GetValue(obj);
+        prop.Set = (obj, val) => field.SetValue(obj, val);
+        typeInfo.Properties.Add(prop);
+    }
 }

--- a/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/NombreColaboradorMensajes.resx
+++ b/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/NombreColaboradorMensajes.resx
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" msdata:Ordinal="0" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter</value></resheader>
+  <data name="PrimerNombreRequerido" xml:space="preserve">
+    <value>El primer nombre del colaborador es obligatorio</value>
+  </data>
+  <data name="PrimerApellidoRequerido" xml:space="preserve">
+    <value>El primer apellido del colaborador es obligatorio</value>
+  </data>
+</root>

--- a/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/TipoIdentificacion.Mensajes.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/TipoIdentificacion.Mensajes.cs
@@ -1,0 +1,16 @@
+using System.Resources;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+
+public sealed partial class TipoIdentificacion
+{
+    private static readonly ResourceManager ResourceManager = new(
+        "Bitakora.ControlAsistencia.Colaboradores.DomainEvents.TipoIdentificacionMensajes",
+        typeof(TipoIdentificacion).Assembly);
+
+    public static class Mensajes
+    {
+        public static string CodigoNoReconocido =>
+            ResourceManager.GetString(nameof(CodigoNoReconocido))!;
+    }
+}

--- a/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/TipoIdentificacion.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/TipoIdentificacion.cs
@@ -23,13 +23,28 @@ public sealed partial class TipoIdentificacion
     public static readonly TipoIdentificacion PA = new("PA");
     public static readonly TipoIdentificacion PT = new("PT");
 
+    // Lookup map por clave discreta (codigo -> instancia), no switch/if: agregar un tipo de
+    // documento nuevo es agregar una fila aqui, no una rama.
+    private static readonly IReadOnlyDictionary<string, TipoIdentificacion> PorCodigo =
+        new Dictionary<string, TipoIdentificacion>
+        {
+            [CC._codigo] = CC,
+            [CE._codigo] = CE,
+            [TI._codigo] = TI,
+            [PA._codigo] = PA,
+            [PT._codigo] = PT,
+        };
+
     private readonly string _codigo;
 
     private TipoIdentificacion(string codigo) => _codigo = codigo;
 
     // CA-2: rehidrata desde el codigo persistido; rechaza codigos fuera de la lista cerrada.
-    public static TipoIdentificacion Desde(string codigo) => throw new NotImplementedException();
+    public static TipoIdentificacion Desde(string codigo) =>
+        PorCodigo.TryGetValue(codigo, out var tipo)
+            ? tipo
+            : throw new ArgumentException(Mensajes.CodigoNoReconocido, nameof(codigo));
 
     // El codigo literal ("CC") -- contrato de persistencia y de composicion de la clave de stream.
-    public override string ToString() => throw new NotImplementedException();
+    public override string ToString() => _codigo;
 }

--- a/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/TipoIdentificacion.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/TipoIdentificacion.cs
@@ -1,0 +1,35 @@
+namespace Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+
+/// <summary>
+/// Tipo de documento de identificacion del colaborador -- lista cerrada segun la Resolucion
+/// 2388/2016 (PILA): CC, CE, TI, PA, PT.
+/// </summary>
+/// <remarks>
+/// Issue #348: VO de lista cerrada -- instancias estaticas con constructor privado (MEF-ADR-0012),
+/// NUNCA un enum C#: lo persistido y lo que compone claves de stream es siempre el codigo literal
+/// ("CC"), jamas una sombra numerica. Extensible por despliegue: agregar un tipo de documento es
+/// agregar una instancia estatica y desplegar, sin migrar datos existentes.
+/// Nota: TipoBloque (ControlHoras.DomainEvents) es enum, pero no es precedente aplicable aqui -- no
+/// compone claves de stream ni persiste como codigo literal.
+/// Igualdad por referencia (deliberado, decision de pipeline): Desde() siempre retorna la instancia
+/// canonica de la lista cerrada, nunca crea una nueva, asi que no hace falta IEquatable custom. La
+/// interfaz publica propuesta por el planner dejaba esta decision explicitamente revisable.
+/// </remarks>
+public sealed partial class TipoIdentificacion
+{
+    public static readonly TipoIdentificacion CC = new("CC");
+    public static readonly TipoIdentificacion CE = new("CE");
+    public static readonly TipoIdentificacion TI = new("TI");
+    public static readonly TipoIdentificacion PA = new("PA");
+    public static readonly TipoIdentificacion PT = new("PT");
+
+    private readonly string _codigo;
+
+    private TipoIdentificacion(string codigo) => _codigo = codigo;
+
+    // CA-2: rehidrata desde el codigo persistido; rechaza codigos fuera de la lista cerrada.
+    public static TipoIdentificacion Desde(string codigo) => throw new NotImplementedException();
+
+    // El codigo literal ("CC") -- contrato de persistencia y de composicion de la clave de stream.
+    public override string ToString() => throw new NotImplementedException();
+}

--- a/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/TipoIdentificacion.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/TipoIdentificacion.cs
@@ -40,8 +40,15 @@ public sealed partial class TipoIdentificacion
     private TipoIdentificacion(string codigo) => _codigo = codigo;
 
     // CA-2: rehidrata desde el codigo persistido; rechaza codigos fuera de la lista cerrada.
+    // El chequeo de null NO es defensivo redundante: este es el boundary de rehidratacion desde
+    // JSON (Identificacion.ConfigurarSerializacion lo llama con el valor crudo del payload), asi
+    // que un "tipo": null persistido debe fallar con el mensaje de dominio y no con el
+    // ArgumentNullException del diccionario, que no dice nada del contrato roto.
+    // La comparacion es exacta y sensible a mayusculas: lo persistido es siempre el codigo
+    // canonico ("CC"), y aceptar "cc" en silencio abriria dos representaciones para la misma
+    // identidad -- y con ellas dos claves de stream distintas.
     public static TipoIdentificacion Desde(string codigo) =>
-        PorCodigo.TryGetValue(codigo, out var tipo)
+        codigo is not null && PorCodigo.TryGetValue(codigo, out var tipo)
             ? tipo
             : throw new ArgumentException(Mensajes.CodigoNoReconocido, nameof(codigo));
 

--- a/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/TipoIdentificacionMensajes.resx
+++ b/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/TipoIdentificacionMensajes.resx
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" msdata:Ordinal="0" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter</value></resheader>
+  <data name="CodigoNoReconocido" xml:space="preserve">
+    <value>El codigo de tipo de identificacion no esta en la lista permitida (CC, CE, TI, PA, PT)</value>
+  </data>
+</root>

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ValueObjects/IdentificacionIgualdadTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ValueObjects/IdentificacionIgualdadTests.cs
@@ -1,0 +1,24 @@
+// HU-348: Igualdad por valor de Identificacion (CA-1, CA-5).
+using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Tests.ValueObjects;
+
+/// <summary>
+/// Hereda los 8 tests de IgualdadTestBase que verifican el contrato IEquatable completo.
+/// CA-1: la normalizacion (trim + MAYUSCULAS) hace que " ab-123 " y "AB-123" sean la misma
+/// identidad. CA-5: CC:123 != CE:123 (difiere el tipo).
+/// </summary>
+public class IdentificacionIgualdadTests : IgualdadTestBase<Identificacion>
+{
+    protected override Identificacion CrearInstancia() =>
+        Identificacion.Crear(TipoIdentificacion.CC, " ab-123 ");
+
+    protected override Identificacion CrearInstanciaCopia() =>
+        Identificacion.Crear(TipoIdentificacion.CC, "AB-123");
+
+    protected override IEnumerable<(string, Identificacion)> CrearInstanciasDiferentes()
+    {
+        yield return ("Tipo", Identificacion.Crear(TipoIdentificacion.CE, "AB-123"));
+        yield return ("Numero", Identificacion.Crear(TipoIdentificacion.CC, "XY-999"));
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ValueObjects/IdentificacionSerializacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ValueObjects/IdentificacionSerializacionTests.cs
@@ -1,0 +1,63 @@
+// HU-348 CA-6: round-trip de serializacion (patron Marten) para Identificacion.
+// ConfiguracionSerializacionColaboradores todavia no existe -- este issue no introduce ningun
+// evento persistido (ver "Investigacion del planner" del issue #348), asi que el resolver se
+// arma localmente con Identificacion.ConfigurarSerializacion, igual que
+// Programacion.Tests/ValueObjects/SubFranjaSerializacionTests.cs hace con SubFranja antes de que
+// un evento persistido la reclame como payload.
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Tests.ValueObjects;
+
+public class IdentificacionSerializacionTests
+{
+    private static JsonSerializerOptions CrearOpciones()
+    {
+        var resolver = new DefaultJsonTypeInfoResolver();
+        Identificacion.ConfigurarSerializacion(resolver);
+        return new JsonSerializerOptions { TypeInfoResolver = resolver, PropertyNamingPolicy = null };
+    }
+
+    [Fact]
+    public void RoundTrip_PreservaIgualdad_CuandoIdentificacionValida()
+    {
+        var original = Identificacion.Crear(TipoIdentificacion.CC, "1098765432");
+        var opciones = CrearOpciones();
+
+        var json = JsonSerializer.Serialize(original, opciones);
+        var restaurado = JsonSerializer.Deserialize<Identificacion>(json, opciones);
+
+        restaurado.Should().Be(original);
+    }
+
+    [Fact]
+    public void RoundTrip_PreservaTipoYNumero_CuandoIdentificacionEsPasaporte()
+    {
+        var original = Identificacion.Crear(TipoIdentificacion.PA, "AB1234567");
+        var opciones = CrearOpciones();
+
+        var json = JsonSerializer.Serialize(original, opciones);
+        var restaurado = JsonSerializer.Deserialize<Identificacion>(json, opciones);
+
+        restaurado.Should().NotBeNull();
+        restaurado!.Tipo.Should().BeSameAs(TipoIdentificacion.PA);
+        restaurado.Numero.Should().Be("AB1234567");
+    }
+
+    // Barrera anti-regresion: sin el resolver custom (equivalente a olvidar registrar el VO), STJ
+    // no puede reconstruir Identificacion -- su unico constructor es privado y no hay
+    // [JsonConstructor] (proscrito por MEF-ADR-0012).
+    [Fact]
+    public void Deserializar_Falla_CuandoResolverNoTieneRegistroDeIdentificacion()
+    {
+        var original = Identificacion.Crear(TipoIdentificacion.CC, "1098765432");
+        var json = JsonSerializer.Serialize(original, CrearOpciones());
+        var opciones = new JsonSerializerOptions { TypeInfoResolver = new DefaultJsonTypeInfoResolver() };
+
+        var act = () => JsonSerializer.Deserialize<Identificacion>(json, opciones);
+
+        act.Should().Throw<NotSupportedException>();
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ValueObjects/IdentificacionSerializacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ValueObjects/IdentificacionSerializacionTests.cs
@@ -46,6 +46,26 @@ public class IdentificacionSerializacionTests
         restaurado.Numero.Should().Be("AB1234567");
     }
 
+    // El contrato central de TipoIdentificacion es la FORMA de lo persistido, no solo que el
+    // round-trip cierre: "lo persistido es SIEMPRE el codigo literal, jamas un numero" (issue #348,
+    // razon por la que el tipo no es un enum C#). El round-trip de arriba pasaria en verde aunque
+    // el tipo se guardara como sombra numerica o como objeto anidado -- solo esta asercion sobre el
+    // JSON lo impide, y es lo que blinda los streams ya escritos el dia que alguien "simplifique"
+    // el mapping.
+    [Fact]
+    public void Serializar_PersisteElTipoComoCodigoLiteral_CuandoIdentificacionValida()
+    {
+        var original = Identificacion.Crear(TipoIdentificacion.CC, "1098765432");
+
+        var json = JsonSerializer.Serialize(original, CrearOpciones());
+
+        using var documento = JsonDocument.Parse(json);
+        var tipo = documento.RootElement.GetProperty("tipo");
+        tipo.ValueKind.Should().Be(JsonValueKind.String, "el tipo nunca se persiste como numero");
+        tipo.GetString().Should().Be("CC");
+        documento.RootElement.GetProperty("numero").GetString().Should().Be("1098765432");
+    }
+
     // Barrera anti-regresion: sin el resolver custom (equivalente a olvidar registrar el VO), STJ
     // no puede reconstruir Identificacion -- su unico constructor es privado y no hay
     // [JsonConstructor] (proscrito por MEF-ADR-0012).

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ValueObjects/IdentificacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ValueObjects/IdentificacionTests.cs
@@ -1,0 +1,78 @@
+// HU-348: Value object Identificacion -- compone la clave del stream de Colaborador.
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Tests.ValueObjects;
+
+/// <summary>
+/// Interfaz publica: Crear(tipo, numero), Tipo, Numero, ToString() -- contrato de clave de stream.
+/// </summary>
+public class IdentificacionTests
+{
+    // ---------- CA-1: normalizacion trim + MAYUSCULAS garantiza el mismo stream ----------
+
+    [Fact]
+    public void Crear_NormalizaNumeroATrimYMayusculas_CuandoNumeroTraeEspaciosYMinusculas()
+    {
+        var identificacion = Identificacion.Crear(TipoIdentificacion.CC, " ab-123 ");
+
+        identificacion.ToString().Should().Be("CC:AB-123");
+    }
+
+    [Fact]
+    public void ToString_ComponeTipoYNumeroConDosPuntos_CuandoIdentificacionValida()
+    {
+        var identificacion = Identificacion.Crear(TipoIdentificacion.CE, "1098765432");
+
+        identificacion.ToString().Should().Be("CE:1098765432");
+    }
+
+    // ---------- CA-2: numero alfanumerico aceptado (pasaportes traen letras) ----------
+
+    [Fact]
+    public void Crear_AceptaNumeroAlfanumerico_CuandoEsPasaporte()
+    {
+        var identificacion = Identificacion.Crear(TipoIdentificacion.PA, "AB1234567");
+
+        identificacion.Numero.Should().Be("AB1234567");
+        identificacion.Tipo.Should().BeSameAs(TipoIdentificacion.PA);
+    }
+
+    // ---------- CA-2: numero vacio o whitespace rechazado con mensaje .resx ----------
+
+    [Fact]
+    public void Crear_LanzaArgumentException_CuandoNumeroEsVacio()
+    {
+        var act = () => Identificacion.Crear(TipoIdentificacion.CC, string.Empty);
+
+        act.Should().ThrowExactly<ArgumentException>()
+            .WithMessage($"*{Identificacion.Mensajes.NumeroVacio}*");
+    }
+
+    [Fact]
+    public void Crear_LanzaArgumentException_CuandoNumeroEsWhitespace()
+    {
+        var act = () => Identificacion.Crear(TipoIdentificacion.CC, "   ");
+
+        act.Should().ThrowExactly<ArgumentException>()
+            .WithMessage($"*{Identificacion.Mensajes.NumeroVacio}*");
+    }
+
+    // ---------- Tipo/Numero: observables de solo lectura (identidad misma, no dato intermedio) ----------
+
+    [Fact]
+    public void Tipo_ExponeElTipoDeIdentificacion_CuandoIdentificacionCreada()
+    {
+        var identificacion = Identificacion.Crear(TipoIdentificacion.TI, "12345");
+
+        identificacion.Tipo.Should().BeSameAs(TipoIdentificacion.TI);
+    }
+
+    [Fact]
+    public void Numero_ExponeElNumeroNormalizado_CuandoIdentificacionCreada()
+    {
+        var identificacion = Identificacion.Crear(TipoIdentificacion.CC, " ab-123 ");
+
+        identificacion.Numero.Should().Be("AB-123");
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ValueObjects/IgualdadTestBase.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ValueObjects/IgualdadTestBase.cs
@@ -1,0 +1,86 @@
+using AwesomeAssertions;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Tests.ValueObjects;
+
+/// <summary>
+/// Clase base generica para tests de contrato IEquatable en value objects.
+/// Subclases solo definen las instancias de prueba; los 8 tests se heredan.
+/// </summary>
+public abstract class IgualdadTestBase<T> where T : class, IEquatable<T>
+{
+    protected abstract T CrearInstancia();
+    protected abstract T CrearInstanciaCopia();
+    protected abstract IEnumerable<(string atributo, T diferente)> CrearInstanciasDiferentes();
+
+    [Fact]
+    public void Equals_RetornaTrue_CuandoMismosValores()
+    {
+        var a = CrearInstancia();
+        var b = CrearInstanciaCopia();
+
+        a.Equals(b).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Equals_RetornaFalse_CuandoAtributoDiferente()
+    {
+        var instancia = CrearInstancia();
+
+        foreach (var (atributo, diferente) in CrearInstanciasDiferentes())
+        {
+            instancia.Equals(diferente).Should().BeFalse(
+                $"Equals deberia retornar false cuando '{atributo}' es diferente");
+        }
+    }
+
+    [Fact]
+    public void Equals_RetornaFalse_CuandoOtroEsNull()
+    {
+        var a = CrearInstancia();
+
+        a.Equals((T?)null).Should().BeFalse();
+    }
+
+    [Fact]
+    public void EqualsObject_RetornaTrue_CuandoMismoValorComoObject()
+    {
+        var a = CrearInstancia();
+        object b = CrearInstanciaCopia();
+
+        a.Equals(b).Should().BeTrue();
+    }
+
+    [Fact]
+    public void EqualsObject_RetornaFalse_CuandoTipoDiferente()
+    {
+        var a = CrearInstancia();
+
+        a.Equals("no es el tipo correcto").Should().BeFalse();
+    }
+
+    [Fact]
+    public void EqualsObject_RetornaFalse_CuandoObjectNull()
+    {
+        var a = CrearInstancia();
+
+        a.Equals((object?)null).Should().BeFalse();
+    }
+
+    [Fact]
+    public void GetHashCode_RetornaMismoHash_CuandoMismosValores()
+    {
+        var a = CrearInstancia();
+        var b = CrearInstanciaCopia();
+
+        a.GetHashCode().Should().Be(b.GetHashCode());
+    }
+
+    [Fact]
+    public void GetHashCode_RetornaHashDiferente_CuandoValoresDiferentes()
+    {
+        var a = CrearInstancia();
+        var b = CrearInstanciasDiferentes().First().diferente;
+
+        a.GetHashCode().Should().NotBe(b.GetHashCode());
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ValueObjects/MensajesResxTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ValueObjects/MensajesResxTests.cs
@@ -1,0 +1,38 @@
+// HU-348: guardrail de resolucion de los .resx de los VOs de identidad (MEF-ADR-0009).
+//
+// Por que existe: la clase Mensajes de cada VO devuelve ResourceManager.GetString(...)! -- el "!"
+// es supresion del compilador, no garantia de runtime. Si la CLAVE desaparece del .resx (rename de
+// la clave, merge que la pierde), GetString retorna null en silencio y los tests de validacion de
+// este issue pasan en FALSO: sus aserciones son WithMessage($"*{Mensajes.X}*"), que con X == null
+// se vuelve "**" y matchea cualquier excepcion.
+//
+// Verificado por mutacion durante la revision de #348: al renombrar la clave NumeroVacio en el
+// .resx, los dos tests de Crear_LanzaArgumentException_CuandoNumeroEs* siguieron en VERDE y solo
+// fallo este archivo. (El otro modo de falla -- romper el nombre logico del recurso -- si lanza
+// MissingManifestResourceException y lo detecta cualquier test; el silencioso es este.)
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Tests.ValueObjects;
+
+public class MensajesResxTests
+{
+    [Fact]
+    public void Mensajes_ResuelvenTextoNoVacio_CuandoPertenecenAIdentificacion()
+    {
+        Identificacion.Mensajes.NumeroVacio.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public void Mensajes_ResuelvenTextoNoVacio_CuandoPertenecenATipoIdentificacion()
+    {
+        TipoIdentificacion.Mensajes.CodigoNoReconocido.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public void Mensajes_ResuelvenTextoNoVacio_CuandoPertenecenANombreColaborador()
+    {
+        NombreColaborador.Mensajes.PrimerNombreRequerido.Should().NotBeNullOrWhiteSpace();
+        NombreColaborador.Mensajes.PrimerApellidoRequerido.Should().NotBeNullOrWhiteSpace();
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ValueObjects/NombreColaboradorIgualdadTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ValueObjects/NombreColaboradorIgualdadTests.cs
@@ -1,0 +1,25 @@
+// HU-348: Igualdad por valor de NombreColaborador (CA-5).
+using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Tests.ValueObjects;
+
+/// <summary>
+/// Hereda los 8 tests de IgualdadTestBase que verifican el contrato IEquatable completo.
+/// </summary>
+public class NombreColaboradorIgualdadTests : IgualdadTestBase<NombreColaborador>
+{
+    protected override NombreColaborador CrearInstancia() =>
+        NombreColaborador.Crear("Luis", "Augusto", "Barreto", "Gomez");
+
+    protected override NombreColaborador CrearInstanciaCopia() =>
+        NombreColaborador.Crear("Luis", "Augusto", "Barreto", "Gomez");
+
+    protected override IEnumerable<(string, NombreColaborador)> CrearInstanciasDiferentes()
+    {
+        yield return ("PrimerNombre", NombreColaborador.Crear("Carlos", "Augusto", "Barreto", "Gomez"));
+        yield return ("SegundoNombre", NombreColaborador.Crear("Luis", "Andres", "Barreto", "Gomez"));
+        yield return ("PrimerApellido", NombreColaborador.Crear("Luis", "Augusto", "Romero", "Gomez"));
+        yield return ("SegundoApellido", NombreColaborador.Crear("Luis", "Augusto", "Barreto", "Arango"));
+        yield return ("SegundoNombreAusente", NombreColaborador.Crear("Luis", null, "Barreto", "Gomez"));
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ValueObjects/NombreColaboradorSerializacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ValueObjects/NombreColaboradorSerializacionTests.cs
@@ -1,0 +1,59 @@
+// HU-348 CA-6: round-trip de serializacion (patron Marten) para NombreColaborador.
+// ConfiguracionSerializacionColaboradores todavia no existe (mismo razonamiento que
+// IdentificacionSerializacionTests.cs): el resolver se arma localmente con
+// NombreColaborador.ConfigurarSerializacion.
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Tests.ValueObjects;
+
+public class NombreColaboradorSerializacionTests
+{
+    private static JsonSerializerOptions CrearOpciones()
+    {
+        var resolver = new DefaultJsonTypeInfoResolver();
+        NombreColaborador.ConfigurarSerializacion(resolver);
+        return new JsonSerializerOptions { TypeInfoResolver = resolver, PropertyNamingPolicy = null };
+    }
+
+    [Fact]
+    public void RoundTrip_PreservaIgualdad_CuandoLos4ComponentesEstanPresentes()
+    {
+        var original = NombreColaborador.Crear("Luis", "Augusto", "Barreto", "Gomez");
+        var opciones = CrearOpciones();
+
+        var json = JsonSerializer.Serialize(original, opciones);
+        var restaurado = JsonSerializer.Deserialize<NombreColaborador>(json, opciones);
+
+        restaurado.Should().Be(original);
+    }
+
+    [Fact]
+    public void RoundTrip_PreservaAusenciaDeSegundos_CuandoSegundosSonNull()
+    {
+        var original = NombreColaborador.Crear("Luis", null, "Barreto", null);
+        var opciones = CrearOpciones();
+
+        var json = JsonSerializer.Serialize(original, opciones);
+        var restaurado = JsonSerializer.Deserialize<NombreColaborador>(json, opciones);
+
+        restaurado.Should().NotBeNull();
+        restaurado!.NombreCompleto.Should().Be("Luis Barreto");
+    }
+
+    // Barrera anti-regresion: sin el resolver custom, STJ no puede reconstruir NombreColaborador --
+    // su unico constructor es privado y no hay [JsonConstructor] (proscrito por MEF-ADR-0012).
+    [Fact]
+    public void Deserializar_Falla_CuandoResolverNoTieneRegistroDeNombreColaborador()
+    {
+        var original = NombreColaborador.Crear("Luis", "Augusto", "Barreto", "Gomez");
+        var json = JsonSerializer.Serialize(original, CrearOpciones());
+        var opciones = new JsonSerializerOptions { TypeInfoResolver = new DefaultJsonTypeInfoResolver() };
+
+        var act = () => JsonSerializer.Deserialize<NombreColaborador>(json, opciones);
+
+        act.Should().Throw<NotSupportedException>();
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ValueObjects/NombreColaboradorTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ValueObjects/NombreColaboradorTests.cs
@@ -1,0 +1,138 @@
+// HU-348: Value object NombreColaborador -- dueno unico de la composicion del nombre completo.
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Tests.ValueObjects;
+
+/// <summary>
+/// Interfaz publica: Crear(primerNombre, segundoNombre?, primerApellido, segundoApellido?),
+/// NombreCompleto, ToString(). Los 4 componentes NO son publicos (Tell-don't-Ask, MEF-ADR-0012).
+/// </summary>
+public class NombreColaboradorTests
+{
+    // ---------- CA-3: primer nombre obligatorio ----------
+
+    [Fact]
+    public void Crear_LanzaArgumentException_CuandoPrimerNombreEsNull()
+    {
+        var act = () => NombreColaborador.Crear(null!, null, "Barreto", null);
+
+        act.Should().ThrowExactly<ArgumentException>()
+            .WithMessage($"*{NombreColaborador.Mensajes.PrimerNombreRequerido}*");
+    }
+
+    [Fact]
+    public void Crear_LanzaArgumentException_CuandoPrimerNombreEsVacio()
+    {
+        var act = () => NombreColaborador.Crear(string.Empty, null, "Barreto", null);
+
+        act.Should().ThrowExactly<ArgumentException>()
+            .WithMessage($"*{NombreColaborador.Mensajes.PrimerNombreRequerido}*");
+    }
+
+    [Fact]
+    public void Crear_LanzaArgumentException_CuandoPrimerNombreEsWhitespace()
+    {
+        var act = () => NombreColaborador.Crear("   ", null, "Barreto", null);
+
+        act.Should().ThrowExactly<ArgumentException>()
+            .WithMessage($"*{NombreColaborador.Mensajes.PrimerNombreRequerido}*");
+    }
+
+    // ---------- CA-3: primer apellido obligatorio ----------
+
+    [Fact]
+    public void Crear_LanzaArgumentException_CuandoPrimerApellidoEsNull()
+    {
+        var act = () => NombreColaborador.Crear("Luis", null, null!, null);
+
+        act.Should().ThrowExactly<ArgumentException>()
+            .WithMessage($"*{NombreColaborador.Mensajes.PrimerApellidoRequerido}*");
+    }
+
+    [Fact]
+    public void Crear_LanzaArgumentException_CuandoPrimerApellidoEsVacio()
+    {
+        var act = () => NombreColaborador.Crear("Luis", null, string.Empty, null);
+
+        act.Should().ThrowExactly<ArgumentException>()
+            .WithMessage($"*{NombreColaborador.Mensajes.PrimerApellidoRequerido}*");
+    }
+
+    [Fact]
+    public void Crear_LanzaArgumentException_CuandoPrimerApellidoEsWhitespace()
+    {
+        var act = () => NombreColaborador.Crear("Luis", null, "   ", null);
+
+        act.Should().ThrowExactly<ArgumentException>()
+            .WithMessage($"*{NombreColaborador.Mensajes.PrimerApellidoRequerido}*");
+    }
+
+    // ---------- CA-4: NombreCompleto compone con espacios simples ----------
+
+    [Fact]
+    public void NombreCompleto_ComponeLos4Componentes_CuandoTodosPresentes()
+    {
+        var nombre = NombreColaborador.Crear("Luis", "Augusto", "Barreto", "Gomez");
+
+        nombre.NombreCompleto.Should().Be("Luis Augusto Barreto Gomez");
+    }
+
+    [Fact]
+    public void NombreCompleto_OmiteSegundosAusentes_CuandoSonNull()
+    {
+        var nombre = NombreColaborador.Crear("Luis", null, "Barreto", null);
+
+        nombre.NombreCompleto.Should().Be("Luis Barreto");
+    }
+
+    [Fact]
+    public void NombreCompleto_OmiteSegundosAusentes_CuandoSonVaciosOWhitespace()
+    {
+        var nombre = NombreColaborador.Crear("Luis", "  ", "Barreto", string.Empty);
+
+        nombre.NombreCompleto.Should().Be("Luis Barreto");
+    }
+
+    [Fact]
+    public void NombreCompleto_ComponeSoloSegundoNombre_CuandoSegundoApellidoAusente()
+    {
+        var nombre = NombreColaborador.Crear("Luis", "Augusto", "Barreto", null);
+
+        nombre.NombreCompleto.Should().Be("Luis Augusto Barreto");
+    }
+
+    [Fact]
+    public void NombreCompleto_ComponeSoloSegundoApellido_CuandoSegundoNombreAusente()
+    {
+        var nombre = NombreColaborador.Crear("Luis", null, "Barreto", "Gomez");
+
+        nombre.NombreCompleto.Should().Be("Luis Barreto Gomez");
+    }
+
+    [Fact]
+    public void Crear_NormalizaConTrim_CuandoComponentesTraenEspacios()
+    {
+        var nombre = NombreColaborador.Crear(" Luis ", " Augusto ", " Barreto ", " Gomez ");
+
+        nombre.NombreCompleto.Should().Be("Luis Augusto Barreto Gomez");
+    }
+
+    [Fact]
+    public void ToString_RetornaElNombreCompletoLiteral_CuandoNombreValido()
+    {
+        var nombre = NombreColaborador.Crear("Luis", "Augusto", "Barreto", "Gomez");
+
+        nombre.ToString().Should().Be("Luis Augusto Barreto Gomez");
+    }
+
+    // El issue declara ToString() como identico a NombreCompleto (contrato de diseno explicito,
+    // no coincidencia derivada de la logica bajo prueba): ambos deben mostrar el mismo texto.
+    [Fact]
+    public void ToString_EsIgualANombreCompleto_CuandoNombreValido()
+    {
+        var nombre = NombreColaborador.Crear("Luis", "Augusto", "Barreto", "Gomez");
+
+        nombre.ToString().Should().Be(nombre.NombreCompleto);
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ValueObjects/TipoIdentificacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ValueObjects/TipoIdentificacionTests.cs
@@ -1,0 +1,78 @@
+// HU-348: Value object de lista cerrada TipoIdentificacion (Resolucion 2388/2016, PILA).
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Tests.ValueObjects;
+
+/// <summary>
+/// TipoIdentificacion es una lista cerrada de instancias estaticas (CC, CE, TI, PA, PT) -- NUNCA
+/// un enum C#: lo persistido y lo que compone claves de stream es siempre el codigo literal.
+/// Interfaz publica: instancias estaticas CC/CE/TI/PA/PT, Desde(codigo), ToString().
+/// </summary>
+public class TipoIdentificacionTests
+{
+    // ---------- CA-2: Desde() rehidrata desde el codigo persistido ----------
+
+    [Fact]
+    public void Desde_RetornaInstanciaCC_CuandoCodigoEsCC()
+    {
+        var resultado = TipoIdentificacion.Desde("CC");
+
+        resultado.Should().BeSameAs(TipoIdentificacion.CC);
+    }
+
+    [Fact]
+    public void Desde_RetornaInstanciaCE_CuandoCodigoEsCE()
+    {
+        var resultado = TipoIdentificacion.Desde("CE");
+
+        resultado.Should().BeSameAs(TipoIdentificacion.CE);
+    }
+
+    [Fact]
+    public void Desde_RetornaInstanciaTI_CuandoCodigoEsTI()
+    {
+        var resultado = TipoIdentificacion.Desde("TI");
+
+        resultado.Should().BeSameAs(TipoIdentificacion.TI);
+    }
+
+    [Fact]
+    public void Desde_RetornaInstanciaPA_CuandoCodigoEsPA()
+    {
+        var resultado = TipoIdentificacion.Desde("PA");
+
+        resultado.Should().BeSameAs(TipoIdentificacion.PA);
+    }
+
+    [Fact]
+    public void Desde_RetornaInstanciaPT_CuandoCodigoEsPT()
+    {
+        var resultado = TipoIdentificacion.Desde("PT");
+
+        resultado.Should().BeSameAs(TipoIdentificacion.PT);
+    }
+
+    [Fact]
+    public void Desde_LanzaArgumentException_CuandoCodigoFueraDeLaListaCerrada()
+    {
+        var act = () => TipoIdentificacion.Desde("XX");
+
+        act.Should().ThrowExactly<ArgumentException>()
+            .WithMessage($"*{TipoIdentificacion.Mensajes.CodigoNoReconocido}*");
+    }
+
+    // ---------- ToString(): el codigo literal, contrato de persistencia y de clave de stream ----------
+
+    [Fact]
+    public void ToString_RetornaCodigoLiteral_CuandoInstanciaEsCC()
+    {
+        TipoIdentificacion.CC.ToString().Should().Be("CC");
+    }
+
+    [Fact]
+    public void ToString_RetornaCodigoLiteral_CuandoInstanciaEsPA()
+    {
+        TipoIdentificacion.PA.ToString().Should().Be("PA");
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ValueObjects/TipoIdentificacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ValueObjects/TipoIdentificacionTests.cs
@@ -62,6 +62,29 @@ public class TipoIdentificacionTests
             .WithMessage($"*{TipoIdentificacion.Mensajes.CodigoNoReconocido}*");
     }
 
+    // Desde() es el boundary de rehidratacion desde el payload persistido: un "tipo": null en el
+    // JSON debe fallar con el mensaje de dominio, no con el ArgumentNullException que el
+    // diccionario lanzaria por su cuenta (que no dice nada del contrato roto).
+    [Fact]
+    public void Desde_LanzaArgumentException_CuandoCodigoEsNull()
+    {
+        var act = () => TipoIdentificacion.Desde(null!);
+
+        act.Should().ThrowExactly<ArgumentException>()
+            .WithMessage($"*{TipoIdentificacion.Mensajes.CodigoNoReconocido}*");
+    }
+
+    // El codigo canonico es el unico aceptado: tolerar "cc" abriria dos representaciones para la
+    // misma identidad y, con ellas, dos claves de stream distintas para el mismo colaborador.
+    [Fact]
+    public void Desde_LanzaArgumentException_CuandoCodigoVieneEnMinusculas()
+    {
+        var act = () => TipoIdentificacion.Desde("cc");
+
+        act.Should().ThrowExactly<ArgumentException>()
+            .WithMessage($"*{TipoIdentificacion.Mensajes.CodigoNoReconocido}*");
+    }
+
     // ---------- ToString(): el codigo literal, contrato de persistencia y de clave de stream ----------
 
     [Fact]


### PR DESCRIPTION
## Resumen

Pipeline TDD completado:
- Fase roja: tests escritos con stubs
- Fase verde: implementación completa
- Fase refactor: revisión de calidad

## Decisiones del pipeline

<details>
<summary>Test Writer (fase roja) — 12m 55s</summary>

## ES Test Writer - Decisiones

### Tests creados

- `ValueObjects/TipoIdentificacionTests.cs`: 8 tests
  - `Desde_RetornaInstanciaCC_CuandoCodigoEsCC` / `...CE...` / `...TI...` / `...PA...` / `...PT...` - CA-2 (rehidratacion desde codigo persistido, cada instancia de la lista cerrada)
  - `Desde_LanzaArgumentException_CuandoCodigoFueraDeLaListaCerrada` - CA-2 (rechazo de codigo fuera de la lista)
  - `ToString_RetornaCodigoLiteral_CuandoInstanciaEsCC` / `...PA` - contrato del codigo literal (sin sombra numerica)

- `ValueObjects/IdentificacionTests.cs`: 6 tests
  - `Crear_NormalizaNumeroATrimYMayusculas_CuandoNumeroTraeEspaciosYMinusculas` - CA-1
  - `ToString_ComponeTipoYNumeroConDosPuntos_CuandoIdentificacionValida` - CA-1 (contrato de clave de stream)
  - `Crear_AceptaNumeroAlfanumerico_CuandoEsPasaporte` - CA-2 (alfanumerico aceptado)
  - `Crear_LanzaArgumentException_CuandoNumeroEsVacio` / `...EsWhitespace` - CA-2 (rechazo con mensaje .resx)
  - `Tipo_ExponeElTipoDeIdentificacion_CuandoIdentificacionCreada`, `Numero_ExponeElNumeroNormalizado_CuandoIdentificacionCreada` - interfaz publica (Tipo/Numero observables)

- `ValueObjects/IdentificacionIgualdadTests.cs` (hereda `IgualdadTestBase<Identificacion>`, 8 tests heredados): CA-1 (misma identidad tras normalizacion), CA-5 (CC:123 != CE:123, CC:123 != CC:456)

- `ValueObjects/IdentificacionSerializacionTests.cs`: 3 tests
  - `RoundTrip_PreservaIgualdad_CuandoIdentificacionValida`, `RoundTrip_PreservaTipoYNumero_CuandoIdentificacionEsPasaporte` - CA-6
  - `Deserializar_Falla_CuandoResolverNoTieneRegistroDeIdentificacion` - barrera anti-regresion (patron seccion 6d)

- `ValueObjects/NombreColaboradorTests.cs`: 12 tests
  - `Crear_LanzaArgumentException_CuandoPrimerNombreEs{Null,Vacio,Whitespace}` / `...PrimerApellidoEs...` - CA-3
  - `NombreCompleto_ComponeLos4Componentes_CuandoTodosPresentes`, `..._OmiteSegundosAusentes_CuandoSonNull`, `..._CuandoSonVaciosOWhitespace`, `..._ComponeSoloSegundoNombre_...`, `..._ComponeSoloSegundoApellido_...` - CA-4
  - `Crear_NormalizaConTrim_CuandoComponentesTraenEspacios` - CA-3/CA-4 (trim de todos los componentes)
  - `ToString_RetornaElNombreCompletoLiteral_CuandoNombreValido` - oraculo literal independiente
  - `ToString_EsIgualANombreCompleto_CuandoNombreValido` - contrato de diseno explicito del issue (ToString == NombreCompleto)

- `ValueObjects/NombreColaboradorIgualdadTests.cs` (hereda `IgualdadTestBase<NombreColaborador>`, 8 tests heredados): CA-5

- `ValueObjects/NombreColaboradorSerializacionTests.cs`: 3 tests
  - `RoundTrip_PreservaIgualdad_CuandoLos4ComponentesEstanPresentes`, `RoundTrip_PreservaAusenciaDeSegundos_CuandoSegundosSonNull` - CA-6
  - `Deserializar_Falla_CuandoResolverNoTieneRegistroDeNombreColaborador` - barrera anti-regresion

- `ValueObjects/IgualdadTestBase.cs`: infraestructura de test compartida (duplicada del precedente de `ControlHoras.Tests`/`Programacion.Tests` -- cada proyecto de tests tiene su propia copia porque no se referencian entre si).

### Estructura elegida

- **Un archivo de test por responsabilidad**, no por VO completo: `<Tipo>Tests.cs` (comportamiento/validacion), `<Tipo>IgualdadTests.cs` (contrato `IEquatable` via `IgualdadTestBase<T>`), `<Tipo>SerializacionTests.cs` (round-trip). Replica exactamente el patron ya usado en `ControlHoras.Tests/ValueObjects/` y `Programacion.Tests/ValueObjects/` (ej. `MomentoDelDiaTests.cs` + `MomentoDelDiaIgualdadTests.cs` + `MomentoDelDiaSerializacionTests.cs`).
- `TipoIdentificacionTests.cs` no tiene archivo de igualdad separado: la decision de diseno fue igualdad por referencia (ver mas abajo), asi que no hereda `IgualdadTestBase<T>`.
- Todos los VOs viven directamente en la raiz de `Colaboradores.DomainEvents/` (no en un subfolder `ValueObjects/`), replicando el precedente `SubFranja.cs`/`FranjaOrdinaria.cs`/`SedeProgramada.cs` en `Programacion.DomainEvents/`.
- Tests unitarios puros (sin `CommandHandlerAsyncTest`/harness de Marten): el issue es la capa de VOs del desglose, sin comando ni evento ni aggregate. Por eso ningun test usa `Given/When/Then/And<>` -- esa regla del rol aplica solo a tests de command handlers.

### Stubs creados

- `TipoIdentificacion.cs`: sealed class con 5 instancias estaticas (`CC`, `CE`, `TI`, `PA`, `PT`) reales (declaracion trivial de datos, sin logica) + ctor privado real (asignacion trivial) + `Desde(string)` y `ToString()` con `throw new NotImplementedException()` (logica de busqueda/validacion/formato).
- `Identificacion.cs`: sealed partial class, ctor privado real + ctor vacio real (para STJ/Marten, estado valido trivial) + `Tipo`/`Numero` como propiedades de solo lectura reales (getters triviales de campo) + `Crear`, `ToString`, `Equals`, `GetHashCode`, `ConfigurarSerializacion` con `throw new NotImplementedException()`.
- `NombreColaborador.cs`: mismo patron -- ctor privado/vacio reales, 4 campos privados (sin getters publicos, Tell-don't-Ask), `Crear`, `NombreCompleto`, `ToString`, `Equals`, `GetHashCode`, `ConfigurarSerializacion` con `throw new NotImplementedException()`.
- `.resx` + `.Mensajes.cs` para los 3 VOs: `TipoIdentificacionMensajes.resx` (`CodigoNoReconocido`), `IdentificacionMensajes.resx` (`NumeroVacio`), `NombreColaboradorMensajes.resx` (`PrimerNombreRequerido`, `PrimerApellidoRequerido`).

### Decisiones de diseno

- **`TipoIdentificacion` sin `IEquatable` (igualdad por referencia)**: el issue dejaba esto explicitamente revisable ("con instancias estaticas + Desde puede bastar referencia -- decision del pipeline"). Decidi NO implementar `IEquatable<TipoIdentificacion>` porque `Desde()` siempre retorna la instancia canonica de la lista cerrada (nunca crea una nueva), asi que la igualdad por referencia es correcta incluso post-deserializacion (el resolver de `Identificacion` rehidrata `_tipo` via `Desde`, nunca con `new`). Esto simplifica el VO y evita una capa de indireccion innecesaria.
- **`Identificacion.Tipo`/`Numero` publicos**: seguido tal cual la propuesta del planner (son la identidad misma, no datos intermedios de calculo -- MEF-ADR-0012). No hubo razon tecnica para desviarme.
- **`NombreColaborador`: los 4 componentes quedan `private`**, sin getters. Seguido tal cual la propuesta del planner (Tell-don't-Ask: `NombreCompleto` es la unica composicion canonica).
- **Serializacion sin `ConfiguracionSerializacionColaboradores`**: seguida la propuesta del planner de NO crear esa clase en este issue (no existe ningun evento persistido todavia que la necesite). Los tests de round-trip arman el resolver localmente llamando directo a `Identificacion.ConfigurarSerializacion` / `NombreColaborador.ConfigurarSerializacion` -- exactamente el mismo patron que ya existe en el repo en `Programacion.Tests/ValueObjects/SubFranjaSerializacionTests.cs` (VO probado antes de que el evento persistido que lo consume exista). Cuando el primer evento persistido de Colaboradores llegue (#349+), esa clase se creara y podra reusar estos mismos `ConfigurarSerializacion`.
- **Constructores privados y campos triviales NO tiran `NotImplementedException`**: siguiendo el precedente verificado en el propio historial del repo (commit `748d702`, tests de HU-112 para `MomentoDelDia`/`IntervaloTemporal`), solo los metodos con logica de negocio (validacion, busqueda, formato, composicion, igualdad) tiran `NotImplementedException`. Las declaraciones estructurales (constructores triviales, instancias estaticas de la lista cerrada, propiedades que exponen un campo sin transformacion) quedan reales para que el tipo exista con la forma correcta.

### Cobertura de criterios

| Criterio de aceptacion | Test(s) |
|---|---|
| CA-1: normalizacion trim+MAYUSCULAS -> mismo stream, igualdad por valor | `IdentificacionTests.Crear_NormalizaNumeroATrimYMayusculas_CuandoNumeroTraeEspaciosYMinusculas`, `IdentificacionTests.ToString_ComponeTipoYNumeroConDosPuntos_CuandoIdentificacionValida`, `IdentificacionIgualdadTests.Equals_RetornaTrue_CuandoMismosValores` (heredado) |
| CA-2: numero alfanumerico aceptado / vacio-whitespace rechazado / `Desde` invalido rechazado / `Desde` valido retorna instancia | `IdentificacionTests.Crear_AceptaNumeroAlfanumerico_CuandoEsPasaporte`, `IdentificacionTests.Crear_LanzaArgumentException_CuandoNumeroEsVacio`, `IdentificacionTests.Crear_LanzaArgumentException_CuandoNumeroEsWhitespace`, `TipoIdentificacionTests.Desde_LanzaArgumentException_CuandoCodigoFueraDeLaListaCerrada`, `TipoIdentificacionTests.Desde_RetornaInstanciaCC_CuandoCodigoEsCC` |
| CA-3: `NombreColaborador.Crear` sin primer nombre/apellido -> rechazo con mensaje .resx | `NombreColaboradorTests.Crear_LanzaArgumentException_CuandoPrimerNombreEs{Null,Vacio,Whitespace}`, `...CuandoPrimerApellidoEs{Null,Vacio,Whitespace}` |
| CA-4: `NombreCompleto` compone con espacios simples, omite opcionales ausentes | `NombreColaboradorTests.NombreCompleto_ComponeLos4Componentes_CuandoTodosPresentes`, `..._OmiteSegundosAusentes_CuandoSonNull`, `..._CuandoSonVaciosOWhitespace`, `..._ComponeSoloSegundoNombre_...`, `..._ComponeSoloSegundoApellido_...` |
| CA-5: igualdad por valor en `Identificacion`/`NombreColaborador`, distintos cuando difiere un campo, `GetHashCode` consistente | `IdentificacionIgualdadTests` (8 tests heredados de `IgualdadTestBase`), `NombreColaboradorIgualdadTests` (8 tests heredados) |
| CA-6: round-trip de serializacion (patron Marten) sin `[JsonConstructor]` | `IdentificacionSerializacionTests.RoundTrip_*`, `NombreColaboradorSerializacionTests.RoundTrip_*` (+ barrera anti-regresion `Deserializar_Falla_*`) |

### Desviaciones del plan del planner

Ninguna estructural. Dos decisiones explicitamente dejadas "revisables" por el planner, resueltas asi:

| Sugerencia del issue | Desviacion aplicada | Razon tecnica | Consecuencia |
|---|---|---|---|
| "Igualdad por valor (necesaria si se deserializa; ... puede bastar referencia -- decision del pipeline)" para `TipoIdentificacion` | No se implemento `IEquatable<TipoIdentificacion>`; se usa igualdad por referencia (default de `object`) | `Desde()` siempre retorna la instancia canonica de la lista cerrada (nunca `new`), incluso al rehidratar desde el resolver de `Identificacion`. Referencia = valor en este caso, sin necesidad de una capa adicional | Ningun CA se ve afectado: `TipoIdentificacionTests` no depende de `Equals` custom; `IdentificacionIgualdadTests`/`NombreColaboradorIgualdadTests` comparan `Identificacion`/`NombreColaborador` (que si implementan `IEquatable`), no `TipoIdentificacion` directamente |
| "`ConfiguracionSerializacionColaboradores` no existe aun ... Propuesta: NO crearla en este issue" | Seguida tal cual: no se creo esa clase; los tests de round-trip arman el resolver localmente | El planner ya identifico que esa clase gemela solo tiene sentido cuando exista un evento persistido que registrar (ninguno en este issue); crearla vacia o con solo VOs rompería el patron establecido en `ConfiguracionSerializacionProgramacion`/`ConfiguracionSerializacionControlHoras` (que registran tipos de evento, no VOs sueltos) | El implementer del primer evento persistido de Colaboradores (#349+) creara esa clase reusando `Identificacion.ConfigurarSerializacion`/`NombreColaborador.ConfigurarSerializacion` ya definidos aqui |

No se toco `IdentidadEventosColaboradores.cs` ni ningun `.csproj` (confirmado por build de la solucion completa sin errores).

</details>

<details>
<summary>Implementer (fase verde) — 6m 4s</summary>

## ES Implementer - Decisiones

### Enfoque de implementacion
El test-writer dejo los tres VOs (`TipoIdentificacion`, `Identificacion`, `NombreColaborador`)
con la interfaz publica completa (campos, constructores, propiedades, mensajes .resx) y solo los
cuerpos en `throw new NotImplementedException()`. Implemente cada cuerpo siguiendo al pie de la
letra el patron canonico `SubFranja`/`FranjaTemporal` (ctor privado real + ctor vacio para
STJ/Marten, factory `Crear`/`Desde` con validacion, `ConfigurarSerializacion` con reflexion sobre
campos privados, sin `[JsonConstructor]`). No fue necesario tocar ninguna firma publica ni ningun
archivo de test.

### Decisiones de diseno
- **`TipoIdentificacion.Desde`**: lookup map (`Dictionary<string, TipoIdentificacion>` estatico a
  nivel de clase, `PorCodigo`) en vez de un `switch`/cadena de `if` -- la seleccion es por clave
  discreta (el codigo literal), heuristica "Lookup map sobre switch/if" del agente. Agregar un
  tipo de documento nuevo (ej. si algun dia se agrega otro codigo PILA) es agregar una fila al
  diccionario, no una rama.
- **`Identificacion.ConfigurarSerializacion`**: registre `_tipo` como una property JSON de tipo
  `string` (no como `TipoIdentificacion` anidado), con `Get` que llama `_tipo.ToString()` (el
  codigo literal) y `Set` que llama `TipoIdentificacion.Desde(...)` para rehidratar la instancia
  canonica. Esto evita depender de que `TipoIdentificacion` tenga su propio
  `ConfigurarSerializacion` (no lo tiene ni lo necesita: sus unicas instancias son estaticas y
  `Desde` ya resuelve la rehidratacion) y preserva el contrato "lo persistido es el codigo
  literal, nunca una sombra numerica" (issue #348, alcance de `TipoIdentificacion`).
- **Igualdad de `Identificacion` sobre `_tipo`**: comparacion por referencia (`_tipo ==
  other._tipo`), consistente con la decision ya documentada en los comentarios del test-writer en
  `TipoIdentificacion.cs` (`Desde()` siempre retorna la instancia canonica de la lista cerrada).
  No fue necesario agregar `IEquatable<TipoIdentificacion>`.
- **`NombreColaborador.NombreCompleto`**: `string.Join(" ", array.Where(...))` con LINQ (regla
  #5 del agente: nunca `for`/`foreach` cuando LINQ resuelve el problema) para omitir componentes
  ausentes (null/vacio/whitespace) y componer con espacios simples.
- **Reflexion para readonly fields en `ConfigurarSerializacion`**: igual que `SubFranja`, los
  campos son `private readonly`, por lo que el `Set` de cada `JsonPropertyInfo` usa
  `FieldInfo.SetValue` (bypassa la restriccion de solo-constructor de C# para `readonly`, ya
  probado en el precedente `FranjaTemporal.RegistrarCampo`). El `Get`, en cambio, no necesita
  reflexion para `Identificacion._tipo`/`._numero` (se accede directo dentro de la propia clase);
  para `NombreColaborador` use un helper `RegistrarCampo` local (mismo nombre y forma que
  `FranjaTemporal.RegistrarCampo`, pero sin clase base compartida ya que `NombreColaborador` no
  hereda de nada) que usa reflexion tanto para `Get` como para `Set`, por simetria y para reusar
  una sola funcion para los 4 campos string/string?.

### ADRs consultados
- MEF-ADR-0012: ctor privado, factory `Crear`, `ConfigurarSerializacion`, Tell-don't-Ask,
  proscripcion `[JsonConstructor]`.
- CA-ADR-0029 / MEF-ADR-0039: isla `DomainEvents` sin referencias de proyecto ni paquetes -- no
  se agrego ninguna dependencia nueva al `.csproj`.
- MEF-ADR-0009: mensajes de validacion via `.resx` (ya provistos por el test-writer, solo se
  consumieron).
- MEF-ADR-0016: convencion de nombres de tests (ya aplicada por el test-writer, no me
  correspondia tocarla).

### Desviaciones de ADRs
Ninguna desviacion -- todos los ADRs aplicados al pie de la letra.

### Desviaciones del plan del planner
Ninguna desviacion relevante de "Interfaz publica propuesta". El planner dejaba explicitamente
revisables dos puntos, ambos resueltos como sugeria el issue sin cambiar la interfaz publica:
- Igualdad de `TipoIdentificacion` por referencia (no se agrego `IEquatable<TipoIdentificacion>`):
  el propio test-writer ya habia fijado esta decision en el comentario de `TipoIdentificacion.cs`
  antes de que yo tocara el archivo; la mantuve.
- Persistencia de `Identificacion._tipo` como su codigo string + rehidratacion via `Desde`: tal
  como sugeria el issue ("Sugerencia: persistir el tipo como su codigo string y rehidratar via
  Desde").

### Precedentes consultados
- `Programacion.DomainEvents/SubFranja.cs` + `FranjaTemporal.cs`: patron de
  `ConfigurarSerializacion` con reflexion (ctor privado invocado via `ConstructorInfo.Invoke`,
  campos registrados con `FieldInfo.GetValue`/`SetValue`). Alineado con MEF-ADR-0012 -- se
  replico sin modificaciones de fondo.
- `ControlHoras.DomainEvents/Empleado.cs` (mencionado en el issue, no fue necesario leerlo: el
  payload plano de bus queda fuera del alcance de este issue, #349+ lo resolvera).

### Infraestructura modificada
Ninguna. Este issue no introduce comando, evento ni aggregate; no hay publicacion a ningun bus ni
cambios de Terraform.

### Complejidad encontrada
Ninguna significativa. Los tres VOs seguian un patron ya establecido en el proyecto
(`SubFranja`/`FranjaTemporal`); la unica decision de diseno propia fue como mapear
`TipoIdentificacion` (VO anidado sin su propio soporte de serializacion Marten) dentro de
`Identificacion.ConfigurarSerializacion`, resuelta con conversion string <-> instancia canonica
via `ToString()`/`Desde()`.

### Resultado
- Tests pasando: 906/906 en la suite completa (885 correctos + 21 omitidos por falta de
  configuracion local de ServiceBus/Postgres en smoke tests, comportamiento esperado y
  preexistente). 61/61 en `Bitakora.ControlAsistencia.Colaboradores.Tests` (los nuevos de este
  issue).

</details>
<details>
<summary>Reviewer (fase refactor) — 12m 29s</summary>

## ES Reviewer - Revision

### Evaluacion general
- Calidad: **buena** — el diff replica fielmente el patron canonico `SubFranja`/`FranjaTemporal`, sin warnings nuevos, sin codigo muerto y con nombres que hablan el lenguaje del dominio. Los hallazgos son de robustez de boundary y de guardrails ausentes, no de diseno.
- Cambios realizados: **si** (commit `3297d62`)
- Suite: 912 tests, 0 errores, 21 omitidos (smoke tests sin config local, preexistente). Colaboradores.Tests: 61 -> 67.

### Cumplimiento de ADRs aplicables

| ADR | Cumplimiento | Observacion |
|---|---|---|
| MEF-ADR-0012: estilo de modelado de objetos de dominio | ok con 1 desviacion NO declarada | `sealed class` + ctor privado real + ctor vacio + factory `Crear` + `IEquatable<T>` + `ConfigurarSerializacion` sin `[JsonConstructor]`: todo correcto. La desviacion es la exposicion de `Identificacion.Tipo`/`Numero` (ver abajo). |
| CA-ADR-0029 / MEF-ADR-0039: ensamblados de eventos por rol | ok | El diff **no toca ningun `.csproj`** (verificado con `git diff main...HEAD -- '**/*.csproj'`: vacio). La isla `Colaboradores.DomainEvents` conserva cero `ProjectReference` y cero `PackageReference`. No se declara ningun tipo de evento nuevo, asi que no aplican los items (a)-(e) del gate de habilitacion. |
| MEF-ADR-0009: mensajes `.resx` por clase | ok | Un `.resx` por VO, co-localizado, `partial class` + clase `Mensajes` anidada, nombre logico correcto. **Verificado empiricamente** (no por inspeccion): los tres `.resources` estan embebidos en el ensamblado y los textos resuelven. Formato XML identico al precedente `FranjaTemporalMensajes.resx`. |
| MEF-ADR-0016: naming de tests | ok | Todos los tests siguen `<Sujeto>_<LoQuePasa>_Cuando<Condicion>`; solo `[Fact]`, ningun `[Theory]`. |

### Desviaciones de ADRs

**Desviaciones declaradas por el implementer**: ninguna (su resumen dice "Ninguna desviacion — todos los ADRs aplicados al pie de la letra").

**Desviaciones detectadas por el reviewer (NO declaradas por el implementer)**:

#### Desviacion: MEF-ADR-0012 (antipatrones 1 y 3 del checklist de encapsulamiento)
- **Regla del ADR**: "Si una clase externa necesita leer estado interno de un VO para operar sobre el, la operacion pertenece al propio VO... La salida facil — exponer una propiedad publica nueva para que la clase externa la consuma — es exactamente lo que esta proscrito." Antipatron 3: "getter expuesto solo para que los tests verifiquen estado interno".
- **Desviacion encontrada en el diff**: `Identificacion.Tipo` y `Identificacion.Numero` (`Identificacion.cs:26-27`). **Hoy no existe ningun consumidor de produccion**: sus unicos lectores son tests (`IdentificacionTests.Tipo_Expone...`, `Numero_Expone...`, `IdentificacionSerializacionTests`). El consumidor real se anticipa para #349+ (mapeo rico -> plano de bus).
- **Contexto atenuante**: el issue #348 fija estos observables **explicitamente** en su "Interfaz publica propuesta", con justificacion frente a MEF-ADR-0012 ("son la identidad misma, no datos intermedios de calculo") y marcandolos "revisable: si el pipeline prefiere exponerlos via metodo de conversion, documentar la desviacion". El implementer no ejercio esa revision ni la declaro.
- **Evaluacion del reviewer**: **cuestionable, no inaceptable**. La justificacion del issue es defendible (a diferencia de `IntervaloTemporal.MinutosAbsolutosInicio` del PR #155, estos no son insumos de un calculo ajeno sino el valor mismo del VO). Pero el propio issue cita como precedente de estilo `SubFranja`, que resuelve la misma necesidad **sin exponer getters**, via `ToDetalle()` — la via Tell-don't-Ask ya establecida en este repo. El riesgo concreto no es la exposicion en si: es que un consumidor futuro escriba `$"{id.Tipo}:{id.Numero}"` y duplique el punto de conversion de la clave de stream (MEF-ADR-0037, punto 2).
- **Accion tomada**: **no corregida** (eliminar API publica que el issue fija explicitamente excede el mandato del reviewer y reduciria cobertura). **Riesgo mitigado**: documente en `Identificacion.cs:26-31` que la clave del stream sale unicamente de `ToString()` y que recomponerla a mano duplicaria el punto de conversion.
- **Recomendacion para #349**: cuando aterrice el mapeo rico -> plano, preferir `ToContrato()`/`ToDetalle()` en el VO y **retirar** `Tipo`/`Numero` si quedan sin consumidor real.
- **Status**: pendiente de evaluacion del usuario

### Precedentes consultados por el implementer

| Precedente | ADR aplicable | Veredicto |
|---|---|---|
| `Programacion.DomainEvents/SubFranja.cs` | MEF-ADR-0012 | alineado — patron canonico correcto (ctor vacio privado, `CreateObject` via reflexion, campos privados registrados, sin `[JsonConstructor]`) |
| `Programacion.DomainEvents/FranjaTemporal.cs` (helper `RegistrarCampo`) | MEF-ADR-0012 | alineado — y notable: **no expone ningun getter publico**, lo que refuerza el hallazgo sobre `Tipo`/`Numero` |
| `ControlHoras.DomainEvents/Empleado.cs` | CA-ADR-0029 decision #5 | alineado (payload plano por rol); el implementer declara no haberlo leido, sin consecuencia en este corte |

### Convenciones del pipeline (no ADRs)

| Convencion | Estado | Observacion |
|---|---|---|
| Cada test con `Then()` + `And<>()` | n/a | No hay command handlers ni harness de event sourcing en este corte: son tests unitarios puros de VOs, como el issue prescribe |
| Overloads correctos para stream IDs compuestos | n/a | No hay aggregate todavia (#349+) |
| Fakes manuales (no NSubstitute) | n/a | Sin dependencias que fakear |
| Feature folders (produccion y tests) | ok | `ValueObjects/` en tests espeja la ubicacion en la isla; un archivo por responsabilidad (VO / igualdad / serializacion) |
| Smoke tests: SkipWhen, secrets, cobertura | n/a | El diff no introduce endpoint ni efecto secundario |
| Proyecciones read-side | n/a | Diff puramente write-side |
| Antipatrones de habilitacion (MEF-ADR-0039) | n/a | El diff no toca ningun `.csproj` ni declara evento nuevo |
| Compatibilidad Marten write-side/read-side | n/a | No toca version del paquete ni config Marten |
| Identidad de stream (MEF-ADR-0037) | n/a con observacion | El diff no toca `StartStream`/`ComputarStreamId`/GET alguno. No hay `Guid` ni `ToString("N")`. `ToUpperInvariant()` se aplica a un **string alfanumerico de dominio**, no a un `Guid`: es normalizacion legitima (garantiza un unico stream para " ab-123 " y "AB-123"). Observacion preventiva registrada en el codigo (ver desviacion arriba) |
| Control de volumen de telemetria (MEF-ADR-0038) | n/a | No toca seams de observabilidad ni el callback de Wolverine |
| Tests via ToString/comportamiento | parcial | Mayoritariamente si; dos tests afirman sobre getters (`Tipo_Expone...`, `Numero_Expone...`) — antipatron 3, ligado a la desviacion de arriba |
| Sin numeros magicos | ok | Ninguno |
| Condiciones en positivo | ok | Las validaciones son guard clauses con early-throw (`if (string.IsNullOrWhiteSpace(...)) throw`), forma correcta segun la excepcion documentada |

### Elegancia del codigo

El codigo llego en buen estado: LINQ idiomatico en `NombreCompleto`, lookup map en vez de `switch` para `Desde` (decision correcta y bien argumentada por el implementer), XML docs que explican el *por que* y no el *que*, cero warnings nuevos (`dotnet build`: los 4 `NU1902`/`IDE0005` reportados son **preexistentes en `main`**, verificado con `git stash`).

Dos asperezas corregidas:
1. **Asimetria en `Identificacion.ConfigurarSerializacion`**: `tipoProp.Get` accedia al campo directamente pero `numeroProp.Get` usaba reflexion (`numeroField.GetValue`) sin necesidad — el codigo vive dentro de la propia clase. El resumen del implementer incluso afirmaba haber usado acceso directo "para `_tipo`/`_numero`", pero el codigo solo lo hacia para uno. Unificado, con comentario de por que solo los `Set` necesitan reflexion (campos `readonly`).
2. **`typeof(Identificacion)` repetido 3 veces**; extraido a `tipoClase`, en simetria con `NombreColaborador`.

### Criticas y hallazgos

1. **[mayor — corregido] `TipoIdentificacion.Desde(null)` fallaba con el error equivocado.** `Desde` es el boundary de rehidratacion desde JSON: `Identificacion.ConfigurarSerializacion` lo invoca con el valor crudo del payload. Un `"tipo": null` persistido producia el `ArgumentNullException: 'key'` del `Dictionary`, que no dice nada del contrato roto, en vez del mensaje de dominio. Corregido con `codigo is not null && PorCodigo.TryGetValue(...)`, mas dos tests.

2. **[mayor — corregido] El contrato central del issue no tenia guardrail.** El issue insiste en que `TipoIdentificacion` no es enum porque "lo persistido es SIEMPRE el codigo literal, jamas un numero". Ningun test lo verificaba: `RoundTrip_PreservaIgualdad` pasa en verde **igual** si el tipo se persistiera como sombra numerica o como objeto anidado, porque solo compara el objeto restaurado. Agregado `Serializar_PersisteElTipoComoCodigoLiteral`, que afirma sobre el JSON (`ValueKind == String` y valor `"CC"`).

3. **[mayor — corregido] Falso verde latente en los 8 tests de validacion `.resx`.** `Mensajes.X` devuelve `GetString(...)!` — el `!` es supresion del compilador, no garantia. Si una clave desaparece del `.resx`, `GetString` retorna `null`, y las aserciones `WithMessage($"*{Mensajes.X}*")` se vuelven `"**"`, que matchea **cualquier** excepcion. **Verificado por mutacion**: al renombrar la clave `NumeroVacio`, los dos tests `Crear_LanzaArgumentException_CuandoNumeroEs*` siguieron en **verde** y ningun test del repo lo detecto. Agregado `MensajesResxTests` (3 tests); su prueba de mutacion confirma que falla exactamente ante ese escenario y que no es vacuo.

4. **[menor — no corregido, documentado] `Desde` es sensible a mayusculas.** Es la decision correcta (aceptar `"cc"` abriria dos representaciones del mismo tipo y con ellas dos claves de stream para el mismo colaborador), pero era implicita. Fijada ahora con un test (`Desde_LanzaArgumentException_CuandoCodigoVieneEnMinusculas`) y comentario.

5. **[menor — no corregido, escalado] `ConfigurarSerializacion` es hoy codigo muerto en produccion.** MEF-ADR-0012 es explicito: "Sin este registro, `ConfigurarSerializacion` es codigo muerto — solo funciona en tests unitarios con opciones propias, nunca en produccion a traves de Marten". No existe `ConfiguracionSerializacionColaboradores` ni invocacion en `ComposicionServicios`. **Es correcto para este corte** (no hay ningun evento persistido que cargue estos VOs; `IdentidadEventosColaboradores.TiposPersistidos` esta vacia) y el issue lo decide explicitamente. **Riesgo diferido a #349**: si ese issue agrega el primer evento persistido sin crear la clase de configuracion y registrarla dentro del `ConfigureMarten` existente, la deserializacion fallara en runtime, no en el build. El `ComposicionServicios` de Colaboradores ya trae el comentario que lo anticipa — conviene que #349 lo trate como CA explicito.

6. **[cosmetico — no corregido] `IgualdadTestBase` es la sexta copia del repo** (`PublicEvents.Tests`, `PrivateEvents.Tests`, `ControlHoras.Tests`, `Programacion.Tests`, ahora `Colaboradores.Tests`), byte-identica salvo el namespace. Es la convencion vigente y consolidarla exigiria un proyecto de tests compartido — fuera del alcance de esta HU (regla 4). Se deja anotado como candidato a issue propio.

### Refactorings aplicados

1. `TipoIdentificacion.Desde`: guarda de `null` para que el boundary responda con el mensaje de dominio (hallazgo 1).
2. `Identificacion.ConfigurarSerializacion`: `Get` unificados a acceso directo, `typeof()` extraido a local, comentario del porque de la reflexion solo en `Set`.
3. `Identificacion.Tipo`/`Numero`: comentario que ata la construccion de la clave de stream exclusivamente a `ToString()` (mitigacion de la desviacion MEF-ADR-0012 / riesgo MEF-ADR-0037).

Cada cambio se verifico con `dotnet test` inmediatamente despues; ninguno requirio revertirse.

### Cobertura de criterios de aceptacion

| Criterio | Estado | Test(s) |
|---|---|---|
| CA-1: normalizacion trim + MAYUSCULAS -> mismo `ToString()` e igualdad | cubierto | `Crear_NormalizaNumeroATrimYMayusculas_CuandoNumeroTraeEspaciosYMinusculas`, `ToString_ComponeTipoYNumeroConDosPuntos_CuandoIdentificacionValida`, `IdentificacionIgualdadTests` (instancia `" ab-123 "` vs copia `"AB-123"`) |
| CA-2: alfanumerico aceptado; vacio/whitespace rechazado con `.resx`; `Desde("XX")` rechazado; `Desde("CC")` retorna `CC` | cubierto (reforzado) | `Crear_AceptaNumeroAlfanumerico_CuandoEsPasaporte`, `Crear_LanzaArgumentException_CuandoNumeroEsVacio`/`_EsWhitespace`, `Desde_LanzaArgumentException_CuandoCodigoFueraDeLaListaCerrada`, `Desde_RetornaInstanciaCC/CE/TI/PA/PT_*` + **agregados** `Desde_LanzaArgumentException_CuandoCodigoEsNull`, `_CuandoCodigoVieneEnMinusculas` |
| CA-3: sin primer nombre o sin primer apellido (null/vacio/whitespace) -> rechazo `.resx` | cubierto | 6 tests `Crear_LanzaArgumentException_CuandoPrimer{Nombre,Apellido}Es{Null,Vacio,Whitespace}` |
| CA-4: `NombreCompleto` con espacios simples, omite ausentes | cubierto | `NombreCompleto_ComponeLos4Componentes_*`, `_OmiteSegundosAusentes_CuandoSonNull`, `_CuandoSonVaciosOWhitespace`, `_ComponeSoloSegundoNombre_*`, `_ComponeSoloSegundoApellido_*`, `Crear_NormalizaConTrim_*` |
| CA-5: igualdad por valor en ambos VOs, `GetHashCode` consistente | cubierto | `IdentificacionIgualdadTests` + `NombreColaboradorIgualdadTests` (8 tests heredados c/u; `CC:AB-123` vs `CE:AB-123` cubre "difiere el tipo") |
| CA-6: round-trip con resolver preserva igualdad, sin `[JsonConstructor]` | cubierto (reforzado) | `RoundTrip_PreservaIgualdad_*` (x2), `RoundTrip_PreservaTipoYNumero_CuandoIdentificacionEsPasaporte`, `RoundTrip_PreservaAusenciaDeSegundos_*`, `Deserializar_Falla_CuandoResolverNoTieneRegistroDe*` (x2) + **agregado** `Serializar_PersisteElTipoComoCodigoLiteral_CuandoIdentificacionValida` |

Sin CAs sin cubrir.

### Tests agregados

6 tests (61 -> 67 en `Colaboradores.Tests`), todos de contrato o caso borde sobre implementacion ya existente:

- `IdentificacionSerializacionTests.Serializar_PersisteElTipoComoCodigoLiteral_CuandoIdentificacionValida` — blinda el contrato "codigo literal, jamas sombra numerica" afirmando sobre el JSON, no sobre el objeto restaurado.
- `TipoIdentificacionTests.Desde_LanzaArgumentException_CuandoCodigoEsNull` — boundary de rehidratacion.
- `TipoIdentificacionTests.Desde_LanzaArgumentException_CuandoCodigoVieneEnMinusculas` — fija la sensibilidad a mayusculas como decision, no accidente.
- `MensajesResxTests` (3 tests) — cierra el falso verde de los mensajes `.resx`; su valor se verifico por mutacion.

Nota: no se agregaron tests de igualdad ni de serializacion adicionales porque el test-writer ya habia cubierto ambos contratos (`IgualdadTestBase<T>` con las dos subclases, y round-trip + barrera "sin resolver falla" por VO). El guardrail de round-trip **con serializador por defecto** (seccion 6e del test-writer) no aplica: ningun tipo de este diff lleva marker de bus (`IPublicEvent`/`IPrivateEvent`), y por diseno estos VOs ricos no deben cruzar bus alguno.

</details>

## Cobertura

| Archivo | Cobertura | Umbral | Estado |
|---|---|---|---|
| Identificacion.Mensajes.cs | - | excluido | - |
| NombreColaborador.Mensajes.cs | - | excluido | - |
| TipoIdentificacion.Mensajes.cs | - | excluido | - |
| Identificacion.cs | - | no evaluado | - |
| NombreColaborador.cs | - | no evaluado | - |
| TipoIdentificacion.cs | - | no evaluado | - |
## Commits

3297d62 refactor(hu-348): robustez del boundary de rehidratacion y guardrails de contrato
691b0b7 feat(hu-348): implementa los value objects de identidad del colaborador (fase verde)
2c12d64 test(hu-348): tests para value objects de identidad del colaborador (fase roja)

Closes #348