### PR TITLE
Terminar la vinculacion de un colaborador

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,7 @@ Si tu trabajo toca uno de estos temas, consulta el ADR correspondiente antes de 
 | **Encapsulamiento, Tell-don't-Ask, ocultación de estado interno (aplica por igual a aggregates y a value objects)** | MEF-ADR-0012 |
 | Serialización, value objects con ctor privado, records vs sealed class, `ConfigurarSerializacion`, proscripción de `[JsonConstructor]` | MEF-ADR-0012 |
 | Manejo de errores en event sourcing, eventos de fallo, no-throw en `Apply()` | MEF-ADR-0004 |
+| **Violación de regla de negocio en un comando HTTP sin consumidores downstream: el aggregate declina con resultado (no lanza, no emite evento de fallo) y el handler traduce a 409/404 con `.resx`; los eventos de fallo persistidos se reservan para flujos con un consumidor que reaccione** | CA-ADR-0030 (precisa el criterio capa 2 vs capa 3 de MEF-ADR-0004) |
 | Naming de eventos, versionado | MEF-ADR-0005 |
 | Naming de funciones Azure (HTTP y Service Bus) | MEF-ADR-0006 |
 | Topics y subscriptions de Service Bus, un topic por evento | MEF-ADR-0001 |

--- a/docs/adr/ca-adr-0030-fallos-sincronos-comandos-http-sin-consumidores.md
+++ b/docs/adr/ca-adr-0030-fallos-sincronos-comandos-http-sin-consumidores.md
@@ -1,0 +1,134 @@
+# CA-ADR-0030: Fallos sincronos para comandos HTTP sin consumidores downstream
+
+## Estado
+
+Aceptado.
+
+## Contexto
+
+El issue #349 (terminar la vinculacion de un colaborador) es el segundo comando del ciclo de vida
+de `ColaboradorAggregateRoot` (desglose #348-#357) y el primero de esa cadena en violar una regla
+de negocio evaluada por el propio aggregate, no una precondicion de orquestacion del handler. El
+borrador inicial del issue proponia `TerminacionVinculacionFallida`, un evento de fallo persistido,
+por lectura literal de MEF-ADR-0004 capa 3 ("eventos de fallo para reglas de negocio del
+aggregate"). Al refinar el issue (sesion planner, 2026-08-11) esa lectura resulto incompleta: la
+razon de ser de un evento de fallo en MEF-ADR-0004 es que **un consumidor downstream reacciona** a
+el (un handler de Service Bus, una saga). `TerminarVinculacion` no tiene ninguno: el dominio
+Colaboradores es event-sourcing puro en este comando, "Consumidores: ninguno", y el trigger es
+HTTP -- un canal sincrono que ya tiene un mecanismo de respuesta inmediata (el status code).
+
+Persistir `TerminacionVinculacionFallida` sin un lector tenia tres costos concretos:
+
+1. **Deja ciego al caller.** Sin un evento de exito posterior que lo desmienta, el caller recibe
+   202 Accepted por un comando que en realidad fue rechazado -- el patron correcto para eso es
+   sincronizar con el resultado ya, no diferirlo a un evento que nadie procesa.
+2. **Contamina el stream del colaborador legitimo** con hechos que nunca le pasaron: el stream de
+   event sourcing es la fuente de verdad de lo que ocurrio, y un intento rechazado no es un hecho
+   del dominio, es un hecho de la interaccion HTTP.
+3. **Estrena un patron sin lector.** Ningun handler de Colaboradores suscribe eventos de fallo
+   propios; anadir el primero sin que nada lo consuma es deuda tecnica de dia uno.
+
+Este ADR fija la decision para que los comandos hermanos de la misma cadena (#350 reingreso, #351,
+#352 ajuste de fechas, #355) la apliquen sin volver a discutirla, y para que `reviewer` no la marque
+como desviacion cuando la vea repetida.
+
+## Decision
+
+**Un comando HTTP sin consumidores downstream que reciba de un aggregate el rechazo de una regla de
+negocio responde ese rechazo con un status code sincrono (409 Conflict via
+`InvalidOperationException`, o 404 Not Found via `KeyNotFoundException` cuando la precondicion es
+"el recurso no existe"), nunca con un evento de fallo persistido.**
+
+Los eventos de fallo persistidos (MEF-ADR-0004 capa 3) se reservan para flujos donde existe un
+consumidor que reacciona a la falla -- un handler de Service Bus, una saga, un proceso downstream
+que necesita saber que algo no ocurrio para compensar o notificar. Si el canal es HTTP y no hay
+consumidor, el status code sincrono ya resuelve el mismo problema sin pagar el costo de persistir
+un hecho que nadie lee.
+
+### Mecanismo: el aggregate declina con resultado, nunca lanza
+
+El aggregate sigue sin lanzar excepciones para logica de dominio (MEF-ADR-0004 capa 4) y sin
+interrogar su propio estado desde fuera (Tell-don't-Ask, MEF-ADR-0012). En vez de eso, el metodo que
+ejerce la regla de negocio **responde el resultado de la operacion** -- exito o la razon puntual del
+rechazo -- y dos causas ya no requieren un evento para comunicarse:
+
+- El aggregate no muta nada y no agrega eventos a `_uncommittedEvents` cuando declina.
+- El handler consulta unicamente ese resultado (nunca el estado interno) y traduce la razon de
+  rechazo a la excepcion correspondiente, con mensaje `.resx` (MEF-ADR-0009).
+
+Precedente interno de "declinar sin emitir": `ControlDiarioAggregateRoot.AdicionarMarcacion`
+(idempotencia de marcaciones duplicadas) ya ignora silenciosamente sin lanzar ni emitir. Este ADR
+generaliza ese mecanismo para el caso en que el handler **si** necesita distinguir la razon del
+rechazo (aqui, "ya terminada" vs "fecha anterior al inicio"), usando el valor de retorno del metodo
+en vez de un booleano o un efecto silencioso.
+
+### Cuando SI corresponde un evento de fallo persistido
+
+Este ADR no reemplaza MEF-ADR-0004 capa 3 en general -- solo fija el criterio de decision para el
+caso "HTTP + sin consumidor". Un evento de fallo sigue siendo la eleccion correcta cuando:
+
+- El trigger no es HTTP (Service Bus, timer) y por tanto no hay un canal de respuesta sincrono.
+- Existe un consumidor real (otro dominio, una saga, una proyeccion) que necesita reaccionar al
+  rechazo -- no solo un futuro hipotetico.
+
+## Alternativas consideradas
+
+**Evento de fallo `TerminacionVinculacionFallida` + 202 Accepted** (propuesta original del
+borrador). Descartada: caller ciego hasta que consultara el stream (que no expone HTTP en este
+issue), stream contaminado con hechos que no ocurrieron, patron sin consumidor. Ver "Contexto".
+
+**Validar la regla en el handler, antes de invocar al aggregate.** Descartada: moveria la logica de
+negocio ("una vinculacion no puede terminarse dos veces", "la fecha efectiva no puede ser anterior
+al inicio") fuera del aggregate, que es quien tiene el estado necesario para evaluarla. El handler
+quedaria interrogando el estado interno del aggregate para decidir -- exactamente lo que
+Tell-don't-Ask (MEF-ADR-0012) prohibe.
+
+**Un booleano (`bool TryTerminarVinculacion(...)`) en vez de un resultado con razon.** Descartada
+para este caso especifico: el handler necesita distinguir "ya terminada" (409 con un mensaje) de
+"fecha anterior al inicio" (409 con otro mensaje), y un booleano no transporta esa distincion sin
+que el handler vuelva a interrogar el estado del aggregate para averiguar cual fue.
+
+## Consecuencias
+
+### Positivas
+
+- El caller HTTP recibe la respuesta correcta (409/404/202) en la misma request, sin depender de
+  que algo lea un evento que nadie procesa.
+- El stream de `ColaboradorAggregateRoot` solo contiene hechos que efectivamente ocurrieron.
+- El patron es replicable sin discusion en #350/#351/#352/#355: cualquier comando HTTP de esa
+  cadena que necesite rechazar una regla de negocio del aggregate usa el mismo mecanismo
+  (declinar con resultado -> handler traduce -> status code).
+- Simetria con el comando hermano de creacion (#330): crear dos veces -> 409; terminar dos veces
+  -> 409. Misma familia de respuesta para la misma familia de violacion ("el hecho ya ocurrio").
+
+### Negativas y deuda asumida
+
+- Si un futuro consumidor downstream (por ejemplo, una integracion con nomina que reaccione a
+  intentos de terminacion rechazados) apareciera para este comando, este ADR no lo cubre: ese caso
+  requeriria revisar la decision y anadir el evento de fallo que hoy se descarta. Costo aceptado
+  deliberadamente (ver "Notas tecnicas" del issue #349: la asimetria de reversa es barata --
+  MEF-ADR-0005 -- agregar el evento despues es aditivo).
+- El enum de resultado (`ResultadoTerminacionVinculacion`) es especifico de este comando; comandos
+  hermanos con distintas razones de rechazo definiran su propio tipo de resultado. Este ADR no
+  fija una forma generica de "resultado de operacion" para todo el dominio, solo el mecanismo
+  (declinar sin lanzar, sin emitir; el handler traduce en el borde).
+
+## Referencias
+
+- MEF-ADR-0004 (manejo de errores en event sourcing): capa 2 (excepciones de orquestacion del
+  handler -> HTTP status codes), capa 3 (eventos de fallo con consumidor), capa 4 (el aggregate
+  nunca lanza). Este ADR precisa el criterio de eleccion entre capa 2 y capa 3 para comandos HTTP.
+- MEF-ADR-0012 (Tell-don't-Ask, estilo de modelado de objetos de dominio): el aggregate decide y
+  responde el resultado; el handler no interroga su estado interno.
+- MEF-ADR-0009 (mensajes en `.resx` por aggregate/handler): los mensajes de las excepciones
+  traducidas viven en el `.resx` del handler, no del aggregate (el aggregate no lanza).
+- Precedente de "declinar sin emitir": `ControlDiarioAggregateRoot.AdicionarMarcacion`
+  (idempotencia de marcaciones duplicadas, ControlHoras).
+- Precedente de endpoint 404+409: `SolicitarProgramacionTurnoFunction.FunctionEndpoint`
+  (Programacion).
+
+## Control de cambios
+
+- 2026-08-11: creacion (issue #349). Fija el patron "declinar con resultado + status code sincrono"
+  para comandos HTTP sin consumidores downstream, descartando el evento de fallo persistido que el
+  borrador original proponia.

--- a/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/IdentidadEventosColaboradores.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/IdentidadEventosColaboradores.cs
@@ -17,5 +17,6 @@ public static class IdentidadEventosColaboradores
     [
         typeof(ColaboradorRegistrado),
         typeof(VinculacionIniciada),
+        typeof(VinculacionTerminada),
     ];
 }

--- a/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/VinculacionTerminada.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/VinculacionTerminada.cs
@@ -1,0 +1,18 @@
+namespace Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+
+/// <summary>
+/// Evento de event sourcing que registra el cierre de la vinculacion vigente de un colaborador,
+/// con la fecha efectiva de terminacion. Se persiste en el stream de ColaboradorAggregateRoot.
+/// </summary>
+/// <remarks>
+/// Issue #349: payload plano, sin VOs ricos -- mismo criterio que VinculacionIniciada. SIN Motivo
+/// (decision de refinamiento 2026-08-11): ninguna regla, consulta ni vista de este BC lo consume;
+/// la fuente autoritativa del "por que" es RRHH/nomina, fuera de este dominio.
+/// FechaEfectiva puede ser pasada (registro tardio) o futura (preaviso) -- el evento no valida
+/// contra el reloj del servidor, esa regla vive en ColaboradorAggregateRoot.TerminarVinculacion.
+/// No necesita ConfigurarSerializacion: tipo primitivo (DateOnly), STJ lo reconstruye sin ayuda --
+/// mismo criterio que VinculacionIniciada/ProgramacionTurnoSolicitada.
+/// No cruza el bus (sin marker IPrivateEvent/IPublicEvent): event-sourcing puro, sin consumidores
+/// (issue #349 "Consumidores: ninguno").
+/// </remarks>
+public sealed record VinculacionTerminada(DateOnly FechaEfectiva);

--- a/src/Bitakora.ControlAsistencia.Colaboradores/Entities/ColaboradorAggregateRoot.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/Entities/ColaboradorAggregateRoot.cs
@@ -59,9 +59,8 @@ public partial class ColaboradorAggregateRoot : AggregateRoot
     }
 
     // Issue #349: registra la terminacion de la vinculacion vigente. Nunca lanza (MEF-ADR-0004
-    // capa 4) -- STUB (fase roja): el implementer asigna _fechaTerminacionVinculacionVigente =
-    // e.FechaEfectiva.
-    public void Apply(VinculacionTerminada e) => throw new NotImplementedException();
+    // capa 4).
+    public void Apply(VinculacionTerminada e) => _fechaTerminacionVinculacionVigente = e.FechaEfectiva;
 
     // Issue #349: mecanismo "declinar con resultado" (CA-ADR-0030) -- nunca lanza, nunca emite un
     // evento de fallo persistido. Dos razones de rechazo evaluables solo con la historia del
@@ -73,9 +72,20 @@ public partial class ColaboradorAggregateRoot : AggregateRoot
     //     negativa). fechaEfectiva == _fechaInicioVinculacionVigente es valida (vinculacion de un
     //     solo dia).
     // Exito: appendea VinculacionTerminada a _uncommittedEvents y lo aplica.
-    // STUB (fase roja, issue #349): el cuerpo completo queda para el implementer.
-    public ResultadoTerminacionVinculacion TerminarVinculacion(DateOnly fechaEfectiva) =>
-        throw new NotImplementedException();
+    public ResultadoTerminacionVinculacion TerminarVinculacion(DateOnly fechaEfectiva)
+    {
+        if (_fechaTerminacionVinculacionVigente is not null)
+            return ResultadoTerminacionVinculacion.YaTerminada;
+
+        if (fechaEfectiva < _fechaInicioVinculacionVigente)
+            return ResultadoTerminacionVinculacion.FechaAnteriorAInicio;
+
+        var evento = new VinculacionTerminada(fechaEfectiva);
+        _uncommittedEvents.Add(evento);
+        Apply(evento);
+
+        return ResultadoTerminacionVinculacion.Exitosa;
+    }
 
     // Factory interno: agrega los DOS eventos del commit a _uncommittedEvents y los aplica -- patron
     // RegistroDeMarcacionAggregateRoot.Iniciar, generalizado a dos eventos en el mismo commit.

--- a/src/Bitakora.ControlAsistencia.Colaboradores/Entities/ColaboradorAggregateRoot.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/Entities/ColaboradorAggregateRoot.cs
@@ -25,11 +25,19 @@ public partial class ColaboradorAggregateRoot : AggregateRoot
     private NombreColaborador? _nombre;
     private string? _codigoVinculacionVigente;
     private DateOnly _fechaInicioVinculacionVigente;
+    private DateOnly? _fechaTerminacionVinculacionVigente;
 
     internal Identificacion Identificacion => _identificacion!;
     internal NombreColaborador Nombre => _nombre!;
     internal string CodigoVinculacionVigente => _codigoVinculacionVigente!;
     internal DateOnly FechaInicioVinculacionVigente => _fechaInicioVinculacionVigente;
+
+    // Issue #349: null mientras la vinculacion vigente esta abierta; con valor una vez que
+    // TerminarVinculacion tuvo exito (registro tardio o preaviso, sin distincion de estado). No
+    // publico: es insumo del DSL de tests (And<>), no lectura expuesta a otros consumidores del
+    // ensamblado (Tell-don't-Ask, MEF-ADR-0012) -- el handler decide unicamente por el resultado
+    // que TerminarVinculacion le responde, nunca interrogando este campo.
+    internal DateOnly? FechaTerminacionVinculacionVigente => _fechaTerminacionVinculacionVigente;
 
     // Contrato: clave del stream de Colaborador. Delega en el ToString() canonico del VO (#348) --
     // ningun handler/endpoint concatena la clave por su cuenta (MEF-ADR-0037).
@@ -49,6 +57,25 @@ public partial class ColaboradorAggregateRoot : AggregateRoot
         _codigoVinculacionVigente = e.Codigo;
         _fechaInicioVinculacionVigente = e.FechaInicio;
     }
+
+    // Issue #349: registra la terminacion de la vinculacion vigente. Nunca lanza (MEF-ADR-0004
+    // capa 4) -- STUB (fase roja): el implementer asigna _fechaTerminacionVinculacionVigente =
+    // e.FechaEfectiva.
+    public void Apply(VinculacionTerminada e) => throw new NotImplementedException();
+
+    // Issue #349: mecanismo "declinar con resultado" (CA-ADR-0030) -- nunca lanza, nunca emite un
+    // evento de fallo persistido. Dos razones de rechazo evaluables solo con la historia del
+    // stream, sin reloj (decision de refinamiento):
+    //   - YaTerminada: _fechaTerminacionVinculacionVigente ya tiene valor (incluye un preaviso
+    //     cuya fecha aun no llego -- "ya terminada" es "tiene terminacion registrada", no "la
+    //     fecha ya paso").
+    //   - FechaAnteriorAInicio: fechaEfectiva < _fechaInicioVinculacionVigente (duracion
+    //     negativa). fechaEfectiva == _fechaInicioVinculacionVigente es valida (vinculacion de un
+    //     solo dia).
+    // Exito: appendea VinculacionTerminada a _uncommittedEvents y lo aplica.
+    // STUB (fase roja, issue #349): el cuerpo completo queda para el implementer.
+    public ResultadoTerminacionVinculacion TerminarVinculacion(DateOnly fechaEfectiva) =>
+        throw new NotImplementedException();
 
     // Factory interno: agrega los DOS eventos del commit a _uncommittedEvents y los aplica -- patron
     // RegistroDeMarcacionAggregateRoot.Iniciar, generalizado a dos eventos en el mismo commit.

--- a/src/Bitakora.ControlAsistencia.Colaboradores/Entities/ColaboradorAggregateRoot.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/Entities/ColaboradorAggregateRoot.cs
@@ -72,7 +72,9 @@ public partial class ColaboradorAggregateRoot : AggregateRoot
     //     negativa). fechaEfectiva == _fechaInicioVinculacionVigente es valida (vinculacion de un
     //     solo dia).
     // Exito: appendea VinculacionTerminada a _uncommittedEvents y lo aplica.
-    public ResultadoTerminacionVinculacion TerminarVinculacion(DateOnly fechaEfectiva)
+    // internal, como Registrar y como los metodos de comando de los demas aggregates del repo: el
+    // unico llamador es el handler del mismo ensamblado (los tests lo alcanzan via InternalsVisibleTo).
+    internal ResultadoTerminacionVinculacion TerminarVinculacion(DateOnly fechaEfectiva)
     {
         if (_fechaTerminacionVinculacionVigente is not null)
             return ResultadoTerminacionVinculacion.YaTerminada;

--- a/src/Bitakora.ControlAsistencia.Colaboradores/Entities/ResultadoTerminacionVinculacion.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/Entities/ResultadoTerminacionVinculacion.cs
@@ -7,9 +7,11 @@ namespace Bitakora.ControlAsistencia.Colaboradores.Entities;
 // Compatible con Tell-don't-Ask (MEF-ADR-0012): el handler consulta el RESULTADO, nunca interroga
 // el estado interno del aggregate para decidir por si mismo.
 // Vive en el mismo ensamblado que el handler que lo consume (Entities/ y CommandHandler/ estan en
-// el mismo proyecto Function App) -- puede ser public sin ampliar la superficie del dominio hacia
-// afuera del ensamblado.
-public enum ResultadoTerminacionVinculacion
+// el mismo proyecto Function App), asi que es internal: nadie fuera del ensamblado decide sobre
+// este resultado. Misma visibilidad que los metodos de comando de los otros aggregates del repo
+// (ControlDiarioAggregateRoot.AdicionarMarcacion, CatalogoTurnos.ObtenerDetalle) -- publicos son
+// solo Apply(...) (los necesita el TestStore via GetMethods()) y ComputarStreamId.
+internal enum ResultadoTerminacionVinculacion
 {
     Exitosa,
     YaTerminada,

--- a/src/Bitakora.ControlAsistencia.Colaboradores/Entities/ResultadoTerminacionVinculacion.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/Entities/ResultadoTerminacionVinculacion.cs
@@ -1,0 +1,17 @@
+namespace Bitakora.ControlAsistencia.Colaboradores.Entities;
+
+// Issue #349: resultado de ColaboradorAggregateRoot.TerminarVinculacion. Mecanismo "declinar con
+// resultado" (CA-ADR-0030): el aggregate nunca lanza y nunca emite un evento de fallo persistido
+// -- responde el resultado de la operacion (exito o razon del rechazo) y el handler traduce la
+// razon a InvalidOperationException con mensaje .resx en el borde (MEF-ADR-0004 capa 2).
+// Compatible con Tell-don't-Ask (MEF-ADR-0012): el handler consulta el RESULTADO, nunca interroga
+// el estado interno del aggregate para decidir por si mismo.
+// Vive en el mismo ensamblado que el handler que lo consume (Entities/ y CommandHandler/ estan en
+// el mismo proyecto Function App) -- puede ser public sin ampliar la superficie del dominio hacia
+// afuera del ensamblado.
+public enum ResultadoTerminacionVinculacion
+{
+    Exitosa,
+    YaTerminada,
+    FechaAnteriorAInicio
+}

--- a/src/Bitakora.ControlAsistencia.Colaboradores/TerminarVinculacionFunction/CommandHandler/TerminarVinculacionCommandHandler.Mensajes.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/TerminarVinculacionFunction/CommandHandler/TerminarVinculacionCommandHandler.Mensajes.cs
@@ -1,0 +1,24 @@
+using System.Resources;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.TerminarVinculacionFunction.CommandHandler;
+
+// MEF-ADR-0009: mensajes del handler en .resx separado.
+// internal: accesible desde tests via InternalsVisibleTo en el .csproj.
+public partial class TerminarVinculacionCommandHandler
+{
+    private static readonly ResourceManager ResourceManager = new(
+        "Bitakora.ControlAsistencia.Colaboradores.TerminarVinculacionFunction.CommandHandler.TerminarVinculacionCommandHandlerMensajes",
+        typeof(TerminarVinculacionCommandHandler).Assembly);
+
+    internal static class Mensajes
+    {
+        public static string ColaboradorNoEncontrado =>
+            ResourceManager.GetString(nameof(ColaboradorNoEncontrado))!;
+
+        public static string VinculacionYaTerminada =>
+            ResourceManager.GetString(nameof(VinculacionYaTerminada))!;
+
+        public static string FechaAnteriorAInicio =>
+            ResourceManager.GetString(nameof(FechaAnteriorAInicio))!;
+    }
+}

--- a/src/Bitakora.ControlAsistencia.Colaboradores/TerminarVinculacionFunction/CommandHandler/TerminarVinculacionCommandHandler.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/TerminarVinculacionFunction/CommandHandler/TerminarVinculacionCommandHandler.cs
@@ -1,0 +1,32 @@
+using Cosmos.EventSourcing.Abstractions.Commands;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.TerminarVinculacionFunction.CommandHandler;
+
+// Issue #349: handler del comando TerminarVinculacion.
+// Flujo esperado (precedente SolicitarProgramacionTurnoCommandHandler, MEF-ADR-0004 capa 2 --
+// CA-ADR-0030):
+//   1. Normalizar y parsear TipoIdentificacion -> TipoIdentificacion.Desde(...) (borde HTTP:
+//      normalizar trim+MAYUSCULAS ANTES de Desde, mismo criterio que RegistrarColaboradorCommandHandler).
+//   2. Identificacion.Crear(tipo, command.NumeroIdentificacion) -- normaliza el numero.
+//   3. ComputarStreamId(identificacion) -> GetAggregateRootAsync<ColaboradorAggregateRoot> -- si
+//      es null, throw KeyNotFoundException(Mensajes.ColaboradorNoEncontrado) (-> 404).
+//   4. colaborador.TerminarVinculacion(command.FechaEfectiva) -- el aggregate declina con
+//      resultado (nunca lanza, nunca emite evento de fallo persistido):
+//        - ResultadoTerminacionVinculacion.YaTerminada -> throw
+//          InvalidOperationException(Mensajes.VinculacionYaTerminada) (-> 409).
+//        - ResultadoTerminacionVinculacion.FechaAnteriorAInicio -> throw
+//          InvalidOperationException(Mensajes.FechaAnteriorAInicio) (-> 409).
+//        - ResultadoTerminacionVinculacion.Exitosa -> el aggregate ya agrego VinculacionTerminada
+//          a _uncommittedEvents; WhenAsync/el middleware persiste via SaveChanges.
+// Sin publicacion a bus (event-sourcing puro, issue #349 "Consumidores: ninguno").
+// STUB (fase roja, issue #349): el cuerpo completo queda para el implementer.
+public partial class TerminarVinculacionCommandHandler : ICommandHandlerAsync<TerminarVinculacion>
+{
+    private readonly IEventStore _eventStore;
+
+    public TerminarVinculacionCommandHandler(IEventStore eventStore) =>
+        _eventStore = eventStore;
+
+    public Task HandleAsync(TerminarVinculacion command, CancellationToken ct = default) =>
+        throw new NotImplementedException();
+}

--- a/src/Bitakora.ControlAsistencia.Colaboradores/TerminarVinculacionFunction/CommandHandler/TerminarVinculacionCommandHandler.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/TerminarVinculacionFunction/CommandHandler/TerminarVinculacionCommandHandler.cs
@@ -1,3 +1,5 @@
+using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+using Bitakora.ControlAsistencia.Colaboradores.Entities;
 using Cosmos.EventSourcing.Abstractions.Commands;
 
 namespace Bitakora.ControlAsistencia.Colaboradores.TerminarVinculacionFunction.CommandHandler;
@@ -27,6 +29,25 @@ public partial class TerminarVinculacionCommandHandler : ICommandHandlerAsync<Te
     public TerminarVinculacionCommandHandler(IEventStore eventStore) =>
         _eventStore = eventStore;
 
-    public Task HandleAsync(TerminarVinculacion command, CancellationToken ct = default) =>
-        throw new NotImplementedException();
+    public async Task HandleAsync(TerminarVinculacion command, CancellationToken ct = default)
+    {
+        // Parseo tipado unico del borde (MEF-ADR-0037 seccion 2), mismo criterio que
+        // RegistrarColaboradorCommandHandler.
+        var tipo = TipoIdentificacion.Desde(command.TipoIdentificacion.Trim().ToUpperInvariant());
+        var identificacion = Identificacion.Crear(tipo, command.NumeroIdentificacion);
+
+        var streamId = ColaboradorAggregateRoot.ComputarStreamId(identificacion);
+        var colaborador = await _eventStore.GetAggregateRootAsync<ColaboradorAggregateRoot>(streamId, ct);
+        if (colaborador is null)
+            throw new KeyNotFoundException(Mensajes.ColaboradorNoEncontrado);
+
+        var resultado = colaborador.TerminarVinculacion(command.FechaEfectiva);
+        switch (resultado)
+        {
+            case ResultadoTerminacionVinculacion.YaTerminada:
+                throw new InvalidOperationException(Mensajes.VinculacionYaTerminada);
+            case ResultadoTerminacionVinculacion.FechaAnteriorAInicio:
+                throw new InvalidOperationException(Mensajes.FechaAnteriorAInicio);
+        }
+    }
 }

--- a/src/Bitakora.ControlAsistencia.Colaboradores/TerminarVinculacionFunction/CommandHandler/TerminarVinculacionCommandHandlerMensajes.resx
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/TerminarVinculacionFunction/CommandHandler/TerminarVinculacionCommandHandlerMensajes.resx
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" msdata:Ordinal="0" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter</value></resheader>
+  <data name="ColaboradorNoEncontrado" xml:space="preserve">
+    <value>No existe un colaborador registrado con esa identificacion</value>
+  </data>
+  <data name="VinculacionYaTerminada" xml:space="preserve">
+    <value>La vinculacion vigente ya tiene una terminacion registrada</value>
+  </data>
+  <data name="FechaAnteriorAInicio" xml:space="preserve">
+    <value>La fecha efectiva de terminacion no puede ser anterior a la fecha de inicio de la vinculacion</value>
+  </data>
+</root>

--- a/src/Bitakora.ControlAsistencia.Colaboradores/TerminarVinculacionFunction/CommandHandler/TerminarVinculacionValidator.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/TerminarVinculacionFunction/CommandHandler/TerminarVinculacionValidator.cs
@@ -1,3 +1,4 @@
+using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
 using FluentValidation;
 
 namespace Bitakora.ControlAsistencia.Colaboradores.TerminarVinculacionFunction.CommandHandler;
@@ -8,8 +9,38 @@ namespace Bitakora.ControlAsistencia.Colaboradores.TerminarVinculacionFunction.C
 // de entrada que RegistrarColaboradorValidator), NumeroIdentificacion y FechaEfectiva requeridos.
 // Se descubre via el AddValidatorsFromAssemblyContaining que ComposicionServicios ya configura:
 // no requiere tocar el wiring de DI.
-// STUB (fase roja, issue #349): sin reglas todavia -- el implementer las agrega (precedente
-// RegistrarColaboradorValidator, issue #330).
 public class TerminarVinculacionValidator : AbstractValidator<TerminarVinculacion>
 {
+    public TerminarVinculacionValidator()
+    {
+        // Cascade(Stop) evita que Must evalue un valor vacio que NotEmpty ya rechazo -- mismo
+        // criterio que RegistrarColaboradorValidator.
+        RuleFor(x => x.TipoIdentificacion)
+            .Cascade(CascadeMode.Stop)
+            .NotEmpty()
+            .Must(EsTipoIdentificacionReconocido)
+            .WithMessage("El tipo de identificacion no es uno de los reconocidos");
+
+        RuleFor(x => x.NumeroIdentificacion).NotEmpty();
+
+        // FechaEfectiva es REQUERIDA -- el default de DateOnly (0001-01-01) equivale a "no llego"
+        // (doctrina bitemporal del BC: el tiempo de los hechos viene del cliente).
+        RuleFor(x => x.FechaEfectiva).NotEqual(default(DateOnly));
+    }
+
+    // Consulta la lista cerrada (#348) sin propagar la excepcion de dominio al boundary de
+    // validacion -- un codigo fuera de la lista debe traducirse en un error de FluentValidation
+    // (400), no en una excepcion no controlada.
+    private static bool EsTipoIdentificacionReconocido(string tipo)
+    {
+        try
+        {
+            TipoIdentificacion.Desde(tipo.Trim().ToUpperInvariant());
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+    }
 }

--- a/src/Bitakora.ControlAsistencia.Colaboradores/TerminarVinculacionFunction/CommandHandler/TerminarVinculacionValidator.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/TerminarVinculacionFunction/CommandHandler/TerminarVinculacionValidator.cs
@@ -1,0 +1,15 @@
+using FluentValidation;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.TerminarVinculacionFunction.CommandHandler;
+
+// Issue #349: validacion de forma del comando TerminarVinculacion en el borde (MEF-ADR-0004
+// capa 1 -> 400 BadRequest). CA-6: TipoIdentificacion (requerido + en la lista cerrada --
+// normalizar trim+MAYUSCULAS antes de TipoIdentificacion.Desde, mismo criterio de normalizacion
+// de entrada que RegistrarColaboradorValidator), NumeroIdentificacion y FechaEfectiva requeridos.
+// Se descubre via el AddValidatorsFromAssemblyContaining que ComposicionServicios ya configura:
+// no requiere tocar el wiring de DI.
+// STUB (fase roja, issue #349): sin reglas todavia -- el implementer las agrega (precedente
+// RegistrarColaboradorValidator, issue #330).
+public class TerminarVinculacionValidator : AbstractValidator<TerminarVinculacion>
+{
+}

--- a/src/Bitakora.ControlAsistencia.Colaboradores/TerminarVinculacionFunction/FunctionEndpoint.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/TerminarVinculacionFunction/FunctionEndpoint.cs
@@ -1,0 +1,46 @@
+using Bitakora.ControlAsistencia.Colaboradores.Infraestructura;
+using Cosmos.EventSourcing.Abstractions.Commands;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.TerminarVinculacionFunction;
+
+// Issue #349: endpoint HTTP POST para terminar la vinculacion vigente de un colaborador.
+// MEF-ADR-0006: [Function("TerminarVinculacion")]; carpeta CON sufijo "Function" -- mismo criterio
+// que RegistrarColaboradorFunction (issue #330, refactor 63270fa): el record del comando es
+// homonimo del feature folder, y las carpetas sin sufijo son queries GET sin ese conflicto.
+// Route = "Colaboradores/Terminaciones": la terminacion como sub-recurso (estilo
+// programacion/solicitudes) -- la identificacion viaja en el body porque su representacion
+// ("CC:79543210") contiene ":", hostil como segmento de URL.
+// CA-ADR-0030 / MEF-ADR-0004 (precedente SolicitarProgramacionTurnoFunction.FunctionEndpoint):
+// validar request (400 via IRequestValidator) -> despachar comando -> InvalidOperationException
+// -> 409 Conflict, KeyNotFoundException -> 404 NotFound; exito -> 202 Accepted.
+public class FunctionEndpoint(IRequestValidator requestValidator, ICommandRouter commandRouter)
+{
+    [Function("TerminarVinculacion")]
+    public async Task<IActionResult> Run(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "Colaboradores/Terminaciones")]
+        HttpRequest req,
+        CancellationToken ct)
+    {
+        var (comando, error) = await requestValidator.ValidarAsync<TerminarVinculacion>(req, ct);
+        if (error is not null)
+            return error;
+
+        try
+        {
+            await commandRouter.InvokeAsync(comando!, ct);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return new ConflictObjectResult(ex.Message);
+        }
+        catch (KeyNotFoundException ex)
+        {
+            return new NotFoundObjectResult(ex.Message);
+        }
+
+        return new AcceptedResult();
+    }
+}

--- a/src/Bitakora.ControlAsistencia.Colaboradores/TerminarVinculacionFunction/TerminarVinculacion.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/TerminarVinculacionFunction/TerminarVinculacion.cs
@@ -1,0 +1,18 @@
+namespace Bitakora.ControlAsistencia.Colaboradores.TerminarVinculacionFunction;
+
+// Issue #349: comando para terminar la vinculacion vigente de un colaborador bajo control de
+// asistencia (retiro/despido/promocion sin control -- el "por que" no le pertenece a este BC).
+// Trigger: HTTP POST, Route: Colaboradores/Terminaciones.
+// Payload primitivo -- igual que RegistrarColaborador (MEF-ADR-0039 decision 6, payload por rol):
+// NUNCA reusa un tipo de Colaboradores.DomainEvents como campo. El handler construye
+// TipoIdentificacion/Identificacion a partir de estos primitivos (parseo tipado unico en el
+// borde, MEF-ADR-0037 seccion 2).
+// FechaEfectiva es REQUERIDA (DateOnly, sin default del servidor) -- puede ser pasada (registro
+// tardio) o futura (preaviso); nunca se valida contra el reloj del servidor en ninguna direccion
+// (decision de refinamiento 2026-08-11, doctrina bitemporal del BC).
+// SIN Motivo (eliminado en el refinamiento): la fuente autoritativa del "por que" es RRHH/nomina,
+// sin lector en este BC.
+public record TerminarVinculacion(
+    string TipoIdentificacion,
+    string NumeroIdentificacion,
+    DateOnly FechaEfectiva);

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/TerminarVinculacionFunction/TerminarVinculacionSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/TerminarVinculacionFunction/TerminarVinculacionSmokeTests.cs
@@ -1,0 +1,293 @@
+// Issue #349: smoke tests del endpoint POST Colaboradores/Terminaciones (terminar la vinculacion
+// vigente de un colaborador). Molde: CrearTurnoSmokeTests (Programacion) -- ambos comandos son
+// event-sourcing puro sin consumidores downstream (CA-ADR-0030): sin ServiceBusFixture, la unica
+// verificacion black-box de los efectos del handler es leer mt_events via PostgresFixture.
+//
+// Arrange: TerminarVinculacion exige un ColaboradorAggregateRoot existente con una vinculacion
+// abierta -- el arrange de cada test registra el colaborador via POST Colaboradores (el mismo
+// comando que lo origina, #330), nunca sembrando datos por fuera del API.
+//
+// CA-1/CA-2/CA-4 (rutas de exito): 202 + el evento vinculacion_terminada queda persistido en el
+// stream "{Tipo}:{Numero}" con la FechaEfectiva exacta del request -- pasada, futura (preaviso, sin
+// validacion contra el reloj del servidor en ninguna direccion) o igual a la FechaInicio (vinculacion
+// de un solo dia).
+// CA-3/CA-4 (rutas de rechazo): el aggregate declina con resultado (nunca lanza, nunca emite un
+// evento de fallo persistido) y el handler traduce a 409 -- "ya terminada" (incluye un preaviso cuya
+// fecha no ha llegado) y "fecha anterior al inicio" de la vinculacion abierta.
+// CA-5: colaborador inexistente -> 404.
+// CA-6: request invalida -> 400, sin tocar el event store.
+using System.Globalization;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.SmokeTests.Fixtures;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.SmokeTests.TerminarVinculacionFunction;
+
+public class TerminarVinculacionSmokeTests(ApiFixture api, PostgresFixture postgres)
+{
+    private readonly HttpClient _client = api.Client;
+
+    private const string RutaRegistrar = "/api/Colaboradores";
+    private const string RutaTerminaciones = "/api/Colaboradores/Terminaciones";
+    private const string SchemaColaboradores = "colaboradores";
+    private const string TipoEventoVinculacionTerminada = "vinculacion_terminada";
+    private const string TipoIdentificacionCc = "CC";
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
+
+    // Numero unico por test -- evita colisiones entre ejecuciones repetidas del smoke test: la
+    // identidad del stream es Identificacion.ToString() ("CC:<numero>"), no un Guid nuevo por
+    // llamada, asi que reusar un numero fijo haria que el arrange (RegistrarColaborador) choque con
+    // 409 en la segunda corrida.
+    private static string NuevoNumeroIdentificacion() => Guid.CreateVersion7().ToString("N").ToUpperInvariant();
+
+    private static string ComputarStreamId(string numeroIdentificacion) =>
+        $"{TipoIdentificacionCc}:{numeroIdentificacion}";
+
+    private static string FormatearFecha(DateOnly fecha) =>
+        fecha.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+
+    private static object PayloadRegistro(string numeroIdentificacion, DateOnly fechaInicio) => new
+    {
+        tipoIdentificacion = TipoIdentificacionCc,
+        numeroIdentificacion,
+        primerNombre = "[TEST]",
+        segundoNombre = (string?)null,
+        primerApellido = "Smoke",
+        segundoApellido = (string?)null,
+        codigoColaborador = $"[TEST]-{Guid.CreateVersion7()}",
+        fechaInicio
+    };
+
+    private static object PayloadTerminacion(
+        string numeroIdentificacion, DateOnly fechaEfectiva, string tipoIdentificacion = TipoIdentificacionCc) => new
+    {
+        tipoIdentificacion,
+        numeroIdentificacion,
+        fechaEfectiva
+    };
+
+    // Arrange comun: registra un colaborador con una vinculacion abierta -- via el comando que la
+    // origina (#330), nunca sembrando el event store por fuera del API.
+    private async Task RegistrarColaboradorAsync(
+        string numeroIdentificacion, DateOnly fechaInicio, CancellationToken ct)
+    {
+        var response = await _client.PostAsJsonAsync(
+            RutaRegistrar, PayloadRegistro(numeroIdentificacion, fechaInicio), ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted,
+            "el arrange de este smoke test depende de que RegistrarColaborador funcione");
+    }
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task DebeEstarDisponible_CuandoSeConsultaHealthCheck()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var response = await _client.GetAsync("/api/health", ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    // CA-1: camino feliz -- colaborador con vinculacion abierta + FechaEfectiva valida (pasada) ->
+    // 202 y el stream recibe vinculacion_terminada con la FechaEfectiva exacta del request. Sin
+    // Service Bus (event-sourcing puro): mt_events es la unica ventana black-box a lo que quedo
+    // grabado.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task TerminarVinculacion_Retorna202YPersisteFechaEfectiva_CuandoVinculacionEstaAbierta()
+    {
+        Assert.SkipWhen(!postgres.IsConfigured, postgres.SkipReason ?? "Postgres no disponible.");
+
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion();
+        var fechaInicio = new DateOnly(2026, 1, 15);
+        var fechaEfectiva = new DateOnly(2026, 3, 20);
+
+        await RegistrarColaboradorAsync(numeroIdentificacion, fechaInicio, ct);
+
+        var response = await _client.PostAsJsonAsync(
+            RutaTerminaciones, PayloadTerminacion(numeroIdentificacion, fechaEfectiva), ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+
+        var streamId = ComputarStreamId(numeroIdentificacion);
+
+        var existe = await postgres.ExisteEventoAsync(
+            SchemaColaboradores, streamId, TipoEventoVinculacionTerminada, Timeout,
+            campoJson: "FechaEfectiva", valorJson: FormatearFecha(fechaEfectiva));
+
+        existe.Should().BeTrue(
+            $"el evento {TipoEventoVinculacionTerminada} deberia existir en el stream {streamId} con FechaEfectiva {FormatearFecha(fechaEfectiva)}");
+
+        var eventoPersistido = await postgres.ObtenerEventoAsync<JsonElement>(
+            SchemaColaboradores, streamId, TipoEventoVinculacionTerminada,
+            campoJson: "FechaEfectiva", valorJson: FormatearFecha(fechaEfectiva), Timeout);
+
+        eventoPersistido.GetProperty("FechaEfectiva").GetString().Should().Be(FormatearFecha(fechaEfectiva));
+    }
+
+    // CA-2: FechaEfectiva futura (preaviso) se acepta igual que una pasada -- sin validacion contra
+    // el reloj del servidor en ninguna direccion (doctrina bitemporal del BC).
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task TerminarVinculacion_Retorna202YPersisteFechaEfectiva_CuandoFechaEfectivaEsFutura()
+    {
+        Assert.SkipWhen(!postgres.IsConfigured, postgres.SkipReason ?? "Postgres no disponible.");
+
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion();
+        var fechaInicio = new DateOnly(2026, 1, 1);
+        // Preaviso muy en el futuro -- el punto de esta CA es que NINGUNA fecha, sin importar que
+        // tan lejana, se valida contra el reloj del servidor.
+        var fechaEfectivaFutura = new DateOnly(2030, 12, 31);
+
+        await RegistrarColaboradorAsync(numeroIdentificacion, fechaInicio, ct);
+
+        var response = await _client.PostAsJsonAsync(
+            RutaTerminaciones, PayloadTerminacion(numeroIdentificacion, fechaEfectivaFutura), ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+
+        var streamId = ComputarStreamId(numeroIdentificacion);
+
+        var existe = await postgres.ExisteEventoAsync(
+            SchemaColaboradores, streamId, TipoEventoVinculacionTerminada, Timeout,
+            campoJson: "FechaEfectiva", valorJson: FormatearFecha(fechaEfectivaFutura));
+
+        existe.Should().BeTrue(
+            $"el preaviso con FechaEfectiva futura ({FormatearFecha(fechaEfectivaFutura)}) deberia persistirse igual que una fecha pasada");
+    }
+
+    // CA-4 (rama exitosa): FechaEfectiva == FechaInicio de la vinculacion abierta es una vinculacion
+    // de un solo dia, valida.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task TerminarVinculacion_Retorna202YPersisteFechaEfectiva_CuandoFechaEfectivaEsIgualAFechaInicio()
+    {
+        Assert.SkipWhen(!postgres.IsConfigured, postgres.SkipReason ?? "Postgres no disponible.");
+
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion();
+        var fechaUnicoDia = new DateOnly(2026, 7, 4);
+
+        await RegistrarColaboradorAsync(numeroIdentificacion, fechaUnicoDia, ct);
+
+        var response = await _client.PostAsJsonAsync(
+            RutaTerminaciones, PayloadTerminacion(numeroIdentificacion, fechaUnicoDia), ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+
+        var streamId = ComputarStreamId(numeroIdentificacion);
+
+        var existe = await postgres.ExisteEventoAsync(
+            SchemaColaboradores, streamId, TipoEventoVinculacionTerminada, Timeout,
+            campoJson: "FechaEfectiva", valorJson: FormatearFecha(fechaUnicoDia));
+
+        existe.Should().BeTrue(
+            "una vinculacion de un solo dia (FechaEfectiva == FechaInicio) deberia terminar con exito");
+    }
+
+    // CA-3: la ultima vinculacion ya tiene terminacion registrada -> 409, sin importar si la
+    // primera terminacion fue un preaviso cuya fecha aun no llego. Simetria con RegistrarColaborador
+    // (crear dos veces -> 409); no requiere Postgres, el status code ya prueba que el aggregate
+    // declino con resultado y el handler lo tradujo (CA-ADR-0030).
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task TerminarVinculacion_Retorna409_CuandoVinculacionYaFueTerminada()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion();
+        var fechaInicio = new DateOnly(2026, 1, 10);
+        var payloadTerminacion = PayloadTerminacion(numeroIdentificacion, new DateOnly(2026, 2, 1));
+
+        await RegistrarColaboradorAsync(numeroIdentificacion, fechaInicio, ct);
+        await _client.PostAsJsonAsync(RutaTerminaciones, payloadTerminacion, ct);
+
+        var response = await _client.PostAsJsonAsync(RutaTerminaciones, payloadTerminacion, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    // CA-4 (rama de rechazo): FechaEfectiva anterior a la FechaInicio de la vinculacion abierta
+    // implicaria una duracion negativa -> 409.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task TerminarVinculacion_Retorna409_CuandoFechaEfectivaEsAnteriorAFechaInicio()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion();
+        var fechaInicio = new DateOnly(2026, 5, 10);
+        var fechaEfectivaAnterior = new DateOnly(2026, 5, 1);
+
+        await RegistrarColaboradorAsync(numeroIdentificacion, fechaInicio, ct);
+
+        var response = await _client.PostAsJsonAsync(
+            RutaTerminaciones, PayloadTerminacion(numeroIdentificacion, fechaEfectivaAnterior), ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    // CA-5: colaborador inexistente -> 404, sin escribir nada al event store (no hay stream para
+    // consultar: la ausencia de escritura la garantiza el propio 404 -- el handler lanza antes de
+    // llegar al aggregate).
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task TerminarVinculacion_Retorna404_CuandoColaboradorNoExiste()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion(); // nunca registrado
+
+        var response = await _client.PostAsJsonAsync(
+            RutaTerminaciones, PayloadTerminacion(numeroIdentificacion, new DateOnly(2026, 3, 1)), ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    // CA-6: FechaEfectiva vacia (default de DateOnly, "no llego" segun la doctrina bitemporal del
+    // BC) -> 400.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task TerminarVinculacion_Retorna400_CuandoFechaEfectivaEsVacia()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var payload = new
+        {
+            tipoIdentificacion = TipoIdentificacionCc,
+            numeroIdentificacion = NuevoNumeroIdentificacion(),
+            fechaEfectiva = default(DateOnly)
+        };
+
+        var response = await _client.PostAsJsonAsync(RutaTerminaciones, payload, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    // CA-6: NumeroIdentificacion vacio -> 400.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task TerminarVinculacion_Retorna400_CuandoNumeroIdentificacionEsVacio()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var payload = PayloadTerminacion(numeroIdentificacion: "", new DateOnly(2026, 3, 1));
+
+        var response = await _client.PostAsJsonAsync(RutaTerminaciones, payload, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    // CA-6: TipoIdentificacion fuera de la lista cerrada (PILA: CC, CE, TI, PA, PT) -> 400.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task TerminarVinculacion_Retorna400_CuandoTipoIdentificacionNoEsReconocido()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var payload = PayloadTerminacion(
+            NuevoNumeroIdentificacion(), new DateOnly(2026, 3, 1), tipoIdentificacion: "XX");
+
+        var response = await _client.PostAsJsonAsync(RutaTerminaciones, payload, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/TerminarVinculacionFunction/TerminarVinculacionSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/TerminarVinculacionFunction/TerminarVinculacionSmokeTests.cs
@@ -62,11 +62,11 @@ public class TerminarVinculacionSmokeTests(ApiFixture api, PostgresFixture postg
 
     private static object PayloadTerminacion(
         string numeroIdentificacion, DateOnly fechaEfectiva, string tipoIdentificacion = TipoIdentificacionCc) => new
-    {
-        tipoIdentificacion,
-        numeroIdentificacion,
-        fechaEfectiva
-    };
+        {
+            tipoIdentificacion,
+            numeroIdentificacion,
+            fechaEfectiva
+        };
 
     // Arrange comun: registra un colaborador con una vinculacion abierta -- via el comando que la
     // origina (#330), nunca sembrando el event store por fuera del API.

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/Infraestructura/AliasEventosColaboradoresTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/Infraestructura/AliasEventosColaboradoresTests.cs
@@ -46,4 +46,16 @@ public class AliasEventosColaboradoresTests
 
         AliasDe<VinculacionIniciada>(options).Should().Be("vinculacion_iniciada");
     }
+
+    // Issue #349 (gemela de las dos pruebas anteriores): congela el alias de VinculacionTerminada,
+    // segundo evento persistido de la vinculacion (terminar). Rojo esperado (fase roja, issue
+    // #349): IdentidadEventosColaboradores.TiposPersistidos sigue sin VinculacionTerminada hasta
+    // que el implementer lo registre -- el implementer lo agrega ahi (no aqui, MEF-ADR-0002).
+    [Fact]
+    public void VinculacionTerminada_TieneAliasVinculacionTerminada()
+    {
+        var options = CrearOpcionesConEventosDeColaboradoresRegistrados();
+
+        AliasDe<VinculacionTerminada>(options).Should().Be("vinculacion_terminada");
+    }
 }

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/Infraestructura/ComposicionServiciosTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/Infraestructura/ComposicionServiciosTests.cs
@@ -213,7 +213,9 @@ public class ComposicionServiciosTests
     // IdentidadEventosColaboradores.TiposPersistidos acoplaria el guardrail al mismo artefacto que
     // AliasEventosColaboradoresTests ya verifica, y la asercion pasaria en verde aunque la lista
     // quedara vacia.
-    // Rojo esperado (fase roja, issue #330): TiposPersistidos sigue vacio.
+    // Issue #349: agrega VinculacionTerminada (segundo evento persistido de la vinculacion) a la
+    // lista esperada -- mismo criterio, mismo guardrail.
+    // Rojo esperado (fase roja, issue #349): TiposPersistidos todavia no incluye VinculacionTerminada.
     [Fact]
     public async Task AgregarServiciosColaboradores_RegistraLosTiposDeEventoPersistidos_CuandoElContenedorEstaCompuesto()
     {
@@ -223,15 +225,15 @@ public class ComposicionServiciosTests
         var store = scope.ServiceProvider.GetRequiredService<IDocumentStore>();
 
         store.AssertEventosPersistidosRegistrados(
-            [typeof(ColaboradorRegistrado), typeof(VinculacionIniciada)]);
+            [typeof(ColaboradorRegistrado), typeof(VinculacionIniciada), typeof(VinculacionTerminada)]);
     }
 
     // Issue #330: registrar el tipo solo sirve si el alias sigue siendo el que las filas ya
     // escritas llevan en su columna "type". AliasEventosColaboradoresTests lo congela sobre un
     // StoreOptions standalone; esta guarda lo congela sobre el store del contenedor, el unico lugar
     // donde un MapEventType o un EventNamingStyle agregados al wiring podrian cambiarlo.
-    // Rojo esperado (fase roja, issue #330): TiposPersistidos sigue vacio, AllKnownEventTypes() no
-    // trae ninguna de las dos claves del diccionario esperado.
+    // Issue #349: agrega VinculacionTerminada -> "vinculacion_terminada" al diccionario esperado.
+    // Rojo esperado (fase roja, issue #349): VinculacionTerminada no aparece en AllKnownEventTypes().
     [Fact]
     public async Task AgregarServiciosColaboradores_DerivaElAliasDeEventoDelNombreDeClase_CuandoElContenedorEstaCompuesto()
     {
@@ -243,7 +245,8 @@ public class ComposicionServiciosTests
         store.AssertAliasDeEventosPersistidos(new Dictionary<Type, string>
         {
             [typeof(ColaboradorRegistrado)] = "colaborador_registrado",
-            [typeof(VinculacionIniciada)] = "vinculacion_iniciada"
+            [typeof(VinculacionIniciada)] = "vinculacion_iniciada",
+            [typeof(VinculacionTerminada)] = "vinculacion_terminada"
         });
     }
 

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/TerminarVinculacionFunction/Eventos/VinculacionTerminadaSerializacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/TerminarVinculacionFunction/Eventos/VinculacionTerminadaSerializacionTests.cs
@@ -1,0 +1,49 @@
+// Issue #349. Requerido por regla 16: todo evento persistido en Marten debe sobrevivir
+// Serialize -> Deserialize con las opciones REALES de Marten del dominio (regla 6d).
+
+using System.Text.Json;
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Tests.TerminarVinculacionFunction.Eventos;
+
+/// <summary>
+/// Verifica que VinculacionTerminada (payload plano: DateOnly, sin VOs anidados) sobrevive un
+/// roundtrip de serializacion STJ con las opciones reales de Marten del dominio. Igual que
+/// VinculacionIniciada, este evento NO necesita ConfigurarSerializacion propio (ctor publico, tipo
+/// primitivo) -- no hay un test "sin registro falla": no hay ningun registro que proteger.
+/// </summary>
+public class VinculacionTerminadaSerializacionTests
+{
+    private static JsonSerializerOptions CrearOpcionesMarten() =>
+        ConfiguracionSerializacionColaboradores.CrearOpcionesMarten();
+
+    // CA-1: VinculacionTerminada persiste FechaEfectiva tal como llego (sin default del servidor)
+    // y sobrevive el roundtrip completo.
+    [Fact]
+    public void RoundTrip_ReconstruyeEvento_ConDatosCompletos()
+    {
+        var evento = new VinculacionTerminada(new DateOnly(2026, 6, 1));
+        var opciones = CrearOpcionesMarten();
+
+        var json = JsonSerializer.Serialize(evento, opciones);
+        var deserializado = JsonSerializer.Deserialize<VinculacionTerminada>(json, opciones);
+
+        deserializado.Should().NotBeNull();
+        deserializado!.FechaEfectiva.Should().Be(new DateOnly(2026, 6, 1));
+    }
+
+    // CA-2: una FechaEfectiva futura (preaviso) sobrevive el roundtrip igual que una pasada.
+    [Fact]
+    public void RoundTrip_ReconstruyeEvento_ConFechaEfectivaFutura()
+    {
+        var evento = new VinculacionTerminada(new DateOnly(2030, 1, 1));
+        var opciones = CrearOpcionesMarten();
+
+        var json = JsonSerializer.Serialize(evento, opciones);
+        var deserializado = JsonSerializer.Deserialize<VinculacionTerminada>(json, opciones);
+
+        deserializado.Should().NotBeNull();
+        deserializado!.FechaEfectiva.Should().Be(new DateOnly(2030, 1, 1));
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/TerminarVinculacionFunction/FunctionEndpointTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/TerminarVinculacionFunction/FunctionEndpointTests.cs
@@ -1,0 +1,141 @@
+// Issue #349: tests del endpoint HTTP POST Colaboradores/Terminaciones (terminar vinculacion).
+// CA-ADR-0030 / MEF-ADR-0004: InvalidOperationException -> 409, KeyNotFoundException -> 404,
+// exito -> 202. Precedente: SolicitarProgramacionTurnoFunction.FunctionEndpoint.
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.Infraestructura;
+using Bitakora.ControlAsistencia.Colaboradores.TerminarVinculacionFunction;
+using Cosmos.EventSourcing.Abstractions.Commands;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Tests.TerminarVinculacionFunction;
+
+public class FunctionEndpointTests
+{
+    private static TerminarVinculacion ComandoValido() => new(
+        TipoIdentificacion: "CC",
+        NumeroIdentificacion: "79543210",
+        FechaEfectiva: new DateOnly(2026, 6, 1));
+
+    private static HttpRequest FakeHttpRequest()
+    {
+        var context = new DefaultHttpContext();
+        return context.Request;
+    }
+
+    // CA-1: POST exitoso retorna 202 Accepted
+    [Fact]
+    public async Task TerminarVinculacion_Retorna202_CuandoComandoEsValido()
+    {
+        var validator = new FakeTerminarVinculacionRequestValidator(ComandoValido());
+        var router = new FakeTerminarVinculacionCommandRouter();
+        var function = new FunctionEndpoint(validator, router);
+
+        var result = await function.Run(FakeHttpRequest(), CancellationToken.None);
+
+        result.Should().BeOfType<AcceptedResult>();
+    }
+
+    // CA-3/CA-4: violacion de regla de negocio (ya terminada / fecha anterior al inicio) retorna
+    // 409 Conflict.
+    [Fact]
+    public async Task TerminarVinculacion_Retorna409_CuandoLaVinculacionYaTieneTerminacionRegistrada()
+    {
+        var validator = new FakeTerminarVinculacionRequestValidator(ComandoValido());
+        var router = new FakeTerminarVinculacionCommandRouter(
+            lanzar: new InvalidOperationException("La vinculacion ya tiene una terminacion registrada"));
+        var function = new FunctionEndpoint(validator, router);
+
+        var result = await function.Run(FakeHttpRequest(), CancellationToken.None);
+
+        result.Should().BeOfType<ConflictObjectResult>();
+    }
+
+    // CA-5: colaborador inexistente retorna 404 Not Found
+    [Fact]
+    public async Task TerminarVinculacion_Retorna404_CuandoColaboradorNoExiste()
+    {
+        var validator = new FakeTerminarVinculacionRequestValidator(ComandoValido());
+        var router = new FakeTerminarVinculacionCommandRouter(
+            lanzar: new KeyNotFoundException("No existe un colaborador registrado con esa identificacion"));
+        var function = new FunctionEndpoint(validator, router);
+
+        var result = await function.Run(FakeHttpRequest(), CancellationToken.None);
+
+        result.Should().BeOfType<NotFoundObjectResult>();
+    }
+
+    // CA-6: request invalida (sin FechaEfectiva, sin identificacion, tipo fuera de la lista
+    // cerrada) retorna 400 Bad Request
+    [Fact]
+    public async Task TerminarVinculacion_Retorna400_CuandoRequestEsInvalido()
+    {
+        var errorDeValidacion = new BadRequestObjectResult("El body es invalido o esta malformado");
+        var validator = new FakeTerminarVinculacionRequestValidator(error: errorDeValidacion);
+        var router = new FakeTerminarVinculacionCommandRouter();
+        var function = new FunctionEndpoint(validator, router);
+
+        var result = await function.Run(FakeHttpRequest(), CancellationToken.None);
+
+        result.Should().BeOfType<BadRequestObjectResult>();
+    }
+}
+
+// ---- Fakes manuales - NO NSubstitute ----
+
+/// <summary>
+/// Fake configurable de IRequestValidator. Retorna un comando pre-configurado o un error segun lo
+/// que se le pase en el constructor.
+/// </summary>
+internal class FakeTerminarVinculacionRequestValidator : IRequestValidator
+{
+    private readonly TerminarVinculacion? _comando;
+    private readonly IActionResult? _error;
+
+    public FakeTerminarVinculacionRequestValidator(
+        TerminarVinculacion? comando = null,
+        IActionResult? error = null)
+    {
+        _comando = comando;
+        _error = error;
+    }
+
+    public Task<(T? Comando, IActionResult? Error)> ValidarAsync<T>(
+        HttpRequest req, CancellationToken ct)
+    {
+        if (_error is not null)
+            return Task.FromResult<(T?, IActionResult?)>((default, _error));
+
+        if (_comando is T resultado)
+            return Task.FromResult<(T?, IActionResult?)>((resultado, null));
+
+        return Task.FromResult<(T?, IActionResult?)>((default, null));
+    }
+}
+
+/// <summary>
+/// Fake configurable de ICommandRouter. Puede completar exitosamente o lanzar la excepcion
+/// configurada (InvalidOperationException -> 409, KeyNotFoundException -> 404).
+/// </summary>
+internal class FakeTerminarVinculacionCommandRouter : ICommandRouter
+{
+    private readonly Exception? _excepcion;
+
+    public FakeTerminarVinculacionCommandRouter(Exception? lanzar = null) =>
+        _excepcion = lanzar;
+
+    public Task InvokeAsync<TCommand>(TCommand command, CancellationToken ct = default)
+        where TCommand : class
+    {
+        if (_excepcion is not null)
+            throw _excepcion;
+
+        return Task.CompletedTask;
+    }
+
+    public Task<TResult> InvokeAsync<TCommand, TResult>(
+        TCommand command, CancellationToken ct = default)
+        where TCommand : class
+        => throw new NotImplementedException();
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/TerminarVinculacionFunction/TerminarVinculacionCommandHandlerMensajesTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/TerminarVinculacionFunction/TerminarVinculacionCommandHandlerMensajesTests.cs
@@ -1,0 +1,28 @@
+// Issue #349: guardrail de resolucion del .resx del handler (MEF-ADR-0009), gemelo del que
+// ValueObjects/MensajesResxTests.cs ya aplica a los .resx de los VOs.
+//
+// Por que existe: TerminarVinculacionCommandHandler.Mensajes devuelve
+// ResourceManager.GetString(...)! -- el "!" es supresion del compilador, no garantia de runtime. Si
+// la CLAVE desaparece del .resx (rename, merge que la pierde) GetString retorna null en silencio y
+// los tests del handler pasan en FALSO: sus aserciones son WithMessage($"*{Mensajes.X}*"), que con
+// X == null se vuelve "**" y matchea cualquier excepcion.
+//
+// El modo de falla es exactamente el que se verifico por mutacion durante la revision de #348, pero
+// aqui es mas amplio: las tres claves de este handler son la unica evidencia de que un 404 o un 409
+// llevan mensaje de dominio, y ninguna otra prueba del issue las verificaria vacias.
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.TerminarVinculacionFunction.CommandHandler;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Tests.TerminarVinculacionFunction;
+
+public class TerminarVinculacionCommandHandlerMensajesTests
+{
+    [Fact]
+    public void Mensajes_ResuelvenTextoNoVacio_CuandoPertenecenATerminarVinculacionCommandHandler()
+    {
+        TerminarVinculacionCommandHandler.Mensajes.ColaboradorNoEncontrado.Should().NotBeNullOrWhiteSpace();
+        TerminarVinculacionCommandHandler.Mensajes.VinculacionYaTerminada.Should().NotBeNullOrWhiteSpace();
+        TerminarVinculacionCommandHandler.Mensajes.FechaAnteriorAInicio.Should().NotBeNullOrWhiteSpace();
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/TerminarVinculacionFunction/TerminarVinculacionCommandHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/TerminarVinculacionFunction/TerminarVinculacionCommandHandlerTests.cs
@@ -1,0 +1,184 @@
+// Issue #349: terminar la vinculacion de un colaborador -- segundo comando del ciclo de vida de
+// ColaboradorAggregateRoot (desglose #348-#357). CA-ADR-0030: el aggregate declina con resultado
+// (nunca lanza, nunca emite evento de fallo); el handler traduce la razon a InvalidOperationException
+// (409) o KeyNotFoundException (404).
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+using Bitakora.ControlAsistencia.Colaboradores.Entities;
+using Bitakora.ControlAsistencia.Colaboradores.TerminarVinculacionFunction;
+using Bitakora.ControlAsistencia.Colaboradores.TerminarVinculacionFunction.CommandHandler;
+using Cosmos.EventSourcing.Abstractions.Commands;
+using Cosmos.EventSourcing.Testing.Utilities;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Tests.TerminarVinculacionFunction;
+
+// El aggregate usa un stream ID compuesto (Identificacion.ToString(), "CC:79543210"), no el
+// GuidAggregateId del harness -- overloads explicitos de Given/Then/And (regla 18 del test-writer,
+// mismo criterio que RegistrarColaboradorCommandHandlerTests).
+public class TerminarVinculacionCommandHandlerTests : CommandHandlerAsyncTest<TerminarVinculacion>
+{
+    private const string NumeroValido = "79543210";
+
+    // Oraculo independiente de la clave de stream (MEF-ADR-0002 + MEF-ADR-0037): literal, no
+    // derivado de ColaboradorAggregateRoot.ComputarStreamId (mismo criterio que #330).
+    private const string StreamIdEsperado = "CC:79543210";
+
+    private const string CodigoVinculacionVigente = "COL-001";
+    private static readonly DateOnly FechaInicioVinculacionVigente = new(2026, 1, 15);
+    private static readonly DateOnly FechaEfectivaValida = new(2026, 6, 1);
+
+    protected override ICommandHandlerAsync<TerminarVinculacion> Handler =>
+        new TerminarVinculacionCommandHandler(EventStore);
+
+    private static TerminarVinculacion ComandoValido() => new(
+        TipoIdentificacion: "CC",
+        NumeroIdentificacion: NumeroValido,
+        FechaEfectiva: FechaEfectivaValida);
+
+    private static Identificacion IdentificacionValida() =>
+        Identificacion.Crear(TipoIdentificacion.CC, NumeroValido);
+
+    private static NombreColaborador NombreValido() =>
+        NombreColaborador.Crear("Luis", "Augusto", "Barreto", null);
+
+    private static ColaboradorRegistrado ColaboradorRegistradoValido() =>
+        new(IdentificacionValida(), NombreValido());
+
+    private static VinculacionIniciada VinculacionIniciadaVigente() =>
+        new(CodigoVinculacionVigente, FechaInicioVinculacionVigente);
+
+    // Precondicion compartida: colaborador registrado con una vinculacion abierta (sin terminacion).
+    private void DadoUnColaboradorConVinculacionAbierta() =>
+        Given(StreamIdEsperado, ColaboradorRegistradoValido(), VinculacionIniciadaVigente());
+
+    // CA-1: colaborador con vinculacion abierta + comando valido -> el stream recibe
+    // VinculacionTerminada con la FechaEfectiva del request; el aggregate rehidratado refleja la
+    // terminacion. (El registro en IdentidadEventosColaboradores.TiposPersistidos lo cubren
+    // AliasEventosColaboradoresTests/ComposicionServiciosTests, no este handler.)
+    [Fact]
+    public async Task TerminarVinculacion_EmiteVinculacionTerminada_CuandoLaVinculacionEstaAbierta()
+    {
+        DadoUnColaboradorConVinculacionAbierta();
+
+        await WhenAsync(ComandoValido());
+
+        Then(StreamIdEsperado, new VinculacionTerminada(FechaEfectivaValida));
+        And<ColaboradorAggregateRoot, DateOnly?>(
+            StreamIdEsperado, c => c.FechaTerminacionVinculacionVigente, FechaEfectivaValida);
+    }
+
+    // CA-2: FechaEfectiva futura (preaviso) -> aceptada igual que una pasada -- ninguna validacion
+    // contra el reloj del servidor en ninguna direccion.
+    [Fact]
+    public async Task TerminarVinculacion_EmiteVinculacionTerminada_CuandoFechaEfectivaEsFutura()
+    {
+        DadoUnColaboradorConVinculacionAbierta();
+        var fechaFutura = new DateOnly(2030, 1, 1);
+
+        await WhenAsync(ComandoValido() with { FechaEfectiva = fechaFutura });
+
+        Then(StreamIdEsperado, new VinculacionTerminada(fechaFutura));
+        And<ColaboradorAggregateRoot, DateOnly?>(
+            StreamIdEsperado, c => c.FechaTerminacionVinculacionVigente, fechaFutura);
+    }
+
+    // CA-2 (segunda direccion): FechaEfectiva pasada (registro tardio, posterior al inicio de la
+    // vinculacion pero anterior a "hoy") -> tambien aceptada, sin validacion contra el reloj.
+    [Fact]
+    public async Task TerminarVinculacion_EmiteVinculacionTerminada_CuandoFechaEfectivaEsPasada()
+    {
+        DadoUnColaboradorConVinculacionAbierta();
+        var fechaPasada = FechaInicioVinculacionVigente.AddDays(5);
+
+        await WhenAsync(ComandoValido() with { FechaEfectiva = fechaPasada });
+
+        Then(StreamIdEsperado, new VinculacionTerminada(fechaPasada));
+        And<ColaboradorAggregateRoot, DateOnly?>(
+            StreamIdEsperado, c => c.FechaTerminacionVinculacionVigente, fechaPasada);
+    }
+
+    // CA-3: la ultima vinculacion ya tiene terminacion registrada -> 409, ningun evento nuevo en
+    // el stream, y el estado conserva la terminacion previa (no la del comando rechazado).
+    [Fact]
+    public async Task TerminarVinculacion_LanzaInvalidOperationException_CuandoLaVinculacionYaTieneTerminacionRegistrada()
+    {
+        var fechaTerminacionPrevia = new DateOnly(2026, 3, 1);
+        Given(StreamIdEsperado,
+            ColaboradorRegistradoValido(),
+            VinculacionIniciadaVigente(),
+            new VinculacionTerminada(fechaTerminacionPrevia));
+
+        var act = async () => await WhenAsync(ComandoValido());
+
+        await act.Should().ThrowExactlyAsync<InvalidOperationException>()
+            .WithMessage($"*{TerminarVinculacionCommandHandler.Mensajes.VinculacionYaTerminada}*");
+        Then(StreamIdEsperado);
+        And<ColaboradorAggregateRoot, DateOnly?>(
+            StreamIdEsperado, c => c.FechaTerminacionVinculacionVigente, fechaTerminacionPrevia);
+    }
+
+    // CA-3 (preaviso no vencido): un preaviso con fecha futura ya registrado bloquea igual una
+    // segunda terminacion -- "ya terminada" se evalua solo con la historia del stream, sin reloj.
+    [Fact]
+    public async Task TerminarVinculacion_LanzaInvalidOperationException_CuandoYaExisteUnPreavisoConFechaFutura()
+    {
+        var fechaPreavisoFutura = new DateOnly(2030, 1, 1);
+        Given(StreamIdEsperado,
+            ColaboradorRegistradoValido(),
+            VinculacionIniciadaVigente(),
+            new VinculacionTerminada(fechaPreavisoFutura));
+
+        var act = async () => await WhenAsync(ComandoValido());
+
+        await act.Should().ThrowExactlyAsync<InvalidOperationException>()
+            .WithMessage($"*{TerminarVinculacionCommandHandler.Mensajes.VinculacionYaTerminada}*");
+        Then(StreamIdEsperado);
+        And<ColaboradorAggregateRoot, DateOnly?>(
+            StreamIdEsperado, c => c.FechaTerminacionVinculacionVigente, fechaPreavisoFutura);
+    }
+
+    // CA-4: FechaEfectiva anterior a FechaInicio -> 409 (duracion negativa); el estado no cambia
+    // (la vinculacion sigue abierta, sin terminacion).
+    [Fact]
+    public async Task TerminarVinculacion_LanzaInvalidOperationException_CuandoFechaEfectivaEsAnteriorAFechaInicio()
+    {
+        DadoUnColaboradorConVinculacionAbierta();
+        var fechaAnterior = FechaInicioVinculacionVigente.AddDays(-1);
+
+        var act = async () => await WhenAsync(ComandoValido() with { FechaEfectiva = fechaAnterior });
+
+        await act.Should().ThrowExactlyAsync<InvalidOperationException>()
+            .WithMessage($"*{TerminarVinculacionCommandHandler.Mensajes.FechaAnteriorAInicio}*");
+        Then(StreamIdEsperado);
+        And<ColaboradorAggregateRoot, DateOnly?>(
+            StreamIdEsperado, c => c.FechaTerminacionVinculacionVigente, null);
+    }
+
+    // CA-4 (limite): FechaEfectiva == FechaInicio -> exito (vinculacion de un solo dia).
+    [Fact]
+    public async Task TerminarVinculacion_EmiteVinculacionTerminada_CuandoFechaEfectivaEsIgualAFechaInicio()
+    {
+        DadoUnColaboradorConVinculacionAbierta();
+
+        await WhenAsync(ComandoValido() with { FechaEfectiva = FechaInicioVinculacionVigente });
+
+        Then(StreamIdEsperado, new VinculacionTerminada(FechaInicioVinculacionVigente));
+        And<ColaboradorAggregateRoot, DateOnly?>(
+            StreamIdEsperado, c => c.FechaTerminacionVinculacionVigente, FechaInicioVinculacionVigente);
+    }
+
+    // CA-5: colaborador inexistente -> 404 (KeyNotFoundException), sin escribir nada al event
+    // store. Sin Given: el stream no existe. Sin And<>: el aggregate no existe en el TestStore
+    // (GetAggregateRoot retorna null), invocarlo lanzaria ArgumentNullException -- Then sin
+    // eventos esperados ya demuestra "sin escribir nada al event store".
+    [Fact]
+    public async Task TerminarVinculacion_LanzaKeyNotFoundException_CuandoColaboradorNoExiste()
+    {
+        var act = async () => await WhenAsync(ComandoValido());
+
+        await act.Should().ThrowExactlyAsync<KeyNotFoundException>()
+            .WithMessage($"*{TerminarVinculacionCommandHandler.Mensajes.ColaboradorNoEncontrado}*");
+        Then(StreamIdEsperado);
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/TerminarVinculacionFunction/TerminarVinculacionValidatorTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/TerminarVinculacionFunction/TerminarVinculacionValidatorTests.cs
@@ -1,0 +1,98 @@
+// Issue #349: validacion de forma del comando TerminarVinculacion en el borde (CA-6).
+// Patron de referencia: RegistrarColaboradorValidatorTests (ValidateAsync + verificacion de
+// PropertyName en resultado.Errors).
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.TerminarVinculacionFunction;
+using Bitakora.ControlAsistencia.Colaboradores.TerminarVinculacionFunction.CommandHandler;
+using FluentValidation.Results;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Tests.TerminarVinculacionFunction;
+
+public class TerminarVinculacionValidatorTests
+{
+    private readonly TerminarVinculacionValidator _validator = new();
+
+    private static TerminarVinculacion ComandoValido() => new(
+        TipoIdentificacion: "CC",
+        NumeroIdentificacion: "79543210",
+        FechaEfectiva: new DateOnly(2026, 6, 1));
+
+    private Task<ValidationResult> Validar(TerminarVinculacion comando) =>
+        _validator.ValidateAsync(comando, TestContext.Current.CancellationToken);
+
+    // Camino feliz -- todos los campos correctos
+    [Fact]
+    public async Task Validar_Aprueba_CuandoTodosLosCamposSonCorrectos()
+    {
+        var resultado = await Validar(ComandoValido());
+
+        resultado.IsValid.Should().BeTrue();
+    }
+
+    // CA-6: TipoIdentificacion vacio produce 400
+    [Fact]
+    public async Task Validar_RechazaTipoIdentificacion_CuandoEstaVacio()
+    {
+        var resultado = await Validar(ComandoValido() with { TipoIdentificacion = "" });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e =>
+            e.PropertyName == nameof(TerminarVinculacion.TipoIdentificacion));
+    }
+
+    // CA-6: TipoIdentificacion fuera de la lista cerrada (PILA: CC/CE/TI/PA/PT) produce 400, no 500
+    [Fact]
+    public async Task Validar_RechazaTipoIdentificacion_CuandoNoEstaEnLaListaCerrada()
+    {
+        var resultado = await Validar(ComandoValido() with { TipoIdentificacion = "XX" });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e =>
+            e.PropertyName == nameof(TerminarVinculacion.TipoIdentificacion));
+    }
+
+    // TipoIdentificacion en minusculas ("cc") DEBE seguir siendo valido -- la normalizacion de
+    // entrada (trim+MAYUSCULAS antes de TipoIdentificacion.Desde) es responsabilidad del borde,
+    // no un rechazo (mismo criterio que RegistrarColaboradorValidator, issue #330 CA-4).
+    [Fact]
+    public async Task Validar_Aprueba_CuandoTipoIdentificacionLlegaEnMinusculas()
+    {
+        var resultado = await Validar(ComandoValido() with { TipoIdentificacion = "cc" });
+
+        resultado.IsValid.Should().BeTrue();
+    }
+
+    // CA-6: NumeroIdentificacion vacio produce 400
+    [Fact]
+    public async Task Validar_RechazaNumeroIdentificacion_CuandoEstaVacio()
+    {
+        var resultado = await Validar(ComandoValido() with { NumeroIdentificacion = "" });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e =>
+            e.PropertyName == nameof(TerminarVinculacion.NumeroIdentificacion));
+    }
+
+    // CA-6: FechaEfectiva con el valor default de DateOnly produce 400 -- REQUERIDA, sin default
+    // del servidor (doctrina bitemporal del BC: el tiempo de los hechos viene del cliente).
+    [Fact]
+    public async Task Validar_RechazaFechaEfectiva_CuandoEsDefault()
+    {
+        var resultado = await Validar(ComandoValido() with { FechaEfectiva = default });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e =>
+            e.PropertyName == nameof(TerminarVinculacion.FechaEfectiva));
+    }
+
+    // CA-2: FechaEfectiva futura DEBE seguir siendo valida -- sin validacion contra el reloj del
+    // servidor en ninguna direccion (decision de refinamiento del issue #349).
+    [Fact]
+    public async Task Validar_Aprueba_CuandoFechaEfectivaEsFutura()
+    {
+        var resultado = await Validar(ComandoValido() with { FechaEfectiva = new DateOnly(2030, 1, 1) });
+
+        resultado.IsValid.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Resumen

Pipeline TDD completado:
- Fase roja: tests escritos con stubs
- Fase verde: implementación completa
- Smoke tests: escritos para endpoints detectados
- Fase refactor: revisión de calidad

## Decisiones del pipeline

<details>
<summary>Test Writer (fase roja) — 15m 0s</summary>

## ES Test Writer - Decisiones (issue #349)

### Tests creados

- `TerminarVinculacionFunction/TerminarVinculacionCommandHandlerTests.cs`: 8 tests
  - `TerminarVinculacion_EmiteVinculacionTerminada_CuandoLaVinculacionEstaAbierta` - CA-1
  - `TerminarVinculacion_EmiteVinculacionTerminada_CuandoFechaEfectivaEsFutura` - CA-2 (preaviso)
  - `TerminarVinculacion_EmiteVinculacionTerminada_CuandoFechaEfectivaEsPasada` - CA-2 (registro tardio)
  - `TerminarVinculacion_LanzaInvalidOperationException_CuandoLaVinculacionYaTieneTerminacionRegistrada` - CA-3
  - `TerminarVinculacion_LanzaInvalidOperationException_CuandoYaExisteUnPreavisoConFechaFutura` - CA-3 (sin reloj)
  - `TerminarVinculacion_LanzaInvalidOperationException_CuandoFechaEfectivaEsAnteriorAFechaInicio` - CA-4
  - `TerminarVinculacion_EmiteVinculacionTerminada_CuandoFechaEfectivaEsIgualAFechaInicio` - CA-4 (limite)
  - `TerminarVinculacion_LanzaKeyNotFoundException_CuandoColaboradorNoExiste` - CA-5

- `TerminarVinculacionFunction/TerminarVinculacionValidatorTests.cs`: 7 tests
  - Camino feliz + 4 rechazos (tipo vacio, tipo fuera de lista, numero vacio, fecha default) + 2 aprobaciones (minusculas, fecha futura) - CA-6

- `TerminarVinculacionFunction/FunctionEndpointTests.cs`: 4 tests
  - 202 (exito), 409 (InvalidOperationException), 404 (KeyNotFoundException), 400 (validacion) - CA-1/3/4/5/6

- `TerminarVinculacionFunction/Eventos/VinculacionTerminadaSerializacionTests.cs`: 2 tests
  - Roundtrip con fecha normal y con fecha futura (preaviso) - regla 16 / seccion 6d

- Modificados (guardrail de identidad de evento persistido, seccion 6f adaptada al patron real del proyecto):
  - `Infraestructura/AliasEventosColaboradoresTests.cs`: +1 test (`VinculacionTerminada_TieneAliasVinculacionTerminada`)
  - `Infraestructura/ComposicionServiciosTests.cs`: 2 tests existentes extendidos (listas literales `AssertEventosPersistidosRegistrados`/`AssertAliasDeEventosPersistidos` ahora incluyen `VinculacionTerminada`)

Total: 21 tests nuevos + 2 tests existentes extendidos.

### Estructura elegida

- Una clase por responsabilidad (Handler/Validator/Endpoint/Serializacion), siguiendo el molde
  exacto de `RegistrarColaboradorFunction` (#330): sin nested classes porque no hay multiples
  handlers sobre el mismo Given compartido en este issue.
- Sin clase base intermedia: solo un command handler en este issue, no aplica Rule of Three.

### Stubs creados

- `ColaboradorAggregateRoot` (modificado): campo `_fechaTerminacionVinculacionVigente` (`DateOnly?`)
  + observable `internal FechaTerminacionVinculacionVigente`; metodo
  `TerminarVinculacion(DateOnly): ResultadoTerminacionVinculacion` (stub `NotImplementedException`);
  `Apply(VinculacionTerminada)` (stub `NotImplementedException`).
- `ResultadoTerminacionVinculacion` (enum nuevo, `Entities/`): `Exitosa`, `YaTerminada`,
  `FechaAnteriorAInicio`. Mecanismo "declinar con resultado" (CA-ADR-0030) -- Tell-don't-Ask, el
  handler consulta el resultado, nunca el estado interno del aggregate.
- `VinculacionTerminada` (evento, record plano completo -- sin logica, no requiere stub).
- `TerminarVinculacion` (comando, record plano completo).
- `TerminarVinculacionValidator` (stub vacio, sin reglas -- mismo patron que
  `RegistrarColaboradorValidator` en su fase roja, issue #330, verificado en `git show ed9a308`).
- `TerminarVinculacionCommandHandler` (stub: `HandleAsync` -> `NotImplementedException`).
- `TerminarVinculacionCommandHandler.Mensajes.cs` + `.resx` (completos, 3 mensajes:
  `ColaboradorNoEncontrado`, `VinculacionYaTerminada`, `FechaAnteriorAInicio`).
- `FunctionEndpoint` (completo -- molde exacto de `SolicitarProgramacionTurnoFunction`, sin logica
  propia que implementar: solo delega en `IRequestValidator`/`ICommandRouter` y traduce excepciones).
- No se toco `IdentidadEventosColaboradores.TiposPersistidos` (sigue con los 2 tipos de #330) --
  registrar `VinculacionTerminada` ahi es tarea del implementer; por eso los tests de alias/registro
  estan en rojo.

### Decisiones de diseno

- **Mecanismo de "declinar con resultado"**: enum `ResultadoTerminacionVinculacion` con 3 valores.
  El aggregate nunca lanza excepciones ni emite eventos de fallo (CA-ADR-0030, nuevo). El handler
  traduce cada valor de rechazo a `InvalidOperationException` con mensaje `.resx` propio del
  handler (no del aggregate, que no tiene clase Mensajes en este corte).
- **CA-ADR-0030 creado**: documenta el patron "status code sincrono para comandos HTTP sin
  consumidores downstream, en vez de evento de fallo persistido" -- CA-7 del issue (documental).
  Se crea en esta fase porque documenta una decision de diseño de tests (que patron de handler
  probar) que #350/#351/#352/#355 replicaran sin volver a discutirla.
- **Verificacion de "ya terminada" sin reloj**: dos tests distintos en el handler
  (`CuandoLaVinculacionYaTieneTerminacionRegistrada` y `CuandoYaExisteUnPreavisoConFechaFutura`)
  para dejar explicito que un preaviso NO vencido bloquea igual una segunda terminacion.
- **CA-5 sin `And<>()`**: el aggregate no existe en el `TestStore` cuando no hay `Given` ni
  eventos emitidos -- `GetAggregateRoot` retorna null y `And<>()` lanzaria
  `ArgumentNullException`. Sigue el precedente explicito del propio rol de test-writer (ejemplo
  de "Aggregate no encontrado" en la seccion de proceso), que tampoco usa `And<>()` en ese
  escenario. Se conserva `Then(StreamIdEsperado)` (verifica cero eventos nuevos) para demostrar
  la segunda mitad del CA-5 ("sin escribir nada al event store").

### Cobertura de criterios

| Criterio de aceptacion | Test(s) |
|---|---|
| CA-1: exito, evento persistido, aggregate rehidratado, tipo registrado | `TerminarVinculacion_EmiteVinculacionTerminada_CuandoLaVinculacionEstaAbierta` + `AliasEventosColaboradoresTests.VinculacionTerminada_TieneAliasVinculacionTerminada` + 2 tests de `ComposicionServiciosTests` extendidos |
| CA-2: fecha futura y pasada aceptadas sin reloj | `..._CuandoFechaEfectivaEsFutura`, `..._CuandoFechaEfectivaEsPasada`, `Validar_Aprueba_CuandoFechaEfectivaEsFutura` |
| CA-3: ya terminada (incluye preaviso no vencido) -> 409 | `..._CuandoLaVinculacionYaTieneTerminacionRegistrada`, `..._CuandoYaExisteUnPreavisoConFechaFutura`, `FunctionEndpointTests..._Retorna409...` |
| CA-4: fecha anterior a inicio -> 409; igual a inicio -> exito | `..._CuandoFechaEfectivaEsAnteriorAFechaInicio`, `..._CuandoFechaEfectivaEsIgualAFechaInicio` |
| CA-5: colaborador inexistente -> 404 | `..._LanzaKeyNotFoundException_CuandoColaboradorNoExiste`, `FunctionEndpointTests..._Retorna404...` |
| CA-6: request invalida -> 400 | `TerminarVinculacionValidatorTests` (5 rechazos) + `FunctionEndpointTests..._Retorna400...` |
| CA-7: CA-ADR-0030 documentado | `docs/adr/ca-adr-0030-fallos-sincronos-comandos-http-sin-consumidores.md` (documental, sin test -- lo verifica el reviewer) |

### Desviaciones del plan del planner

| Sugerencia del issue | Desviacion aplicada | Razon tecnica | Consecuencia |
|---|---|---|---|
| "Carpeta: `TerminarVinculacion/` sin sufijo Function (misma decision que #330)" | Carpeta creada como `TerminarVinculacionFunction/` (CON sufijo) | Contradice el estado REAL del precedente #330: el commit `63270fa` ("refactor(hu-330): alinea el read-side de Colaboradores y el feature folder con sus ADRs") renombro explicitamente `RegistrarColaborador/` -> `RegistrarColaboradorFunction/` documentando que "el feature folder de un comando HTTP lleva sufijo Function (las carpetas sin sufijo son queries GET, que no tienen record de comando homonimo con el que colisionar)". La nota del planner reflejaba el estado PRE-refactor (fase roja original de #330, commit `ed9a308`), ya superado. Regla 19: contradiccion estructural resuelta con criterio propio, siguiendo el precedente real vigente en el codigo, no la nota historica. | Namespace `Bitakora.ControlAsistencia.Colaboradores.TerminarVinculacionFunction` en produccion y tests, sin alias de using por colision record/carpeta -- mismo patron que el dominio ya usa hoy para `RegistrarColaboradorFunction`. |
| "docs/adr/ca-adr-0030-...": no se especifica que agente lo crea | Creado por el test-writer (esta fase), no diferido al implementer | El ADR documenta la decision de DISEÑO DE TESTS (que patron de handler exigir: declinar-con-resultado vs evento de fallo) tomada en esta misma fase al escribir `TerminarVinculacionCommandHandlerTests`. Crearlo ahora fija el patron para que #350/#351/#352/#355 lo apliquen sin re-discutirlo, tal como el propio issue lo exige ("para que el reviewer no lo marque como desviacion"). | Ninguna negativa -- el ADR es documentacion, no codigo de produccion ni test; no infringe la regla "nunca implementacion real". |
| Ninguna otra desviacion relevante | -- | -- | -- |

### Verificacion de compilacion y fase roja

- `dotnet build ControlAsistencias.slnx`: compilacion correcta, 0 errores (solo warnings preexistentes
  + 1 warning esperado de campo sin asignar en el stub del aggregate).
- `dotnet test` en `Bitakora.ControlAsistencia.Colaboradores.Tests`: 142 tests totales, 15 en rojo
  (los 21 nuevos que dependen de logica real: 8 handler + 4 validator + 1 alias + 2 composicion menos
  los que ya pasaban por depender solo de forma), 127 en verde (incluye los 6 tests nuevos que no
  requieren implementacion real: 4 de `FunctionEndpointTests` con fakes + 2 de
  `VinculacionTerminadaSerializacionTests`, y todo lo preexistente de #330/#348 sin romperse).

</details>

<details>
<summary>Implementer (fase verde) — 5m 47s</summary>

## ES Implementer - Decisiones

### Enfoque de implementacion
El test-writer dejo los stubs con instrucciones muy detalladas en comentarios (flujo exacto del
handler, razones de rechazo del aggregate, mensajes .resx ya creados en el .resx). El trabajo se
redujo a implementar literalmente lo que esos comentarios ya especificaban, verificando contra los
tests y los precedentes citados (`RegistrarColaboradorCommandHandler`/`RegistrarColaboradorValidator`
del propio issue #330).

1. `ColaboradorAggregateRoot.Apply(VinculacionTerminada)`: asigna `_fechaTerminacionVinculacionVigente
   = e.FechaEfectiva`. No lanza (MEF-ADR-0004 capa 4).
2. `ColaboradorAggregateRoot.TerminarVinculacion(DateOnly)`: mecanismo "declinar con resultado"
   (CA-ADR-0030) -- dos guard clauses en positivo sobre las razones de rechazo (`YaTerminada` si
   `_fechaTerminacionVinculacionVigente is not null`; `FechaAnteriorAInicio` si `fechaEfectiva <
   _fechaInicioVinculacionVigente`), y en el camino exitoso appendea `VinculacionTerminada` a
   `_uncommittedEvents` y lo aplica, retornando `Exitosa`.
3. `TerminarVinculacionCommandHandler.HandleAsync`: parseo tipado unico en el borde
   (`TipoIdentificacion.Desde` sobre el input normalizado trim+MAYUSCULAS, luego
   `Identificacion.Crear`) -> `ComputarStreamId` -> `GetAggregateRootAsync` (null -> `KeyNotFoundException`
   con `.resx`) -> `TerminarVinculacion(...)` -> `switch` sobre el resultado que traduce
   `YaTerminada`/`FechaAnteriorAInicio` a `InvalidOperationException` con el mensaje `.resx`
   correspondiente. Caso `Exitosa`: no hace nada mas -- el middleware persiste el append
   automaticamente (stream existente, sin `StartStream`/`SaveChangesAsync` manual).
4. `TerminarVinculacionValidator`: mismas reglas que `RegistrarColaboradorValidator` adaptadas al
   comando (TipoIdentificacion requerido + lista cerrada via `TipoIdentificacion.Desde` en
   try/catch; NumeroIdentificacion requerido; FechaEfectiva `NotEqual(default(DateOnly))` -- sin
   validacion contra el reloj en ninguna direccion, futura y pasada son ambas validas).
5. `IdentidadEventosColaboradores.TiposPersistidos`: se agrego `typeof(VinculacionTerminada)`.

### Decisiones de diseno
- El `switch` en el handler sobre `ResultadoTerminacionVinculacion` se dejo como `switch` statement
  (no como lookup map `Dictionary`): es pattern matching/guard clause sobre un resultado de
  operacion con dos ramas que lanzan y una (implicita, `Exitosa`) que continua -- no es una
  seleccion de VALOR por clave discreta, es control de flujo de guardas. Encaja en la excepcion
  documentada ("guard clauses / early-return" y "switch exhaustivo... no forzar el mapa donde no
  corresponde").
- Las dos guardas de rechazo en `TerminarVinculacion` se escribieron en positivo
  (`if (_fechaTerminacionVinculacionVigente is not null) return ...`) como guard clauses de salida
  temprana -- no hay una rama `else` con la que permutar, son early-returns legitimos.
- No se agrego ningun `IEventSender`/publicacion a bus: el issue fija "Consumidores: ninguno",
  event-sourcing puro. El handler solo recibe `IEventStore`, igual que
  `RegistrarColaboradorCommandHandler`.

### ADRs consultados
- MEF-ADR-0004 (manejo de errores en event sourcing, capas 2/4)
- CA-ADR-0030 (nuevo, entregable de este issue -- ya redactado por el test-writer/planner;
  verificado que el mecanismo implementado coincide con el documentado)
- MEF-ADR-0012 (Tell-don't-Ask, serializacion, ctor privado + ConfigurarSerializacion)
- MEF-ADR-0037 (punto unico de conversion de la clave del stream)
- CA-ADR-0029 / MEF-ADR-0039 (islas de eventos, `IdentidadEventosColaboradores.TiposPersistidos`)
- MEF-ADR-0009 (mensajes en .resx, ya provistos por el test-writer)
- MEF-ADR-0006, CA-ADR-0027, MEF-ADR-0002, MEF-ADR-0016, MEF-ADR-0005 (consultados, sin impacto
  directo en el codigo de esta fase mas alla de lo ya fijado por el test-writer)

### Desviaciones de ADRs
Ninguna desviacion -- todos los ADRs aplicados al pie de la letra. El diseño completo (aggregate,
evento, handler, validator, endpoint, ADR documental) ya venia especificado por el test-writer en
comentarios STUB detallados y en el propio `CA-ADR-0030`; la implementacion siguio esas
instrucciones sin apartarse.

### Precedentes consultados
- `RegistrarColaboradorCommandHandler`/`RegistrarColaboradorValidator` (issue #330, mismo dominio):
  alineado con MEF-ADR-0037/MEF-ADR-0004 -- se replico el mismo patron de parseo tipado unico y
  normalizacion de entrada.
- `SolicitarProgramacionTurnoFunction.FunctionEndpoint` (citado por el issue para el endpoint
  404/409): el `FunctionEndpoint` ya lo dejo escrito el test-writer, verificado alineado.
- `ControlDiarioAggregateRoot.AdicionarMarcacion` (precedente de "declinar sin emitir", citado por
  CA-ADR-0030): no se leyo directamente porque el mecanismo ya estaba completamente especificado en
  los comentarios del stub y en el ADR; el patron replicado (guard + return de razon) es consistente
  con la doctrina citada.

### Infraestructura modificada
Ninguna. El comando no publica a ningun bus (event-sourcing puro, "Consumidores: ninguno" segun el
issue) -- no se toco `infra/environments/dev/main.tf`.

### Complejidad encontrada
Ninguna significativa. El test-writer dejo los stubs con el flujo exacto documentado en comentarios
(incluyendo los mensajes .resx ya creados), por lo que la implementacion fue directa. Todos los
tests pasaron en el primer intento tras completar los cuatro archivos de produccion.

### Resultado
- Tests del proyecto Colaboradores.Tests: 142/142 pasando
- Suite completa del repo: 968 correctos, 0 errores, 21 omitidos (requieren ServiceBus/Postgres
  locales no configurados en este entorno -- preexistente, no relacionado con este issue)

</details>
<details>
<summary>Smoke Test Writer — 6m 37s</summary>

_(El agente no generó resumen)_

</details>
<details>
<summary>Reviewer (fase refactor) — 15m 24s</summary>

## ES Reviewer - Revision

### Evaluacion general
- Calidad: **buena**
- Cambios realizados: **si** (commit `a2aa7a1`)

El diff es un slice vertical limpio y muy alineado con sus precedentes. Los hallazgos fueron dos
menores (superficie publica innecesaria y un guardrail de `.resx` ausente), ambos corregidos, mas
observaciones que deliberadamente NO se tocaron por estar fuera de alcance segun MEF-ADR-0018.

**Estado de tests**: 936/936 verdes en los seis proyectos de tests unitarios (Colaboradores subio de
142 a 143 con el guardrail agregado). Los 5 rojos de `Colaboradores.SmokeTests` son esperados y no
son defecto -- ver "Nota sobre los smoke tests rojos" al final.

---

### Cumplimiento de ADRs aplicables

| ADR | Cumplimiento | Observacion |
|---|---|---|
| MEF-ADR-0004: manejo de errores | ok | Capa 1 (validator -> 400), capa 2 (`KeyNotFoundException` -> 404, `InvalidOperationException` -> 409), capa 4 (`Apply(VinculacionTerminada)` no lanza). La capa 3 (evento de fallo) se sustituye deliberadamente por CA-ADR-0030, que es entregable de este issue -- no es desviacion. |
| **CA-ADR-0030 (NUEVO, entregable)** | ok | Existe `docs/adr/ca-adr-0030-fallos-sincronos-comandos-http-sin-consumidores.md` con contexto, decision, alternativas, consecuencias y control de cambios. El codigo implementa exactamente lo que documenta: el aggregate declina con `ResultadoTerminacionVinculacion` sin lanzar ni mutar, el handler traduce en el borde. Ver hallazgo #4 (indice de CLAUDE.md, corregido). |
| MEF-ADR-0012: Tell-don't-Ask / modelado | ok (tras correccion) | El handler decide solo por el resultado, nunca interroga estado. `VinculacionTerminada` es `record` plano sin invariantes -> correcto segun la tabla de heuristicas. `FechaTerminacionVinculacionVigente` es `internal` (insumo del DSL, no API). Corregido: el metodo de comando y su enum eran `public` sin consumidor externo (hallazgo #1). |
| MEF-ADR-0037: identidad de stream | ok | Punto unico: el handler usa `ColaboradorAggregateRoot.ComputarStreamId(identificacion)`; ninguna concatenacion paralela en produccion. Sin `ToString("N"/"D"/...)` sobre `Guid` de identidad. `.Trim().ToUpperInvariant()` aparece solo sobre el **codigo de tipo de documento** (normalizacion de entrada del borde), no sobre una clave de stream. El literal `"CC:79543210"` en los tests es el oraculo independiente que MEF-ADR-0002 exige, no una reconstruccion de produccion. |
| CA-ADR-0029 / MEF-ADR-0039 | ok | `VinculacionTerminada` vive en la isla `Colaboradores.DomainEvents`, sin marker de bus, y esta en `IdentidadEventosColaboradores.TiposPersistidos`. El issue **no toca ningun `.csproj`** (verificado con `git diff 1ca05ad..HEAD -- '**/*.csproj'` = vacio), asi que los cuatro antipatrones de habilitacion son inaplicables; ademas no existe tipo homonimo en `PublicEvents`/`PrivateEvents`. |
| MEF-ADR-0006: naming de funciones | ok | `[Function("TerminarVinculacion")]`, `Route = "Colaboradores/Terminaciones"` explicito, carpeta con sufijo `Function` (misma razon que #330: el record del comando es homonimo del feature folder). |
| MEF-ADR-0009: mensajes en `.resx` | ok (tras correccion) | `.resx` por handler, clase `Mensajes` parcial, tres claves. Corregido: faltaba el guardrail de resolucion (hallazgo #2). |
| MEF-ADR-0005: naming/versionado de eventos | ok | Evento en pasado, payload aditivo y plano; `Motivo` omitido a proposito (agregarlo despues es aditivo). |
| MEF-ADR-0002 / MEF-ADR-0016: testing | ok | DSL Given/WhenAsync/Then/And con overloads de stream id compuesto; solo `[Fact]`; naming `<Sujeto>_<LoQuePasa>_Cuando<Condicion>` con sujeto = nombre del comando. |
| CA-ADR-0027: tenancy | ok | Sin cambios de wiring; `TenantResolverFijo` ya cableado. |
| MEF-ADR-0036: identidad del evento persistido | ok | Solo hay **alta** de tipo, ningun rename ni movimiento de namespace -> el protocolo de dos despliegues no aplica. El alias `vinculacion_terminada` queda congelado por dos guardrails: `AliasEventosColaboradoresTests` (StoreOptions standalone) y `ComposicionServiciosTests` (store real del contenedor). |
| MEF-ADR-0018: extraccion vs duplicacion | ok | Ver observaciones #5 y #6: la duplicacion detectada esta en 2 sitios y su extraccion **no corresponde al reviewer** segun la heuristica "Autoridad de extraccion". |

Gates no aplicables a este diff (fila `n/a` justificada): compatibilidad de configuracion Marten
write/read (no toca version de paquete ni config), control de volumen de telemetria (no toca
`ComposicionServicios` ni el callback de Wolverine), doctrina de proyecciones read-side (no toca
`ReadModels`/`Projections`).

---

### Desviaciones de ADRs

**Declaradas por el implementer** (`stage-2-implementer.md`): "Ninguna desviacion".
Evaluacion del reviewer: **correcto**, se confirma. Las dos decisiones de diseno que el implementer
si documento (dejar el `switch` como control de flujo en vez de lookup map; guardas en positivo como
early-return) caen dentro de las excepciones explicitas de las convenciones del pipeline, no son
desviaciones de ADR.

**Detectadas por el reviewer (NO declaradas)**: ninguna desviacion de ADR.

Los dos hallazgos corregidos (#1 y #2) no son desviaciones de una regla escrita en un ADR, sino
inconsistencias con la convencion establecida del propio repo. Se listan en "Criticas y hallazgos".

**Ninguna desviacion -- todos los ADRs aplicables se cumplen.**

---

### Precedentes consultados por el implementer

| Precedente | ADR aplicable | Veredicto |
|---|---|---|
| `RegistrarColaboradorCommandHandler` / `RegistrarColaboradorValidator` (#330) | MEF-ADR-0037, MEF-ADR-0004 | alineado (parseo tipado unico en el borde, normalizacion antes de `Desde`) |
| `SolicitarProgramacionTurnoFunction.FunctionEndpoint` | MEF-ADR-0004 capa 2 | alineado (404/409 con `.resx`, 202 en exito) |
| `ControlDiarioAggregateRoot.AdicionarMarcacion` | CA-ADR-0030, MEF-ADR-0012 | alineado. **El implementer declaro no haberlo leido** ("el patron replicado es consistente con la doctrina citada"). Lo verifique yo: el precedente existe, declina sin emitir y ademas es `internal void` -- justamente la visibilidad que motiva el hallazgo #1. Leerlo habria evitado ese hallazgo. |

**Verificacion adicional no pedida al implementer**: el handler no llama `StartStream` ni
`SaveChangesAsync` tras `TerminarVinculacion` (append sobre stream existente). Verifique que no es un
olvido: el paquete expone `UnitOfWorkMiddleware`/`SaveChangesAsync` (simbolos presentes en
`Cosmos.EventSourcing.CritterStack` 2.3.1) y el patron esta probado **en produccion** por los smoke
tests de ControlHoras, que confirman contra Postgres que `marcacion_adicionada` se persiste con el
mismo flujo `GetAggregateRootAsync` -> mutar -> sin persistencia explicita. No es defecto.

---

### Convenciones del pipeline (no ADRs)

| Convencion | Estado | Observacion |
|---|---|---|
| Cada test con `Then()` + `And<>()` | ok (con 1 excepcion verificada) | Los 7 tests del handler cumplen salvo `TerminarVinculacion_LanzaKeyNotFoundException_CuandoColaboradorNoExiste`. **Verifique empiricamente** que `And<>` es imposible ahi: agregarlo produce `ArgumentNullException: Value cannot be null. (Parameter 'entidad')` desde `CommandHandlerTestBase.And<,>` porque el aggregate no existe. Experimento revertido. El test conserva `Then(streamId)` sin eventos, que ya demuestra "sin escribir nada al event store" -- es mas fuerte que el precedente equivalente de Programacion (`DebeLanzarExcepcion_CuandoTurnoNoExisteEnElCatalogo`, que no tiene ni `Then`). |
| Overloads correctos para stream IDs compuestos | ok | `Given(streamId, ...)`, `Then(streamId, ...)`, `And<T,P>(streamId, ...)` en todos los tests. |
| Fakes manuales (no NSubstitute) | ok | Clases fake concretas; cero NSubstitute. |
| Feature folders (produccion y tests) | ok | `TerminarVinculacionFunction/` con `FunctionEndpoint.cs`, `TerminarVinculacion.cs` y `CommandHandler/`; tests en espejo, un archivo por responsabilidad. |
| Smoke tests: SkipWhen, secrets, cobertura | ok | `Assert.SkipWhen` (xUnit v3) en los 3 tests con `PostgresFixture`; `appsettings.json` con connection strings vacios; `deploy-colaboradores.yml` ya pasa ambos secretos. Cobertura de efectos: el handler solo persiste (sin `PublishAsync`), y los 3 caminos 202 verifican `mt_events` via `ExisteEventoAsync`/`ObtenerEventoAsync` filtrando por stream id unico por corrida. Sin suscripcion `smoke-tests` que exigir: el comando no publica a ningun topic. Un solo archivo por comando. |
| Proyecciones read-side | n/a | El diff no toca `ReadModels`/`Projections` ni ninguna Function GET. |
| Antipatrones de habilitacion (MEF-ADR-0039) | n/a | El issue no toca ningun `.csproj` y el evento nuevo no tiene homonimo en los ensamblados de bus. |
| Compatibilidad Marten write-side/read-side | n/a | No toca version de `Cosmos.EventSourcing.*` ni configuracion de Marten. |
| Identidad de stream (MEF-ADR-0037) | ok | Punto unico via `ComputarStreamId`; sin formato explicito sobre `Guid`; sin GET de read-side en el diff. |
| Control de volumen de telemetria (MEF-ADR-0038) | n/a | No toca los seams de observabilidad ni el callback de Wolverine. |
| Tests via ToString/comportamiento | ok | El unico observable nuevo (`FechaTerminacionVinculacionVigente`) es `internal` y sostiene una invariante real del aggregate, no un getter abierto para el test. |
| Sin numeros magicos | ok | Fechas literales con nombre (`FechaInicioVinculacionVigente`, `FechaEfectivaValida`); constantes en el smoke test. |
| Condiciones en positivo (guardas if/else afirmativas) | ok | Las dos guardas de `TerminarVinculacion` son early-return sin rama `else`; no hay `if (!x)` permutable. |
| Sin caracter U+2500 en `.cs` | ok | Verificado sobre todo el diff. |
| Warnings de compilacion | ok | `dotnet build` sin warnings nuevos (los NU1902 de `OpenTelemetry.Api` son preexistentes en Programacion). |
| `dotnet format --verify-no-changes` | ok (tras correccion) | Habia 5 errores WHITESPACE en el smoke test; corregidos. |

---

### Elegancia del codigo

El codigo llego elegante y bien comentado: nombres que revelan intencion, comentarios que explican
el *por que* (no el *que*), payload plano sin ceremonia, y cero cruft (ni `Console.WriteLine`, ni
TODO/FIXME, ni imports sobrantes). Hallazgos por atributo:

- **Compacto**: `TerminarVinculacion` son 11 lineas para dos reglas de negocio y un append. Nada que quitar.
- **Legible**: `ResultadoTerminacionVinculacion.{Exitosa, YaTerminada, FechaAnteriorAInicio}` nombra las razones en lenguaje de dominio; el handler se lee como la especificacion del issue.
- **Idiomatico**: `record` para el evento plano, `enum` para el resultado cerrado, `is not null` / `switch` sobre el resultado, DSL Given/When/Then en tests. Correcto.
- **Robusto**: ver hallazgo #3 (riesgo residual aceptado y documentado).
- **Eficiente**: sin bucles ni colecciones; no aplica.
- **Limpio**: sin warnings, formato corregido.

---

### Criticas y hallazgos

**#1 (menor, CORREGIDO) -- superficie publica sin consumidor externo.**
`TerminarVinculacion(...)` y `ResultadoTerminacionVinculacion` nacieron `public`. El unico llamador
es el handler del mismo ensamblado, y todos los metodos de comando de los demas aggregates del repo
son `internal` (`ControlDiarioAggregateRoot.AdicionarMarcacion`, `.AsignarTurno`,
`CatalogoTurnos.ObtenerDetalle`, `ColaboradorAggregateRoot.Registrar`); publicos son solo `Apply(...)`
-- que el `TestStore` necesita via `GetMethods()` -- y `ComputarStreamId`. Ademas el propio archivo
del aggregate declara la convencion contraria en su cabecera ("el issue no expone lectura de la
vinculacion al exterior del ensamblado"). Corregido: ambos a `internal`; los tests siguen
alcanzandolos via el `InternalsVisibleTo` ya existente. 143/143 verdes.

**#2 (mayor, CORREGIDO) -- las tres claves `.resx` del handler no tenian guardrail de resolucion.**
Los tests del handler asertan `WithMessage($"*{Mensajes.X}*")`. Si una clave desaparece del `.resx`,
`ResourceManager.GetString` devuelve `null`, el `!` no lo detecta y el patron degrada a `"**"`, que
matchea **cualquier** excepcion: los tests de 404 y 409 pasarian en verde con mensajes vacios. Este
modo de falla no es hipotetico -- esta documentado y **verificado por mutacion** en la cabecera de
`ValueObjects/MensajesResxTests.cs` durante la revision de #348. Ese guardrail existia solo para los
VOs. Agregado `TerminarVinculacionCommandHandlerMensajesTests` con el gemelo para las tres claves del
handler. Pasa en verde, lo que ademas confirma que el nombre logico del recurso embebido resuelve
correctamente (algo que ninguna otra prueba del issue verificaba).

**#3 (menor, EVALUADO -- se deja como esta) -- el `switch` del handler no es exhaustivo.**
Si un issue futuro (#352/#354) agrega una razon de rechazo al enum y nadie la mapea en el handler, el
`switch` cae por el final y el comando responde **202 sin haber persistido nada** -- un exito
silencioso. Considere convertirlo a `switch` expression con `_ => throw new UnreachableException()`.
**Decidi no hacerlo**: (a) ese arm es una linea inalcanzable por construccion contra un gate de
cobertura del 95% sobre un archivo pequeno (MEF-ADR-0014 reserva ese margen justamente para
"fallbacks defensivos", pero gastarlo aqui es innecesario); (b) el guardrail real es el propio TDD
del issue futuro -- una razon nueva llega con su test de 409, que fallaria ruidosamente. Riesgo
residual documentado aqui para quien tome #352/#354.

**#4 (menor, CORREGIDO) -- CA-ADR-0030 no entro al indice tematico de `CLAUDE.md`.**
El proposito declarado del ADR es que #350/#351/#352/#355 lo apliquen "sin re-discutir"; un ADR fuera
del indice que CLAUDE.md ofrece como puerta de entrada no se encuentra. La convencion del repo lo
respalda: el commit que creo CA-ADR-0029 (`ddcd534`) actualizo `CLAUDE.md` en el mismo cambio.
Agregada la fila, contigua a la de MEF-ADR-0004 y declarando la relacion entre ambos.

**#5 (observacion, NO corregida) -- fakes duplicados por feature folder.**
`FakeTerminarVinculacionRequestValidator` es una copia de `FakeRequestValidator<T>` (que ya es
generico, en el mismo ensamblado de tests) con el parametro de tipo fijado. **No lo consolide** por
tres razones: MEF-ADR-0018 "Autoridad de extraccion" (el reviewer no inicia extracciones que el
implementer no ofrece, salvo que un cambio reciente haya tocado ambos sitios -- este PR no toco el
de #330); el patron es **repo-wide**, con 4 archivos en 3 dominios que hacen exactamente lo mismo
(`FakeSolicitud*` en Programacion es el molde que se copio); y unificar solo Colaboradores dejaria el
repo heterogeneo. **Recomendacion**: como #350/#351/#352/#355 sumaran cuatro copias mas, esto merece
un issue de tooling propio (fakes compartidos por proyecto de tests), no una decision unilateral aqui.

**#6 (observacion, NO corregida) -- `EsTipoIdentificacionReconocido` duplicado y basado en excepciones.**
Identico en `RegistrarColaboradorValidator` y `TerminarVinculacionValidator`, y usa `try/catch
(ArgumentException)` como control de flujo. La forma Tell-don't-Ask seria que `TipoIdentificacion`
expusiera la pregunta (`EsReconocido(string)` o un `TryDesde`), lo que eliminaria el `catch` y la
duplicacion de una vez. Hoy son 2 sitios -> Rule of Three dice esperar (MEF-ADR-0018), y ademas
tocaria `TipoIdentificacion` (artefacto de #348, fuera de este diff). Con #350/#351/#352 pasara a 3+:
ese es el momento natural de resolverlo.

**#7 (observacion, NO corregida) -- mismo hueco de `.resx` en #330.**
`RegistrarColaboradorCommandHandler.Mensajes.ColaboradorYaRegistrado` tiene exactamente la
vulnerabilidad del hallazgo #2 y ningun guardrail. Fuera del diff de este issue; se reporta para que
se resuelva donde corresponda.

---

### Refactorings aplicados

Commit `a2aa7a1` (`dotnet test` verde despues de cada paso):

1. `TerminarVinculacion` y `ResultadoTerminacionVinculacion` -> `internal` (hallazgo #1).
2. Nuevo `TerminarVinculacionCommandHandlerMensajesTests` (hallazgo #2).
3. `dotnet format whitespace` sobre `TerminarVinculacionSmokeTests.cs` (5 errores WHITESPACE).
4. Fila de CA-ADR-0030 en el indice tematico de `CLAUDE.md` (hallazgo #4).

Experimento revertido (no forma parte del commit): agregar `And<>` al test de 404 para cumplir la
convencion -- se comprobo que el harness lo hace imposible y se restauro el archivo con
`git checkout --`.

---

### Cobertura de criterios de aceptacion

| Criterio | Estado | Test(s) |
|---|---|---|
| CA-1: 202 + `VinculacionTerminada` con la `FechaEfectiva` + aggregate rehidratado + tipo en `TiposPersistidos` | cubierto | `TerminarVinculacion_EmiteVinculacionTerminada_CuandoLaVinculacionEstaAbierta`; `TerminarVinculacion_Retorna202_CuandoComandoEsValido`; `VinculacionTerminada_TieneAliasVinculacionTerminada`; `AgregarServiciosColaboradores_RegistraLosTiposDeEventoPersistidos_...`; `AgregarServiciosColaboradores_DerivaElAliasDeEventoDelNombreDeClase_...`; smoke `TerminarVinculacion_Retorna202YPersisteFechaEfectiva_CuandoVinculacionEstaAbierta` |
| CA-2: fecha futura (preaviso) aceptada; cero validacion contra el reloj | cubierto | `TerminarVinculacion_EmiteVinculacionTerminada_CuandoFechaEfectivaEsFutura`; `..._CuandoFechaEfectivaEsPasada` (la otra direccion); `Validar_Aprueba_CuandoFechaEfectivaEsFutura`; `RoundTrip_ReconstruyeEvento_ConFechaEfectivaFutura`; smoke `..._CuandoFechaEfectivaEsFutura` |
| CA-3: terminacion ya registrada (incluido preaviso no vencido) -> 409 sin evento nuevo | cubierto | `TerminarVinculacion_LanzaInvalidOperationException_CuandoLaVinculacionYaTieneTerminacionRegistrada`; `..._CuandoYaExisteUnPreavisoConFechaFutura` (ambos con `Then(streamId)` vacio + `And<>` sobre la terminacion previa); `TerminarVinculacion_Retorna409_CuandoLaVinculacionYaTieneTerminacionRegistrada`; smoke `..._Retorna409_CuandoVinculacionYaFueTerminada` |
| CA-4: `FechaEfectiva < FechaInicio` -> 409; `== FechaInicio` -> exito | cubierto | `TerminarVinculacion_LanzaInvalidOperationException_CuandoFechaEfectivaEsAnteriorAFechaInicio`; `TerminarVinculacion_EmiteVinculacionTerminada_CuandoFechaEfectivaEsIgualAFechaInicio`; smoke de ambas ramas |
| CA-5: colaborador inexistente -> 404 sin escribir nada | cubierto | `TerminarVinculacion_LanzaKeyNotFoundException_CuandoColaboradorNoExiste`; `TerminarVinculacion_Retorna404_CuandoColaboradorNoExiste`; smoke homonimo |
| CA-6: request invalida -> 400 sin tocar el event store | cubierto | `Validar_RechazaTipoIdentificacion_CuandoEstaVacio`; `..._CuandoNoEstaEnLaListaCerrada`; `Validar_RechazaNumeroIdentificacion_CuandoEstaVacio`; `Validar_RechazaFechaEfectiva_CuandoEsDefault`; `Validar_Aprueba_CuandoTipoIdentificacionLlegaEnMinusculas`; `TerminarVinculacion_Retorna400_CuandoRequestEsInvalido`; 3 smoke de 400 |
| CA-7 (documental): existe el CA-ADR con contexto/decision/consecuencias | cubierto (verificado por el reviewer) | `docs/adr/ca-adr-0030-fallos-sincronos-comandos-http-sin-consumidores.md` -- ademas de contexto/decision/consecuencias trae alternativas descartadas, referencias y control de cambios. Ahora tambien indexado en `CLAUDE.md`. |

Sin CAs descubiertos. No detecte casos borde faltantes: el test-writer ya cubrio las dos direcciones
de CA-2 y ambos limites de CA-4, y el round-trip de serializacion existe pese a que el payload es
primitivo.

---

### Tests agregados

- `TerminarVinculacionCommandHandlerMensajesTests` -- guardrail de resolucion de las 3 claves `.resx`
  del handler (test de contrato, no de comportamiento: generarlo en fase refactor no viola TDD).
- Contratos de igualdad (`IgualdadTestBase<T>`) y round-trip de serializacion: **no aplican**. El
  diff no introduce ningun tipo con `IEquatable<T>` ni con `ConfigurarSerializacion`;
  `VinculacionTerminada` es un `record` de un solo `DateOnly` y su round-trip con las opciones reales
  de Marten ya lo cubre `VinculacionTerminadaSerializacionTests`. Tampoco aplica el guardrail de
  portabilidad por bus: el evento no lleva marker `IPrivateEvent`/`IPublicEvent` (event-sourcing puro,
  "Consumidores: ninguno").

---

### Nota sobre los smoke tests rojos (no es defecto, no requiere accion)

`dotnet test` a nivel de solucion reporta 5 errores en `Colaboradores.SmokeTests`. **Todos fallan con
404 sobre `/api/Colaboradores/Terminaciones`**: el endpoint todavia no esta desplegado en dev, que es
el estado normal de un smoke test escrito antes del deploy.

| Test | Esperado | Obtenido |
|---|---|---|
| `..._Retorna409_CuandoVinculacionYaFueTerminada` | 409 | 404 |
| `..._Retorna409_CuandoFechaEfectivaEsAnteriorAFechaInicio` | 409 | 404 |
| `..._Retorna400_CuandoFechaEfectivaEsVacia` | 400 | 404 |
| `..._Retorna400_CuandoNumeroIdentificacionEsVacio` | 400 | 404 |
| `..._Retorna400_CuandoTipoIdentificacionNoEsReconocido` | 400 | 404 |

No bloquean el PR: `ci.yml` itera `tests/Bitakora.ControlAsistencia.*.Tests/`, glob que **no** matchea
`*.SmokeTests` (confirmado ejecutando el mismo glob: solo los 6 proyectos unitarios). Su ejecucion
real ocurre en `deploy-colaboradores.yml`, despues del deploy y con el gate de SHA.

**Aviso para quien lea el reporte de smoke post-deploy**: `TerminarVinculacion_Retorna404_CuandoColaboradorNoExiste`
esta hoy en **verde por la razon equivocada** -- recibe 404 porque la ruta no existe, no porque el
colaborador no exista. Solo despues del deploy ese verde significa lo que dice.

</details>

## Commits

a2aa7a1 refactor(hu-349): acota la superficie del aggregate y blinda los .resx del handler
1a1fa9d test(issue-349): smoke tests para terminar la vinculacion de un colaborador
deeb347 feat(issue-349): implementacion de terminar la vinculacion de un colaborador (fase verde)
0dfb265 test(issue-349): tests para terminar la vinculacion de un colaborador (fase roja)

Closes #349