### PR TITLE
Reingresar a un colaborador

### DIFF
--- a/src/Bitakora.ControlAsistencia.Colaboradores/Entities/ColaboradorAggregateRoot.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/Entities/ColaboradorAggregateRoot.cs
@@ -102,11 +102,9 @@ public partial class ColaboradorAggregateRoot : AggregateRoot
     //     previo sin terminar).
     //   - FechaSolapaVinculacionAnterior: fechaInicio <= _fechaTerminacionVinculacionVigente.Value
     //     (estrictamente posterior es la unica fecha valida -- el mismo dia se rechaza).
-    // Exito: appendea VinculacionIniciada(codigo, fechaInicio) a _uncommittedEvents y lo aplica.
-    // NOTA para el implementer: Apply(VinculacionIniciada) debe reabrir la vinculacion (limpiar
-    // _fechaTerminacionVinculacionVigente) al re-aplicarse -- si #330 lo dejo asumiendo una unica
-    // aplicacion, ajustarlo es parte natural del alcance de este issue (ver comentario de #330 en
-    // Apply(VinculacionIniciada) mas arriba).
+    // Exito: appendea VinculacionIniciada(codigo, fechaInicio) a _uncommittedEvents y lo aplica --
+    // ese Apply reabre la vinculacion (limpia _fechaTerminacionVinculacionVigente), de modo que el
+    // ciclo registro-terminacion-reingreso-terminacion es encadenable sin estado residual.
     // internal: mismo criterio de visibilidad que TerminarVinculacion y Registrar.
     internal ResultadoReingresoColaborador Reingresar(string codigo, DateOnly fechaInicio)
     {

--- a/src/Bitakora.ControlAsistencia.Colaboradores/Entities/ColaboradorAggregateRoot.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/Entities/ColaboradorAggregateRoot.cs
@@ -89,6 +89,25 @@ public partial class ColaboradorAggregateRoot : AggregateRoot
         return ResultadoTerminacionVinculacion.Exitosa;
     }
 
+    // Issue #350: mecanismo "declinar con resultado" (CA-ADR-0030) -- nunca lanza, nunca emite un
+    // evento de fallo persistido. Reutiliza VinculacionIniciada (CA-ADR-0029: un evento no conoce
+    // su comando) -- mismo hecho que Registrar, comando distinto.
+    // Dos razones de rechazo evaluables solo con la historia del stream, sin reloj (invariante de
+    // no-solape, doctrina del preaviso #349):
+    //   - VinculacionAbierta: _fechaTerminacionVinculacionVigente is null (incluye un reingreso
+    //     previo sin terminar).
+    //   - FechaSolapaVinculacionAnterior: fechaInicio <= _fechaTerminacionVinculacionVigente.Value
+    //     (estrictamente posterior es la unica fecha valida -- el mismo dia se rechaza).
+    // Exito: appendea VinculacionIniciada(codigo, fechaInicio) a _uncommittedEvents y lo aplica.
+    // NOTA para el implementer: Apply(VinculacionIniciada) debe reabrir la vinculacion (limpiar
+    // _fechaTerminacionVinculacionVigente) al re-aplicarse -- si #330 lo dejo asumiendo una unica
+    // aplicacion, ajustarlo es parte natural del alcance de este issue (ver comentario de #330 en
+    // Apply(VinculacionIniciada) mas arriba).
+    // internal: mismo criterio de visibilidad que TerminarVinculacion y Registrar.
+    // STUB (fase roja, issue #350): el cuerpo completo queda para el implementer.
+    internal ResultadoReingresoColaborador Reingresar(string codigo, DateOnly fechaInicio) =>
+        throw new NotImplementedException();
+
     // Factory interno: agrega los DOS eventos del commit a _uncommittedEvents y los aplica -- patron
     // RegistroDeMarcacionAggregateRoot.Iniciar, generalizado a dos eventos en el mismo commit.
     internal static ColaboradorAggregateRoot Registrar(

--- a/src/Bitakora.ControlAsistencia.Colaboradores/Entities/ColaboradorAggregateRoot.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/Entities/ColaboradorAggregateRoot.cs
@@ -52,10 +52,14 @@ public partial class ColaboradorAggregateRoot : AggregateRoot
         _nombre = e.Nombre;
     }
 
+    // Issue #350: reabre la vinculacion al re-aplicarse -- una segunda VinculacionIniciada en el
+    // mismo stream (reingreso) deja limpia la terminacion de la vinculacion anterior, sin lo cual
+    // el reingreso rehidratado quedaria "ya terminado" heredando la terminacion previa.
     public void Apply(VinculacionIniciada e)
     {
         _codigoVinculacionVigente = e.Codigo;
         _fechaInicioVinculacionVigente = e.FechaInicio;
+        _fechaTerminacionVinculacionVigente = null;
     }
 
     // Issue #349: registra la terminacion de la vinculacion vigente. Nunca lanza (MEF-ADR-0004
@@ -104,9 +108,20 @@ public partial class ColaboradorAggregateRoot : AggregateRoot
     // aplicacion, ajustarlo es parte natural del alcance de este issue (ver comentario de #330 en
     // Apply(VinculacionIniciada) mas arriba).
     // internal: mismo criterio de visibilidad que TerminarVinculacion y Registrar.
-    // STUB (fase roja, issue #350): el cuerpo completo queda para el implementer.
-    internal ResultadoReingresoColaborador Reingresar(string codigo, DateOnly fechaInicio) =>
-        throw new NotImplementedException();
+    internal ResultadoReingresoColaborador Reingresar(string codigo, DateOnly fechaInicio)
+    {
+        if (_fechaTerminacionVinculacionVigente is null)
+            return ResultadoReingresoColaborador.VinculacionAbierta;
+
+        if (fechaInicio <= _fechaTerminacionVinculacionVigente.Value)
+            return ResultadoReingresoColaborador.FechaSolapaVinculacionAnterior;
+
+        var evento = new VinculacionIniciada(codigo, fechaInicio);
+        _uncommittedEvents.Add(evento);
+        Apply(evento);
+
+        return ResultadoReingresoColaborador.Exitosa;
+    }
 
     // Factory interno: agrega los DOS eventos del commit a _uncommittedEvents y los aplica -- patron
     // RegistroDeMarcacionAggregateRoot.Iniciar, generalizado a dos eventos en el mismo commit.

--- a/src/Bitakora.ControlAsistencia.Colaboradores/Entities/ResultadoReingresoColaborador.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/Entities/ResultadoReingresoColaborador.cs
@@ -1,0 +1,23 @@
+namespace Bitakora.ControlAsistencia.Colaboradores.Entities;
+
+// Issue #350: resultado de ColaboradorAggregateRoot.Reingresar. Gemelo de
+// ResultadoTerminacionVinculacion (#349) -- mismo mecanismo "declinar con resultado"
+// (CA-ADR-0030): el aggregate nunca lanza y nunca emite un evento de fallo persistido -- responde
+// el resultado de la operacion (exito o razon del rechazo) y el handler traduce la razon a
+// InvalidOperationException con mensaje .resx en el borde (MEF-ADR-0004 capa 2).
+// Dos razones de rechazo, invariante de no-solape (doctrina del preaviso, #349 "vigente y operable
+// hasta su fecha"), evaluables solo con la historia del stream, sin reloj:
+//   - VinculacionAbierta: la ultima vinculacion no tiene terminacion registrada (incluye el caso
+//     de un reingreso previo que aun no se termino).
+//   - FechaSolapaVinculacionAnterior: FechaInicio <= FechaEfectiva de la ultima terminacion -- el
+//     mismo dia se rechaza (el dia de la fecha efectiva pertenece a la vinculacion que termina;
+//     estrictamente posterior es la unica fecha valida).
+// internal: mismo criterio de visibilidad que ResultadoTerminacionVinculacion -- vive en el mismo
+// ensamblado que el handler que lo consume (Entities/ y CommandHandler/ en el mismo proyecto
+// Function App), publicos son solo Apply(...) y ComputarStreamId.
+internal enum ResultadoReingresoColaborador
+{
+    Exitosa,
+    VinculacionAbierta,
+    FechaSolapaVinculacionAnterior
+}

--- a/src/Bitakora.ControlAsistencia.Colaboradores/Entities/ResultadoReingresoColaborador.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/Entities/ResultadoReingresoColaborador.cs
@@ -4,14 +4,9 @@ namespace Bitakora.ControlAsistencia.Colaboradores.Entities;
 // ResultadoTerminacionVinculacion (#349) -- mismo mecanismo "declinar con resultado"
 // (CA-ADR-0030): el aggregate nunca lanza y nunca emite un evento de fallo persistido -- responde
 // el resultado de la operacion (exito o razon del rechazo) y el handler traduce la razon a
-// InvalidOperationException con mensaje .resx en el borde (MEF-ADR-0004 capa 2).
-// Dos razones de rechazo, invariante de no-solape (doctrina del preaviso, #349 "vigente y operable
-// hasta su fecha"), evaluables solo con la historia del stream, sin reloj:
-//   - VinculacionAbierta: la ultima vinculacion no tiene terminacion registrada (incluye el caso
-//     de un reingreso previo que aun no se termino).
-//   - FechaSolapaVinculacionAnterior: FechaInicio <= FechaEfectiva de la ultima terminacion -- el
-//     mismo dia se rechaza (el dia de la fecha efectiva pertenece a la vinculacion que termina;
-//     estrictamente posterior es la unica fecha valida).
+// InvalidOperationException con mensaje .resx en el borde (MEF-ADR-0004 capa 2). Las dos razones de
+// rechazo componen la invariante de no-solape y las evalua ColaboradorAggregateRoot.Reingresar solo
+// con la historia del stream, sin reloj (ver el detalle de cada una alli).
 // internal: mismo criterio de visibilidad que ResultadoTerminacionVinculacion -- vive en el mismo
 // ensamblado que el handler que lo consume (Entities/ y CommandHandler/ en el mismo proyecto
 // Function App), publicos son solo Apply(...) y ComputarStreamId.

--- a/src/Bitakora.ControlAsistencia.Colaboradores/ReingresarColaboradorFunction/CommandHandler/ReingresarColaboradorCommandHandler.Mensajes.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/ReingresarColaboradorFunction/CommandHandler/ReingresarColaboradorCommandHandler.Mensajes.cs
@@ -1,0 +1,24 @@
+using System.Resources;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.ReingresarColaboradorFunction.CommandHandler;
+
+// MEF-ADR-0009: mensajes del handler en .resx separado.
+// internal: accesible desde tests via InternalsVisibleTo en el .csproj.
+public partial class ReingresarColaboradorCommandHandler
+{
+    private static readonly ResourceManager ResourceManager = new(
+        "Bitakora.ControlAsistencia.Colaboradores.ReingresarColaboradorFunction.CommandHandler.ReingresarColaboradorCommandHandlerMensajes",
+        typeof(ReingresarColaboradorCommandHandler).Assembly);
+
+    internal static class Mensajes
+    {
+        public static string ColaboradorNoEncontrado =>
+            ResourceManager.GetString(nameof(ColaboradorNoEncontrado))!;
+
+        public static string VinculacionAbierta =>
+            ResourceManager.GetString(nameof(VinculacionAbierta))!;
+
+        public static string FechaSolapaVinculacionAnterior =>
+            ResourceManager.GetString(nameof(FechaSolapaVinculacionAnterior))!;
+    }
+}

--- a/src/Bitakora.ControlAsistencia.Colaboradores/ReingresarColaboradorFunction/CommandHandler/ReingresarColaboradorCommandHandler.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/ReingresarColaboradorFunction/CommandHandler/ReingresarColaboradorCommandHandler.cs
@@ -1,0 +1,32 @@
+using Cosmos.EventSourcing.Abstractions.Commands;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.ReingresarColaboradorFunction.CommandHandler;
+
+// Issue #350: handler del comando ReingresarColaborador.
+// Flujo esperado (precedente TerminarVinculacionCommandHandler, MEF-ADR-0004 capa 2 -- CA-ADR-0030):
+//   1. Normalizar y parsear TipoIdentificacion -> TipoIdentificacion.Desde(...) (borde HTTP:
+//      normalizar trim+MAYUSCULAS ANTES de Desde, mismo criterio que los demas handlers del
+//      dominio).
+//   2. Identificacion.Crear(tipo, command.NumeroIdentificacion) -- normaliza el numero.
+//   3. ComputarStreamId(identificacion) -> GetAggregateRootAsync<ColaboradorAggregateRoot> -- si
+//      es null, throw KeyNotFoundException(Mensajes.ColaboradorNoEncontrado) (-> 404).
+//   4. colaborador.Reingresar(command.CodigoColaborador, command.FechaInicio) -- el aggregate
+//      declina con resultado (nunca lanza, nunca emite evento de fallo persistido):
+//        - ResultadoReingresoColaborador.VinculacionAbierta -> throw
+//          InvalidOperationException(Mensajes.VinculacionAbierta) (-> 409).
+//        - ResultadoReingresoColaborador.FechaSolapaVinculacionAnterior -> throw
+//          InvalidOperationException(Mensajes.FechaSolapaVinculacionAnterior) (-> 409).
+//        - ResultadoReingresoColaborador.Exitosa -> el aggregate ya agrego VinculacionIniciada a
+//          _uncommittedEvents; WhenAsync/el middleware persiste via SaveChanges.
+// Sin publicacion a bus (event-sourcing puro, issue #350 "Consumidores: ninguno").
+// STUB (fase roja, issue #350): el cuerpo completo queda para el implementer.
+public partial class ReingresarColaboradorCommandHandler : ICommandHandlerAsync<ReingresarColaborador>
+{
+    private readonly IEventStore _eventStore;
+
+    public ReingresarColaboradorCommandHandler(IEventStore eventStore) =>
+        _eventStore = eventStore;
+
+    public Task HandleAsync(ReingresarColaborador command, CancellationToken ct = default) =>
+        throw new NotImplementedException();
+}

--- a/src/Bitakora.ControlAsistencia.Colaboradores/ReingresarColaboradorFunction/CommandHandler/ReingresarColaboradorCommandHandler.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/ReingresarColaboradorFunction/CommandHandler/ReingresarColaboradorCommandHandler.cs
@@ -1,3 +1,5 @@
+using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+using Bitakora.ControlAsistencia.Colaboradores.Entities;
 using Cosmos.EventSourcing.Abstractions.Commands;
 
 namespace Bitakora.ControlAsistencia.Colaboradores.ReingresarColaboradorFunction.CommandHandler;
@@ -27,6 +29,25 @@ public partial class ReingresarColaboradorCommandHandler : ICommandHandlerAsync<
     public ReingresarColaboradorCommandHandler(IEventStore eventStore) =>
         _eventStore = eventStore;
 
-    public Task HandleAsync(ReingresarColaborador command, CancellationToken ct = default) =>
-        throw new NotImplementedException();
+    public async Task HandleAsync(ReingresarColaborador command, CancellationToken ct = default)
+    {
+        // Parseo tipado unico del borde (MEF-ADR-0037 seccion 2), mismo criterio que
+        // TerminarVinculacionCommandHandler.
+        var tipo = TipoIdentificacion.Desde(command.TipoIdentificacion.Trim().ToUpperInvariant());
+        var identificacion = Identificacion.Crear(tipo, command.NumeroIdentificacion);
+
+        var streamId = ColaboradorAggregateRoot.ComputarStreamId(identificacion);
+        var colaborador = await _eventStore.GetAggregateRootAsync<ColaboradorAggregateRoot>(streamId, ct);
+        if (colaborador is null)
+            throw new KeyNotFoundException(Mensajes.ColaboradorNoEncontrado);
+
+        var resultado = colaborador.Reingresar(command.CodigoColaborador, command.FechaInicio);
+        switch (resultado)
+        {
+            case ResultadoReingresoColaborador.VinculacionAbierta:
+                throw new InvalidOperationException(Mensajes.VinculacionAbierta);
+            case ResultadoReingresoColaborador.FechaSolapaVinculacionAnterior:
+                throw new InvalidOperationException(Mensajes.FechaSolapaVinculacionAnterior);
+        }
+    }
 }

--- a/src/Bitakora.ControlAsistencia.Colaboradores/ReingresarColaboradorFunction/CommandHandler/ReingresarColaboradorCommandHandler.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/ReingresarColaboradorFunction/CommandHandler/ReingresarColaboradorCommandHandler.cs
@@ -4,24 +4,13 @@ using Cosmos.EventSourcing.Abstractions.Commands;
 
 namespace Bitakora.ControlAsistencia.Colaboradores.ReingresarColaboradorFunction.CommandHandler;
 
-// Issue #350: handler del comando ReingresarColaborador.
-// Flujo esperado (precedente TerminarVinculacionCommandHandler, MEF-ADR-0004 capa 2 -- CA-ADR-0030):
-//   1. Normalizar y parsear TipoIdentificacion -> TipoIdentificacion.Desde(...) (borde HTTP:
-//      normalizar trim+MAYUSCULAS ANTES de Desde, mismo criterio que los demas handlers del
-//      dominio).
-//   2. Identificacion.Crear(tipo, command.NumeroIdentificacion) -- normaliza el numero.
-//   3. ComputarStreamId(identificacion) -> GetAggregateRootAsync<ColaboradorAggregateRoot> -- si
-//      es null, throw KeyNotFoundException(Mensajes.ColaboradorNoEncontrado) (-> 404).
-//   4. colaborador.Reingresar(command.CodigoColaborador, command.FechaInicio) -- el aggregate
-//      declina con resultado (nunca lanza, nunca emite evento de fallo persistido):
-//        - ResultadoReingresoColaborador.VinculacionAbierta -> throw
-//          InvalidOperationException(Mensajes.VinculacionAbierta) (-> 409).
-//        - ResultadoReingresoColaborador.FechaSolapaVinculacionAnterior -> throw
-//          InvalidOperationException(Mensajes.FechaSolapaVinculacionAnterior) (-> 409).
-//        - ResultadoReingresoColaborador.Exitosa -> el aggregate ya agrego VinculacionIniciada a
-//          _uncommittedEvents; WhenAsync/el middleware persiste via SaveChanges.
-// Sin publicacion a bus (event-sourcing puro, issue #350 "Consumidores: ninguno").
-// STUB (fase roja, issue #350): el cuerpo completo queda para el implementer.
+// Issue #350: handler del comando ReingresarColaborador (precedente TerminarVinculacionCommandHandler).
+// El aggregate declina con resultado (CA-ADR-0030): nunca lanza ni emite un evento de fallo
+// persistido, y este handler traduce la razon del rechazo a la excepcion que el borde convierte en
+// status code (MEF-ADR-0004 capa 2): stream inexistente -> 404, regla de negocio violada -> 409.
+// En el camino de exito el aggregate ya dejo VinculacionIniciada en _uncommittedEvents -- el
+// middleware persiste via SaveChanges. Sin publicacion a bus (event-sourcing puro, "Consumidores:
+// ninguno").
 public partial class ReingresarColaboradorCommandHandler : ICommandHandlerAsync<ReingresarColaborador>
 {
     private readonly IEventStore _eventStore;

--- a/src/Bitakora.ControlAsistencia.Colaboradores/ReingresarColaboradorFunction/CommandHandler/ReingresarColaboradorCommandHandlerMensajes.resx
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/ReingresarColaboradorFunction/CommandHandler/ReingresarColaboradorCommandHandlerMensajes.resx
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" msdata:Ordinal="0" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter</value></resheader>
+  <data name="ColaboradorNoEncontrado" xml:space="preserve">
+    <value>No existe un colaborador registrado con esa identificacion</value>
+  </data>
+  <data name="VinculacionAbierta" xml:space="preserve">
+    <value>La vinculacion vigente del colaborador no tiene una terminacion registrada</value>
+  </data>
+  <data name="FechaSolapaVinculacionAnterior" xml:space="preserve">
+    <value>La fecha de inicio del reingreso debe ser estrictamente posterior a la fecha efectiva de terminacion de la vinculacion anterior</value>
+  </data>
+</root>

--- a/src/Bitakora.ControlAsistencia.Colaboradores/ReingresarColaboradorFunction/CommandHandler/ReingresarColaboradorValidator.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/ReingresarColaboradorFunction/CommandHandler/ReingresarColaboradorValidator.cs
@@ -1,3 +1,4 @@
+using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
 using FluentValidation;
 
 namespace Bitakora.ControlAsistencia.Colaboradores.ReingresarColaboradorFunction.CommandHandler;
@@ -9,8 +10,40 @@ namespace Bitakora.ControlAsistencia.Colaboradores.ReingresarColaboradorFunction
 // FechaInicio requeridos.
 // Se descubre via el AddValidatorsFromAssemblyContaining que ComposicionServicios ya configura: no
 // requiere tocar el wiring de DI.
-// STUB (fase roja, issue #350): sin reglas todavia -- el implementer las agrega (precedente
-// TerminarVinculacionValidator, issue #349).
 public class ReingresarColaboradorValidator : AbstractValidator<ReingresarColaborador>
 {
+    public ReingresarColaboradorValidator()
+    {
+        // Cascade(Stop) evita que Must evalue un valor vacio que NotEmpty ya rechazo -- mismo
+        // criterio que TerminarVinculacionValidator.
+        RuleFor(x => x.TipoIdentificacion)
+            .Cascade(CascadeMode.Stop)
+            .NotEmpty()
+            .Must(EsTipoIdentificacionReconocido)
+            .WithMessage("El tipo de identificacion no es uno de los reconocidos");
+
+        RuleFor(x => x.NumeroIdentificacion).NotEmpty();
+
+        RuleFor(x => x.CodigoColaborador).NotEmpty();
+
+        // FechaInicio es REQUERIDA -- el default de DateOnly (0001-01-01) equivale a "no llego"
+        // (doctrina bitemporal del BC: el tiempo de los hechos viene del cliente).
+        RuleFor(x => x.FechaInicio).NotEqual(default(DateOnly));
+    }
+
+    // Consulta la lista cerrada (#348) sin propagar la excepcion de dominio al boundary de
+    // validacion -- un codigo fuera de la lista debe traducirse en un error de FluentValidation
+    // (400), no en una excepcion no controlada.
+    private static bool EsTipoIdentificacionReconocido(string tipo)
+    {
+        try
+        {
+            TipoIdentificacion.Desde(tipo.Trim().ToUpperInvariant());
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+    }
 }

--- a/src/Bitakora.ControlAsistencia.Colaboradores/ReingresarColaboradorFunction/CommandHandler/ReingresarColaboradorValidator.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/ReingresarColaboradorFunction/CommandHandler/ReingresarColaboradorValidator.cs
@@ -1,0 +1,16 @@
+using FluentValidation;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.ReingresarColaboradorFunction.CommandHandler;
+
+// Issue #350: validacion de forma del comando ReingresarColaborador en el borde (MEF-ADR-0004
+// capa 1 -> 400 BadRequest). CA-6: TipoIdentificacion (requerido + en la lista cerrada --
+// normalizar trim+MAYUSCULAS antes de TipoIdentificacion.Desde, mismo criterio de normalizacion de
+// entrada que los demas validators del dominio), NumeroIdentificacion, CodigoColaborador y
+// FechaInicio requeridos.
+// Se descubre via el AddValidatorsFromAssemblyContaining que ComposicionServicios ya configura: no
+// requiere tocar el wiring de DI.
+// STUB (fase roja, issue #350): sin reglas todavia -- el implementer las agrega (precedente
+// TerminarVinculacionValidator, issue #349).
+public class ReingresarColaboradorValidator : AbstractValidator<ReingresarColaborador>
+{
+}

--- a/src/Bitakora.ControlAsistencia.Colaboradores/ReingresarColaboradorFunction/FunctionEndpoint.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/ReingresarColaboradorFunction/FunctionEndpoint.cs
@@ -1,0 +1,46 @@
+using Bitakora.ControlAsistencia.Colaboradores.Infraestructura;
+using Cosmos.EventSourcing.Abstractions.Commands;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.ReingresarColaboradorFunction;
+
+// Issue #350: endpoint HTTP POST para reingresar a un colaborador bajo control de asistencia.
+// MEF-ADR-0006: [Function("ReingresarColaborador")]; carpeta CON sufijo "Function" -- mismo
+// criterio que RegistrarColaboradorFunction/TerminarVinculacionFunction: el record del comando es
+// homonimo del feature folder.
+// Route = "Colaboradores/Reingresos": sub-recurso gemelo de Colaboradores/Terminaciones (#349) --
+// la identificacion viaja en el body porque su representacion ("CC:79543210") contiene ":",
+// hostil como segmento de URL.
+// CA-ADR-0030 / MEF-ADR-0004 (precedente TerminarVinculacionFunction.FunctionEndpoint): validar
+// request (400 via IRequestValidator) -> despachar comando -> InvalidOperationException -> 409
+// Conflict, KeyNotFoundException -> 404 NotFound; exito -> 202 Accepted.
+public class FunctionEndpoint(IRequestValidator requestValidator, ICommandRouter commandRouter)
+{
+    [Function("ReingresarColaborador")]
+    public async Task<IActionResult> Run(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "Colaboradores/Reingresos")]
+        HttpRequest req,
+        CancellationToken ct)
+    {
+        var (comando, error) = await requestValidator.ValidarAsync<ReingresarColaborador>(req, ct);
+        if (error is not null)
+            return error;
+
+        try
+        {
+            await commandRouter.InvokeAsync(comando!, ct);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return new ConflictObjectResult(ex.Message);
+        }
+        catch (KeyNotFoundException ex)
+        {
+            return new NotFoundObjectResult(ex.Message);
+        }
+
+        return new AcceptedResult();
+    }
+}

--- a/src/Bitakora.ControlAsistencia.Colaboradores/ReingresarColaboradorFunction/ReingresarColaborador.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/ReingresarColaboradorFunction/ReingresarColaborador.cs
@@ -1,0 +1,22 @@
+namespace Bitakora.ControlAsistencia.Colaboradores.ReingresarColaboradorFunction;
+
+// Issue #350: comando para reingresar a un colaborador bajo control de asistencia (regreso a rol
+// operativo, recontratacion con el mismo documento) -- tercer comando del ciclo de vida de
+// ColaboradorAggregateRoot (desglose #348-#357). Opera contra el stream EXISTENTE del colaborador:
+// la identificacion es la misma persona, lo que nace es una vinculacion nueva con su propio codigo
+// transaccional.
+// Trigger: HTTP POST, Route: Colaboradores/Reingresos.
+// Payload primitivo -- mismo criterio que TerminarVinculacion/RegistrarColaborador (MEF-ADR-0039
+// decision 6, payload por rol): NUNCA reusa un tipo de Colaboradores.DomainEvents como campo. El
+// handler construye TipoIdentificacion/Identificacion a partir de estos primitivos (parseo tipado
+// unico en el borde, MEF-ADR-0037 seccion 2).
+// SIN nombres (corregir nombres es otra intencion, #351 -- no se mezclan) y SIN motivo (la fuente
+// autoritativa del "por que" es RRHH/nomina, sin lector en este BC) -- payload minimo
+// (identificacion + codigo + fecha), decision de refinamiento 2026-08-11.
+// FechaInicio es REQUERIDA (DateOnly, sin default del servidor) -- doctrina bitemporal del BC: el
+// tiempo de los hechos viene del cliente, nunca del reloj del servidor (CA-4).
+public record ReingresarColaborador(
+    string TipoIdentificacion,
+    string NumeroIdentificacion,
+    string CodigoColaborador,
+    DateOnly FechaInicio);

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/ReingresarColaboradorFunction/ReingresarColaboradorSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/ReingresarColaboradorFunction/ReingresarColaboradorSmokeTests.cs
@@ -1,0 +1,397 @@
+// Issue #350: smoke tests del endpoint POST Colaboradores/Reingresos (reingresar a un colaborador
+// cuya ultima vinculacion ya fue terminada -- regreso a rol operativo, recontratacion con el mismo
+// documento). Molde: TerminarVinculacionSmokeTests (#349) -- mismo comando event-sourcing puro sin
+// consumidores downstream (CA-ADR-0030): sin ServiceBusFixture, la unica verificacion black-box de
+// los efectos del handler es leer mt_events via PostgresFixture.
+//
+// Arrange: ReingresarColaborador exige un ColaboradorAggregateRoot existente con la ultima
+// vinculacion terminada -- el arrange de cada test registra el colaborador y, cuando aplica,
+// termina su vinculacion via los mismos comandos que los originan (#330 y #349), nunca sembrando
+// datos por fuera del API.
+//
+// Evento reutilizado (CA-ADR-0029/MEF-ADR-0039: un evento no conoce su comando): el exito NO crea
+// un tipo nuevo -- persiste otra VinculacionIniciada (tipo persistido "vinculacion_iniciada") en el
+// stream existente "{Tipo}:{Numero}", con el codigo transaccional nuevo del reingreso.
+//
+// CA-1/CA-4 (rutas de exito): 202 + una segunda VinculacionIniciada persistida con el Codigo y la
+// FechaInicio exactos del request -- ya sea sobre una terminacion pasada (CA-1) o sobre un preaviso
+// registrado a futuro (CA-4), sin ninguna validacion contra el reloj del servidor.
+// CA-2/CA-3 (rutas de rechazo): el aggregate declina con resultado (nunca lanza, nunca emite un
+// evento de fallo persistido) y el handler traduce a 409 -- "vinculacion abierta" (nunca terminada,
+// o ya reingresada sin volver a terminar) y "fecha solapa la vinculacion anterior" (FechaInicio
+// igual o anterior a la FechaEfectiva de la ultima terminacion, incluido un preaviso no vencido).
+// CA-5: colaborador inexistente -> 404.
+// CA-6: request invalida -> 400, sin tocar el event store.
+using System.Globalization;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.SmokeTests.Fixtures;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.SmokeTests.ReingresarColaboradorFunction;
+
+public class ReingresarColaboradorSmokeTests(ApiFixture api, PostgresFixture postgres)
+{
+    private readonly HttpClient _client = api.Client;
+
+    private const string RutaRegistrar = "/api/Colaboradores";
+    private const string RutaTerminaciones = "/api/Colaboradores/Terminaciones";
+    private const string RutaReingresos = "/api/Colaboradores/Reingresos";
+    private const string SchemaColaboradores = "colaboradores";
+    private const string TipoEventoVinculacionIniciada = "vinculacion_iniciada";
+    private const string TipoIdentificacionCc = "CC";
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
+
+    // Numero unico por test -- evita colisiones entre ejecuciones repetidas del smoke test: la
+    // identidad del stream es Identificacion.ToString() ("CC:<numero>"), no un Guid nuevo por
+    // llamada, asi que reusar un numero fijo haria que el arrange (RegistrarColaborador) choque con
+    // 409 en la segunda corrida.
+    private static string NuevoNumeroIdentificacion() => Guid.CreateVersion7().ToString("N").ToUpperInvariant();
+
+    private static string NuevoCodigoColaborador() => $"[TEST]-{Guid.CreateVersion7()}";
+
+    private static string ComputarStreamId(string numeroIdentificacion) =>
+        $"{TipoIdentificacionCc}:{numeroIdentificacion}";
+
+    private static string FormatearFecha(DateOnly fecha) =>
+        fecha.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+
+    private static object PayloadRegistro(string numeroIdentificacion, DateOnly fechaInicio) => new
+    {
+        tipoIdentificacion = TipoIdentificacionCc,
+        numeroIdentificacion,
+        primerNombre = "[TEST]",
+        segundoNombre = (string?)null,
+        primerApellido = "Smoke",
+        segundoApellido = (string?)null,
+        codigoColaborador = NuevoCodigoColaborador(),
+        fechaInicio
+    };
+
+    private static object PayloadTerminacion(string numeroIdentificacion, DateOnly fechaEfectiva) => new
+    {
+        tipoIdentificacion = TipoIdentificacionCc,
+        numeroIdentificacion,
+        fechaEfectiva
+    };
+
+    private static object PayloadReingreso(
+        string numeroIdentificacion, string codigoColaborador, DateOnly fechaInicio,
+        string tipoIdentificacion = TipoIdentificacionCc) => new
+        {
+            tipoIdentificacion,
+            numeroIdentificacion,
+            codigoColaborador,
+            fechaInicio
+        };
+
+    // Arrange comun: registra un colaborador con una vinculacion abierta -- via el comando que la
+    // origina (#330), nunca sembrando el event store por fuera del API.
+    private async Task RegistrarColaboradorAsync(
+        string numeroIdentificacion, DateOnly fechaInicio, CancellationToken ct)
+    {
+        var response = await _client.PostAsJsonAsync(
+            RutaRegistrar, PayloadRegistro(numeroIdentificacion, fechaInicio), ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted,
+            "el arrange de este smoke test depende de que RegistrarColaborador funcione");
+    }
+
+    // Arrange comun: cierra la vinculacion vigente -- via el comando que la origina (#349), nunca
+    // sembrando el event store por fuera del API.
+    private async Task TerminarVinculacionAsync(
+        string numeroIdentificacion, DateOnly fechaEfectiva, CancellationToken ct)
+    {
+        var response = await _client.PostAsJsonAsync(
+            RutaTerminaciones, PayloadTerminacion(numeroIdentificacion, fechaEfectiva), ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted,
+            "el arrange de este smoke test depende de que TerminarVinculacion funcione");
+    }
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task DebeEstarDisponible_CuandoSeConsultaHealthCheck()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var response = await _client.GetAsync("/api/health", ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    // CA-1: camino feliz -- ultima vinculacion terminada + FechaInicio estrictamente posterior a la
+    // FechaEfectiva -> 202 y el stream recibe otra VinculacionIniciada con el codigo nuevo del
+    // reingreso. Sin Service Bus (event-sourcing puro): mt_events es la unica ventana black-box a
+    // lo que quedo grabado.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ReingresarColaborador_Retorna202YPersisteVinculacionIniciada_CuandoFechaInicioEsPosteriorATerminacion()
+    {
+        Assert.SkipWhen(!postgres.IsConfigured, postgres.SkipReason ?? "Postgres no disponible.");
+
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion();
+        var fechaInicioOriginal = new DateOnly(2025, 1, 15);
+        var fechaEfectivaTerminacion = new DateOnly(2025, 6, 30);
+        var fechaReingreso = new DateOnly(2025, 7, 1);
+        var codigoReingreso = NuevoCodigoColaborador();
+
+        await RegistrarColaboradorAsync(numeroIdentificacion, fechaInicioOriginal, ct);
+        await TerminarVinculacionAsync(numeroIdentificacion, fechaEfectivaTerminacion, ct);
+
+        var response = await _client.PostAsJsonAsync(
+            RutaReingresos, PayloadReingreso(numeroIdentificacion, codigoReingreso, fechaReingreso), ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+
+        var streamId = ComputarStreamId(numeroIdentificacion);
+
+        var existe = await postgres.ExisteEventoAsync(
+            SchemaColaboradores, streamId, TipoEventoVinculacionIniciada, Timeout,
+            campoJson: "Codigo", valorJson: codigoReingreso);
+
+        existe.Should().BeTrue(
+            $"el evento {TipoEventoVinculacionIniciada} con Codigo {codigoReingreso} deberia existir en el stream {streamId}");
+
+        var eventoPersistido = await postgres.ObtenerEventoAsync<JsonElement>(
+            SchemaColaboradores, streamId, TipoEventoVinculacionIniciada,
+            campoJson: "Codigo", valorJson: codigoReingreso, Timeout);
+
+        eventoPersistido.GetProperty("FechaInicio").GetString().Should().Be(FormatearFecha(fechaReingreso));
+    }
+
+    // CA-4: la ultima terminacion fue un preaviso registrado a futuro y la FechaInicio del reingreso
+    // es posterior a ese preaviso -> 202, sin ninguna consulta al reloj del servidor (doctrina
+    // bitemporal del BC, en cualquier direccion).
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ReingresarColaborador_Retorna202YPersisteVinculacionIniciada_CuandoTerminacionFuePreavisoFuturo()
+    {
+        Assert.SkipWhen(!postgres.IsConfigured, postgres.SkipReason ?? "Postgres no disponible.");
+
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion();
+        var fechaInicioOriginal = new DateOnly(2025, 1, 1);
+        // Preaviso muy en el futuro -- el punto de esta CA es que NINGUNA fecha, sin importar que
+        // tan lejana, se valida contra el reloj del servidor.
+        var fechaEfectivaPreaviso = new DateOnly(2030, 12, 31);
+        var fechaReingreso = new DateOnly(2031, 1, 1);
+        var codigoReingreso = NuevoCodigoColaborador();
+
+        await RegistrarColaboradorAsync(numeroIdentificacion, fechaInicioOriginal, ct);
+        await TerminarVinculacionAsync(numeroIdentificacion, fechaEfectivaPreaviso, ct);
+
+        var response = await _client.PostAsJsonAsync(
+            RutaReingresos, PayloadReingreso(numeroIdentificacion, codigoReingreso, fechaReingreso), ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+
+        var streamId = ComputarStreamId(numeroIdentificacion);
+
+        var existe = await postgres.ExisteEventoAsync(
+            SchemaColaboradores, streamId, TipoEventoVinculacionIniciada, Timeout,
+            campoJson: "Codigo", valorJson: codigoReingreso);
+
+        existe.Should().BeTrue(
+            "el reingreso posterior a un preaviso futuro deberia aceptarse sin validar contra el reloj del servidor");
+    }
+
+    // CA-2: vinculacion abierta -- nunca hubo una terminacion registrada -> 409. No requiere
+    // Postgres: el status code ya prueba que el aggregate declino con resultado y el handler lo
+    // tradujo (CA-ADR-0030).
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ReingresarColaborador_Retorna409_CuandoVinculacionNuncaFueTerminada()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion();
+
+        await RegistrarColaboradorAsync(numeroIdentificacion, new DateOnly(2025, 3, 1), ct);
+
+        var response = await _client.PostAsJsonAsync(
+            RutaReingresos,
+            PayloadReingreso(numeroIdentificacion, NuevoCodigoColaborador(), new DateOnly(2025, 4, 1)),
+            ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    // CA-2: vinculacion abierta -- un reingreso previo tuvo exito y todavia no se termino -> el
+    // segundo reingreso tambien se rechaza (regresion directa del ajuste a Apply(VinculacionIniciada)
+    // que reabre la vinculacion: si no reabriera, este segundo reingreso heredaria en falso la
+    // terminacion de la vinculacion original y se aceptaria).
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ReingresarColaborador_Retorna409_CuandoYaFueReingresadoSinTerminarDeNuevo()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion();
+        var fechaEfectivaTerminacion = new DateOnly(2025, 3, 1);
+        var fechaPrimerReingreso = new DateOnly(2025, 3, 15);
+
+        await RegistrarColaboradorAsync(numeroIdentificacion, new DateOnly(2025, 1, 1), ct);
+        await TerminarVinculacionAsync(numeroIdentificacion, fechaEfectivaTerminacion, ct);
+
+        var primerReingreso = await _client.PostAsJsonAsync(
+            RutaReingresos,
+            PayloadReingreso(numeroIdentificacion, NuevoCodigoColaborador(), fechaPrimerReingreso),
+            ct);
+
+        primerReingreso.StatusCode.Should().Be(HttpStatusCode.Accepted,
+            "el arrange de este smoke test depende de que el primer reingreso funcione");
+
+        var segundoReingreso = await _client.PostAsJsonAsync(
+            RutaReingresos,
+            PayloadReingreso(numeroIdentificacion, NuevoCodigoColaborador(), new DateOnly(2025, 4, 1)),
+            ct);
+
+        segundoReingreso.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    // CA-3: FechaInicio == FechaEfectiva de la ultima terminacion -> 409 -- el mismo dia se rechaza
+    // (el dia de la fecha efectiva pertenece a la vinculacion que termina).
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ReingresarColaborador_Retorna409_CuandoFechaInicioEsIgualAFechaEfectivaDeTerminacion()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion();
+        var fechaEfectivaTerminacion = new DateOnly(2025, 6, 1);
+
+        await RegistrarColaboradorAsync(numeroIdentificacion, new DateOnly(2025, 1, 1), ct);
+        await TerminarVinculacionAsync(numeroIdentificacion, fechaEfectivaTerminacion, ct);
+
+        var response = await _client.PostAsJsonAsync(
+            RutaReingresos,
+            PayloadReingreso(numeroIdentificacion, NuevoCodigoColaborador(), fechaEfectivaTerminacion),
+            ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    // CA-3: FechaInicio anterior a la FechaEfectiva de la ultima terminacion -> 409 por no-solape.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ReingresarColaborador_Retorna409_CuandoFechaInicioEsAnteriorAFechaEfectivaDeTerminacion()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion();
+        var fechaEfectivaTerminacion = new DateOnly(2025, 6, 1);
+        var fechaReingresoAnterior = new DateOnly(2025, 5, 1);
+
+        await RegistrarColaboradorAsync(numeroIdentificacion, new DateOnly(2025, 1, 1), ct);
+        await TerminarVinculacionAsync(numeroIdentificacion, fechaEfectivaTerminacion, ct);
+
+        var response = await _client.PostAsJsonAsync(
+            RutaReingresos,
+            PayloadReingreso(numeroIdentificacion, NuevoCodigoColaborador(), fechaReingresoAnterior),
+            ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    // CA-3: preaviso no vencido -- la ultima terminacion es un preaviso a futuro y la FechaInicio
+    // del reingreso no supera esa fecha futura -> 409 (el preaviso deja "no abierta" la vinculacion,
+    // pero la fecha del reingreso sigue exigiendo ser estrictamente posterior a la FechaEfectiva).
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ReingresarColaborador_Retorna409_CuandoFechaInicioNoSuperaElPreavisoNoVencido()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion();
+        var fechaEfectivaPreaviso = new DateOnly(2030, 12, 31);
+        var fechaReingresoAnteriorAlPreaviso = new DateOnly(2026, 1, 1);
+
+        await RegistrarColaboradorAsync(numeroIdentificacion, new DateOnly(2025, 1, 1), ct);
+        await TerminarVinculacionAsync(numeroIdentificacion, fechaEfectivaPreaviso, ct);
+
+        var response = await _client.PostAsJsonAsync(
+            RutaReingresos,
+            PayloadReingreso(numeroIdentificacion, NuevoCodigoColaborador(), fechaReingresoAnteriorAlPreaviso),
+            ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    // CA-5: colaborador inexistente -> 404, sin escribir nada al event store (no hay stream para
+    // consultar: la ausencia de escritura la garantiza el propio 404 -- el handler lanza antes de
+    // llegar al aggregate).
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ReingresarColaborador_Retorna404_CuandoColaboradorNoExiste()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion(); // nunca registrado
+
+        var response = await _client.PostAsJsonAsync(
+            RutaReingresos,
+            PayloadReingreso(numeroIdentificacion, NuevoCodigoColaborador(), new DateOnly(2025, 3, 1)),
+            ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    // CA-6: CodigoColaborador vacio -> 400.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ReingresarColaborador_Retorna400_CuandoCodigoColaboradorEsVacio()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var payload = PayloadReingreso(
+            NuevoNumeroIdentificacion(), codigoColaborador: "", new DateOnly(2025, 3, 1));
+
+        var response = await _client.PostAsJsonAsync(RutaReingresos, payload, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    // CA-6: FechaInicio vacia (default de DateOnly, "no llego" segun la doctrina bitemporal del BC)
+    // -> 400.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ReingresarColaborador_Retorna400_CuandoFechaInicioEsVacia()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var payload = new
+        {
+            tipoIdentificacion = TipoIdentificacionCc,
+            numeroIdentificacion = NuevoNumeroIdentificacion(),
+            codigoColaborador = NuevoCodigoColaborador(),
+            fechaInicio = default(DateOnly)
+        };
+
+        var response = await _client.PostAsJsonAsync(RutaReingresos, payload, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    // CA-6: NumeroIdentificacion vacio -> 400.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ReingresarColaborador_Retorna400_CuandoNumeroIdentificacionEsVacio()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var payload = PayloadReingreso(
+            numeroIdentificacion: "", NuevoCodigoColaborador(), new DateOnly(2025, 3, 1));
+
+        var response = await _client.PostAsJsonAsync(RutaReingresos, payload, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    // CA-6: TipoIdentificacion fuera de la lista cerrada (PILA: CC, CE, TI, PA, PT) -> 400.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ReingresarColaborador_Retorna400_CuandoTipoIdentificacionNoEsReconocido()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var payload = PayloadReingreso(
+            NuevoNumeroIdentificacion(), NuevoCodigoColaborador(), new DateOnly(2025, 3, 1),
+            tipoIdentificacion: "XX");
+
+        var response = await _client.PostAsJsonAsync(RutaReingresos, payload, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ReingresarColaboradorFunction/FunctionEndpointTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ReingresarColaboradorFunction/FunctionEndpointTests.cs
@@ -1,0 +1,143 @@
+// Issue #350: tests del endpoint HTTP POST Colaboradores/Reingresos (reingresar a un colaborador).
+// CA-ADR-0030 / MEF-ADR-0004: InvalidOperationException -> 409, KeyNotFoundException -> 404,
+// exito -> 202. Precedente: TerminarVinculacionFunction.FunctionEndpoint.
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.Infraestructura;
+using Bitakora.ControlAsistencia.Colaboradores.ReingresarColaboradorFunction;
+using Cosmos.EventSourcing.Abstractions.Commands;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Tests.ReingresarColaboradorFunction;
+
+public class FunctionEndpointTests
+{
+    private static ReingresarColaborador ComandoValido() => new(
+        TipoIdentificacion: "CC",
+        NumeroIdentificacion: "79543210",
+        CodigoColaborador: "COL-002",
+        FechaInicio: new DateOnly(2026, 6, 2));
+
+    private static HttpRequest FakeHttpRequest()
+    {
+        var context = new DefaultHttpContext();
+        return context.Request;
+    }
+
+    // CA-1: POST exitoso retorna 202 Accepted
+    [Fact]
+    public async Task ReingresarColaborador_Retorna202_CuandoComandoEsValido()
+    {
+        var validator = new FakeReingresarColaboradorRequestValidator(ComandoValido());
+        var router = new FakeReingresarColaboradorCommandRouter();
+        var function = new FunctionEndpoint(validator, router);
+
+        var result = await function.Run(FakeHttpRequest(), CancellationToken.None);
+
+        result.Should().BeOfType<AcceptedResult>();
+    }
+
+    // CA-2/CA-3: violacion de la invariante de no-solape (vinculacion abierta / fecha solapa la
+    // anterior) retorna 409 Conflict.
+    [Fact]
+    public async Task ReingresarColaborador_Retorna409_CuandoLaVinculacionVigenteEstaAbierta()
+    {
+        var validator = new FakeReingresarColaboradorRequestValidator(ComandoValido());
+        var router = new FakeReingresarColaboradorCommandRouter(
+            lanzar: new InvalidOperationException(
+                "La vinculacion vigente del colaborador no tiene una terminacion registrada"));
+        var function = new FunctionEndpoint(validator, router);
+
+        var result = await function.Run(FakeHttpRequest(), CancellationToken.None);
+
+        result.Should().BeOfType<ConflictObjectResult>();
+    }
+
+    // CA-5: colaborador inexistente retorna 404 Not Found
+    [Fact]
+    public async Task ReingresarColaborador_Retorna404_CuandoColaboradorNoExiste()
+    {
+        var validator = new FakeReingresarColaboradorRequestValidator(ComandoValido());
+        var router = new FakeReingresarColaboradorCommandRouter(
+            lanzar: new KeyNotFoundException("No existe un colaborador registrado con esa identificacion"));
+        var function = new FunctionEndpoint(validator, router);
+
+        var result = await function.Run(FakeHttpRequest(), CancellationToken.None);
+
+        result.Should().BeOfType<NotFoundObjectResult>();
+    }
+
+    // CA-6: request invalida (sin CodigoColaborador, sin FechaInicio, sin identificacion, tipo
+    // fuera de la lista cerrada) retorna 400 Bad Request
+    [Fact]
+    public async Task ReingresarColaborador_Retorna400_CuandoRequestEsInvalido()
+    {
+        var errorDeValidacion = new BadRequestObjectResult("El body es invalido o esta malformado");
+        var validator = new FakeReingresarColaboradorRequestValidator(error: errorDeValidacion);
+        var router = new FakeReingresarColaboradorCommandRouter();
+        var function = new FunctionEndpoint(validator, router);
+
+        var result = await function.Run(FakeHttpRequest(), CancellationToken.None);
+
+        result.Should().BeOfType<BadRequestObjectResult>();
+    }
+}
+
+// ---- Fakes manuales - NO NSubstitute ----
+
+/// <summary>
+/// Fake configurable de IRequestValidator. Retorna un comando pre-configurado o un error segun lo
+/// que se le pase en el constructor.
+/// </summary>
+internal class FakeReingresarColaboradorRequestValidator : IRequestValidator
+{
+    private readonly ReingresarColaborador? _comando;
+    private readonly IActionResult? _error;
+
+    public FakeReingresarColaboradorRequestValidator(
+        ReingresarColaborador? comando = null,
+        IActionResult? error = null)
+    {
+        _comando = comando;
+        _error = error;
+    }
+
+    public Task<(T? Comando, IActionResult? Error)> ValidarAsync<T>(
+        HttpRequest req, CancellationToken ct)
+    {
+        if (_error is not null)
+            return Task.FromResult<(T?, IActionResult?)>((default, _error));
+
+        if (_comando is T resultado)
+            return Task.FromResult<(T?, IActionResult?)>((resultado, null));
+
+        return Task.FromResult<(T?, IActionResult?)>((default, null));
+    }
+}
+
+/// <summary>
+/// Fake configurable de ICommandRouter. Puede completar exitosamente o lanzar la excepcion
+/// configurada (InvalidOperationException -> 409, KeyNotFoundException -> 404).
+/// </summary>
+internal class FakeReingresarColaboradorCommandRouter : ICommandRouter
+{
+    private readonly Exception? _excepcion;
+
+    public FakeReingresarColaboradorCommandRouter(Exception? lanzar = null) =>
+        _excepcion = lanzar;
+
+    public Task InvokeAsync<TCommand>(TCommand command, CancellationToken ct = default)
+        where TCommand : class
+    {
+        if (_excepcion is not null)
+            throw _excepcion;
+
+        return Task.CompletedTask;
+    }
+
+    public Task<TResult> InvokeAsync<TCommand, TResult>(
+        TCommand command, CancellationToken ct = default)
+        where TCommand : class
+        => throw new NotImplementedException();
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ReingresarColaboradorFunction/ReingresarColaboradorCommandHandlerMensajesTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ReingresarColaboradorFunction/ReingresarColaboradorCommandHandlerMensajesTests.cs
@@ -1,0 +1,24 @@
+// Issue #350: guardrail de resolucion del .resx del handler (MEF-ADR-0009), gemelo del que
+// TerminarVinculacionCommandHandlerMensajesTests.cs aplica.
+//
+// Por que existe: ReingresarColaboradorCommandHandler.Mensajes devuelve
+// ResourceManager.GetString(...)! -- el "!" es supresion del compilador, no garantia de runtime. Si
+// la CLAVE desaparece del .resx (rename, merge que la pierde) GetString retorna null en silencio y
+// los tests del handler pasan en FALSO: sus aserciones son WithMessage($"*{Mensajes.X}*"), que con
+// X == null se vuelve "**" y matchea cualquier excepcion.
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.ReingresarColaboradorFunction.CommandHandler;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Tests.ReingresarColaboradorFunction;
+
+public class ReingresarColaboradorCommandHandlerMensajesTests
+{
+    [Fact]
+    public void Mensajes_ResuelvenTextoNoVacio_CuandoPertenecenAReingresarColaboradorCommandHandler()
+    {
+        ReingresarColaboradorCommandHandler.Mensajes.ColaboradorNoEncontrado.Should().NotBeNullOrWhiteSpace();
+        ReingresarColaboradorCommandHandler.Mensajes.VinculacionAbierta.Should().NotBeNullOrWhiteSpace();
+        ReingresarColaboradorCommandHandler.Mensajes.FechaSolapaVinculacionAnterior.Should().NotBeNullOrWhiteSpace();
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ReingresarColaboradorFunction/ReingresarColaboradorCommandHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ReingresarColaboradorFunction/ReingresarColaboradorCommandHandlerTests.cs
@@ -1,0 +1,212 @@
+// Issue #350: reingresar a un colaborador -- tercer comando del ciclo de vida de
+// ColaboradorAggregateRoot (desglose #348-#357) y primer ejercicio real de la invariante de
+// no-solape. CA-ADR-0030: el aggregate declina con resultado (nunca lanza, nunca emite evento de
+// fallo); el handler traduce la razon a InvalidOperationException (409) o KeyNotFoundException
+// (404). El evento de exito es VinculacionIniciada, EL MISMO del registro (#330) -- cero tipos
+// nuevos (CA-ADR-0029: un evento no conoce su comando).
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+using Bitakora.ControlAsistencia.Colaboradores.Entities;
+using Bitakora.ControlAsistencia.Colaboradores.ReingresarColaboradorFunction;
+using Bitakora.ControlAsistencia.Colaboradores.ReingresarColaboradorFunction.CommandHandler;
+using Cosmos.EventSourcing.Abstractions.Commands;
+using Cosmos.EventSourcing.Testing.Utilities;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Tests.ReingresarColaboradorFunction;
+
+// El aggregate usa un stream ID compuesto (Identificacion.ToString(), "CC:79543210"), no el
+// GuidAggregateId del harness -- overloads explicitos de Given/Then/And (regla 18 del
+// test-writer, mismo criterio que TerminarVinculacionCommandHandlerTests).
+public class ReingresarColaboradorCommandHandlerTests : CommandHandlerAsyncTest<ReingresarColaborador>
+{
+    private const string NumeroValido = "79543210";
+
+    // Oraculo independiente de la clave de stream (MEF-ADR-0002 + MEF-ADR-0037): literal, no
+    // derivado de ColaboradorAggregateRoot.ComputarStreamId.
+    private const string StreamIdEsperado = "CC:79543210";
+
+    private const string CodigoVinculacionOriginal = "COL-001";
+    private const string CodigoReingreso = "COL-002";
+    private static readonly DateOnly FechaInicioOriginal = new(2026, 1, 15);
+    private static readonly DateOnly FechaEfectivaTerminacionOriginal = new(2026, 6, 1);
+    private static readonly DateOnly FechaInicioReingresoValida =
+        FechaEfectivaTerminacionOriginal.AddDays(1);
+
+    protected override ICommandHandlerAsync<ReingresarColaborador> Handler =>
+        new ReingresarColaboradorCommandHandler(EventStore);
+
+    private static ReingresarColaborador ComandoValido() => new(
+        TipoIdentificacion: "CC",
+        NumeroIdentificacion: NumeroValido,
+        CodigoColaborador: CodigoReingreso,
+        FechaInicio: FechaInicioReingresoValida);
+
+    private static Identificacion IdentificacionValida() =>
+        Identificacion.Crear(TipoIdentificacion.CC, NumeroValido);
+
+    private static NombreColaborador NombreValido() =>
+        NombreColaborador.Crear("Luis", "Augusto", "Barreto", null);
+
+    private static ColaboradorRegistrado ColaboradorRegistradoValido() =>
+        new(IdentificacionValida(), NombreValido());
+
+    private static VinculacionIniciada VinculacionIniciadaOriginal() =>
+        new(CodigoVinculacionOriginal, FechaInicioOriginal);
+
+    // Precondicion: colaborador registrado con una vinculacion abierta (sin terminacion) -- CA-2
+    // (vinculacion abierta desde el registro, nunca terminada).
+    private void DadoUnColaboradorConVinculacionAbierta() =>
+        Given(StreamIdEsperado, ColaboradorRegistradoValido(), VinculacionIniciadaOriginal());
+
+    // Precondicion: colaborador registrado con la vinculacion original ya terminada en la fecha
+    // dada -- base de CA-1, CA-3 y CA-4 (la fecha puede ser un registro tardio o un preaviso).
+    private void DadoUnColaboradorConVinculacionTerminada(DateOnly fechaEfectiva) =>
+        Given(StreamIdEsperado,
+            ColaboradorRegistradoValido(),
+            VinculacionIniciadaOriginal(),
+            new VinculacionTerminada(fechaEfectiva));
+
+    // CA-1: colaborador con la ultima vinculacion terminada + FechaInicio estrictamente posterior
+    // a la FechaEfectiva -> el stream recibe VinculacionIniciada con el codigo nuevo; el aggregate
+    // rehidratado refleja vinculacion abierta (codigo nuevo, sin terminacion registrada). Este es
+    // el ajuste que #350 exige sobre Apply(VinculacionIniciada): debe reabrir la vinculacion.
+    [Fact]
+    public async Task ReingresarColaborador_EmiteVinculacionIniciada_CuandoFechaInicioEsPosteriorALaTerminacion()
+    {
+        DadoUnColaboradorConVinculacionTerminada(FechaEfectivaTerminacionOriginal);
+
+        await WhenAsync(ComandoValido());
+
+        Then(StreamIdEsperado, new VinculacionIniciada(CodigoReingreso, FechaInicioReingresoValida));
+        And<ColaboradorAggregateRoot, string>(
+            StreamIdEsperado, c => c.CodigoVinculacionVigente, CodigoReingreso);
+        And<ColaboradorAggregateRoot, DateOnly>(
+            StreamIdEsperado, c => c.FechaInicioVinculacionVigente, FechaInicioReingresoValida);
+        And<ColaboradorAggregateRoot, DateOnly?>(
+            StreamIdEsperado, c => c.FechaTerminacionVinculacionVigente, null);
+    }
+
+    // CA-2: la vinculacion vigente esta abierta (recien registrada, nunca terminada) -> 409,
+    // ningun evento nuevo en el stream, el estado conserva el codigo original.
+    [Fact]
+    public async Task ReingresarColaborador_LanzaInvalidOperationException_CuandoLaVinculacionVigenteEstaAbierta()
+    {
+        DadoUnColaboradorConVinculacionAbierta();
+
+        var act = async () => await WhenAsync(ComandoValido());
+
+        await act.Should().ThrowExactlyAsync<InvalidOperationException>()
+            .WithMessage($"*{ReingresarColaboradorCommandHandler.Mensajes.VinculacionAbierta}*");
+        Then(StreamIdEsperado);
+        And<ColaboradorAggregateRoot, string>(
+            StreamIdEsperado, c => c.CodigoVinculacionVigente, CodigoVinculacionOriginal);
+    }
+
+    // CA-2 (segunda variante): un reingreso previo sigue abierto (ciclo completo
+    // registro-terminacion-reingreso) -> 409 igual, la invariante de no-solape aplica sobre
+    // CUALQUIER vinculacion vigente sin terminar, no solo la primera.
+    [Fact]
+    public async Task ReingresarColaborador_LanzaInvalidOperationException_CuandoElReingresoPrevioSigueAbierto()
+    {
+        Given(StreamIdEsperado,
+            ColaboradorRegistradoValido(),
+            VinculacionIniciadaOriginal(),
+            new VinculacionTerminada(FechaEfectivaTerminacionOriginal),
+            new VinculacionIniciada(CodigoReingreso, FechaInicioReingresoValida));
+
+        var segundoReingreso = ComandoValido() with { CodigoColaborador = "COL-003" };
+        var act = async () => await WhenAsync(segundoReingreso);
+
+        await act.Should().ThrowExactlyAsync<InvalidOperationException>()
+            .WithMessage($"*{ReingresarColaboradorCommandHandler.Mensajes.VinculacionAbierta}*");
+        Then(StreamIdEsperado);
+        And<ColaboradorAggregateRoot, string>(
+            StreamIdEsperado, c => c.CodigoVinculacionVigente, CodigoReingreso);
+    }
+
+    // CA-3: FechaInicio igual a la FechaEfectiva de la ultima terminacion -> 409 por no-solape (el
+    // mismo dia se rechaza -- el dia de la fecha efectiva pertenece a la vinculacion que termina).
+    [Fact]
+    public async Task ReingresarColaborador_LanzaInvalidOperationException_CuandoFechaInicioEsIgualALaFechaEfectivaDeTerminacion()
+    {
+        DadoUnColaboradorConVinculacionTerminada(FechaEfectivaTerminacionOriginal);
+
+        var act = async () => await WhenAsync(
+            ComandoValido() with { FechaInicio = FechaEfectivaTerminacionOriginal });
+
+        await act.Should().ThrowExactlyAsync<InvalidOperationException>()
+            .WithMessage($"*{ReingresarColaboradorCommandHandler.Mensajes.FechaSolapaVinculacionAnterior}*");
+        Then(StreamIdEsperado);
+        And<ColaboradorAggregateRoot, string>(
+            StreamIdEsperado, c => c.CodigoVinculacionVigente, CodigoVinculacionOriginal);
+    }
+
+    // CA-3 (segunda direccion): FechaInicio anterior a la FechaEfectiva de terminacion -> 409
+    // igual, con mayor margen de solape.
+    [Fact]
+    public async Task ReingresarColaborador_LanzaInvalidOperationException_CuandoFechaInicioEsAnteriorALaFechaEfectivaDeTerminacion()
+    {
+        DadoUnColaboradorConVinculacionTerminada(FechaEfectivaTerminacionOriginal);
+        var fechaAnterior = FechaEfectivaTerminacionOriginal.AddDays(-1);
+
+        var act = async () => await WhenAsync(ComandoValido() with { FechaInicio = fechaAnterior });
+
+        await act.Should().ThrowExactlyAsync<InvalidOperationException>()
+            .WithMessage($"*{ReingresarColaboradorCommandHandler.Mensajes.FechaSolapaVinculacionAnterior}*");
+        Then(StreamIdEsperado);
+        And<ColaboradorAggregateRoot, string>(
+            StreamIdEsperado, c => c.CodigoVinculacionVigente, CodigoVinculacionOriginal);
+    }
+
+    // CA-3 (preaviso no vencido): un preaviso con fecha futura ya registrado bloquea el reingreso
+    // si su FechaInicio no supera la fecha del preaviso -- la regla de no-solape se compone sin
+    // reloj (decision de refinamiento 2026-08-11).
+    [Fact]
+    public async Task ReingresarColaborador_LanzaInvalidOperationException_CuandoFechaInicioNoSuperaElPreavisoRegistrado()
+    {
+        var fechaPreavisoFutura = new DateOnly(2030, 1, 1);
+        DadoUnColaboradorConVinculacionTerminada(fechaPreavisoFutura);
+
+        var act = async () => await WhenAsync(ComandoValido() with { FechaInicio = fechaPreavisoFutura });
+
+        await act.Should().ThrowExactlyAsync<InvalidOperationException>()
+            .WithMessage($"*{ReingresarColaboradorCommandHandler.Mensajes.FechaSolapaVinculacionAnterior}*");
+        Then(StreamIdEsperado);
+        And<ColaboradorAggregateRoot, string>(
+            StreamIdEsperado, c => c.CodigoVinculacionVigente, CodigoVinculacionOriginal);
+    }
+
+    // CA-4: un reingreso con FechaInicio posterior a la fecha del preaviso registrado procede sin
+    // ninguna consulta al reloj del servidor -- el preaviso se resuelve componiendo CA-2 (no
+    // abierta) + CA-3 (no-solape), sin regla nueva.
+    [Fact]
+    public async Task ReingresarColaborador_EmiteVinculacionIniciada_CuandoFechaInicioEsPosteriorAlPreavisoRegistrado()
+    {
+        var fechaPreavisoFutura = new DateOnly(2030, 1, 1);
+        var fechaInicioReingreso = fechaPreavisoFutura.AddDays(1);
+        DadoUnColaboradorConVinculacionTerminada(fechaPreavisoFutura);
+
+        await WhenAsync(ComandoValido() with { FechaInicio = fechaInicioReingreso });
+
+        Then(StreamIdEsperado, new VinculacionIniciada(CodigoReingreso, fechaInicioReingreso));
+        And<ColaboradorAggregateRoot, string>(
+            StreamIdEsperado, c => c.CodigoVinculacionVigente, CodigoReingreso);
+        And<ColaboradorAggregateRoot, DateOnly?>(
+            StreamIdEsperado, c => c.FechaTerminacionVinculacionVigente, null);
+    }
+
+    // CA-5: colaborador inexistente -> 404 (KeyNotFoundException), sin escribir nada al event
+    // store. Sin Given: el stream no existe. Sin And<>: el aggregate no existe en el TestStore
+    // (GetAggregateRoot retorna null) -- Then sin eventos esperados ya demuestra "sin escribir
+    // nada al event store" (mismo precedente que TerminarVinculacionCommandHandlerTests CA-5).
+    [Fact]
+    public async Task ReingresarColaborador_LanzaKeyNotFoundException_CuandoColaboradorNoExiste()
+    {
+        var act = async () => await WhenAsync(ComandoValido());
+
+        await act.Should().ThrowExactlyAsync<KeyNotFoundException>()
+            .WithMessage($"*{ReingresarColaboradorCommandHandler.Mensajes.ColaboradorNoEncontrado}*");
+        Then(StreamIdEsperado);
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ReingresarColaboradorFunction/ReingresarColaboradorCommandHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ReingresarColaboradorFunction/ReingresarColaboradorCommandHandlerTests.cs
@@ -87,6 +87,29 @@ public class ReingresarColaboradorCommandHandlerTests : CommandHandlerAsyncTest<
             StreamIdEsperado, c => c.FechaTerminacionVinculacionVigente, null);
     }
 
+    // CA-1 (borde de identidad, MEF-ADR-0037): "cc" en minusculas + numero con espacios sobre un
+    // colaborador ya registrado -> el reingreso alcanza el MISMO stream ("CC:79543210") y tiene
+    // exito. La normalizacion del numero la garantiza Identificacion.Crear (#348); la del codigo de
+    // tipo ("cc" -> "CC") es responsabilidad del handler en el borde, porque TipoIdentificacion.Desde
+    // es case-sensitive por diseno (#348). Sin ella el handler computaria otra clave y responderia
+    // 404 sobre un colaborador que si existe.
+    [Fact]
+    public async Task ReingresarColaborador_EmiteVinculacionIniciada_CuandoTipoYNumeroLleganSinNormalizar()
+    {
+        DadoUnColaboradorConVinculacionTerminada(FechaEfectivaTerminacionOriginal);
+        var comandoSinNormalizar = ComandoValido() with
+        {
+            TipoIdentificacion = "cc",
+            NumeroIdentificacion = "  79543210  "
+        };
+
+        await WhenAsync(comandoSinNormalizar);
+
+        Then(StreamIdEsperado, new VinculacionIniciada(CodigoReingreso, FechaInicioReingresoValida));
+        And<ColaboradorAggregateRoot, string>(
+            StreamIdEsperado, c => c.CodigoVinculacionVigente, CodigoReingreso);
+    }
+
     // CA-2: la vinculacion vigente esta abierta (recien registrada, nunca terminada) -> 409,
     // ningun evento nuevo en el stream, el estado conserva el codigo original.
     [Fact]

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ReingresarColaboradorFunction/ReingresarColaboradorValidatorTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ReingresarColaboradorFunction/ReingresarColaboradorValidatorTests.cs
@@ -1,0 +1,111 @@
+// Issue #350: validacion de forma del comando ReingresarColaborador en el borde (CA-6).
+// Patron de referencia: TerminarVinculacionValidatorTests (ValidateAsync + verificacion de
+// PropertyName en resultado.Errors).
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.ReingresarColaboradorFunction;
+using Bitakora.ControlAsistencia.Colaboradores.ReingresarColaboradorFunction.CommandHandler;
+using FluentValidation.Results;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Tests.ReingresarColaboradorFunction;
+
+public class ReingresarColaboradorValidatorTests
+{
+    private readonly ReingresarColaboradorValidator _validator = new();
+
+    private static ReingresarColaborador ComandoValido() => new(
+        TipoIdentificacion: "CC",
+        NumeroIdentificacion: "79543210",
+        CodigoColaborador: "COL-002",
+        FechaInicio: new DateOnly(2026, 6, 2));
+
+    private Task<ValidationResult> Validar(ReingresarColaborador comando) =>
+        _validator.ValidateAsync(comando, TestContext.Current.CancellationToken);
+
+    // Camino feliz -- todos los campos correctos
+    [Fact]
+    public async Task Validar_Aprueba_CuandoTodosLosCamposSonCorrectos()
+    {
+        var resultado = await Validar(ComandoValido());
+
+        resultado.IsValid.Should().BeTrue();
+    }
+
+    // CA-6: TipoIdentificacion vacio produce 400
+    [Fact]
+    public async Task Validar_RechazaTipoIdentificacion_CuandoEstaVacio()
+    {
+        var resultado = await Validar(ComandoValido() with { TipoIdentificacion = "" });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e =>
+            e.PropertyName == nameof(ReingresarColaborador.TipoIdentificacion));
+    }
+
+    // CA-6: TipoIdentificacion fuera de la lista cerrada (PILA: CC/CE/TI/PA/PT) produce 400, no 500
+    [Fact]
+    public async Task Validar_RechazaTipoIdentificacion_CuandoNoEstaEnLaListaCerrada()
+    {
+        var resultado = await Validar(ComandoValido() with { TipoIdentificacion = "XX" });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e =>
+            e.PropertyName == nameof(ReingresarColaborador.TipoIdentificacion));
+    }
+
+    // TipoIdentificacion en minusculas ("cc") DEBE seguir siendo valido -- la normalizacion de
+    // entrada (trim+MAYUSCULAS antes de TipoIdentificacion.Desde) es responsabilidad del borde, no
+    // un rechazo (mismo criterio que los demas validators del dominio).
+    [Fact]
+    public async Task Validar_Aprueba_CuandoTipoIdentificacionLlegaEnMinusculas()
+    {
+        var resultado = await Validar(ComandoValido() with { TipoIdentificacion = "cc" });
+
+        resultado.IsValid.Should().BeTrue();
+    }
+
+    // CA-6: NumeroIdentificacion vacio produce 400
+    [Fact]
+    public async Task Validar_RechazaNumeroIdentificacion_CuandoEstaVacio()
+    {
+        var resultado = await Validar(ComandoValido() with { NumeroIdentificacion = "" });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e =>
+            e.PropertyName == nameof(ReingresarColaborador.NumeroIdentificacion));
+    }
+
+    // CA-6: CodigoColaborador vacio produce 400 -- el reingreso siempre trae su propio codigo
+    // transaccional.
+    [Fact]
+    public async Task Validar_RechazaCodigoColaborador_CuandoEstaVacio()
+    {
+        var resultado = await Validar(ComandoValido() with { CodigoColaborador = "" });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e =>
+            e.PropertyName == nameof(ReingresarColaborador.CodigoColaborador));
+    }
+
+    // CA-6: FechaInicio con el valor default de DateOnly produce 400 -- REQUERIDA, sin default del
+    // servidor (doctrina bitemporal del BC: el tiempo de los hechos viene del cliente).
+    [Fact]
+    public async Task Validar_RechazaFechaInicio_CuandoEsDefault()
+    {
+        var resultado = await Validar(ComandoValido() with { FechaInicio = default });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e =>
+            e.PropertyName == nameof(ReingresarColaborador.FechaInicio));
+    }
+
+    // FechaInicio futura DEBE seguir siendo valida en la capa de forma -- la regla de no-solape es
+    // del aggregate (CA-3/CA-4), nunca del validator.
+    [Fact]
+    public async Task Validar_Aprueba_CuandoFechaInicioEsFutura()
+    {
+        var resultado = await Validar(ComandoValido() with { FechaInicio = new DateOnly(2030, 1, 1) });
+
+        resultado.IsValid.Should().BeTrue();
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/TerminarVinculacionFunction/TerminarVinculacionCommandHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/TerminarVinculacionFunction/TerminarVinculacionCommandHandlerTests.cs
@@ -168,6 +168,52 @@ public class TerminarVinculacionCommandHandlerTests : CommandHandlerAsyncTest<Te
             StreamIdEsperado, c => c.FechaTerminacionVinculacionVigente, FechaInicioVinculacionVigente);
     }
 
+    // Cierre del ciclo completo (issue #350): la vinculacion vigente nacio de un reingreso, no del
+    // registro. Terminarla vuelve a ser posible porque Apply(VinculacionIniciada) reabre la
+    // vinculacion al re-aplicarse -- sin ese reset, este comando chocaria contra la terminacion
+    // heredada de la vinculacion anterior y responderia 409.
+    [Fact]
+    public async Task TerminarVinculacion_EmiteVinculacionTerminada_CuandoLaVinculacionVigenteNacioDeUnReingreso()
+    {
+        var fechaTerminacionAnterior = new DateOnly(2026, 3, 1);
+        var fechaInicioReingreso = new DateOnly(2026, 4, 1);
+        Given(StreamIdEsperado,
+            ColaboradorRegistradoValido(),
+            VinculacionIniciadaVigente(),
+            new VinculacionTerminada(fechaTerminacionAnterior),
+            new VinculacionIniciada("COL-002", fechaInicioReingreso));
+
+        await WhenAsync(ComandoValido());
+
+        Then(StreamIdEsperado, new VinculacionTerminada(FechaEfectivaValida));
+        And<ColaboradorAggregateRoot, DateOnly?>(
+            StreamIdEsperado, c => c.FechaTerminacionVinculacionVigente, FechaEfectivaValida);
+    }
+
+    // Cierre del ciclo completo (issue #350), segunda direccion: la ventana de fechas validas se
+    // mueve con el reingreso. Una FechaEfectiva posterior al inicio ORIGINAL pero anterior al inicio
+    // del REINGRESO produce duracion negativa sobre la vinculacion vigente -> 409.
+    [Fact]
+    public async Task TerminarVinculacion_LanzaInvalidOperationException_CuandoFechaEfectivaEsAnteriorAlInicioDelReingreso()
+    {
+        var fechaTerminacionAnterior = new DateOnly(2026, 3, 1);
+        var fechaInicioReingreso = new DateOnly(2026, 4, 1);
+        Given(StreamIdEsperado,
+            ColaboradorRegistradoValido(),
+            VinculacionIniciadaVigente(),
+            new VinculacionTerminada(fechaTerminacionAnterior),
+            new VinculacionIniciada("COL-002", fechaInicioReingreso));
+
+        var act = async () => await WhenAsync(
+            ComandoValido() with { FechaEfectiva = fechaInicioReingreso.AddDays(-1) });
+
+        await act.Should().ThrowExactlyAsync<InvalidOperationException>()
+            .WithMessage($"*{TerminarVinculacionCommandHandler.Mensajes.FechaAnteriorAInicio}*");
+        Then(StreamIdEsperado);
+        And<ColaboradorAggregateRoot, DateOnly?>(
+            StreamIdEsperado, c => c.FechaTerminacionVinculacionVigente, null);
+    }
+
     // CA-5: colaborador inexistente -> 404 (KeyNotFoundException), sin escribir nada al event
     // store. Sin Given: el stream no existe. Sin And<>: el aggregate no existe en el TestStore
     // (GetAggregateRoot retorna null), invocarlo lanzaria ArgumentNullException -- Then sin


### PR DESCRIPTION
## Resumen

Pipeline TDD completado:
- Fase roja: tests escritos con stubs
- Fase verde: implementación completa
- Smoke tests: escritos para endpoints detectados
- Fase refactor: revisión de calidad

## Decisiones del pipeline

<details>
<summary>Test Writer (fase roja) — 11m 27s</summary>

## ES Test Writer - Decisiones

### Tests creados

- `ReingresarColaboradorCommandHandlerTests.cs`: 8 tests (ejercitan handler + aggregate juntos,
  mismo patron que `TerminarVinculacionCommandHandlerTests`, stream ID compuesto `"CC:79543210"`)
  - `ReingresarColaborador_EmiteVinculacionIniciada_CuandoFechaInicioEsPosteriorALaTerminacion` - CA-1
  - `ReingresarColaborador_LanzaInvalidOperationException_CuandoLaVinculacionVigenteEstaAbierta` - CA-2
  - `ReingresarColaborador_LanzaInvalidOperationException_CuandoElReingresoPrevioSigueAbierto` - CA-2 (segunda variante: ciclo completo registro-terminacion-reingreso)
  - `ReingresarColaborador_LanzaInvalidOperationException_CuandoFechaInicioEsIgualALaFechaEfectivaDeTerminacion` - CA-3
  - `ReingresarColaborador_LanzaInvalidOperationException_CuandoFechaInicioEsAnteriorALaFechaEfectivaDeTerminacion` - CA-3
  - `ReingresarColaborador_LanzaInvalidOperationException_CuandoFechaInicioNoSuperaElPreavisoRegistrado` - CA-3 (preaviso no vencido)
  - `ReingresarColaborador_EmiteVinculacionIniciada_CuandoFechaInicioEsPosteriorAlPreavisoRegistrado` - CA-4
  - `ReingresarColaborador_LanzaKeyNotFoundException_CuandoColaboradorNoExiste` - CA-5
- `ReingresarColaboradorValidatorTests.cs`: 8 tests - CA-6 (forma del comando)
- `FunctionEndpointTests.cs`: 4 tests - traduccion de excepciones a codigos HTTP (202/409/404/400)
- `ReingresarColaboradorCommandHandlerMensajesTests.cs`: 1 test - guardrail de resolucion .resx
  (gemelo del que `TerminarVinculacionCommandHandlerMensajesTests` aplica)

### Estructura elegida

- Una sola clase de tests (`ReingresarColaboradorCommandHandlerTests`) para handler + regla del
  aggregate, igual que el precedente `TerminarVinculacionCommandHandlerTests`: el metodo
  `Reingresar` es `internal` y solo lo invoca el handler del mismo ensamblado, asi que no hay
  Given/When/Then independiente sobre el aggregate en aislamiento.
- Factory methods compartidos dentro de la clase (`ColaboradorRegistradoValido`,
  `VinculacionIniciadaOriginal`, `DadoUnColaboradorConVinculacionAbierta`,
  `DadoUnColaboradorConVinculacionTerminada(fechaEfectiva)`) -- el segundo factory parametrizado
  por `fechaEfectiva` cubre tanto terminaciones tardias como preavisos futuros sin duplicar Given.

### Stubs creados

- `ColaboradorAggregateRoot.Reingresar(string codigo, DateOnly fechaInicio)` (internal) - stub
  `throw new NotImplementedException()`. Comentario explicito para el implementer: debe ajustar
  `Apply(VinculacionIniciada)` para que reabra la vinculacion (limpiar
  `_fechaTerminacionVinculacionVigente`) al re-aplicarse -- el issue lo anticipa como ajuste
  natural sobre #330.
- `ResultadoReingresoColaborador` (enum, internal): `Exitosa`, `VinculacionAbierta`,
  `FechaSolapaVinculacionAnterior`. Gemelo de `ResultadoTerminacionVinculacion` (#349) -- el issue
  dejaba a criterio del pipeline reutilizar el tipo generico o crear el gemelo; se opto por el
  gemelo porque `ResultadoTerminacionVinculacion` no es generico (es un enum cerrado de 3 valores
  propios de la terminacion) y forzar su reuso habria mezclado semantica de dos operaciones
  distintas en un solo enum.
- `ReingresarColorador` (comando, record, payload plano sin nombres ni motivo).
- `ReingresarColaboradorCommandHandler` (stub `HandleAsync` -> `NotImplementedException`, con
  comentario del flujo esperado -- mismo patron que `TerminarVinculacionCommandHandler` en su
  fase roja).
- `ReingresarColaboradorValidator`: clase **vacia**, sin reglas (mismo precedente exacto que
  `TerminarVinculacionValidator` en fase roja -- las reglas de FluentValidation son logica de
  negocio de la capa 1, no plumbing, asi que quedan para el implementer).
- `.resx` + `.Mensajes.cs` con 3 claves (`ColaboradorNoEncontrado`, `VinculacionAbierta`,
  `FechaSolapaVinculacionAnterior`) -- contenido real desde el inicio (es dato/wiring, no logica,
  mismo criterio que el precedente de #349).
- `FunctionEndpoint`: implementacion completa desde el inicio (traduccion de excepciones a
  codigos HTTP) -- mismo criterio que el precedente `TerminarVinculacionFunction.FunctionEndpoint`
  en su fase roja: es wiring mecanico ya establecido por el molde
  `SolicitarProgramacionTurnoFunction`, no logica de negocio nueva; los tests lo ejercitan con
  fakes de `ICommandRouter`/`IRequestValidator`, nunca contra el handler real.

### Decisiones de diseno

- **Correccion durante el proceso**: la primera version de `ReingresarColaboradorValidator.cs` y
  del handler incluia las reglas reales de FluentValidation (copiadas del `TerminarVinculacion`
  YA IMPLEMENTADO, que es el estado actual del repo tras el merge de #349). Al correr los tests
  se detecto que solo 8/21 fallaban en vez de los 13 esperados -- se verifico el commit de fase
  roja original de #349 (`git show 0dfb265`) y se confirmo que el validator debia quedar VACIO.
  Se corrigio antes de commitear. Documentado aqui porque evidencia el riesgo de usar el estado
  post-merge de un slice hermano como molde literal en vez de su fase roja.
- El "ajuste sobre `Apply(VinculacionIniciada)`" que el issue anticipa NO se implemento (regla
  absoluta: nunca produccion real) -- se dejo documentado en el comentario de `Reingresar` para
  que el implementer lo resuelva. Los tests de CA-1 y CA-4 fallaran hoy por dos razones
  compuestas: (1) `Reingresar` es un stub que lanza `NotImplementedException`, y (2) una vez
  implementado, `Apply` necesitara el reset para que `FechaTerminacionVinculacionVigente` vuelva
  a `null` tras el reingreso exitoso -- ambas quedan evidenciadas por el mismo test.

### Cobertura de criterios

| Criterio de aceptacion | Test(s) |
|---|---|
| CA-1: fecha posterior a terminacion -> 202, VinculacionIniciada, aggregate abierto | `ReingresarColaborador_EmiteVinculacionIniciada_CuandoFechaInicioEsPosteriorALaTerminacion` |
| CA-2: vinculacion abierta (nunca terminada / reingreso previo sin terminar) -> 409 | `ReingresarColaborador_LanzaInvalidOperationException_CuandoLaVinculacionVigenteEstaAbierta`, `ReingresarColaborador_LanzaInvalidOperationException_CuandoElReingresoPrevioSigueAbierto` |
| CA-3: fecha <= fecha efectiva de terminacion (incluye preaviso no vencido) -> 409 | `ReingresarColaborador_LanzaInvalidOperationException_CuandoFechaInicioEsIgualALaFechaEfectivaDeTerminacion`, `...CuandoFechaInicioEsAnteriorALaFechaEfectivaDeTerminacion`, `...CuandoFechaInicioNoSuperaElPreavisoRegistrado` |
| CA-4: fecha posterior al preaviso -> 202, sin reloj | `ReingresarColaborador_EmiteVinculacionIniciada_CuandoFechaInicioEsPosteriorAlPreavisoRegistrado` |
| CA-5: colaborador inexistente -> 404, sin escritura | `ReingresarColaborador_LanzaKeyNotFoundException_CuandoColaboradorNoExiste` |
| CA-6: request invalida -> 400 | `ReingresarColaboradorValidatorTests` (8 tests) + `ReingresarColaborador_Retorna400_CuandoRequestEsInvalido` |

### Desviaciones del plan del planner

Ninguna en la superficie publica -- las sugerencias del planner ("Interfaz publica propuesta") se
aplicaron tal cual: `Reingresar(codigo, fechaInicio): <resultado>` internal, sin exponer estado
interno. Unica decision de nombres no fijada por el issue (dejada explicitamente a "juicio del
pipeline"): se creo el enum gemelo `ResultadoReingresoColaborador` en vez de reutilizar
`ResultadoTerminacionVinculacion` -- ver "Decisiones de diseno" arriba.

</details>

<details>
<summary>Implementer (fase verde) — 3m 16s</summary>

## ES Implementer - Decisiones

### Enfoque de implementacion
El test-writer dejo el andamiaje completo (comando, endpoint, handler stub, validator vacio,
`.resx`/`Mensajes`, resultado del aggregate) siguiendo el molde de #349 (`TerminarVinculacion`).
El trabajo se redujo a cuatro piezas puntuales, todas ya guionizadas por los comentarios del
propio codigo stub:

1. `ColaboradorAggregateRoot.Apply(VinculacionIniciada e)`: se agrego
   `_fechaTerminacionVinculacionVigente = null;` para reabrir la vinculacion al re-aplicarse (el
   NOTA del stub lo pedia explicitamente). Sin este ajuste, un reingreso rehidratado heredaria la
   terminacion de la vinculacion anterior y quedaria "ya terminado" desde el nacimiento.
2. `ColaboradorAggregateRoot.Reingresar(string codigo, DateOnly fechaInicio)`: declina con
   `VinculacionAbierta` si `_fechaTerminacionVinculacionVigente is null`; declina con
   `FechaSolapaVinculacionAnterior` si `fechaInicio <= _fechaTerminacionVinculacionVigente.Value`;
   en exito, appendea y aplica `VinculacionIniciada(codigo, fechaInicio)` (mismo evento del
   registro, CA-ADR-0029). Nunca lanza (CA-ADR-0030).
3. `ReingresarColaboradorCommandHandler.HandleAsync`: parseo tipado unico (`TipoIdentificacion.Desde`
   + `Identificacion.Crear`) -> `ComputarStreamId` -> `GetAggregateRootAsync` (null -> 404) ->
   `Reingresar(...)` -> switch sobre el resultado para traducir a `InvalidOperationException` (409)
   segun la razon. Sin publicacion a bus (event-sourcing puro).
4. `ReingresarColaboradorValidator`: reglas de forma para `TipoIdentificacion` (requerido + lista
   cerrada, normalizando trim+MAYUSCULAS antes de `TipoIdentificacion.Desde`), `NumeroIdentificacion`
   requerido, `CodigoColaborador` requerido, `FechaInicio` distinto del default de `DateOnly`.

### Decisiones de diseno
- Se replico exactamente la forma de `TerminarVinculacionCommandHandler`/`TerminarVinculacionValidator`
  (mismo BC, mismo dominio, precedente explicito en el issue) sin introducir variaciones: mismo
  orden de pasos, mismos nombres de metodos auxiliares (`EsTipoIdentificacionReconocido`), mismo
  criterio de normalizacion de entrada.
- La condicion de rechazo se escribio en forma afirmativa donde el dominio lo permite
  (`if (_fechaTerminacionVinculacionVigente is null) return VinculacionAbierta;`) como guard clause
  de early-return, coherente con la excepcion documentada en la guia del agente (no hay rama
  `else` con la que competir).
- No se toco `ResultadoReingresoColaborador` ni `ReingresarColaborador.cs` (el record del comando):
  ya venian completos y correctos del test-writer.

### ADRs consultados
- CA-ADR-0030: declinar-con-resultado en el aggregate; el handler traduce a 409/404 en el borde.
- MEF-ADR-0004: capa 2 (colaborador inexistente -> `KeyNotFoundException` -> 404), capa 4
  (`Apply` nunca lanza).
- CA-ADR-0029 / MEF-ADR-0039: reutilizacion de `VinculacionIniciada` sin tipos nuevos; el evento no
  conoce su comando.
- MEF-ADR-0012: Tell-don't-Ask -- el handler decide unicamente por el resultado que `Reingresar`
  responde, nunca interrogando estado interno del aggregate.
- MEF-ADR-0037: `ComputarStreamId` como punto unico de conversion de la clave del stream; parseo
  tipado unico en el borde del handler.
- MEF-ADR-0006 (naming + Route), MEF-ADR-0009 (mensajes .resx), CA-ADR-0027 (tenancy, sin cambios
  necesarios), MEF-ADR-0002 / MEF-ADR-0016 (DSL y naming de tests, ya aplicados por el test-writer).

### Desviaciones de ADRs
Ninguna desviacion — todos los ADRs aplicados al pie de la letra.

### Desviaciones del plan del planner
Ninguna desviacion — la interfaz publica propuesta (`Reingresar(codigo, fechaInicio)` con la misma
forma de resultado que `TerminarVinculacion`) y la ubicacion de archivos sugerida coinciden
exactamente con lo que el test-writer ya habia materializado y lo que se implemento.

### Precedentes consultados
- `TerminarVinculacionFunction/` completo (#349): endpoint, handler, validator, `.resx`. Alineado
  con CA-ADR-0030/MEF-ADR-0004 — replicado sin modificaciones de patron.
- `ColaboradorAggregateRoot.TerminarVinculacion` / `ResultadoTerminacionVinculacion`: mismo
  mecanismo "declinar con resultado", replicado para `Reingresar` / `ResultadoReingresoColaborador`.

### Infraestructura modificada
Ninguna. El issue es event-sourcing puro ("Consumidores: ninguno") — no se publica ningun evento a
Service Bus, por lo que no hay topics ni subscriptions que agregar en
`infra/environments/dev/main.tf`.

### Complejidad encontrada
Ninguna. El stub y los comentarios inline del test-writer especificaban el algoritmo completo con
precision (incluyendo la nota sobre reabrir `Apply(VinculacionIniciada)`), asi que la
implementacion fue directa y no requirio iteracion sobre enfoques alternativos.

### Resultado
- Tests pasando: 997/997 ejecutados en la suite completa (24 omitidos por falta de
  Postgres/ServiceBus locales, no relacionados con este issue).
- Proyecto `Bitakora.ControlAsistencia.Colaboradores.Tests`: 164/164 verdes.

</details>
<details>
<summary>Smoke Test Writer — 4m 23s</summary>

_(El agente no generó resumen)_

</details>
<details>
<summary>Reviewer (fase refactor) — 11m 34s</summary>

## ES Reviewer - Revision

### Evaluacion general
- Calidad: **buena**
- Cambios realizados: **si** (commit `a312bca`: limpieza de cruft de fase roja + 3 tests de casos borde)

Baseline: la suite unitaria estaba y quedo **verde** (960 tests en 6 proyectos, 0 errores). Los 9
rojos que aparecen al correr `dotnet test` sobre la solucion completa son de
`Colaboradores.SmokeTests` y responden **404 en todas** las rutas de `Colaboradores/Reingresos`:
el endpoint todavia no esta desplegado en dev. Es el comportamiento esperado del ciclo
(MEF-ADR-0013: los smoke tests corren como job post-deploy; `build-and-test` filtra
`Category!=Smoke`), no un bloqueo. No existe `blockage-report.md` y no fue necesario crearlo.

### Cumplimiento de ADRs aplicables

| ADR | Cumplimiento | Observacion |
|---|---|---|
| CA-ADR-0030: fallos sincronos en comandos HTTP sin consumidores | ok | `Reingresar` declina con `ResultadoReingresoColaborador`, no lanza ni emite evento de fallo; no muta ni agrega a `_uncommittedEvents` al declinar (verificado en los tests: `Then(streamId)` sin eventos + estado conservado). El handler traduce a `InvalidOperationException` (409) / `KeyNotFoundException` (404) con mensaje `.resx`. `ReingresoColaboradorFallido` no existe en ningun lado. |
| MEF-ADR-0004: manejo de errores en event sourcing | ok | Capa 1 en `ReingresarColaboradorValidator` (400), capa 2 en el handler (404/409), capa 4 respetada: los tres `Apply` siguen sin lanzar -- incluido el `Apply(VinculacionIniciada)` modificado. |
| CA-ADR-0029 / MEF-ADR-0039: ensamblados de eventos por rol | ok | Cero tipos de evento nuevos: se reutiliza `VinculacionIniciada` tal cual. El diff **no toca ningun `.csproj`** ni `IdentidadEventosColaboradores.TiposPersistidos`. El comando `ReingresarColaborador` es un record de payload primitivo en el Function App, no reusa ningun tipo de `Colaboradores.DomainEvents` como campo (decision 6, payload por rol). |
| MEF-ADR-0012: Tell-don't-Ask / estilo de modelado | ok | El handler decide **solo** por el valor de retorno de `Reingresar`; nunca interroga `FechaTerminacionVinculacionVigente` ni ninguna otra propiedad del aggregate. Cero propiedades nuevas, cero clases estaticas operando sobre datos crudos del aggregate, cero `InternalsVisibleTo` desde ensamblados de eventos, cero `[JsonConstructor]`, cero eventos con marker de bus (cotejado item por item contra el checklist de antipatrones). |
| MEF-ADR-0037: identidad de stream | ok | `ComputarStreamId(identificacion)` es el unico punto de conversion (el handler no concatena); ningun `ToString("N"/"B"/...)` ni `ToUpper()` sobre un `Guid`; sin endpoint GET. Parseo tipado unico en el borde (`TipoIdentificacion.Desde` + `Identificacion.Crear`). El `$"{Tipo}:{Numero}"` del smoke test es un **oraculo black-box** independiente, no produccion. |
| MEF-ADR-0006: naming de funciones Azure | ok | `[Function("ReingresarColaborador")]` literal, carpeta `ReingresarColaboradorFunction/` con sufijo (comando HTTP), `FunctionEndpoint.cs`, subcarpeta `CommandHandler/`, `Route = "Colaboradores/Reingresos"` explicito y verbo `"post"` declarado. |
| MEF-ADR-0009: mensajes `.resx` por handler | ok | `.resx` propio del handler + `Mensajes` anidada internal, con guardrail de resolucion (`ReingresarColaboradorCommandHandlerMensajesTests`) que evita el falso verde de `WithMessage("**")` si una clave desaparece. |
| CA-ADR-0027: tenancy conjoined | ok | Sin cambios necesarios: el comando pasa por el mismo pipeline de Wolverine/Marten ya compuesto. |
| MEF-ADR-0002 / MEF-ADR-0016: DSL y naming de tests | ok | DSL `Given/WhenAsync/Then/And` con overloads de stream id compuesto en todos los tests del handler; solo `[Fact]`; nombres `<Sujeto>_<LoQuePasa>_Cuando<Condicion>` con el **comando** como sujeto (`ReingresarColaborador_...`) y `Validar_...` en el validator (ejemplo canonico del ADR). |

El issue **si** trae seccion `## ADRs aplicables` y esta completa. Nada que escalar al planner.

### Desviaciones de ADRs

**Ninguna desviacion -- todos los ADRs aplicables se cumplen.**

- El implementer declaro "Ninguna desviacion" y la verificacion linea por linea del diff lo confirma.
- No detecte ninguna desviacion no declarada.

### Precedentes consultados por el implementer

| Precedente | ADR aplicable | Veredicto |
|---|---|---|
| `TerminarVinculacionFunction/` completo (#349) | CA-ADR-0030, MEF-ADR-0004, MEF-ADR-0006, MEF-ADR-0009 | alineado |
| `ColaboradorAggregateRoot.TerminarVinculacion` / `ResultadoTerminacionVinculacion` | CA-ADR-0030, MEF-ADR-0012 | alineado |
| `RegistrarColaboradorCommandHandler` (normalizacion del borde) | MEF-ADR-0037 | alineado |

Ningun precedente citado viola su ADR. Si arrastran una deuda de **comentarios** (ver "Criticas").

### Convenciones del pipeline (no ADRs)

| Convencion | Estado | Observacion |
|---|---|---|
| Cada test con `Then()` + `And<>()` | ok (1 excepcion justificada) | `ReingresarColaborador_LanzaKeyNotFoundException_CuandoColaboradorNoExiste` tiene `Then(streamId)` sin `And<>`: el aggregate no existe en el `TestStore`, invocar `And<>` lanzaria `ArgumentNullException`. El `Then` sin eventos ya prueba "sin escribir nada al event store" (CA-5). Mismo criterio y precedente exacto que #349/#330. |
| Overloads correctos para stream IDs compuestos | ok | `Given(streamId, ...)`, `Then(streamId, ...)`, `And<T,P>(streamId, ...)` en los 12 tests del handler. `StreamIdEsperado` es un literal (oraculo independiente), no derivado de `ComputarStreamId`. |
| Fakes manuales (no NSubstitute) | ok | `FakeReingresarColaboradorRequestValidator` y `FakeReingresarColaboradorCommandRouter`, clases concretas. Nombres prefijados: no colisionan con los de #349/#330. |
| Feature folders (produccion y tests) | ok | Espejo exacto produccion/tests; un archivo por responsabilidad (handler, validator, endpoint, mensajes en archivos separados). |
| Smoke tests: SkipWhen, secrets, cobertura | ok | `Assert.SkipWhen(!postgres.IsConfigured, ...)` (xUnit v3) en los dos unicos tests que usan Postgres; `appsettings.json` con connection strings vacios; el workflow `deploy-colaboradores.yml` pasa los secrets opcionales al reutilizable; **cobertura de efectos secundarios completa** -- los dos caminos de exito (CA-1, CA-4) verifican la persistencia con `ExisteEventoAsync`/`ObtenerEventoAsync` **filtrando por el `Codigo` unico del reingreso**, nunca por posicion; el handler no publica a bus (verificado leyendolo: no hay `PublishAsync`), asi que no hay suscripcion `smoke-tests` que exigir; un solo archivo por comando. |
| Proyecciones read-side | n/a | El diff no toca `ReadModels`/`Projections`. `ConfiguracionMartenProjectionsColaboradores` no registra ninguna proyeccion todavia, asi que reutilizar `VinculacionIniciada` no impacta ningun read model existente (verificado). |
| Antipatrones de habilitacion (MEF-ADR-0039) | n/a | El diff no toca ningun `.csproj` ni declara ningun tipo de evento nuevo. |
| Compatibilidad Marten write-side/read-side | n/a | El diff no toca version del paquete ni configuracion de Marten (`ComposicionServicios`, `ConfiguracionSerializacion*`, `IdentidadEventos*` intactos). |
| Identidad de stream (MEF-ADR-0037) | ok | Ver fila del ADR arriba. |
| Control de volumen de telemetria (MEF-ADR-0038) | n/a | El diff no toca los seams de observabilidad ni el callback de Wolverine. |
| Tests via ToString/comportamiento | ok | Ninguna propiedad nueva expuesta para test; los `And<>` usan los observables internal que #349 ya habia acotado. |
| Sin numeros magicos | ok | Fechas y codigos como constantes/campos con nombre (`FechaEfectivaTerminacionOriginal`, `CodigoReingreso`, `RutaReingresos`, `TipoEventoVinculacionIniciada`). |
| Condiciones en positivo | ok | Las dos guardas de `Reingresar` son early-return de precondicion (`if (... is null) return VinculacionAbierta;`), sin rama `else` con la que competir -- la excepcion documentada. |
| Sin caracteres U+2500 en `.cs` | ok | Verificado: solo guion ASCII. |

### Elegancia del codigo

Lo que ya estaba bien y no toque:

- `Reingresar` son **9 lineas** con dos guardas y un camino de exito: la invariante de no-solape y la
  doctrina del preaviso quedan expresadas sin una sola consulta al reloj y sin ningun estado nuevo.
  El diseno mas limpio posible para este corte.
- El ajuste de una linea en `Apply(VinculacionIniciada)` (`_fechaTerminacionVinculacionVigente = null`)
  resuelve el reingreso **y** el ciclo completo sin agregar campos ni una maquina de estados.
- El `switch` sobre el enum de resultado que lanza por razon se conserva tal cual: es control de
  flujo, no seleccion de valor por clave discreta (la excepcion documentada al lookup map), y es
  identico al hermano #349 -- duplicacion estable y mecanica que MEF-ADR-0018 acepta.

Lo que corregi (limpieza):

- **Comentarios de andamiaje que sobrevivieron a la fase roja.** `ColaboradorAggregateRoot.Reingresar`
  conservaba un bloque `// NOTA para el implementer: Apply(VinculacionIniciada) debe reabrir la
  vinculacion... si #330 lo dejo asumiendo una unica aplicacion, ajustarlo es parte natural del
  alcance` -- instrucciones a un agente que ya hizo el trabajo. Reemplazado por una linea que dice
  el hecho: el `Apply` reabre la vinculacion, de modo que el ciclo es encadenable.
- **`// STUB (fase roja, issue #350): el cuerpo completo queda para el implementer`** en
  `ReingresarColaboradorCommandHandler`, sobre un handler completamente implementado: un comentario
  que afirma lo contrario de lo que el archivo contiene.
- **Narracion paso a paso redundante.** El mismo handler llevaba 16 lineas describiendo en prosa los
  4 pasos que sus 12 lineas de codigo ya dicen literalmente (`1. Normalizar y parsear... 2.
  Identificacion.Crear... 3. ComputarStreamId...`). Comprimido a lo que el codigo **no** puede decir:
  por que declina con resultado y por que no publica a bus. Mismo criterio en
  `ResultadoReingresoColaborador`, cuyo comentario repetia palabra por palabra la explicacion de las
  dos razones que ya vive en el aggregate (ahora remite a ella).

### Criticas y hallazgos

1. **[mayor -- corregido]** *Ningun test cubria la regresion que este issue introduce sobre
   `TerminarVinculacion`.* El cambio a `Apply(VinculacionIniciada)` es compartido por los **tres**
   caminos que aplican ese evento (`Registrar`, `Reingresar` y la rehidratacion de cualquier
   comando). #350 verifica el efecto sobre el reingreso, pero nadie verificaba que tras un reingreso
   la vinculacion se pueda **volver a terminar** -- que es justamente lo que el reset habilita -- ni
   que la ventana de fechas validas de `TerminarVinculacion` se mueva a la fecha del reingreso.
   Agregue los dos tests (ver "Tests agregados"). Ambos pasan; sin el reset del `Apply`, el primero
   responderia 409.
2. **[menor -- corregido]** *El `Trim().ToUpperInvariant()` del handler nuevo no estaba ejercitado.*
   `TipoIdentificacion.Desde` es case-sensitive por diseno (#348), asi que sin esa normalizacion un
   `"cc"` computa otra clave de stream y el reingreso responderia 404 sobre un colaborador que si
   existe. El validator aceptaba `"cc"` (test explicito) pero nada verificaba que el handler llegara
   al mismo stream. Agregue el test; #330 tiene el gemelo en negativo, #349 no lo tiene.
3. **[menor -- no corregido, deuda del precedente]** `TerminarVinculacionCommandHandler.cs` (#349,
   ya en `main`) arrastra el mismo `// STUB (fase roja, issue #349): el cuerpo completo queda para el
   implementer` sobre codigo implementado, mas su bloque de narracion paso a paso. No lo toco por
   alcance (regla 4), pero **el molde se esta replicando slice a slice**: #348-#357 son 10 comandos
   y ya van 2. Recomiendo que el siguiente slice (#351) lo limpie de una vez, o que el `implementer`
   incorpore "borrar el andamiaje de la fase roja" a su cierre.
4. **[menor -- no corregido, evaluacion explicita de Rule of Three]** `EsTipoIdentificacionReconocido`
   (try/catch sobre `TipoIdentificacion.Desde`) va por su **tercera** copia identica
   (`RegistrarColaboradorValidator`, `TerminarVinculacionValidator`, `ReingresarColaboradorValidator`).
   MEF-ADR-0018 exige evaluarla al tercer caso, y la evaluacion es: la abstraccion **si** seria
   estable (mecanica neutral, sin riesgo de divergencia por regla del dominio). Pero la misma tabla
   fija la "Autoridad de extraccion": el implementer no la ofrecio y el PR no toca los otros dos
   sitios -- extraer aqui significaria editar dos archivos ajenos al issue. Ademas el destino
   correcto probablemente no sea un helper compartido sino un `TipoIdentificacion.TryDesde` en el VO
   (el olor real es el try/catch como control de flujo: preguntarle al objeto, no capturarle la
   excepcion), y eso toca la isla `DomainEvents`. Queda registrado para que #351 -- el cuarto
   validator de la cadena -- lo resuelva con el caso ya documentado.
5. **[cosmetico -- no corregido]** El test de health check (`DebeEstarDisponible_CuandoSeConsultaHealthCheck`)
   se repite en cada clase de smoke test del repo (7 sitios, ademas de `HealthSmokeTests` que existe
   para eso) y su nombre usa el patron `Debe...` que MEF-ADR-0016 reemplazo. Es el molde del
   `smoke-test-writer`, no algo que #350 introduzca; corregirlo solo aqui rompe la consistencia.
   Deuda del marco.
6. **[informativo]** Los 9 smoke tests rojos del baseline son 404 de un endpoint aun no desplegado.
   Se pondran verdes en el job post-deploy. Sin accion.

Sin hallazgos bloqueantes. Sin warnings del compilador en el codigo nuevo (los 4 `NU1902` del build
son de `OpenTelemetry.Api` en Programacion, preexistentes y ajenos al diff).

### Refactorings aplicados

| Refactoring | Justificacion |
|---|---|
| Elimino el bloque `NOTA para el implementer` en `ColaboradorAggregateRoot.Reingresar` | Instruccion a un agente, no documentacion del codigo. Sustituido por el hecho que el lector necesita (el `Apply` reabre la vinculacion). |
| Elimino `// STUB (fase roja...)` y comprime el bloque `Flujo esperado` (16 -> 6 lineas) en `ReingresarColaboradorCommandHandler` | El comentario afirmaba que el cuerpo no estaba implementado; el resto narraba en prosa lo que el codigo dice literalmente. Queda solo el "por que" (CA-ADR-0030, capa 2, sin bus). |
| Comprime el comentario de `ResultadoReingresoColaborador` (18 -> 12 lineas) | Repetia palabra por palabra la explicacion de las dos razones de rechazo que ya vive en `Reingresar`. Ahora remite a ella. |

Ningun refactor toco comportamiento: la suite quedo verde despues de cada cambio.

### Cobertura de criterios de aceptacion

| Criterio | Estado | Test(s) |
|---|---|---|
| CA-1: ultima vinculacion terminada + `FechaInicio` posterior -> 202, `VinculacionIniciada` con el codigo nuevo, aggregate con vinculacion abierta | cubierto | `ReingresarColaborador_EmiteVinculacionIniciada_CuandoFechaInicioEsPosteriorALaTerminacion` (verifica los 3 observables, incluido `FechaTerminacionVinculacionVigente == null`), `ReingresarColaborador_EmiteVinculacionIniciada_CuandoTipoYNumeroLleganSinNormalizar` (**agregado**), `ReingresarColaborador_Retorna202_CuandoComandoEsValido` (endpoint), smoke `ReingresarColaborador_Retorna202YPersisteVinculacionIniciada_CuandoFechaInicioEsPosteriorATerminacion` |
| CA-2: vinculacion abierta (nunca terminada / reingreso previo sin terminar) -> 409, ningun evento nuevo | cubierto | `..._CuandoLaVinculacionVigenteEstaAbierta`, `..._CuandoElReingresoPrevioSigueAbierto` (ambos con `Then(streamId)` vacio + estado conservado), `ReingresarColaborador_Retorna409_CuandoLaVinculacionVigenteEstaAbierta` (endpoint), smokes `..._CuandoVinculacionNuncaFueTerminada` y `..._CuandoYaFueReingresadoSinTerminarDeNuevo` |
| CA-3: `FechaInicio` igual o anterior a la `FechaEfectiva` (incluye preaviso no vencido) -> 409 | cubierto | `..._CuandoFechaInicioEsIgualALaFechaEfectivaDeTerminacion`, `..._CuandoFechaInicioEsAnteriorALaFechaEfectivaDeTerminacion`, `..._CuandoFechaInicioNoSuperaElPreavisoRegistrado`, mas los 3 smokes gemelos |
| CA-4: reingreso posterior a un preaviso -> 202, sin consultar el reloj | cubierto | `ReingresarColaborador_EmiteVinculacionIniciada_CuandoFechaInicioEsPosteriorAlPreavisoRegistrado` (preaviso 2030), smoke `..._CuandoTerminacionFuePreavisoFuturo` (preaviso 2030-12-31, reingreso 2031-01-01: ninguna fecha se compara contra `DateTime.Now` en ningun punto del slice -- verificado por lectura) |
| CA-5: colaborador inexistente -> 404, sin escribir nada | cubierto | `ReingresarColaborador_LanzaKeyNotFoundException_CuandoColaboradorNoExiste`, `ReingresarColaborador_Retorna404_CuandoColaboradorNoExiste` (endpoint), smoke `..._Retorna404_CuandoColaboradorNoExiste` |
| CA-6: request invalida -> 400 sin tocar el event store | cubierto | `ReingresarColaboradorValidatorTests` (8 tests: los 4 campos requeridos, tipo fuera de la lista cerrada, mas dos guardas de que "cc" y una fecha futura **no** se rechazan en la capa de forma), `ReingresarColaborador_Retorna400_CuandoRequestEsInvalido` (endpoint), 4 smokes de 400 |

Ciclo de vida completo, ademas de los CAs: `TerminarVinculacion` tras un reingreso queda cubierto en
ambas direcciones (ver "Tests agregados") -- la cadena registro -> terminacion -> reingreso ->
terminacion es hoy verificable de punta a punta.

### Tests agregados

1. `ReingresarColaborador_EmiteVinculacionIniciada_CuandoTipoYNumeroLleganSinNormalizar`
   (`ReingresarColaboradorCommandHandlerTests`) -- `"cc"` + `"  79543210  "` sobre un colaborador
   registrado alcanza el stream `"CC:79543210"` y el reingreso procede. Cubre la normalizacion del
   borde del handler nuevo (MEF-ADR-0037); en positivo, mas fuerte que el gemelo en negativo de #330.
2. `TerminarVinculacion_EmiteVinculacionTerminada_CuandoLaVinculacionVigenteNacioDeUnReingreso`
   (`TerminarVinculacionCommandHandlerTests`) -- cierre del ciclo completo: sin el reset que este
   issue introduce en `Apply(VinculacionIniciada)`, este comando chocaria contra la terminacion
   heredada y respondaria 409.
3. `TerminarVinculacion_LanzaInvalidOperationException_CuandoFechaEfectivaEsAnteriorAlInicioDelReingreso`
   -- segunda direccion del mismo cierre: la ventana de fechas validas se mueve con el reingreso (una
   fecha posterior al inicio original pero anterior al del reingreso produce duracion negativa -> 409).

Los tres siguen el DSL con overloads de stream id compuesto y llevan `Then(...)` + `And<>()`.
No hicieron falta tests de contrato de igualdad ni de serializacion: el diff no introduce ningun
`IEquatable<T>`, ningun `ConfigurarSerializacion` y ningun evento con marker de bus.

</details>

## Commits

a312bca refactor(hu-350): limpia cruft de fase roja y cubre el ciclo completo de vinculacion
98cc2da test(hu-350): smoke tests para endpoints
3f5dd68 feat(issue-350): implementacion de reingresar a un colaborador (fase verde)
952cb28 test(issue-350): tests para reingresar a un colaborador (fase roja)

Closes #350