### PR TITLE
Crear el value object Etiqueta con normalizacion

### DIFF
--- a/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/Etiqueta.Mensajes.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/Etiqueta.Mensajes.cs
@@ -1,0 +1,19 @@
+using System.Resources;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+
+public sealed partial class Etiqueta
+{
+    private static readonly ResourceManager ResourceManager = new(
+        "Bitakora.ControlAsistencia.Colaboradores.DomainEvents.EtiquetaMensajes",
+        typeof(Etiqueta).Assembly);
+
+    public static class Mensajes
+    {
+        public static string CategoriaVacia =>
+            ResourceManager.GetString(nameof(CategoriaVacia))!;
+
+        public static string ValorVacio =>
+            ResourceManager.GetString(nameof(ValorVacio))!;
+    }
+}

--- a/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/Etiqueta.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/Etiqueta.cs
@@ -77,7 +77,7 @@ public sealed partial class Etiqueta : IEquatable<Etiqueta>
     public bool EsMismaCategoria(Etiqueta otra) =>
         _categoriaNormalizada == otra._categoriaNormalizada;
 
-    // Propuesta: "{Categoria}:{Valor}" con las formas originales (display).
+    // Display: "{Categoria}:{Valor}" con las formas originales, no las normalizadas.
     public override string ToString() => $"{_categoria}:{_valor}";
 
     // Igualdad por valor COMPLETA: categoria normalizada + valor normalizado.
@@ -91,8 +91,12 @@ public sealed partial class Etiqueta : IEquatable<Etiqueta>
     public override int GetHashCode() =>
         HashCode.Combine(_categoriaNormalizada, _valorNormalizado);
 
-    // Patron documentado por Microsoft para remover diacriticos: descomponer en FormD, filtrar los
+    // Patron documentado por Microsoft para remover diacriticos: descomponer en FormD, filtrar las
     // marcas de combinacion (NonSpacingMark) y recomponer en FormC, todo en minusculas invariantes.
+    // Consecuencia deliberada: la enie tambien se descompone, asi que "Diseño" y "Diseno" son la
+    // MISMA etiqueta (en etiquetas libres tecleadas por el cliente eso evita fragmentar el reporte;
+    // fijado por Crear_NormalizaLaEnieComoN_CuandoValorLaContiene). La forma original si preserva la
+    // enie -- solo la forma normalizada la colapsa.
     // Fuera de alcance (issue #353): errores de transposicion ("aera" vs "area") -- eso es fuzzy
     // matching de UI, no un invariante del dominio.
     private static string Normalizar(string texto) =>
@@ -103,17 +107,16 @@ public sealed partial class Etiqueta : IEquatable<Etiqueta>
             .ToLowerInvariant();
 
     // Mapping de serializacion -- vive aqui porque cambia con la clase (patron SubFranja /
-    // Identificacion). Persiste las 4 formas (doble forma por campo, decision del planner).
+    // NombreColaborador). Persiste las 4 formas (doble forma por campo, decision del planner): el
+    // evento es autocontenido y no recalcula la normalizacion al rehidratar.
     public static void ConfigurarSerializacion(DefaultJsonTypeInfoResolver resolver)
     {
         var tipoClase = typeof(Etiqueta);
         var ctor = tipoClase.GetConstructor(BindingFlags.NonPublic | BindingFlags.Instance, Type.EmptyTypes)!;
-        var categoriaField = tipoClase.GetField("_categoria", BindingFlags.NonPublic | BindingFlags.Instance)!;
-        var categoriaNormalizadaField = tipoClase.GetField(
-            "_categoriaNormalizada", BindingFlags.NonPublic | BindingFlags.Instance)!;
-        var valorField = tipoClase.GetField("_valor", BindingFlags.NonPublic | BindingFlags.Instance)!;
-        var valorNormalizadoField = tipoClase.GetField(
-            "_valorNormalizado", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var categoriaField = Campo("_categoria");
+        var categoriaNormalizadaField = Campo("_categoriaNormalizada");
+        var valorField = Campo("_valor");
+        var valorNormalizadoField = Campo("_valorNormalizado");
 
         resolver.Modifiers.Add(typeInfo =>
         {
@@ -122,25 +125,23 @@ public sealed partial class Etiqueta : IEquatable<Etiqueta>
 
             typeInfo.CreateObject = () => ctor.Invoke(null);
 
-            var categoriaProp = typeInfo.CreateJsonPropertyInfo(typeof(string), "categoria");
-            categoriaProp.Get = obj => ((Etiqueta)obj)._categoria;
-            categoriaProp.Set = (obj, val) => categoriaField.SetValue(obj, val);
-            typeInfo.Properties.Add(categoriaProp);
-
-            var categoriaNormalizadaProp = typeInfo.CreateJsonPropertyInfo(typeof(string), "categoriaNormalizada");
-            categoriaNormalizadaProp.Get = obj => ((Etiqueta)obj)._categoriaNormalizada;
-            categoriaNormalizadaProp.Set = (obj, val) => categoriaNormalizadaField.SetValue(obj, val);
-            typeInfo.Properties.Add(categoriaNormalizadaProp);
-
-            var valorProp = typeInfo.CreateJsonPropertyInfo(typeof(string), "valor");
-            valorProp.Get = obj => ((Etiqueta)obj)._valor;
-            valorProp.Set = (obj, val) => valorField.SetValue(obj, val);
-            typeInfo.Properties.Add(valorProp);
-
-            var valorNormalizadoProp = typeInfo.CreateJsonPropertyInfo(typeof(string), "valorNormalizado");
-            valorNormalizadoProp.Get = obj => ((Etiqueta)obj)._valorNormalizado;
-            valorNormalizadoProp.Set = (obj, val) => valorNormalizadoField.SetValue(obj, val);
-            typeInfo.Properties.Add(valorNormalizadoProp);
+            RegistrarCampo(typeInfo, categoriaField, "categoria");
+            RegistrarCampo(typeInfo, categoriaNormalizadaField, "categoriaNormalizada");
+            RegistrarCampo(typeInfo, valorField, "valor");
+            RegistrarCampo(typeInfo, valorNormalizadoField, "valorNormalizado");
         });
+    }
+
+    private static FieldInfo Campo(string nombre) =>
+        typeof(Etiqueta).GetField(nombre, BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+    // Los 4 campos son string, asi que el registro es identico salvo el nombre JSON. El Set necesita
+    // reflexion porque los campos son readonly y C# no permite asignarlos fuera del constructor.
+    private static void RegistrarCampo(JsonTypeInfo typeInfo, FieldInfo campo, string nombreJson)
+    {
+        var prop = typeInfo.CreateJsonPropertyInfo(typeof(string), nombreJson);
+        prop.Get = obj => campo.GetValue(obj);
+        prop.Set = (obj, val) => campo.SetValue(obj, val);
+        typeInfo.Properties.Add(prop);
     }
 }

--- a/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/Etiqueta.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/Etiqueta.cs
@@ -1,3 +1,6 @@
+using System.Globalization;
+using System.Reflection;
+using System.Text;
 using System.Text.Json.Serialization.Metadata;
 
 namespace Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
@@ -19,8 +22,6 @@ namespace Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
 /// MEF-ADR-0012: sealed class, constructor privado real + constructor vacio para STJ/Marten,
 /// factory Crear() con validacion, ConfigurarSerializacion registrando campos privados (patron
 /// SubFranja) -- proscrito [JsonConstructor].
-/// STUB (fase roja test-writer): Crear, EsMismaCategoria, ToString, Equals, GetHashCode y
-/// ConfigurarSerializacion lanzan NotImplementedException. El implementer llena la logica real.
 /// </remarks>
 public sealed partial class Etiqueta : IEquatable<Etiqueta>
 {
@@ -58,28 +59,88 @@ public sealed partial class Etiqueta : IEquatable<Etiqueta>
 
     // CA-1, CA-2, CA-5: valida no vacios/whitespace, trim en extremos (conserva espacios internos),
     // calcula formas normalizadas (Normalize(FormD) + remover NonSpacingMark + ToLowerInvariant).
-    public static Etiqueta Crear(string categoria, string valor) =>
-        throw new NotImplementedException();
+    public static Etiqueta Crear(string categoria, string valor)
+    {
+        if (string.IsNullOrWhiteSpace(categoria))
+            throw new ArgumentException(Mensajes.CategoriaVacia, nameof(categoria));
+        if (string.IsNullOrWhiteSpace(valor))
+            throw new ArgumentException(Mensajes.ValorVacio, nameof(valor));
+
+        var categoriaOriginal = categoria.Trim();
+        var valorOriginal = valor.Trim();
+
+        return new Etiqueta(categoriaOriginal, Normalizar(categoriaOriginal),
+            valorOriginal, Normalizar(valorOriginal));
+    }
 
     // CA-4: true si las categorias normalizadas coinciden, sin importar el valor.
     public bool EsMismaCategoria(Etiqueta otra) =>
-        throw new NotImplementedException();
+        _categoriaNormalizada == otra._categoriaNormalizada;
 
     // Propuesta: "{Categoria}:{Valor}" con las formas originales (display).
-    public override string ToString() =>
-        throw new NotImplementedException();
+    public override string ToString() => $"{_categoria}:{_valor}";
 
     // Igualdad por valor COMPLETA: categoria normalizada + valor normalizado.
     public bool Equals(Etiqueta? other) =>
-        throw new NotImplementedException();
+        other is not null
+        && _categoriaNormalizada == other._categoriaNormalizada
+        && _valorNormalizado == other._valorNormalizado;
 
     public override bool Equals(object? obj) => Equals(obj as Etiqueta);
 
     public override int GetHashCode() =>
-        throw new NotImplementedException();
+        HashCode.Combine(_categoriaNormalizada, _valorNormalizado);
+
+    // Patron documentado por Microsoft para remover diacriticos: descomponer en FormD, filtrar los
+    // marcas de combinacion (NonSpacingMark) y recomponer en FormC, todo en minusculas invariantes.
+    // Fuera de alcance (issue #353): errores de transposicion ("aera" vs "area") -- eso es fuzzy
+    // matching de UI, no un invariante del dominio.
+    private static string Normalizar(string texto) =>
+        new string(texto.Normalize(NormalizationForm.FormD)
+                .Where(c => CharUnicodeInfo.GetUnicodeCategory(c) != UnicodeCategory.NonSpacingMark)
+                .ToArray())
+            .Normalize(NormalizationForm.FormC)
+            .ToLowerInvariant();
 
     // Mapping de serializacion -- vive aqui porque cambia con la clase (patron SubFranja /
     // Identificacion). Persiste las 4 formas (doble forma por campo, decision del planner).
-    public static void ConfigurarSerializacion(DefaultJsonTypeInfoResolver resolver) =>
-        throw new NotImplementedException();
+    public static void ConfigurarSerializacion(DefaultJsonTypeInfoResolver resolver)
+    {
+        var tipoClase = typeof(Etiqueta);
+        var ctor = tipoClase.GetConstructor(BindingFlags.NonPublic | BindingFlags.Instance, Type.EmptyTypes)!;
+        var categoriaField = tipoClase.GetField("_categoria", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var categoriaNormalizadaField = tipoClase.GetField(
+            "_categoriaNormalizada", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var valorField = tipoClase.GetField("_valor", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var valorNormalizadoField = tipoClase.GetField(
+            "_valorNormalizado", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        resolver.Modifiers.Add(typeInfo =>
+        {
+            if (typeInfo.Type != tipoClase) return;
+            if (typeInfo.Kind != JsonTypeInfoKind.Object) return;
+
+            typeInfo.CreateObject = () => ctor.Invoke(null);
+
+            var categoriaProp = typeInfo.CreateJsonPropertyInfo(typeof(string), "categoria");
+            categoriaProp.Get = obj => ((Etiqueta)obj)._categoria;
+            categoriaProp.Set = (obj, val) => categoriaField.SetValue(obj, val);
+            typeInfo.Properties.Add(categoriaProp);
+
+            var categoriaNormalizadaProp = typeInfo.CreateJsonPropertyInfo(typeof(string), "categoriaNormalizada");
+            categoriaNormalizadaProp.Get = obj => ((Etiqueta)obj)._categoriaNormalizada;
+            categoriaNormalizadaProp.Set = (obj, val) => categoriaNormalizadaField.SetValue(obj, val);
+            typeInfo.Properties.Add(categoriaNormalizadaProp);
+
+            var valorProp = typeInfo.CreateJsonPropertyInfo(typeof(string), "valor");
+            valorProp.Get = obj => ((Etiqueta)obj)._valor;
+            valorProp.Set = (obj, val) => valorField.SetValue(obj, val);
+            typeInfo.Properties.Add(valorProp);
+
+            var valorNormalizadoProp = typeInfo.CreateJsonPropertyInfo(typeof(string), "valorNormalizado");
+            valorNormalizadoProp.Get = obj => ((Etiqueta)obj)._valorNormalizado;
+            valorNormalizadoProp.Set = (obj, val) => valorNormalizadoField.SetValue(obj, val);
+            typeInfo.Properties.Add(valorNormalizadoProp);
+        });
+    }
 }

--- a/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/Etiqueta.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/Etiqueta.cs
@@ -1,0 +1,85 @@
+using System.Text.Json.Serialization.Metadata;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+
+/// <summary>
+/// Etiqueta dinamica (par categoria:valor libre, definido por el cliente) para segmentar
+/// colaboradores en reportes.
+/// </summary>
+/// <remarks>
+/// Issue #353: doble forma por campo -- la original (display, solo con trim; espacios internos se
+/// conservan) y la normalizada (minusculas, sin tildes -- identidad y busqueda). La normalizacion
+/// es invariante del VO, no truco de base de datos (MEF-ADR-0012).
+/// Igualdad por valor COMPLETA sobre las formas normalizadas (categoria Y valor): dos etiquetas de
+/// la misma categoria con valor distinto NO son iguales. <see cref="EsMismaCategoria"/> es la
+/// superficie separada para la salvaguarda de unicidad por categoria del aggregate (issue #355,
+/// Tell-don't-Ask: el VO decide que significa "misma categoria", no el llamador comparando strings).
+/// Este corte no introduce comando, evento ni aggregate -- <see cref="Etiqueta"/> sera payload rico
+/// de los eventos persistidos de Colaborador (#355+); por eso ya trae ConfigurarSerializacion.
+/// MEF-ADR-0012: sealed class, constructor privado real + constructor vacio para STJ/Marten,
+/// factory Crear() con validacion, ConfigurarSerializacion registrando campos privados (patron
+/// SubFranja) -- proscrito [JsonConstructor].
+/// STUB (fase roja test-writer): Crear, EsMismaCategoria, ToString, Equals, GetHashCode y
+/// ConfigurarSerializacion lanzan NotImplementedException. El implementer llena la logica real.
+/// </remarks>
+public sealed partial class Etiqueta : IEquatable<Etiqueta>
+{
+    private readonly string _categoria;
+    private readonly string _categoriaNormalizada;
+    private readonly string _valor;
+    private readonly string _valorNormalizado;
+
+    // Constructor real: usado por el factory
+    private Etiqueta(string categoria, string categoriaNormalizada, string valor, string valorNormalizado)
+    {
+        _categoria = categoria;
+        _categoriaNormalizada = categoriaNormalizada;
+        _valor = valor;
+        _valorNormalizado = valorNormalizado;
+    }
+
+    // Constructor vacio para STJ/Marten
+    private Etiqueta()
+    {
+        _categoria = string.Empty;
+        _categoriaNormalizada = string.Empty;
+        _valor = string.Empty;
+        _valorNormalizado = string.Empty;
+    }
+
+    // Formas originales (display, con trim aplicado en los extremos).
+    public string Categoria => _categoria;
+    public string Valor => _valor;
+
+    // Formas normalizadas: claves del diccionario del aggregate y de la busqueda en reportes
+    // (MEF-ADR-0012: identidad observable, no dato intermedio de calculo).
+    public string CategoriaNormalizada => _categoriaNormalizada;
+    public string ValorNormalizado => _valorNormalizado;
+
+    // CA-1, CA-2, CA-5: valida no vacios/whitespace, trim en extremos (conserva espacios internos),
+    // calcula formas normalizadas (Normalize(FormD) + remover NonSpacingMark + ToLowerInvariant).
+    public static Etiqueta Crear(string categoria, string valor) =>
+        throw new NotImplementedException();
+
+    // CA-4: true si las categorias normalizadas coinciden, sin importar el valor.
+    public bool EsMismaCategoria(Etiqueta otra) =>
+        throw new NotImplementedException();
+
+    // Propuesta: "{Categoria}:{Valor}" con las formas originales (display).
+    public override string ToString() =>
+        throw new NotImplementedException();
+
+    // Igualdad por valor COMPLETA: categoria normalizada + valor normalizado.
+    public bool Equals(Etiqueta? other) =>
+        throw new NotImplementedException();
+
+    public override bool Equals(object? obj) => Equals(obj as Etiqueta);
+
+    public override int GetHashCode() =>
+        throw new NotImplementedException();
+
+    // Mapping de serializacion -- vive aqui porque cambia con la clase (patron SubFranja /
+    // Identificacion). Persiste las 4 formas (doble forma por campo, decision del planner).
+    public static void ConfigurarSerializacion(DefaultJsonTypeInfoResolver resolver) =>
+        throw new NotImplementedException();
+}

--- a/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/EtiquetaMensajes.resx
+++ b/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/EtiquetaMensajes.resx
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" msdata:Ordinal="0" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter</value></resheader>
+  <data name="CategoriaVacia" xml:space="preserve">
+    <value>La categoria de la etiqueta no puede estar vacia ni contener solo espacios</value>
+  </data>
+  <data name="ValorVacio" xml:space="preserve">
+    <value>El valor de la etiqueta no puede estar vacio ni contener solo espacios</value>
+  </data>
+</root>

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ValueObjects/EtiquetaIgualdadTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ValueObjects/EtiquetaIgualdadTests.cs
@@ -29,7 +29,7 @@ public class EtiquetaIgualdadTests : IgualdadTestBase<Etiqueta>
     // CA-3 explicito: las tres formas de escribir la misma etiqueta son iguales entre si (no solo
     // pares) y su GetHashCode coincide en las tres.
     [Fact]
-    public void Equals_RetornaTrue_ConTresVariantesDeEscrituraDeLaMismaEtiqueta()
+    public void Equals_RetornaTrue_CuandoLasTresVariantesDeEscrituraSonDeLaMismaEtiqueta()
     {
         var conTildesYMixta = Etiqueta.Crear("Área", "Tecnología");
         var minusculas = Etiqueta.Crear("area", "tecnologia");

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ValueObjects/EtiquetaIgualdadTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ValueObjects/EtiquetaIgualdadTests.cs
@@ -1,0 +1,54 @@
+// HU-353 CA-3: igualdad por valor COMPLETA de Etiqueta (categoria normalizada + valor
+// normalizado). Decision discutida y confirmada con el usuario (sesion 2026-08-11): Equals
+// compara ambos campos -- dos etiquetas de la misma categoria con valor distinto NO son iguales.
+// EsMismaCategoria (superficie separada para #355) se testea en EtiquetaTests.cs.
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Tests.ValueObjects;
+
+/// <summary>
+/// Hereda los 8 tests de IgualdadTestBase que verifican el contrato IEquatable completo.
+/// CrearInstancia/CrearInstanciaCopia usan variaciones de tildes/mayusculas de la MISMA etiqueta;
+/// CrearInstanciasDiferentes varia categoria y valor por separado.
+/// </summary>
+public class EtiquetaIgualdadTests : IgualdadTestBase<Etiqueta>
+{
+    protected override Etiqueta CrearInstancia() =>
+        Etiqueta.Crear("Área", "Tecnología");
+
+    protected override Etiqueta CrearInstanciaCopia() =>
+        Etiqueta.Crear("area", "TECNOLOGIA");
+
+    protected override IEnumerable<(string, Etiqueta)> CrearInstanciasDiferentes()
+    {
+        yield return ("Categoria", Etiqueta.Crear("Sede", "Tecnologia"));
+        yield return ("Valor", Etiqueta.Crear("Area", "Ventas"));
+    }
+
+    // CA-3 explicito: las tres formas de escribir la misma etiqueta son iguales entre si (no solo
+    // pares) y su GetHashCode coincide en las tres.
+    [Fact]
+    public void Equals_RetornaTrue_ConTresVariantesDeEscrituraDeLaMismaEtiqueta()
+    {
+        var conTildesYMixta = Etiqueta.Crear("Área", "Tecnología");
+        var minusculas = Etiqueta.Crear("area", "tecnologia");
+        var mayusculas = Etiqueta.Crear("AREA", "TECNOLOGIA");
+
+        conTildesYMixta.Should().Be(minusculas);
+        conTildesYMixta.Should().Be(mayusculas);
+        minusculas.Should().Be(mayusculas);
+        conTildesYMixta.GetHashCode().Should().Be(minusculas.GetHashCode());
+        conTildesYMixta.GetHashCode().Should().Be(mayusculas.GetHashCode());
+    }
+
+    // CA-3 explicito: misma categoria, valor distinto -> NO son iguales.
+    [Fact]
+    public void Equals_RetornaFalse_CuandoMismaCategoriaConValorDistinto()
+    {
+        var areaVentas = Etiqueta.Crear("area", "ventas");
+        var areaTecnologia = Etiqueta.Crear("area", "tecnologia");
+
+        areaVentas.Should().NotBe(areaTecnologia);
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ValueObjects/EtiquetaSerializacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ValueObjects/EtiquetaSerializacionTests.cs
@@ -1,0 +1,83 @@
+// HU-353 CA-6: round-trip de serializacion (patron Marten) para Etiqueta.
+// ConfiguracionSerializacionColaboradores todavia no existe -- este dominio nace sin evento
+// persistido propio (ver IdentidadEventosColaboradores.TiposPersistidos, vacia hasta #355+), asi
+// que el resolver se arma localmente con Etiqueta.ConfigurarSerializacion, igual que
+// IdentificacionSerializacionTests.cs / NombreColaboradorSerializacionTests.cs hacen con sus VOs
+// antes de que un evento persistido los reclame como payload.
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Tests.ValueObjects;
+
+public class EtiquetaSerializacionTests
+{
+    private static JsonSerializerOptions CrearOpciones()
+    {
+        var resolver = new DefaultJsonTypeInfoResolver();
+        Etiqueta.ConfigurarSerializacion(resolver);
+        return new JsonSerializerOptions { TypeInfoResolver = resolver, PropertyNamingPolicy = null };
+    }
+
+    [Fact]
+    public void RoundTrip_PreservaIgualdad_CuandoEtiquetaValida()
+    {
+        var original = Etiqueta.Crear("Área", "Tecnología");
+        var opciones = CrearOpciones();
+
+        var json = JsonSerializer.Serialize(original, opciones);
+        var restaurado = JsonSerializer.Deserialize<Etiqueta>(json, opciones);
+
+        restaurado.Should().Be(original);
+    }
+
+    [Fact]
+    public void RoundTrip_PreservaFormasOriginalesYNormalizadas_CuandoEtiquetaTieneTildesYMayusculas()
+    {
+        var original = Etiqueta.Crear("Área", "Tecnología");
+        var opciones = CrearOpciones();
+
+        var json = JsonSerializer.Serialize(original, opciones);
+        var restaurado = JsonSerializer.Deserialize<Etiqueta>(json, opciones);
+
+        restaurado.Should().NotBeNull();
+        restaurado!.Categoria.Should().Be("Área");
+        restaurado.Valor.Should().Be("Tecnología");
+        restaurado.CategoriaNormalizada.Should().Be("area");
+        restaurado.ValorNormalizado.Should().Be("tecnologia");
+    }
+
+    // Contrato central de la "doble forma persistida" (decision del planner, issue #353): el
+    // evento debe cargar las 4 formas por campo, no solo la original ni solo la normalizada. Este
+    // test sobre el JSON crudo blinda esa decision -- el round-trip de arriba pasaria en verde
+    // aunque se persistiera solo una forma y se recalculara la otra al leer.
+    [Fact]
+    public void Serializar_PersisteLasCuatroFormasPorCampo_CuandoEtiquetaValida()
+    {
+        var original = Etiqueta.Crear("Área", "Tecnología");
+
+        var json = JsonSerializer.Serialize(original, CrearOpciones());
+
+        using var documento = JsonDocument.Parse(json);
+        documento.RootElement.GetProperty("categoria").GetString().Should().Be("Área");
+        documento.RootElement.GetProperty("categoriaNormalizada").GetString().Should().Be("area");
+        documento.RootElement.GetProperty("valor").GetString().Should().Be("Tecnología");
+        documento.RootElement.GetProperty("valorNormalizado").GetString().Should().Be("tecnologia");
+    }
+
+    // Barrera anti-regresion: sin el resolver custom (equivalente a olvidar registrar el VO), STJ
+    // no puede reconstruir Etiqueta -- su unico constructor es privado y no hay [JsonConstructor]
+    // (proscrito por MEF-ADR-0012).
+    [Fact]
+    public void Deserializar_Falla_CuandoResolverNoTieneRegistroDeEtiqueta()
+    {
+        var original = Etiqueta.Crear("Área", "Tecnología");
+        var json = JsonSerializer.Serialize(original, CrearOpciones());
+        var opciones = new JsonSerializerOptions { TypeInfoResolver = new DefaultJsonTypeInfoResolver() };
+
+        var act = () => JsonSerializer.Deserialize<Etiqueta>(json, opciones);
+
+        act.Should().Throw<NotSupportedException>();
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ValueObjects/EtiquetaTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ValueObjects/EtiquetaTests.cs
@@ -36,6 +36,24 @@ public class EtiquetaTests
         etiqueta.ValorNormalizado.Should().Be("recursos humanos");
     }
 
+    // La enie NO es un acento: es una letra propia del espanol. El patron de normalizacion que el
+    // issue prescribe (FormD + remover NonSpacingMark) la descompone en "n" + tilde combinante y la
+    // colapsa a "n", asi que "Diseno" y "Diseño" son la MISMA etiqueta. Es consecuencia inevitable
+    // del patron elegido, no un descuido: en etiquetas libres tecleadas por el cliente evita
+    // fragmentar el reporte cuando alguien escribe sin enie. Este test lo fija como decision
+    // observable en vez de dejarlo tacito -- si el dominio necesitara preservar la enie, este test
+    // es el que debe fallar primero (agregado en revision, issue #353).
+    [Fact]
+    public void Crear_NormalizaLaEnieComoN_CuandoValorLaContiene()
+    {
+        var conEnie = Etiqueta.Crear("Area", "Diseño");
+        var sinEnie = Etiqueta.Crear("Area", "Diseno");
+
+        conEnie.Valor.Should().Be("Diseño", "la forma original preserva la enie tal como se escribio");
+        conEnie.ValorNormalizado.Should().Be("diseno");
+        conEnie.Should().Be(sinEnie);
+    }
+
     // ---------- CA-2: categoria/valor vacios o whitespace -> rechazo con mensaje .resx ----------
 
     [Fact]
@@ -56,6 +74,19 @@ public class EtiquetaTests
             .WithMessage($"*{Etiqueta.Mensajes.CategoriaVacia}*");
     }
 
+    // Los parametros son string no anulable, pero el boundary recibe datos de fuera del dominio
+    // (deserializacion, payload HTTP) donde el null sobrevive al compilador: el rechazo debe ser el
+    // mismo ArgumentException con mensaje .resx, no una NullReferenceException opaca. Paridad con
+    // NombreColaboradorTests (issue #348), que ya cubre null! en sus campos requeridos.
+    [Fact]
+    public void Crear_LanzaArgumentException_CuandoCategoriaEsNull()
+    {
+        var act = () => Etiqueta.Crear(null!, "Tecnologia");
+
+        act.Should().ThrowExactly<ArgumentException>()
+            .WithMessage($"*{Etiqueta.Mensajes.CategoriaVacia}*");
+    }
+
     [Fact]
     public void Crear_LanzaArgumentException_CuandoValorEsVacio()
     {
@@ -69,6 +100,15 @@ public class EtiquetaTests
     public void Crear_LanzaArgumentException_CuandoValorEsWhitespace()
     {
         var act = () => Etiqueta.Crear("Area", "   ");
+
+        act.Should().ThrowExactly<ArgumentException>()
+            .WithMessage($"*{Etiqueta.Mensajes.ValorVacio}*");
+    }
+
+    [Fact]
+    public void Crear_LanzaArgumentException_CuandoValorEsNull()
+    {
+        var act = () => Etiqueta.Crear("Area", null!);
 
         act.Should().ThrowExactly<ArgumentException>()
             .WithMessage($"*{Etiqueta.Mensajes.ValorVacio}*");

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ValueObjects/EtiquetaTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ValueObjects/EtiquetaTests.cs
@@ -1,0 +1,106 @@
+// HU-353: Value object Etiqueta -- par categoria:valor libre con doble forma (original y
+// normalizada) por campo. Este corte solo entrega el VO; la operacion de negocio
+// (asignar/retirar con salvaguarda de unicidad por categoria) es el issue #355.
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Tests.ValueObjects;
+
+/// <summary>
+/// Interfaz publica: Crear(categoria, valor), Categoria, Valor, CategoriaNormalizada,
+/// ValorNormalizado, EsMismaCategoria(otra), ToString().
+/// </summary>
+public class EtiquetaTests
+{
+    // ---------- CA-1: doble forma por campo (original con trim + normalizada sin tildes/mayus) ----------
+
+    [Fact]
+    public void Crear_ProduceFormaOriginalYNormalizada_CuandoCategoriaYValorTienenTildesMayusculasYEspaciosExtremos()
+    {
+        var etiqueta = Etiqueta.Crear(" Área ", " Tecnología ");
+
+        etiqueta.Categoria.Should().Be("Área");
+        etiqueta.Valor.Should().Be("Tecnología");
+        etiqueta.CategoriaNormalizada.Should().Be("area");
+        etiqueta.ValorNormalizado.Should().Be("tecnologia");
+    }
+
+    // ---------- CA-5: espacios internos se conservan (solo se recorta en los extremos) ----------
+
+    [Fact]
+    public void Crear_ConservaEspaciosInternos_CuandoValorTieneVariasPalabras()
+    {
+        var etiqueta = Etiqueta.Crear("Area", "  Recursos Humanos  ");
+
+        etiqueta.Valor.Should().Be("Recursos Humanos");
+        etiqueta.ValorNormalizado.Should().Be("recursos humanos");
+    }
+
+    // ---------- CA-2: categoria/valor vacios o whitespace -> rechazo con mensaje .resx ----------
+
+    [Fact]
+    public void Crear_LanzaArgumentException_CuandoCategoriaEsVacia()
+    {
+        var act = () => Etiqueta.Crear(string.Empty, "Tecnologia");
+
+        act.Should().ThrowExactly<ArgumentException>()
+            .WithMessage($"*{Etiqueta.Mensajes.CategoriaVacia}*");
+    }
+
+    [Fact]
+    public void Crear_LanzaArgumentException_CuandoCategoriaEsWhitespace()
+    {
+        var act = () => Etiqueta.Crear("   ", "Tecnologia");
+
+        act.Should().ThrowExactly<ArgumentException>()
+            .WithMessage($"*{Etiqueta.Mensajes.CategoriaVacia}*");
+    }
+
+    [Fact]
+    public void Crear_LanzaArgumentException_CuandoValorEsVacio()
+    {
+        var act = () => Etiqueta.Crear("Area", string.Empty);
+
+        act.Should().ThrowExactly<ArgumentException>()
+            .WithMessage($"*{Etiqueta.Mensajes.ValorVacio}*");
+    }
+
+    [Fact]
+    public void Crear_LanzaArgumentException_CuandoValorEsWhitespace()
+    {
+        var act = () => Etiqueta.Crear("Area", "   ");
+
+        act.Should().ThrowExactly<ArgumentException>()
+            .WithMessage($"*{Etiqueta.Mensajes.ValorVacio}*");
+    }
+
+    // ---------- ToString: formas originales (display), no las normalizadas ----------
+
+    [Fact]
+    public void ToString_ComponeCategoriaYValorConDosPuntosUsandoFormasOriginales_CuandoEtiquetaValida()
+    {
+        var etiqueta = Etiqueta.Crear("Área", "Tecnología");
+
+        etiqueta.ToString().Should().Be("Área:Tecnología");
+    }
+
+    // ---------- CA-4: EsMismaCategoria -- superficie para la salvaguarda de unicidad de #355 ----------
+
+    [Fact]
+    public void EsMismaCategoria_RetornaTrue_CuandoCategoriasNormalizadasCoincidenConValoresDistintos()
+    {
+        var ventas = Etiqueta.Crear("Área", "Ventas");
+        var tecnologia = Etiqueta.Crear("area", "Tecnología");
+
+        ventas.EsMismaCategoria(tecnologia).Should().BeTrue();
+    }
+
+    [Fact]
+    public void EsMismaCategoria_RetornaFalse_CuandoCategoriasSonDistintas()
+    {
+        var sede = Etiqueta.Crear("Sede", "X");
+        var area = Etiqueta.Crear("Area", "X");
+
+        sede.EsMismaCategoria(area).Should().BeFalse();
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ValueObjects/MensajesResxTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ValueObjects/MensajesResxTests.cs
@@ -35,4 +35,12 @@ public class MensajesResxTests
         NombreColaborador.Mensajes.PrimerNombreRequerido.Should().NotBeNullOrWhiteSpace();
         NombreColaborador.Mensajes.PrimerApellidoRequerido.Should().NotBeNullOrWhiteSpace();
     }
+
+    // HU-353: extiende el mismo guardrail a las claves de Etiqueta.
+    [Fact]
+    public void Mensajes_ResuelvenTextoNoVacio_CuandoPertenecenAEtiqueta()
+    {
+        Etiqueta.Mensajes.CategoriaVacia.Should().NotBeNullOrWhiteSpace();
+        Etiqueta.Mensajes.ValorVacio.Should().NotBeNullOrWhiteSpace();
+    }
 }


### PR DESCRIPTION
## Resumen

Pipeline TDD completado:
- Fase roja: tests escritos con stubs
- Fase verde: implementación completa
- Fase refactor: revisión de calidad

## Decisiones del pipeline

<details>
<summary>Test Writer (fase roja) — 6m 13s</summary>

## ES Test Writer - Decisiones

### Tipo de tarea
TDD normal (no refactoring puro). El issue introduce un VO nuevo (`Etiqueta`) con
comportamiento observable nuevo (normalizacion, igualdad, `EsMismaCategoria`), sin
comando/evento/aggregate. No se creo archivo de senal de refactor.

### Tests creados
- `EtiquetaTests.cs`: 10 tests
  - `Crear_ProduceFormaOriginalYNormalizada_CuandoCategoriaYValorTienenTildesMayusculasYEspaciosExtremos` - CA-1
  - `Crear_ConservaEspaciosInternos_CuandoValorTieneVariasPalabras` - CA-5
  - `Crear_LanzaArgumentException_CuandoCategoriaEsVacia` - CA-2
  - `Crear_LanzaArgumentException_CuandoCategoriaEsWhitespace` - CA-2
  - `Crear_LanzaArgumentException_CuandoValorEsVacio` - CA-2
  - `Crear_LanzaArgumentException_CuandoValorEsWhitespace` - CA-2
  - `ToString_ComponeCategoriaYValorConDosPuntosUsandoFormasOriginales_CuandoEtiquetaValida` - interfaz publica (ToString)
  - `EsMismaCategoria_RetornaTrue_CuandoCategoriasNormalizadasCoincidenConValoresDistintos` - CA-4
  - `EsMismaCategoria_RetornaFalse_CuandoCategoriasSonDistintas` - CA-4
- `EtiquetaIgualdadTests.cs`: hereda 8 tests de `IgualdadTestBase<Etiqueta>` + 2 explicitos
  - `Equals_RetornaTrue_ConTresVariantesDeEscrituraDeLaMismaEtiqueta` - CA-3 (triple variante + hashcode)
  - `Equals_RetornaFalse_CuandoMismaCategoriaConValorDistinto` - CA-3 (misma categoria, valor distinto)
- `EtiquetaSerializacionTests.cs`: 4 tests
  - `RoundTrip_PreservaIgualdad_CuandoEtiquetaValida` - CA-6
  - `RoundTrip_PreservaFormasOriginalesYNormalizadas_CuandoEtiquetaTieneTildesYMayusculas` - CA-6
  - `Serializar_PersisteLasCuatroFormasPorCampo_CuandoEtiquetaValida` - CA-6 (blinda la decision de "doble forma persistida")
  - `Deserializar_Falla_CuandoResolverNoTieneRegistroDeEtiqueta` - anti-regresion (patron Identificacion)
- `MensajesResxTests.cs`: +1 test (extension del guardrail existente)
  - `Mensajes_ResuelvenTextoNoVacio_CuandoPertenecenAEtiqueta`

### Estructura elegida
- Tres archivos (comportamiento / igualdad / serializacion) replicando el patron ya
  establecido en el propio dominio para `Identificacion` y `NombreColaborador`
  (`IdentificacionTests.cs` + `IdentificacionIgualdadTests.cs` + `IdentificacionSerializacionTests.cs`).
- `EtiquetaIgualdadTests.cs` hereda `IgualdadTestBase<T>` ya existente en
  `tests/.../ValueObjects/IgualdadTestBase.cs` (no se duplico).
- Sin harness Given/When/Then/And<>: es un VO puro sin comando/evento/aggregate
  (seccion 6c del rol) — mismo criterio que `IdentificacionTests.cs`, `NombreColaboradorTests.cs`.

### Stubs creados
- `Etiqueta.cs` (sealed partial class, `IEquatable<Etiqueta>`): `Crear`, `EsMismaCategoria`,
  `ToString`, `Equals(Etiqueta?)`, `GetHashCode`, `ConfigurarSerializacion` lanzan
  `NotImplementedException`. `Equals(object?)` delega a `Equals(Etiqueta?)` (no lanza
  directamente, pero termina lanzando via la delegacion). Propiedades `Categoria`, `Valor`,
  `CategoriaNormalizada`, `ValorNormalizado` son getters simples sobre campos privados
  (no requieren stub con excepcion porque no tienen logica, solo se poblarian en un `Crear`
  real).
- `Etiqueta.Mensajes.cs` + `EtiquetaMensajes.resx`: claves `CategoriaVacia`, `ValorVacio`
  (patron `Identificacion.Mensajes.cs` / `IdentificacionMensajes.resx`).

### Decisiones de diseno
- **Doble forma persistida confirmada tal cual el planner la propuso**: el evento (cuando exista)
  cargara las 4 formas (`categoria`, `categoriaNormalizada`, `valor`, `valorNormalizado`). Se
  agrego un test dedicado (`Serializar_PersisteLasCuatroFormasPorCampo...`) que verifica el JSON
  crudo, no solo el round-trip, para blindar esta decision explicitamente documentada en el
  issue ("Investigacion del planner").
- **Resolver local, no `ConfiguracionSerializacionColaboradores`**: verificado que ese tipo NO
  existe todavia en `src/` (el dominio Colaboradores nace sin evento persistido propio,
  `IdentidadEventosColaboradores.TiposPersistidos` esta vacia). Mismo razonamiento documentado
  en los comentarios de cabecera de `IdentificacionSerializacionTests.cs` /
  `NombreColaboradorSerializacionTests.cs`: se arma el resolver localmente con
  `Etiqueta.ConfigurarSerializacion`.
- **Extension de `MensajesResxTests.cs`** en vez de crear un archivo nuevo: ese archivo es
  explicitamente un guardrail generico "por VO" (ya cubre Identificacion, TipoIdentificacion,
  NombreColaborador) — se agrego un `[Fact]` nuevo sin tocar los existentes, coherente con el
  patron establecido.
- **CA-4 (`EsMismaCategoria`) testeado en `EtiquetaTests.cs`, no en `EtiquetaIgualdadTests.cs`**:
  es una superficie de comportamiento distinta de `Equals` (Tell-don't-Ask, no forma parte del
  contrato `IEquatable<T>` que `IgualdadTestBase<T>` verifica).
- Fuera de alcance explicito del issue (transposicion "áera"/"area") -- no se agrego test, tal
  como el issue lo declara explicitamente fuera de alcance.

### Cobertura de criterios
| Criterio de aceptacion | Test(s) |
|---|---|
| CA-1: doble forma por campo (original con trim, normalizada sin tildes/mayus) | `EtiquetaTests.Crear_ProduceFormaOriginalYNormalizada_...` |
| CA-2: categoria/valor vacios o whitespace -> rechazo con mensaje .resx | `EtiquetaTests.Crear_LanzaArgumentException_Cuando{Categoria,Valor}Es{Vacia,Whitespace}` |
| CA-3: igualdad completa normalizada (3 variantes iguales, area:ventas != area:tecnologia) | `EtiquetaIgualdadTests` (heredados + `Equals_RetornaTrue_ConTresVariantesDeEscrituraDeLaMismaEtiqueta` + `Equals_RetornaFalse_CuandoMismaCategoriaConValorDistinto`) |
| CA-4: `EsMismaCategoria` true/false | `EtiquetaTests.EsMismaCategoria_RetornaTrue_...` / `EsMismaCategoria_RetornaFalse_...` |
| CA-5: formas originales preservadas (espacios internos) | `EtiquetaTests.Crear_ConservaEspaciosInternos_...` |
| CA-6: round-trip de serializacion (patron Marten) | `EtiquetaSerializacionTests` (4 tests) |

### Desviaciones del plan del planner

Ninguna - las sugerencias del planner (interfaz publica, ubicacion, doble forma persistida,
mensajes .resx) fueron aplicables tal cual. Unica adicion no listada explicitamente en "Impacto
esperado" es la extension de `MensajesResxTests.cs` (archivo ya existente, no creado por este
issue), que se documenta arriba como decision de diseno, no como desviacion contenciosa.

</details>

<details>
<summary>Implementer (fase verde) — 3m 57s</summary>

## ES Implementer - Decisiones

### Enfoque de implementacion
Se completo el unico archivo con stubs (`Etiqueta.cs`), reemplazando los `throw new
NotImplementedException()` de `Crear`, `EsMismaCategoria`, `ToString`, `Equals`, `GetHashCode` y
`ConfigurarSerializacion` con la logica real, siguiendo al pie de la letra la interfaz publica
propuesta por el planner y ya fijada por el test-writer en la firma del `partial class`.

- `Crear(categoria, valor)`: valida `IsNullOrWhiteSpace` para ambos campos (mensajes `.resx` ya
  provistos por el test-writer), aplica `Trim()` a los extremos (conserva espacios internos) y
  calcula la forma normalizada de cada campo con un metodo privado `Normalizar`.
- `Normalizar`: `Normalize(NormalizationForm.FormD)` -> filtra `UnicodeCategory.NonSpacingMark` con
  LINQ `Where` (regla del harness: LINQ sobre foreach) -> `Normalize(NormalizationForm.FormC)` ->
  `ToLowerInvariant()`. Patron documentado por Microsoft para remover diacriticos, adaptado a LINQ.
- `EsMismaCategoria`: compara solo `_categoriaNormalizada` entre las dos instancias (Tell-don't-Ask:
  la decision de que es "misma categoria" vive en el VO).
- `Equals`/`GetHashCode`: igualdad por valor completa sobre `_categoriaNormalizada` +
  `_valorNormalizado` (confirmada con el usuario segun el issue, distinta de "igualdad por
  categoria" del boceto original).
- `ToString()`: `"{Categoria}:{Valor}"` con las formas originales (display), tal como pedia el test
  `ToString_ComponeCategoriaYValorConDosPuntosUsandoFormasOriginales_CuandoEtiquetaValida`.
- `ConfigurarSerializacion`: registra las 4 propiedades (`categoria`, `categoriaNormalizada`,
  `valor`, `valorNormalizado`) via reflexion sobre los 4 campos privados, mismo patron que
  `SubFranja.cs`/`Identificacion.cs` (ctor vacio invocado por reflexion, Get/Set por campo). Sin
  `[JsonConstructor]` (proscrito por MEF-ADR-0012).

### Decisiones de diseno
- Se agregaron los `using` faltantes (`System.Globalization`, `System.Reflection`, `System.Text`)
  en la cabecera del archivo -- el stub del test-writer solo traia
  `System.Text.Json.Serialization.Metadata`. `NormalizationForm` vive en `System.Text`, no en
  `System.Globalization` (verificado por el compilador tras el primer intento fallido).
- Se elimino la linea de la doc-comment que marcaba el archivo como "STUB (fase roja
  test-writer)", ya que dejo de serlo.

### ADRs consultados
- MEF-ADR-0012: ctor privado + ctor vacio, factory `Crear`, `ConfigurarSerializacion` sin
  `[JsonConstructor]`, igualdad por valor, Tell-don't-Ask (`EsMismaCategoria` en el VO).
- CA-ADR-0029 / MEF-ADR-0039: isla `DomainEvents` sin referencias de proyecto ni paquetes --
  verificado que el csproj de `Colaboradores.DomainEvents` no tiene `ProjectReference` ni
  `PackageReference`, y la implementacion solo usa BCL.
- MEF-ADR-0009: mensajes de validacion ya estaban en `.resx`/`Mensajes.cs` (obra del test-writer);
  no se agrego ningun mensaje nuevo.
- MEF-ADR-0016: convencion de nombres de tests -- no aplica al implementer (no se tocaron tests).

### Desviaciones de ADRs
Ninguna desviacion -- todos los ADRs aplicados al pie de la letra.

### Desviaciones del plan del planner
Ninguna desviacion de la interfaz publica propuesta por el planner. La firma exacta (nombres de
metodos, propiedades y su visibilidad) ya venia fijada por el test-writer en el stub; el
implementer solo lleno los cuerpos.

### Precedentes consultados
- `src/Bitakora.ControlAsistencia.Programacion.DomainEvents/SubFranja.cs` -- patron de
  `ConfigurarSerializacion` con reflexion sobre ctor vacio y campos privados. Alineado con
  MEF-ADR-0012.
- `src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/Identificacion.cs` -- mismo patron,
  aplicado en el mismo proyecto/isla (`Colaboradores.DomainEvents`), con un campo enum (`_tipo`)
  serializado por su codigo literal. Alineado con MEF-ADR-0012. Sirvio de referencia directa para
  el estilo de nombres de variables locales en `ConfigurarSerializacion`.

### Infraestructura modificada
Ninguna. Este issue no introduce comando, evento ni aggregate; no hay handler que publique a
ningun bus (`IPrivateEventSender`/`IPublicEventSender`), por lo que no aplica ningun cambio en
`infra/environments/dev/main.tf`.

### Complejidad encontrada
- Primer intento de compilacion fallo con `CS0103: El nombre 'NormalizationForm' no existe en el
  contexto actual` porque asumi que vivia en `System.Globalization` junto con `UnicodeCategory` y
  `CharUnicodeInfo`. Se corrigio agregando `using System.Text;` (donde realmente vive
  `NormalizationForm`). No conto como "intento enfocado" sobre un test especifico -- fue un error
  de compilacion corregido de inmediato (excluido explicitamente de la definicion de "intento" en
  la seccion 4b de la guia del agente).
- El CLI `dotnet test` de este SDK (Microsoft.Testing.Platform) no acepta `--filter` en el formato
  clasico de VSTest; se uso `--project` + `--filter-namespace` para acotar la corrida antes de
  correr la suite completa.

### Resultado
- Tests pasando: 936/936 en la solucion completa (915 correctos + 21 omitidos por falta de
  ServiceBus/Postgres locales, comportamiento esperado de smoke tests fuera de este alcance).
- Tests del proyecto `Colaboradores.Tests` (incluye los 4 archivos de este issue): 91/91 en verde.

</details>
<details>
<summary>Reviewer (fase refactor) — 9m 20s</summary>

## ES Reviewer - Revision

### Evaluacion general
- Calidad: **buena** — el diff sigue al pie de la letra el patron canonico de VO con invariantes
  (MEF-ADR-0012) y el precedente del propio dominio (`Identificacion`, `NombreColaborador`, ambos de
  #348/PR #363). Cero desviaciones de ADR. Los refactors aplicados son de compacidad y de casos
  borde, no de correccion.
- Cambios realizados: **si** (commit `ce44763`).
- Baseline: 936/936 verde al inicio (915 correctos + 21 omitidos por smoke sin ServiceBus/Postgres
  local). Cierre: **939/939 verde** (918 correctos + 21 omitidos) con los 3 tests agregados.

### Cumplimiento de ADRs aplicables

| ADR | Cumplimiento | Observacion |
|---|---|---|
| MEF-ADR-0012: heuristicas de modelado de objetos de dominio | ok | `sealed partial class` con `IEquatable<Etiqueta>`, ctor privado real + ctor vacio privado para STJ/Marten, factory `Crear` con validacion, campos `readonly` privados, `ConfigurarSerializacion` con `typeInfo.CreateObject` via reflexion del ctor vacio. Sin `[JsonConstructor]` (proscrito). Tell-don't-Ask honrado: `EsMismaCategoria` vive en el VO, `Normalizar` es privado y ningun consumidor normaliza por su cuenta. |
| CA-ADR-0029 / MEF-ADR-0039: composicion por rol del evento, tres islas | ok | El diff **no toca ningun `.csproj`** (verificado con `git diff main...HEAD --stat`). `Colaboradores.DomainEvents.csproj` sigue con cero `<ProjectReference>` y cero `<PackageReference>`; `Etiqueta.cs` usa solo BCL (`System.Globalization`, `System.Reflection`, `System.Text`, `System.Text.Json.Serialization.Metadata`). Ubicacion correcta segun CA-ADR-0029 decision #1: es un VO de **payload** de eventos persistidos, no un VO de calculo. |
| MEF-ADR-0009: mensajes `.resx` per-clase | ok | `EtiquetaMensajes.resx` co-localizado + `Etiqueta.Mensajes.cs` con `ResourceManager` y clase `Mensajes` anidada. Nombre logico correcto (`...Colaboradores.DomainEvents.EtiquetaMensajes`, el proyecto no redefine `RootNamespace`). Formato del `.resx` identico al precedente `IdentificacionMensajes.resx`. El guardrail `MensajesResxTests` se extendio a las dos claves nuevas — es el unico test que detecta la perdida silenciosa de una clave (la asercion `WithMessage($"*{null}*")` matchea cualquier excepcion). |
| MEF-ADR-0016: convencion de nombres de tests | **desviacion NO declarada — corregida** | `Equals_RetornaTrue_ConTresVariantesDeEscrituraDeLaMismaEtiqueta` usaba `_Con...` donde el ADR fija `[_Cuando<Condicion>]`. Renombrado. Los 16 tests restantes ya cumplian. |

El issue **si** trae seccion `## ADRs aplicables` completa y correcta. Sin gap que escalar al planner.

### Desviaciones de ADRs

**Desviaciones declaradas por el implementer** (de `stage-2-implementer.md`):

Ninguna — el implementer declaro "todos los ADRs aplicados al pie de la letra", y la verificacion
del diff lo confirma.

**Desviaciones detectadas por el reviewer (NO declaradas por el implementer)**:

#### Desviacion: MEF-ADR-0016
- **Regla del ADR**: `<Sujeto>_<LoQuePasa>[_Cuando<Condicion>]` — el tercer segmento, cuando existe,
  se prefija con `Cuando`.
- **Desviacion encontrada en el diff**: `EtiquetaIgualdadTests.cs:32` —
  `Equals_RetornaTrue_ConTresVariantesDeEscrituraDeLaMismaEtiqueta`.
- **Accion tomada**: corregida en refactor →
  `Equals_RetornaTrue_CuandoLasTresVariantesDeEscrituraSonDeLaMismaEtiqueta`. Suite verde.
- **Status**: resuelta, no requiere evaluacion del usuario.

Fuera de esa desviacion cosmetica, **todos los ADRs aplicables se cumplen**.

### Precedentes consultados por el implementer

| Precedente | ADR aplicable | Veredicto |
|---|---|---|
| `Programacion.DomainEvents/SubFranja.cs` | MEF-ADR-0012 | alineado — ctor vacio privado + reflexion, sin `[JsonConstructor]` |
| `Colaboradores.DomainEvents/Identificacion.cs` | MEF-ADR-0012 | alineado — mismo patron, misma isla |
| `Colaboradores.DomainEvents/NombreColaborador.cs` (leido por el reviewer, **no** citado por el implementer) | MEF-ADR-0012 + MEF-ADR-0018 | alineado, y **mas evolucionado**: ya extrae el helper `RegistrarCampo` que `Etiqueta` repetia 4 veces. Ver refactor #1. |

Ningun precedente viola su ADR. No hay bug de precedente que reportar.

### Convenciones del pipeline (no ADRs)

| Convencion | Estado | Observacion |
|---|---|---|
| Cada test con `Then()` + `And<>()` | n/a | VO puro sin comando/evento/aggregate — no hay `CommandHandlerAsyncTest<T>` que heredar. Mismo criterio que `IdentificacionTests`/`NombreColaboradorTests` (seccion 6c del test-writer). |
| Overloads correctos para stream IDs compuestos | n/a | Sin aggregate en este corte. |
| Fakes manuales (no NSubstitute) | n/a | Sin dependencias que fakear. |
| Feature folders (produccion y tests) | ok | VO en la raiz de la isla `DomainEvents` (espejo de los otros 3 VOs); tests en `ValueObjects/`, un archivo por responsabilidad (comportamiento / igualdad / serializacion), igual que `Identificacion*` y `NombreColaborador*`. |
| Smoke tests: SkipWhen, secrets, cobertura | n/a | El diff no toca smoke tests ni introduce endpoint. `Colaboradores.SmokeTests` corre sin cambios. |
| Proyecciones read-side | n/a | El diff no toca `ReadModels`/`Projections` ni ninguna Function GET. |
| Antipatrones de habilitacion (MEF-ADR-0039) | n/a | El diff no toca **ningun** `.csproj` ni declara tipo de evento nuevo (solo un VO de payload). Verificado item por item: (a) sin `ProjectReference` nueva, (b) sin `PackageReference` nueva, (c) worker intacto, (d) sin tipo de bus homonimo, (e) `PublicEvents.Tests`/`PrivateEvents.Tests` intactos. |
| Compatibilidad Marten write-side/read-side | n/a | El diff no toca version de `Cosmos.EventSourcing.*` ni configuracion de Marten (`ComposicionServicios`, `IdentidadEventosColaboradores`, serializador). No se decompilo nada. |
| Identidad de stream (MEF-ADR-0037) | n/a | El diff no lee ni escribe ninguna identidad de stream. `Etiqueta.ToString()` es **display**, no clave de stream (a diferencia de `Identificacion.ToString()`, que si es contrato de clave) — y no se pasa a ningun `StartStream`/`LoadAsync`. |
| Control de volumen de telemetria (MEF-ADR-0038) | n/a | El diff no toca `ComposicionServicios*`, `ConfiguracionObservabilidad*` ni el callback de Wolverine. |
| Tests via ToString/comportamiento | ok con reserva | `ToString()` tiene test propio. Las 4 propiedades observables (`Categoria`, `Valor`, `CategoriaNormalizada`, `ValorNormalizado`) se asertan directamente — legitimo: el issue las declara interfaz publica con justificacion escrita bajo MEF-ADR-0012 ("identidad observable, no dato intermedio"). Ver nota de vigilancia para #355. |
| Sin numeros magicos | ok | No hay literales numericos. |
| Condiciones en positivo (guardas if/else afirmativas) | ok | Las dos guardas de `Crear` son guard clauses con early-throw (`if (string.IsNullOrWhiteSpace(...)) throw`), que es la excepcion explicita de la regla — no hay bifurcacion `if`/`else` que permutar. |
| Sin warnings del compilador | ok | `dotnet build` limpio para el diff. Los `NU1902` (OpenTelemetry.Api 1.14.0) y los `IDE0005` que reporta `dotnet format` son **preexistentes en `main`**, en `Programacion` y `ControlHoras.Tests` — ningun archivo del diff aparece en esa salida. No los toco (regla 4: no refactorizar codigo ajeno a la HU). |
| Sin caracter U+2500 en `.cs` | ok | Verificado en todo `src/` y `tests/`. |

### Elegancia del codigo

El codigo llego ya idiomatico: `Normalizar` como expresion LINQ compacta, igualdad y `GetHashCode`
con `HashCode.Combine`, comentarios que explican el *por que* y no el *que*. Dos hallazgos de
compacidad y uno de precision en los comentarios:

1. **Repeticion evitable en `ConfigurarSerializacion`** (compacidad): los 4 campos se registraban con
   4 bloques de 4 lineas literalmente identicos salvo el nombre — 20 lineas de ceremonia. El
   precedente del **mismo folder** (`NombreColaborador`, tambien con 4 campos `string`) ya habia
   resuelto exactamente esto extrayendo `RegistrarCampo`. Aplicado: `Etiqueta` ahora usa
   `Campo(nombre)` + `RegistrarCampo(typeInfo, campo, nombreJson)`. El metodo baja de 39 a 22 lineas
   y los dos VOs hermanos quedan consistentes entre si. Sin `foreach` (regla 5 del implementer: LINQ
   sobre `for`/`foreach`; aqui el registro es efecto secundario, asi que la forma correcta son las 4
   llamadas explicitas del precedente, no un LINQ forzado).
2. **`ToString()` documentado como "Propuesta"** (precision): el comentario arrastraba el lenguaje
   deliberativo del issue (`// Propuesta: "{Categoria}:{Valor}"...`). En el codigo ya es contrato,
   no propuesta — reescrito como `// Display: ... con las formas originales, no las normalizadas.`
3. **Concordancia en el comentario de `Normalizar`** ("filtrar **los** marcas" → "las marcas").

### Criticas y hallazgos

1. **[menor — corregido]** Repeticion de 4 bloques identicos en `ConfigurarSerializacion` con helper
   ya disponible como precedente en el mismo folder. Ver refactor #1.
2. **[cosmetico — corregido]** Nombre de test fuera de MEF-ADR-0016 (`_Con...` en vez de
   `_Cuando...`).
3. **[cosmetico — corregido]** Dos comentarios imprecisos (lenguaje de "propuesta"; concordancia).
4. **[menor — no corregido, es alcance de producto]** *Un valor compuesto solo por diacriticos
   normaliza a cadena vacia.* `Crear("Area", "́")` (una tilde combinante suelta) pasa la guarda
   de `IsNullOrWhiteSpace` (no es whitespace) pero `Normalizar` la reduce a `""`. Consecuencia: dos
   etiquetas con diacriticos puros distintos serian **iguales** entre si (ambas normalizan a `""`),
   y su clave normalizada en el diccionario del aggregate (#355) seria vacia. Es un caso degenerado
   improbable (nadie teclea una tilde combinante como valor de etiqueta) y **no lo corregi
   deliberadamente**: el invariante "la forma normalizada no puede quedar vacia" no esta en ningun CA
   del issue y exigiria un mensaje `.resx` nuevo, es decir una decision de producto, no un refactor.
   **Recomendacion**: evaluarlo al escribir #355, donde la forma normalizada pasa a ser clave real.
5. **[observacion — no es hallazgo del diff]** `ConfigurarSerializacion` de los 4 VOs de
   `Colaboradores.DomainEvents` (incluida `Etiqueta`) **todavia no esta registrado en Marten**:
   `IdentidadEventosColaboradores.TiposPersistidos` esta vacia y
   `ComposicionServicios.cs:81-93` tiene el `ConfigureMarten` con el sitio reservado y el comentario
   de donde debe invocarse. Segun MEF-ADR-0012, sin ese registro `ConfigurarSerializacion` es
   "codigo muerto" fuera de los tests. **No es defecto de este diff**: es el estado deliberado del
   dominio en `main` desde el scaffold (#360/PR #361) y es identico para `Identificacion` y
   `NombreColaborador` (ya mergeados). Queda como **precondicion de #355**: el primer evento
   persistido de `Colaborador` debe registrar los 4 VOs dentro de **ese mismo** `ConfigureMarten`
   (nunca en un segundo callback — riesgo documentado en el propio comentario del archivo).
6. **[vigilancia para #355 — no accionable hoy]** `CategoriaNormalizada`/`ValorNormalizado` son
   publicas y hoy su unico consumidor son los tests. No lo marco como violacion del antipatron 1/3
   de MEF-ADR-0012 porque el issue las justifica por escrito como identidad observable (claves del
   diccionario del aggregate y de la busqueda en reportes) y la decision se discutio con el usuario;
   ademas la superficie de comportamiento (`EsMismaCategoria`) **si** vive en el VO, que es lo que el
   ADR exige. **Lo que hay que vigilar en #355**: que el aggregate use `EsMismaCategoria(otra)` para
   decidir "misma categoria" y no reescriba `a.CategoriaNormalizada == b.CategoriaNormalizada` — eso
   ultimo seria la violacion de la contrapartida activa del ADR ("consume la riqueza expuesta"), el
   mismo defecto del caso PR #155 round 2.

### Refactorings aplicados

1. `Etiqueta.ConfigurarSerializacion`: extraidos `Campo(string)` y
   `RegistrarCampo(JsonTypeInfo, FieldInfo, string)`; eliminados los 4 bloques de registro
   duplicados. Justificacion: Rule of Three (MEF-ADR-0018) con 4 repeticiones y helper ya existente
   como precedente en el mismo folder (`NombreColaborador`). Consistencia entre los dos VOs
   hermanos.
2. Comentario de `ToString()`: de lenguaje de propuesta a enunciado de contrato de display.
3. Comentario de `Normalizar()`: concordancia corregida + **documentada la consecuencia de la enie**
   (ver "Tests agregados").
4. Rename del test para cumplir MEF-ADR-0016.

`dotnet test` corrido despues de cada cambio; ningun revert fue necesario.

### Cobertura de criterios de aceptacion

| Criterio | Estado | Test(s) |
|---|---|---|
| CA-1: `Crear(" Área ", " Tecnología ")` produce doble forma (originales con trim + normalizadas) | cubierto | `Crear_ProduceFormaOriginalYNormalizada_CuandoCategoriaYValorTienenTildesMayusculasYEspaciosExtremos` |
| CA-2: categoria o valor vacios o whitespace -> rechazo con mensaje `.resx` | cubierto (**reforzado**) | `Crear_LanzaArgumentException_Cuando{Categoria,Valor}Es{Vacia/Vacio,Whitespace,**Null**}` (6 tests) + `MensajesResxTests.Mensajes_ResuelvenTextoNoVacio_CuandoPertenecenAEtiqueta` |
| CA-3: igualdad completa normalizada; `area:ventas` != `area:tecnologia` | cubierto | `Equals_RetornaTrue_CuandoLasTresVariantesDeEscrituraSonDeLaMismaEtiqueta`, `Equals_RetornaFalse_CuandoMismaCategoriaConValorDistinto` + los 8 heredados de `IgualdadTestBase<Etiqueta>` |
| CA-4: `EsMismaCategoria` true con valores distintos / false con categorias distintas | cubierto | `EsMismaCategoria_RetornaTrue_CuandoCategoriasNormalizadasCoincidenConValoresDistintos`, `EsMismaCategoria_RetornaFalse_CuandoCategoriasSonDistintas` |
| CA-5: formas originales preservadas salvo trim; espacios internos intactos | cubierto | `Crear_ConservaEspaciosInternos_CuandoValorTieneVariasPalabras`, mas las aserciones de forma original en CA-1 y en el round-trip |
| CA-6: round-trip con resolver configurado, sin `[JsonConstructor]` | cubierto | `RoundTrip_PreservaIgualdad_CuandoEtiquetaValida`, `RoundTrip_PreservaFormasOriginalesYNormalizadas_CuandoEtiquetaTieneTildesYMayusculas`, `Serializar_PersisteLasCuatroFormasPorCampo_CuandoEtiquetaValida`, `Deserializar_Falla_CuandoResolverNoTieneRegistroDeEtiqueta` |

Nota sobre CA-6 y la frontera de serializacion (MEF-ADR-0012): el guardrail de **portabilidad por el
bus** (round-trip con `JsonSerializerOptions` vanilla) **no aplica** aqui y su ausencia es correcta —
`Etiqueta` no implementa `IPublicEvent` ni `IPrivateEvent` y no cruza ningun bus. Al contrario:
`Deserializar_Falla_CuandoResolverNoTieneRegistroDeEtiqueta` afirma deliberadamente lo **inverso**
(que sin resolver falla), que es lo esperado de un tipo del event store. Cuando #355 publique
etiquetas por un bus, el payload debe aplanarse — el VO rico se queda en el event store.

### Tests agregados

Tres tests (contrato y casos borde sobre implementacion ya existente — no violan TDD):

1. `Crear_LanzaArgumentException_CuandoCategoriaEsNull` y `Crear_LanzaArgumentException_CuandoValorEsNull`
   — CA-2 hablaba de "vacios o whitespace" y el diff cubria ambos, pero no `null`. Los parametros son
   `string` no anulable, sin embargo el boundary real (deserializacion, payload HTTP) deja pasar
   `null` sin que el compilador intervenga, y el resultado debe ser el mismo `ArgumentException` con
   mensaje `.resx`, no una `NullReferenceException` opaca. Paridad con `NombreColaboradorTests`
   (#348), que ya cubre `null!` en sus campos requeridos.
2. `Crear_NormalizaLaEnieComoN_CuandoValorLaContiene` — **el caso borde mas relevante del espanol y
   estaba tacito**. El patron que el issue prescribe (`FormD` + remover `NonSpacingMark`) descompone
   la enie en `n` + tilde combinante y la colapsa: `"Diseño"` y `"Diseno"` son la **misma** etiqueta,
   aunque la enie no sea un acento sino una letra propia. El comportamiento es razonable en etiquetas
   libres tecleadas por el cliente (evita fragmentar el reporte cuando alguien escribe sin enie) y
   verificado en verde, pero era **accidental** — ningun test ni comentario lo fijaba. Ahora esta
   fijado como decision observable y documentado en el comentario de `Normalizar`: si el dominio
   necesitara preservar la enie, este es el test que debe fallar primero.

No se agrego test de contrato adicional de igualdad ni de serializacion: `IgualdadTestBase<Etiqueta>`
y `EtiquetaSerializacionTests` ya cubrian ambos contratos completos (incluida la barrera
anti-regresion del resolver ausente).

</details>

## Cobertura

| Archivo | Cobertura | Umbral | Estado |
|---|---|---|---|
| Etiqueta.Mensajes.cs | - | excluido | - |
| Etiqueta.cs | - | no evaluado | - |
## Commits

ce44763 refactor(hu-353): compacta el mapping de serializacion y fija casos borde de Etiqueta
a871ada feat(hu-353): implementacion del VO Etiqueta con normalizacion (fase verde)
1dadc7d test(hu-353): tests para value object Etiqueta con normalizacion (fase roja)

Closes #353