### PR TITLE
Corregir los nombres de un colaborador

### DIFF
--- a/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/IdentidadEventosColaboradores.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/IdentidadEventosColaboradores.cs
@@ -18,5 +18,6 @@ public static class IdentidadEventosColaboradores
         typeof(ColaboradorRegistrado),
         typeof(VinculacionIniciada),
         typeof(VinculacionTerminada),
+        typeof(NombresCorregidos),
     ];
 }

--- a/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/NombresCorregidos.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/NombresCorregidos.cs
@@ -1,0 +1,24 @@
+namespace Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+
+/// <summary>
+/// Evento de event sourcing que registra la correccion de los nombres de un colaborador. Se
+/// persiste en el stream de ColaboradorAggregateRoot.
+/// </summary>
+/// <remarks>
+/// Issue #351: cuarto comando del ciclo de vida de ColaboradorAggregateRoot (desglose #348-#357),
+/// y el mas simple -- sin reglas de estado. El nombre "NombresCorregidos" cuenta un hecho de
+/// dominio (sesion 2026-08-07/10: cedula equivocada corregida al reingresar el dueno legitimo del
+/// documento), en vez de un generico "DatosActualizados" sin semantica (descartado en el
+/// refinamiento 2026-08-11).
+/// Payload rico: Nombre (NombreColaborador, VO de #348) viaja completo -- mismo criterio que
+/// ColaboradorRegistrado. No declara ConfigurarSerializacion propio: NombreColaborador ya trae la
+/// suya (ConfiguracionSerializacionColaboradores.ConfigurarResolver la delega) y el ctor publico
+/// del record es reconstruible por STJ sin ayuda adicional una vez que ese VO este registrado --
+/// mismo patron que ColaboradorRegistrado.
+/// Solo exige EXISTENCIA del colaborador, no vigencia de su vinculacion (decision de refinamiento
+/// 2026-08-11): los nombres son de la PERSONA, no de la vinculacion -- corregirlos sobre un
+/// colaborador con vinculacion terminada es valido.
+/// No cruza el bus (sin marker IPrivateEvent/IPublicEvent): event-sourcing puro, sin consumidores
+/// (issue #351 "Consumidores: ninguno").
+/// </remarks>
+public sealed record NombresCorregidos(NombreColaborador Nombre);

--- a/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/NombresCorregidos.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/NombresCorregidos.cs
@@ -5,19 +5,13 @@ namespace Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
 /// persiste en el stream de ColaboradorAggregateRoot.
 /// </summary>
 /// <remarks>
-/// Issue #351: cuarto comando del ciclo de vida de ColaboradorAggregateRoot (desglose #348-#357),
-/// y el mas simple -- sin reglas de estado. El nombre "NombresCorregidos" cuenta un hecho de
-/// dominio (sesion 2026-08-07/10: cedula equivocada corregida al reingresar el dueno legitimo del
-/// documento), en vez de un generico "DatosActualizados" sin semantica (descartado en el
-/// refinamiento 2026-08-11).
-/// Payload rico: Nombre (NombreColaborador, VO de #348) viaja completo -- mismo criterio que
-/// ColaboradorRegistrado. No declara ConfigurarSerializacion propio: NombreColaborador ya trae la
-/// suya (ConfiguracionSerializacionColaboradores.ConfigurarResolver la delega) y el ctor publico
-/// del record es reconstruible por STJ sin ayuda adicional una vez que ese VO este registrado --
-/// mismo patron que ColaboradorRegistrado.
-/// Solo exige EXISTENCIA del colaborador, no vigencia de su vinculacion (decision de refinamiento
-/// 2026-08-11): los nombres son de la PERSONA, no de la vinculacion -- corregirlos sobre un
-/// colaborador con vinculacion terminada es valido.
+/// Issue #351: el nombre cuenta un hecho de dominio -- la correccion de un nombre mal digitado, o
+/// la del dueno legitimo del documento tras reusar el stream (sesion 2026-08-07/10) -- en vez de un
+/// generico "DatosActualizados" sin semantica, descartado en el refinamiento.
+/// Payload rico: Nombre (NombreColaborador, VO de #348) viaja completo, mismo criterio que
+/// ColaboradorRegistrado. No declara ConfigurarSerializacion propio: la del VO, que
+/// ConfiguracionSerializacionColaboradores ya registra, basta para reconstruir el ctor publico del
+/// record.
 /// No cruza el bus (sin marker IPrivateEvent/IPublicEvent): event-sourcing puro, sin consumidores
 /// (issue #351 "Consumidores: ninguno").
 /// </remarks>

--- a/src/Bitakora.ControlAsistencia.Colaboradores/CorregirNombresFunction/CommandHandler/CorregirNombresCommandHandler.Mensajes.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/CorregirNombresFunction/CommandHandler/CorregirNombresCommandHandler.Mensajes.cs
@@ -1,0 +1,18 @@
+using System.Resources;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.CorregirNombresFunction.CommandHandler;
+
+// MEF-ADR-0009: mensajes del handler en .resx separado.
+// internal: accesible desde tests via InternalsVisibleTo en el .csproj.
+public partial class CorregirNombresCommandHandler
+{
+    private static readonly ResourceManager ResourceManager = new(
+        "Bitakora.ControlAsistencia.Colaboradores.CorregirNombresFunction.CommandHandler.CorregirNombresCommandHandlerMensajes",
+        typeof(CorregirNombresCommandHandler).Assembly);
+
+    internal static class Mensajes
+    {
+        public static string ColaboradorNoEncontrado =>
+            ResourceManager.GetString(nameof(ColaboradorNoEncontrado))!;
+    }
+}

--- a/src/Bitakora.ControlAsistencia.Colaboradores/CorregirNombresFunction/CommandHandler/CorregirNombresCommandHandler.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/CorregirNombresFunction/CommandHandler/CorregirNombresCommandHandler.cs
@@ -25,6 +25,20 @@ public partial class CorregirNombresCommandHandler : ICommandHandlerAsync<Correg
     public CorregirNombresCommandHandler(IEventStore eventStore) =>
         _eventStore = eventStore;
 
-    public Task HandleAsync(CorregirNombres command, CancellationToken ct = default) =>
-        throw new NotImplementedException();
+    public async Task HandleAsync(CorregirNombres command, CancellationToken ct = default)
+    {
+        // Parseo tipado unico del borde (MEF-ADR-0037 seccion 2), mismo criterio que
+        // TerminarVinculacionCommandHandler/ReingresarColaboradorCommandHandler.
+        var tipo = TipoIdentificacion.Desde(command.TipoIdentificacion.Trim().ToUpperInvariant());
+        var identificacion = Identificacion.Crear(tipo, command.NumeroIdentificacion);
+        var nombre = NombreColaborador.Crear(
+            command.PrimerNombre, command.SegundoNombre, command.PrimerApellido, command.SegundoApellido);
+
+        var streamId = ColaboradorAggregateRoot.ComputarStreamId(identificacion);
+        var colaborador = await _eventStore.GetAggregateRootAsync<ColaboradorAggregateRoot>(streamId, ct);
+        if (colaborador is null)
+            throw new KeyNotFoundException(Mensajes.ColaboradorNoEncontrado);
+
+        colaborador.CorregirNombres(nombre);
+    }
 }

--- a/src/Bitakora.ControlAsistencia.Colaboradores/CorregirNombresFunction/CommandHandler/CorregirNombresCommandHandler.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/CorregirNombresFunction/CommandHandler/CorregirNombresCommandHandler.cs
@@ -1,0 +1,30 @@
+using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+using Bitakora.ControlAsistencia.Colaboradores.Entities;
+using Cosmos.EventSourcing.Abstractions.Commands;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.CorregirNombresFunction.CommandHandler;
+
+// Issue #351: handler del comando CorregirNombres. El mas simple del ciclo de vida --
+// sin caso 409: CA-ADR-0030 solo exige el 404 de orquestacion (colaborador inexistente), sin
+// eventos de fallo. El aggregate decide en silencio si hay algo que corregir (idempotencia por
+// igualdad de valor, decision de refinamiento 2026-08-11).
+// Flujo esperado (precedente TerminarVinculacionCommandHandler/ReingresarColaboradorCommandHandler):
+//   1. Parseo tipado unico del borde: TipoIdentificacion.Desde(...) + Identificacion.Crear(...)
+//      (normalizar trim+MAYUSCULAS ANTES de Desde, mismo criterio que los handlers hermanos).
+//   2. NombreColaborador.Crear(...) con los 4 campos del comando.
+//   3. ComputarStreamId(identificacion) -> GetAggregateRootAsync<ColaboradorAggregateRoot> -- si es
+//      null, throw KeyNotFoundException(Mensajes.ColaboradorNoEncontrado) (-> 404).
+//   4. colaborador.CorregirNombres(nombre) -- nunca lanza; si el nombre es distinto por valor ya
+//      quedo en _uncommittedEvents, el middleware persiste via SaveChanges.
+// Sin publicacion a bus (event-sourcing puro, issue #351 "Consumidores: ninguno").
+// STUB (fase roja, issue #351): el cuerpo completo queda para el implementer.
+public partial class CorregirNombresCommandHandler : ICommandHandlerAsync<CorregirNombres>
+{
+    private readonly IEventStore _eventStore;
+
+    public CorregirNombresCommandHandler(IEventStore eventStore) =>
+        _eventStore = eventStore;
+
+    public Task HandleAsync(CorregirNombres command, CancellationToken ct = default) =>
+        throw new NotImplementedException();
+}

--- a/src/Bitakora.ControlAsistencia.Colaboradores/CorregirNombresFunction/CommandHandler/CorregirNombresCommandHandler.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/CorregirNombresFunction/CommandHandler/CorregirNombresCommandHandler.cs
@@ -4,20 +4,12 @@ using Cosmos.EventSourcing.Abstractions.Commands;
 
 namespace Bitakora.ControlAsistencia.Colaboradores.CorregirNombresFunction.CommandHandler;
 
-// Issue #351: handler del comando CorregirNombres. El mas simple del ciclo de vida --
-// sin caso 409: CA-ADR-0030 solo exige el 404 de orquestacion (colaborador inexistente), sin
-// eventos de fallo. El aggregate decide en silencio si hay algo que corregir (idempotencia por
-// igualdad de valor, decision de refinamiento 2026-08-11).
-// Flujo esperado (precedente TerminarVinculacionCommandHandler/ReingresarColaboradorCommandHandler):
-//   1. Parseo tipado unico del borde: TipoIdentificacion.Desde(...) + Identificacion.Crear(...)
-//      (normalizar trim+MAYUSCULAS ANTES de Desde, mismo criterio que los handlers hermanos).
-//   2. NombreColaborador.Crear(...) con los 4 campos del comando.
-//   3. ComputarStreamId(identificacion) -> GetAggregateRootAsync<ColaboradorAggregateRoot> -- si es
-//      null, throw KeyNotFoundException(Mensajes.ColaboradorNoEncontrado) (-> 404).
-//   4. colaborador.CorregirNombres(nombre) -- nunca lanza; si el nombre es distinto por valor ya
-//      quedo en _uncommittedEvents, el middleware persiste via SaveChanges.
-// Sin publicacion a bus (event-sourcing puro, issue #351 "Consumidores: ninguno").
-// STUB (fase roja, issue #351): el cuerpo completo queda para el implementer.
+// Issue #351: handler del comando CorregirNombres (precedente TerminarVinculacionCommandHandler).
+// El mas simple del ciclo de vida: sin caso 409 -- CA-ADR-0030 solo exige el 404 de orquestacion
+// (colaborador inexistente, MEF-ADR-0004 capa 2), y el aggregate declina en SILENCIO cuando no hay
+// nada que corregir, sin razon que traducir. En el camino de exito el aggregate ya dejo
+// NombresCorregidos en _uncommittedEvents -- el middleware persiste via SaveChanges. Sin
+// publicacion a bus (event-sourcing puro, "Consumidores: ninguno").
 public partial class CorregirNombresCommandHandler : ICommandHandlerAsync<CorregirNombres>
 {
     private readonly IEventStore _eventStore;
@@ -27,8 +19,9 @@ public partial class CorregirNombresCommandHandler : ICommandHandlerAsync<Correg
 
     public async Task HandleAsync(CorregirNombres command, CancellationToken ct = default)
     {
-        // Parseo tipado unico del borde (MEF-ADR-0037 seccion 2), mismo criterio que
-        // TerminarVinculacionCommandHandler/ReingresarColaboradorCommandHandler.
+        // Parseo tipado unico del borde (MEF-ADR-0037 seccion 2), mismo criterio que los handlers
+        // hermanos: TipoIdentificacion.Desde es case-sensitive por diseno (#348), asi que el borde
+        // normaliza antes de consultar la lista cerrada.
         var tipo = TipoIdentificacion.Desde(command.TipoIdentificacion.Trim().ToUpperInvariant());
         var identificacion = Identificacion.Crear(tipo, command.NumeroIdentificacion);
         var nombre = NombreColaborador.Crear(

--- a/src/Bitakora.ControlAsistencia.Colaboradores/CorregirNombresFunction/CommandHandler/CorregirNombresCommandHandlerMensajes.resx
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/CorregirNombresFunction/CommandHandler/CorregirNombresCommandHandlerMensajes.resx
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" msdata:Ordinal="0" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter</value></resheader>
+  <data name="ColaboradorNoEncontrado" xml:space="preserve">
+    <value>No existe un colaborador registrado con esa identificacion</value>
+  </data>
+</root>

--- a/src/Bitakora.ControlAsistencia.Colaboradores/CorregirNombresFunction/CommandHandler/CorregirNombresValidator.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/CorregirNombresFunction/CommandHandler/CorregirNombresValidator.cs
@@ -11,7 +11,6 @@ namespace Bitakora.ControlAsistencia.Colaboradores.CorregirNombresFunction.Comma
 // (NombreColaborador.Crear ya los normaliza).
 // Se descubre via el AddValidatorsFromAssemblyContaining que ComposicionServicios ya configura: no
 // requiere tocar el wiring de DI.
-// STUB (fase roja, issue #351): sin reglas -- el implementer las agrega.
 public class CorregirNombresValidator : AbstractValidator<CorregirNombres>
 {
     public CorregirNombresValidator()

--- a/src/Bitakora.ControlAsistencia.Colaboradores/CorregirNombresFunction/CommandHandler/CorregirNombresValidator.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/CorregirNombresFunction/CommandHandler/CorregirNombresValidator.cs
@@ -1,3 +1,4 @@
+using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
 using FluentValidation;
 
 namespace Bitakora.ControlAsistencia.Colaboradores.CorregirNombresFunction.CommandHandler;
@@ -13,4 +14,34 @@ namespace Bitakora.ControlAsistencia.Colaboradores.CorregirNombresFunction.Comma
 // STUB (fase roja, issue #351): sin reglas -- el implementer las agrega.
 public class CorregirNombresValidator : AbstractValidator<CorregirNombres>
 {
+    public CorregirNombresValidator()
+    {
+        // Cascade(Stop) evita que Must evalue un valor vacio que NotEmpty ya rechazo -- mismo
+        // criterio que TerminarVinculacionValidator/RegistrarColaboradorValidator.
+        RuleFor(x => x.TipoIdentificacion)
+            .Cascade(CascadeMode.Stop)
+            .NotEmpty()
+            .Must(EsTipoIdentificacionReconocido)
+            .WithMessage("El tipo de identificacion no es uno de los reconocidos");
+
+        RuleFor(x => x.NumeroIdentificacion).NotEmpty();
+        RuleFor(x => x.PrimerNombre).NotEmpty();
+        RuleFor(x => x.PrimerApellido).NotEmpty();
+    }
+
+    // Consulta la lista cerrada (#348) sin propagar la excepcion de dominio al boundary de
+    // validacion -- un codigo fuera de la lista debe traducirse en un error de FluentValidation
+    // (400), no en una excepcion no controlada.
+    private static bool EsTipoIdentificacionReconocido(string tipo)
+    {
+        try
+        {
+            TipoIdentificacion.Desde(tipo.Trim().ToUpperInvariant());
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+    }
 }

--- a/src/Bitakora.ControlAsistencia.Colaboradores/CorregirNombresFunction/CommandHandler/CorregirNombresValidator.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/CorregirNombresFunction/CommandHandler/CorregirNombresValidator.cs
@@ -1,0 +1,16 @@
+using FluentValidation;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.CorregirNombresFunction.CommandHandler;
+
+// Issue #351: validacion de forma del comando CorregirNombres en el borde (MEF-ADR-0004 capa 1 ->
+// 400 BadRequest). CA-5: TipoIdentificacion (requerido + en la lista cerrada -- normalizar
+// trim+MAYUSCULAS antes de TipoIdentificacion.Desde, mismo criterio de normalizacion de entrada
+// que TerminarVinculacionValidator/RegistrarColaboradorValidator), NumeroIdentificacion,
+// PrimerNombre y PrimerApellido requeridos no vacios. SegundoNombre/SegundoApellido son opcionales
+// (NombreColaborador.Crear ya los normaliza).
+// Se descubre via el AddValidatorsFromAssemblyContaining que ComposicionServicios ya configura: no
+// requiere tocar el wiring de DI.
+// STUB (fase roja, issue #351): sin reglas -- el implementer las agrega.
+public class CorregirNombresValidator : AbstractValidator<CorregirNombres>
+{
+}

--- a/src/Bitakora.ControlAsistencia.Colaboradores/CorregirNombresFunction/CorregirNombres.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/CorregirNombresFunction/CorregirNombres.cs
@@ -1,0 +1,20 @@
+namespace Bitakora.ControlAsistencia.Colaboradores.CorregirNombresFunction;
+
+// Issue #351: comando para corregir los nombres de un colaborador existente. Cuarto comando del
+// ciclo de vida de ColaboradorAggregateRoot (desglose #348-#357) y el mas simple: sin reglas de
+// estado -- solo exige existencia del colaborador, nunca vigencia de su vinculacion (los nombres
+// son de la PERSONA, no de la vinculacion, decision de refinamiento 2026-08-11).
+// Trigger: HTTP POST, Route: Colaboradores/Nombres (el recurso que se reemplaza; la identificacion
+// viaja en el body porque su representacion "CC:79543210" contiene ":", hostil como segmento de
+// URL, mismo criterio que TerminarVinculacion/ReingresarColaborador).
+// Payload primitivo -- igual que RegistrarColaborador/TerminarVinculacion (MEF-ADR-0039 decision 6,
+// payload por rol): NUNCA reusa un tipo de Colaboradores.DomainEvents como campo. El handler
+// construye TipoIdentificacion/Identificacion/NombreColaborador a partir de estos primitivos
+// (parseo tipado unico en el borde, MEF-ADR-0037 seccion 2).
+public record CorregirNombres(
+    string TipoIdentificacion,
+    string NumeroIdentificacion,
+    string PrimerNombre,
+    string? SegundoNombre,
+    string PrimerApellido,
+    string? SegundoApellido);

--- a/src/Bitakora.ControlAsistencia.Colaboradores/CorregirNombresFunction/FunctionEndpoint.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/CorregirNombresFunction/FunctionEndpoint.cs
@@ -19,9 +19,24 @@ namespace Bitakora.ControlAsistencia.Colaboradores.CorregirNombresFunction;
 public class FunctionEndpoint(IRequestValidator requestValidator, ICommandRouter commandRouter)
 {
     [Function("CorregirNombres")]
-    public Task<IActionResult> Run(
+    public async Task<IActionResult> Run(
         [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "Colaboradores/Nombres")]
         HttpRequest req,
-        CancellationToken ct) =>
-        throw new NotImplementedException();
+        CancellationToken ct)
+    {
+        var (comando, error) = await requestValidator.ValidarAsync<CorregirNombres>(req, ct);
+        if (error is not null)
+            return error;
+
+        try
+        {
+            await commandRouter.InvokeAsync(comando!, ct);
+        }
+        catch (KeyNotFoundException ex)
+        {
+            return new NotFoundObjectResult(ex.Message);
+        }
+
+        return new AcceptedResult();
+    }
 }

--- a/src/Bitakora.ControlAsistencia.Colaboradores/CorregirNombresFunction/FunctionEndpoint.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/CorregirNombresFunction/FunctionEndpoint.cs
@@ -15,7 +15,6 @@ namespace Bitakora.ControlAsistencia.Colaboradores.CorregirNombresFunction;
 // CA-ADR-0030 / MEF-ADR-0004 (precedente TerminarVinculacionFunction.FunctionEndpoint): validar
 // request (400 via IRequestValidator) -> despachar comando -> KeyNotFoundException -> 404 NotFound
 // (sin 409: este comando no tiene reglas de estado); exito -> 202 Accepted.
-// STUB (fase roja, issue #351): el cuerpo completo queda para el implementer.
 public class FunctionEndpoint(IRequestValidator requestValidator, ICommandRouter commandRouter)
 {
     [Function("CorregirNombres")]

--- a/src/Bitakora.ControlAsistencia.Colaboradores/CorregirNombresFunction/FunctionEndpoint.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/CorregirNombresFunction/FunctionEndpoint.cs
@@ -1,0 +1,27 @@
+using Bitakora.ControlAsistencia.Colaboradores.Infraestructura;
+using Cosmos.EventSourcing.Abstractions.Commands;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.CorregirNombresFunction;
+
+// Issue #351: endpoint HTTP POST para corregir los nombres de un colaborador existente.
+// MEF-ADR-0006: [Function("CorregirNombres")]; carpeta CON sufijo "Function" -- mismo criterio que
+// RegistrarColaboradorFunction/TerminarVinculacionFunction/ReingresarColaboradorFunction: el
+// record del comando es homonimo del feature folder.
+// Route = "Colaboradores/Nombres": el recurso que se reemplaza -- identificacion en el body porque
+// su representacion ("CC:79543210") contiene ":", hostil como segmento de URL.
+// CA-ADR-0030 / MEF-ADR-0004 (precedente TerminarVinculacionFunction.FunctionEndpoint): validar
+// request (400 via IRequestValidator) -> despachar comando -> KeyNotFoundException -> 404 NotFound
+// (sin 409: este comando no tiene reglas de estado); exito -> 202 Accepted.
+// STUB (fase roja, issue #351): el cuerpo completo queda para el implementer.
+public class FunctionEndpoint(IRequestValidator requestValidator, ICommandRouter commandRouter)
+{
+    [Function("CorregirNombres")]
+    public Task<IActionResult> Run(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "Colaboradores/Nombres")]
+        HttpRequest req,
+        CancellationToken ct) =>
+        throw new NotImplementedException();
+}

--- a/src/Bitakora.ControlAsistencia.Colaboradores/Entities/ColaboradorAggregateRoot.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/Entities/ColaboradorAggregateRoot.cs
@@ -124,18 +124,17 @@ public partial class ColaboradorAggregateRoot : AggregateRoot
         return ResultadoReingresoColaborador.Exitosa;
     }
 
-    // Issue #351: mecanismo "declinar silencioso" (decision de refinamiento 2026-08-11, precedente
-    // ControlDiarioAggregateRoot.AdicionarMarcacion) -- nunca lanza, nunca emite un evento de fallo
-    // persistido. Sin reglas de estado que violar (el comando mas simple del ciclo de vida): solo
-    // compara el nombre nuevo con el actual por igualdad de valor (NombreColaborador.Equals, #348).
-    // Igual por valor -> no hace nada (idempotencia silenciosa, evita ruido en el stream por dobles
-    // envios). Distinto por valor -> appendea NombresCorregidos a _uncommittedEvents y lo aplica.
-    // Solo exige existencia del colaborador (implicita: el handler ya lo rehidrato via
-    // GetAggregateRootAsync antes de llamar aqui), nunca vigencia de su vinculacion -- corregir
-    // sobre un colaborador con vinculacion terminada es valido (decision de refinamiento
-    // 2026-08-11: los nombres son de la PERSONA, no de la vinculacion).
-    // internal: mismo criterio de visibilidad que TerminarVinculacion/Reingresar -- el unico
-    // llamador es el handler del mismo ensamblado (los tests lo alcanzan via InternalsVisibleTo).
+    // Issue #351: mecanismo "declinar en silencio" (precedente ControlDiarioAggregateRoot.
+    // AdicionarMarcacion) -- nunca lanza ni emite un evento de fallo persistido, y a diferencia de
+    // TerminarVinculacion/Reingresar no responde razon: sin reglas de estado que violar, la unica
+    // causa de no emitir es que no haya nada que corregir, y el borde responde 202 igual.
+    // La idempotencia es por igualdad de VALOR (NombreColaborador.Equals, #348), no por los
+    // primitivos crudos del comando: el handler ya construyo el VO, que normaliza trim y opcionales
+    // ausentes antes de que esta comparacion ocurra.
+    // No mira la vigencia de la vinculacion: los nombres son de la PERSONA, no de la vinculacion
+    // (decision de refinamiento 2026-08-11), asi que corregir sobre una vinculacion terminada es
+    // valido. La existencia del colaborador ya la garantizo el handler al rehidratarlo.
+    // internal: mismo criterio de visibilidad que TerminarVinculacion/Reingresar.
     internal void CorregirNombres(NombreColaborador nombre)
     {
         if (nombre.Equals(_nombre))

--- a/src/Bitakora.ControlAsistencia.Colaboradores/Entities/ColaboradorAggregateRoot.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/Entities/ColaboradorAggregateRoot.cs
@@ -66,6 +66,10 @@ public partial class ColaboradorAggregateRoot : AggregateRoot
     // capa 4).
     public void Apply(VinculacionTerminada e) => _fechaTerminacionVinculacionVigente = e.FechaEfectiva;
 
+    // Issue #351: reemplaza el nombre de la persona. Nunca lanza (MEF-ADR-0004 capa 4).
+    // STUB (fase roja, issue #351): el cuerpo completo queda para el implementer.
+    public void Apply(NombresCorregidos e) => throw new NotImplementedException();
+
     // Issue #349: mecanismo "declinar con resultado" (CA-ADR-0030) -- nunca lanza, nunca emite un
     // evento de fallo persistido. Dos razones de rechazo evaluables solo con la historia del
     // stream, sin reloj (decision de refinamiento):
@@ -120,6 +124,21 @@ public partial class ColaboradorAggregateRoot : AggregateRoot
 
         return ResultadoReingresoColaborador.Exitosa;
     }
+
+    // Issue #351: mecanismo "declinar silencioso" (decision de refinamiento 2026-08-11, precedente
+    // ControlDiarioAggregateRoot.AdicionarMarcacion) -- nunca lanza, nunca emite un evento de fallo
+    // persistido. Sin reglas de estado que violar (el comando mas simple del ciclo de vida): solo
+    // compara el nombre nuevo con el actual por igualdad de valor (NombreColaborador.Equals, #348).
+    // Igual por valor -> no hace nada (idempotencia silenciosa, evita ruido en el stream por dobles
+    // envios). Distinto por valor -> appendea NombresCorregidos a _uncommittedEvents y lo aplica.
+    // Solo exige existencia del colaborador (implicita: el handler ya lo rehidrato via
+    // GetAggregateRootAsync antes de llamar aqui), nunca vigencia de su vinculacion -- corregir
+    // sobre un colaborador con vinculacion terminada es valido (decision de refinamiento
+    // 2026-08-11: los nombres son de la PERSONA, no de la vinculacion).
+    // internal: mismo criterio de visibilidad que TerminarVinculacion/Reingresar -- el unico
+    // llamador es el handler del mismo ensamblado (los tests lo alcanzan via InternalsVisibleTo).
+    // STUB (fase roja, issue #351): el cuerpo completo queda para el implementer.
+    internal void CorregirNombres(NombreColaborador nombre) => throw new NotImplementedException();
 
     // Factory interno: agrega los DOS eventos del commit a _uncommittedEvents y los aplica -- patron
     // RegistroDeMarcacionAggregateRoot.Iniciar, generalizado a dos eventos en el mismo commit.

--- a/src/Bitakora.ControlAsistencia.Colaboradores/Entities/ColaboradorAggregateRoot.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/Entities/ColaboradorAggregateRoot.cs
@@ -67,8 +67,7 @@ public partial class ColaboradorAggregateRoot : AggregateRoot
     public void Apply(VinculacionTerminada e) => _fechaTerminacionVinculacionVigente = e.FechaEfectiva;
 
     // Issue #351: reemplaza el nombre de la persona. Nunca lanza (MEF-ADR-0004 capa 4).
-    // STUB (fase roja, issue #351): el cuerpo completo queda para el implementer.
-    public void Apply(NombresCorregidos e) => throw new NotImplementedException();
+    public void Apply(NombresCorregidos e) => _nombre = e.Nombre;
 
     // Issue #349: mecanismo "declinar con resultado" (CA-ADR-0030) -- nunca lanza, nunca emite un
     // evento de fallo persistido. Dos razones de rechazo evaluables solo con la historia del
@@ -137,8 +136,15 @@ public partial class ColaboradorAggregateRoot : AggregateRoot
     // 2026-08-11: los nombres son de la PERSONA, no de la vinculacion).
     // internal: mismo criterio de visibilidad que TerminarVinculacion/Reingresar -- el unico
     // llamador es el handler del mismo ensamblado (los tests lo alcanzan via InternalsVisibleTo).
-    // STUB (fase roja, issue #351): el cuerpo completo queda para el implementer.
-    internal void CorregirNombres(NombreColaborador nombre) => throw new NotImplementedException();
+    internal void CorregirNombres(NombreColaborador nombre)
+    {
+        if (nombre.Equals(_nombre))
+            return;
+
+        var evento = new NombresCorregidos(nombre);
+        _uncommittedEvents.Add(evento);
+        Apply(evento);
+    }
 
     // Factory interno: agrega los DOS eventos del commit a _uncommittedEvents y los aplica -- patron
     // RegistroDeMarcacionAggregateRoot.Iniciar, generalizado a dos eventos en el mismo commit.

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/CorregirNombresFunction/CorregirNombresSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/CorregirNombresFunction/CorregirNombresSmokeTests.cs
@@ -9,14 +9,15 @@
 // registra el colaborador (y, cuando aplica, termina su vinculacion) via los mismos comandos que
 // los originan (#330 y #349), nunca sembrando datos por fuera del API.
 //
-// Contenido persistido (Nombre, un VO con ctor privado): se compara con la SERIALIZACION REAL de
-// produccion -- NombreColaborador + ConfiguracionSerializacionColaboradores.CrearOpcionesMarten(),
-// referenciadas desde Colaboradores.DomainEvents (ya cableado en el .csproj por el
-// domain-scaffolder). Mismo criterio que AsignarTurnoViaSbSmokeTests (ControlHoras, issue #322):
-// "el smoke test deserializa/serializa con el tipo que realmente posee el payload persistido", no
-// con un tipo de bus -- NombreColaborador ES ese tipo (MEF-ADR-0039 decision 6). Round-trip
-// deserializando "Nombre" y comparando por igualdad de valor (NombreColaborador.Equals, #348),
-// nunca comparando texto JSON crudo a mano.
+// Contenido persistido (Nombre, un VO con ctor privado): se verifica deserializando el campo con
+// la SERIALIZACION REAL de produccion -- NombreColaborador +
+// ConfiguracionSerializacionColaboradores.CrearOpcionesMarten(), referenciadas desde
+// Colaboradores.DomainEvents (ya cableado en el .csproj por el domain-scaffolder). Mismo criterio
+// que AsignarTurnoViaSbSmokeTests (ControlHoras, issue #322): "el smoke test deserializa/serializa
+// con el tipo que realmente posee el payload persistido", no con un tipo de bus --
+// NombreColaborador ES ese tipo (MEF-ADR-0039 decision 6). La comparacion es por igualdad de valor
+// (NombreColaborador.Equals, #348), NUNCA contra el texto JSON persistido: mt_events.data es jsonb
+// y PostgreSQL no preserva whitespace ni orden de claves (docs 8.14.1).
 //
 // CA-1/CA-2 (rutas de exito): 202 + el stream recibe NombresCorregidos con el Nombre corregido --
 // ya sea con la vinculacion abierta (CA-1) o con la ultima vinculacion TERMINADA (CA-2, prueba que
@@ -58,6 +59,10 @@ public class CorregirNombresSmokeTests(ApiFixture api, PostgresFixture postgres)
     // alcanza para probarla sin alargar la suite esperando los 30s estandar sin ganar senal.
     private static readonly TimeSpan TimeoutAusencia = TimeSpan.FromSeconds(3);
 
+    // Segunda lectura del mismo evento que ExisteEventoAsync ya espero: si el primer polling
+    // termino, el evento esta -- no hay nada mas que esperar.
+    private static readonly TimeSpan TimeoutLecturaConfirmada = TimeSpan.FromSeconds(5);
+
     private static readonly JsonSerializerOptions OpcionesMarten =
         ConfiguracionSerializacionColaboradores.CrearOpcionesMarten();
 
@@ -71,16 +76,6 @@ public class CorregirNombresSmokeTests(ApiFixture api, PostgresFixture postgres)
 
     private static string ComputarStreamId(string numeroIdentificacion) =>
         $"{TipoIdentificacionCc}:{numeroIdentificacion}";
-
-    // Serializa el VO NombreColaborador con las MISMAS opciones que Marten usa en produccion --
-    // no es un texto adivinado: es la salida real del resolver registrado en
-    // ConfiguracionSerializacionColaboradores (ver comentario de archivo).
-    private static string SerializarNombreEsperado(
-        string primerNombre, string? segundoNombre, string primerApellido, string? segundoApellido)
-    {
-        var nombre = NombreColaborador.Crear(primerNombre, segundoNombre, primerApellido, segundoApellido);
-        return JsonSerializer.Serialize(nombre, OpcionesMarten);
-    }
 
     private static object PayloadRegistro(
         string numeroIdentificacion, DateOnly fechaInicio,
@@ -143,6 +138,29 @@ public class CorregirNombresSmokeTests(ApiFixture api, PostgresFixture postgres)
             "el arrange de este smoke test depende de que TerminarVinculacion funcione");
     }
 
+    // Assert comun de CA-1/CA-2: espera el evento en mt_events y verifica su payload por VALOR,
+    // deserializando el campo Nombre con las opciones reales de Marten (el round-trip que ese VO
+    // hace en produccion). No se compara contra el texto JSON persistido: mt_events.data es jsonb y
+    // PostgreSQL no preserva ni whitespace ni orden de claves (docs 8.14.1), asi que cualquier
+    // igualdad de texto seria un falso rojo -- la igualdad de dominio (NombreColaborador.Equals,
+    // #348) es el oraculo correcto.
+    private async Task ElStreamRecibioElNombreAsync(string streamId, NombreColaborador nombreEsperado)
+    {
+        var existe = await postgres.ExisteEventoAsync(
+            SchemaColaboradores, streamId, TipoEventoNombresCorregidos, Timeout);
+
+        existe.Should().BeTrue(
+            $"el evento {TipoEventoNombresCorregidos} deberia existir en el stream {streamId}");
+
+        var eventoPersistido = await postgres.ObtenerEventoAsync<JsonElement>(
+            SchemaColaboradores, streamId, TipoEventoNombresCorregidos, TimeoutLecturaConfirmada);
+
+        var nombrePersistido = eventoPersistido.GetProperty("Nombre")
+            .Deserialize<NombreColaborador>(OpcionesMarten);
+
+        nombrePersistido.Should().Be(nombreEsperado);
+    }
+
     [Fact]
     [Trait("Category", "Smoke")]
     public async Task DebeEstarDisponible_CuandoSeConsultaHealthCheck()
@@ -176,24 +194,9 @@ public class CorregirNombresSmokeTests(ApiFixture api, PostgresFixture postgres)
 
         response.StatusCode.Should().Be(HttpStatusCode.Accepted);
 
-        var streamId = ComputarStreamId(numeroIdentificacion);
-        var nombreEsperadoJson = SerializarNombreEsperado("[TEST]", "Corregido", "Smoke", "Segundo");
-
-        var existe = await postgres.ExisteEventoAsync(
-            SchemaColaboradores, streamId, TipoEventoNombresCorregidos, Timeout,
-            campoJson: "Nombre", valorJson: nombreEsperadoJson);
-
-        existe.Should().BeTrue(
-            $"el evento {TipoEventoNombresCorregidos} deberia existir en el stream {streamId} con el nombre corregido");
-
-        var eventoPersistido = await postgres.ObtenerEventoAsync<JsonElement>(
-            SchemaColaboradores, streamId, TipoEventoNombresCorregidos,
-            campoJson: "Nombre", valorJson: nombreEsperadoJson, TimeSpan.FromSeconds(5));
-
-        var nombreEsperado = NombreColaborador.Crear("[TEST]", "Corregido", "Smoke", "Segundo");
-        var nombrePersistido = eventoPersistido.GetProperty("Nombre").Deserialize<NombreColaborador>(OpcionesMarten);
-
-        nombrePersistido.Should().Be(nombreEsperado);
+        await ElStreamRecibioElNombreAsync(
+            ComputarStreamId(numeroIdentificacion),
+            NombreColaborador.Crear("[TEST]", "Corregido", "Smoke", "Segundo"));
     }
 
     // CA-2: la ultima vinculacion esta TERMINADA -> la correccion procede igual -- solo exige
@@ -220,16 +223,11 @@ public class CorregirNombresSmokeTests(ApiFixture api, PostgresFixture postgres)
 
         response.StatusCode.Should().Be(HttpStatusCode.Accepted);
 
-        var streamId = ComputarStreamId(numeroIdentificacion);
-        var nombreEsperadoJson = SerializarNombreEsperado("[TEST]", "Reingreso", "Terminada", null);
-
-        var existe = await postgres.ExisteEventoAsync(
-            SchemaColaboradores, streamId, TipoEventoNombresCorregidos, Timeout,
-            campoJson: "Nombre", valorJson: nombreEsperadoJson);
-
-        existe.Should().BeTrue(
-            "la correccion de nombres deberia proceder sobre un colaborador con vinculacion terminada " +
-            "-- solo exige existencia, nunca vigencia");
+        // La correccion procede sobre un colaborador con vinculacion terminada: solo exige
+        // existencia, nunca vigencia.
+        await ElStreamRecibioElNombreAsync(
+            ComputarStreamId(numeroIdentificacion),
+            NombreColaborador.Crear("[TEST]", "Reingreso", "Terminada", null));
     }
 
     // CA-3: nombre igual por valor al actual -> 202 sin evento nuevo en el stream (idempotencia

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/CorregirNombresFunction/CorregirNombresSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/CorregirNombresFunction/CorregirNombresSmokeTests.cs
@@ -1,0 +1,343 @@
+// Issue #351: smoke tests del endpoint POST Colaboradores/Nombres (corregir los nombres de un
+// colaborador existente). Cuarto comando del ciclo de vida de ColaboradorAggregateRoot y el mas
+// simple: sin reglas de estado (CA-ADR-0030) -- por eso este archivo no tiene caso 409. Molde:
+// TerminarVinculacionSmokeTests/ReingresarColaboradorSmokeTests (#349/#350) -- mismo comando
+// event-sourcing puro sin consumidores downstream: sin ServiceBusFixture, la unica verificacion
+// black-box de los efectos del handler es leer mt_events via PostgresFixture.
+//
+// Arrange: CorregirNombres exige un ColaboradorAggregateRoot existente -- el arrange de cada test
+// registra el colaborador (y, cuando aplica, termina su vinculacion) via los mismos comandos que
+// los originan (#330 y #349), nunca sembrando datos por fuera del API.
+//
+// Contenido persistido (Nombre, un VO con ctor privado): se compara con la SERIALIZACION REAL de
+// produccion -- NombreColaborador + ConfiguracionSerializacionColaboradores.CrearOpcionesMarten(),
+// referenciadas desde Colaboradores.DomainEvents (ya cableado en el .csproj por el
+// domain-scaffolder). Mismo criterio que AsignarTurnoViaSbSmokeTests (ControlHoras, issue #322):
+// "el smoke test deserializa/serializa con el tipo que realmente posee el payload persistido", no
+// con un tipo de bus -- NombreColaborador ES ese tipo (MEF-ADR-0039 decision 6). Round-trip
+// deserializando "Nombre" y comparando por igualdad de valor (NombreColaborador.Equals, #348),
+// nunca comparando texto JSON crudo a mano.
+//
+// CA-1/CA-2 (rutas de exito): 202 + el stream recibe NombresCorregidos con el Nombre corregido --
+// ya sea con la vinculacion abierta (CA-1) o con la ultima vinculacion TERMINADA (CA-2, prueba que
+// la correccion solo exige existencia del colaborador, nunca vigencia de su vinculacion).
+// CA-3: nombre igual por valor al actual -> 202 sin evento nuevo en el stream (idempotencia
+// silenciosa, mecanismo "declinar en silencio" -- precedente ControlDiarioAggregateRoot.
+// AdicionarMarcacion). La ausencia se verifica con un timeout corto (3s, no el estandar de 30s):
+// este comando es event-sourcing puro sin proyeccion asincrona downstream -- si el evento no llego
+// ya en la respuesta HTTP, nunca va a llegar; esperar el timeout estandar solo alargaria la
+// suite sin ganar senal.
+// CA-4: colaborador inexistente -> 404, sin escribir nada al event store.
+// CA-5: request invalida (sin primer nombre, sin primer apellido, sin identificacion, tipo fuera
+// de la lista) -> 400, sin tocar el event store.
+// CA-6 (NombresCorregidos registrado en TiposPersistidos + round-trip de serializacion): cubierto
+// transitivamente por CA-1/CA-2 contra el entorno real desplegado; el detalle exhaustivo del
+// round-trip vive en NombresCorregidosSerializacionTests.cs (*.Tests), no se duplica aqui.
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+using Bitakora.ControlAsistencia.Colaboradores.SmokeTests.Fixtures;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.SmokeTests.CorregirNombresFunction;
+
+public class CorregirNombresSmokeTests(ApiFixture api, PostgresFixture postgres)
+{
+    private readonly HttpClient _client = api.Client;
+
+    private const string RutaRegistrar = "/api/Colaboradores";
+    private const string RutaTerminaciones = "/api/Colaboradores/Terminaciones";
+    private const string RutaNombres = "/api/Colaboradores/Nombres";
+    private const string SchemaColaboradores = "colaboradores";
+    private const string TipoEventoNombresCorregidos = "nombres_corregidos";
+    private const string TipoIdentificacionCc = "CC";
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
+
+    // CA-3: la ausencia de evento es sincrona (sin proyeccion downstream) -- un timeout corto
+    // alcanza para probarla sin alargar la suite esperando los 30s estandar sin ganar senal.
+    private static readonly TimeSpan TimeoutAusencia = TimeSpan.FromSeconds(3);
+
+    private static readonly JsonSerializerOptions OpcionesMarten =
+        ConfiguracionSerializacionColaboradores.CrearOpcionesMarten();
+
+    // Numero unico por test -- evita colisiones entre ejecuciones repetidas del smoke test: la
+    // identidad del stream es Identificacion.ToString() ("CC:<numero>"), no un Guid nuevo por
+    // llamada, asi que reusar un numero fijo haria que el arrange (RegistrarColaborador) choque con
+    // 409 en la segunda corrida.
+    private static string NuevoNumeroIdentificacion() => Guid.CreateVersion7().ToString("N").ToUpperInvariant();
+
+    private static string NuevoCodigoColaborador() => $"[TEST]-{Guid.CreateVersion7()}";
+
+    private static string ComputarStreamId(string numeroIdentificacion) =>
+        $"{TipoIdentificacionCc}:{numeroIdentificacion}";
+
+    // Serializa el VO NombreColaborador con las MISMAS opciones que Marten usa en produccion --
+    // no es un texto adivinado: es la salida real del resolver registrado en
+    // ConfiguracionSerializacionColaboradores (ver comentario de archivo).
+    private static string SerializarNombreEsperado(
+        string primerNombre, string? segundoNombre, string primerApellido, string? segundoApellido)
+    {
+        var nombre = NombreColaborador.Crear(primerNombre, segundoNombre, primerApellido, segundoApellido);
+        return JsonSerializer.Serialize(nombre, OpcionesMarten);
+    }
+
+    private static object PayloadRegistro(
+        string numeroIdentificacion, DateOnly fechaInicio,
+        string primerNombre, string? segundoNombre, string primerApellido, string? segundoApellido) => new
+        {
+            tipoIdentificacion = TipoIdentificacionCc,
+            numeroIdentificacion,
+            primerNombre,
+            segundoNombre,
+            primerApellido,
+            segundoApellido,
+            codigoColaborador = NuevoCodigoColaborador(),
+            fechaInicio
+        };
+
+    private static object PayloadTerminacion(string numeroIdentificacion, DateOnly fechaEfectiva) => new
+    {
+        tipoIdentificacion = TipoIdentificacionCc,
+        numeroIdentificacion,
+        fechaEfectiva
+    };
+
+    private static object PayloadCorreccion(
+        string numeroIdentificacion, string primerNombre, string? segundoNombre,
+        string primerApellido, string? segundoApellido, string tipoIdentificacion = TipoIdentificacionCc) => new
+        {
+            tipoIdentificacion,
+            numeroIdentificacion,
+            primerNombre,
+            segundoNombre,
+            primerApellido,
+            segundoApellido
+        };
+
+    // Arrange comun: registra un colaborador con una vinculacion abierta -- via el comando que la
+    // origina (#330), nunca sembrando el event store por fuera del API.
+    private async Task RegistrarColaboradorAsync(
+        string numeroIdentificacion, DateOnly fechaInicio,
+        string primerNombre, string? segundoNombre, string primerApellido, string? segundoApellido,
+        CancellationToken ct)
+    {
+        var response = await _client.PostAsJsonAsync(
+            RutaRegistrar,
+            PayloadRegistro(numeroIdentificacion, fechaInicio, primerNombre, segundoNombre, primerApellido, segundoApellido),
+            ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted,
+            "el arrange de este smoke test depende de que RegistrarColaborador funcione");
+    }
+
+    // Arrange comun (CA-2): cierra la vinculacion vigente -- via el comando que la origina (#349),
+    // nunca sembrando el event store por fuera del API.
+    private async Task TerminarVinculacionAsync(
+        string numeroIdentificacion, DateOnly fechaEfectiva, CancellationToken ct)
+    {
+        var response = await _client.PostAsJsonAsync(
+            RutaTerminaciones, PayloadTerminacion(numeroIdentificacion, fechaEfectiva), ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted,
+            "el arrange de este smoke test depende de que TerminarVinculacion funcione");
+    }
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task DebeEstarDisponible_CuandoSeConsultaHealthCheck()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var response = await _client.GetAsync("/api/health", ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    // CA-1: camino feliz -- colaborador con vinculacion abierta + nombre distinto por valor -> 202
+    // y el stream recibe NombresCorregidos con el Nombre corregido. Sin Service Bus (event-sourcing
+    // puro): mt_events es la unica ventana black-box a lo que quedo grabado.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task CorregirNombres_Retorna202YPersisteNombresCorregidos_CuandoNombreEsDistintoPorValor()
+    {
+        Assert.SkipWhen(!postgres.IsConfigured, postgres.SkipReason ?? "Postgres no disponible.");
+
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion();
+
+        await RegistrarColaboradorAsync(
+            numeroIdentificacion, new DateOnly(2026, 1, 15),
+            "[TEST]", "Original", "Smoke", null, ct);
+
+        var response = await _client.PostAsJsonAsync(
+            RutaNombres,
+            PayloadCorreccion(numeroIdentificacion, "[TEST]", "Corregido", "Smoke", "Segundo"),
+            ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+
+        var streamId = ComputarStreamId(numeroIdentificacion);
+        var nombreEsperadoJson = SerializarNombreEsperado("[TEST]", "Corregido", "Smoke", "Segundo");
+
+        var existe = await postgres.ExisteEventoAsync(
+            SchemaColaboradores, streamId, TipoEventoNombresCorregidos, Timeout,
+            campoJson: "Nombre", valorJson: nombreEsperadoJson);
+
+        existe.Should().BeTrue(
+            $"el evento {TipoEventoNombresCorregidos} deberia existir en el stream {streamId} con el nombre corregido");
+
+        var eventoPersistido = await postgres.ObtenerEventoAsync<JsonElement>(
+            SchemaColaboradores, streamId, TipoEventoNombresCorregidos,
+            campoJson: "Nombre", valorJson: nombreEsperadoJson, TimeSpan.FromSeconds(5));
+
+        var nombreEsperado = NombreColaborador.Crear("[TEST]", "Corregido", "Smoke", "Segundo");
+        var nombrePersistido = eventoPersistido.GetProperty("Nombre").Deserialize<NombreColaborador>(OpcionesMarten);
+
+        nombrePersistido.Should().Be(nombreEsperado);
+    }
+
+    // CA-2: la ultima vinculacion esta TERMINADA -> la correccion procede igual -- solo exige
+    // existencia del colaborador, nunca vigencia de su vinculacion (decision de refinamiento
+    // 2026-08-11: los nombres son de la PERSONA, no de la vinculacion).
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task CorregirNombres_Retorna202YPersisteNombresCorregidos_CuandoVinculacionEstaTerminada()
+    {
+        Assert.SkipWhen(!postgres.IsConfigured, postgres.SkipReason ?? "Postgres no disponible.");
+
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion();
+
+        await RegistrarColaboradorAsync(
+            numeroIdentificacion, new DateOnly(2026, 2, 1),
+            "[TEST]", null, "Terminada", null, ct);
+        await TerminarVinculacionAsync(numeroIdentificacion, new DateOnly(2026, 3, 1), ct);
+
+        var response = await _client.PostAsJsonAsync(
+            RutaNombres,
+            PayloadCorreccion(numeroIdentificacion, "[TEST]", "Reingreso", "Terminada", null),
+            ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+
+        var streamId = ComputarStreamId(numeroIdentificacion);
+        var nombreEsperadoJson = SerializarNombreEsperado("[TEST]", "Reingreso", "Terminada", null);
+
+        var existe = await postgres.ExisteEventoAsync(
+            SchemaColaboradores, streamId, TipoEventoNombresCorregidos, Timeout,
+            campoJson: "Nombre", valorJson: nombreEsperadoJson);
+
+        existe.Should().BeTrue(
+            "la correccion de nombres deberia proceder sobre un colaborador con vinculacion terminada " +
+            "-- solo exige existencia, nunca vigencia");
+    }
+
+    // CA-3: nombre igual por valor al actual -> 202 sin evento nuevo en el stream (idempotencia
+    // silenciosa). Verificacion de ausencia con timeout corto -- ver el porque en el comentario de
+    // TimeoutAusencia (arriba).
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task CorregirNombres_Retorna202SinNuevoEvento_CuandoNombreEsIgualPorValorAlActual()
+    {
+        Assert.SkipWhen(!postgres.IsConfigured, postgres.SkipReason ?? "Postgres no disponible.");
+
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion();
+
+        await RegistrarColaboradorAsync(
+            numeroIdentificacion, new DateOnly(2026, 1, 20),
+            "[TEST]", "Igual", "Smoke", null, ct);
+
+        var response = await _client.PostAsJsonAsync(
+            RutaNombres,
+            PayloadCorreccion(numeroIdentificacion, "[TEST]", "Igual", "Smoke", null),
+            ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+
+        var existe = await postgres.ExisteEventoAsync(
+            SchemaColaboradores, ComputarStreamId(numeroIdentificacion), TipoEventoNombresCorregidos,
+            TimeoutAusencia);
+
+        existe.Should().BeFalse(
+            "un nombre igual por valor al actual no deberia persistir un evento nuevo (idempotencia silenciosa)");
+    }
+
+    // CA-4: colaborador inexistente -> 404, sin escribir nada al event store (no hay stream para
+    // consultar: la ausencia de escritura la garantiza el propio 404 -- el handler lanza antes de
+    // llegar al aggregate).
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task CorregirNombres_Retorna404_CuandoColaboradorNoExiste()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion(); // nunca registrado
+
+        var response = await _client.PostAsJsonAsync(
+            RutaNombres,
+            PayloadCorreccion(numeroIdentificacion, "[TEST]", null, "Smoke", null),
+            ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    // CA-5: PrimerNombre vacio -> 400.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task CorregirNombres_Retorna400_CuandoPrimerNombreEsVacio()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var payload = PayloadCorreccion(
+            NuevoNumeroIdentificacion(), primerNombre: "", segundoNombre: null,
+            primerApellido: "Smoke", segundoApellido: null);
+
+        var response = await _client.PostAsJsonAsync(RutaNombres, payload, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    // CA-5: PrimerApellido vacio -> 400.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task CorregirNombres_Retorna400_CuandoPrimerApellidoEsVacio()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var payload = PayloadCorreccion(
+            NuevoNumeroIdentificacion(), primerNombre: "[TEST]", segundoNombre: null,
+            primerApellido: "", segundoApellido: null);
+
+        var response = await _client.PostAsJsonAsync(RutaNombres, payload, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    // CA-5: NumeroIdentificacion vacio -> 400.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task CorregirNombres_Retorna400_CuandoNumeroIdentificacionEsVacio()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var payload = PayloadCorreccion(
+            numeroIdentificacion: "", primerNombre: "[TEST]", segundoNombre: null,
+            primerApellido: "Smoke", segundoApellido: null);
+
+        var response = await _client.PostAsJsonAsync(RutaNombres, payload, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    // CA-5: TipoIdentificacion fuera de la lista cerrada (PILA: CC, CE, TI, PA, PT) -> 400.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task CorregirNombres_Retorna400_CuandoTipoIdentificacionNoEsReconocido()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var payload = PayloadCorreccion(
+            NuevoNumeroIdentificacion(), primerNombre: "[TEST]", segundoNombre: null,
+            primerApellido: "Smoke", segundoApellido: null, tipoIdentificacion: "XX");
+
+        var response = await _client.PostAsJsonAsync(RutaNombres, payload, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/Fixtures/PostgresFixture.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/Fixtures/PostgresFixture.cs
@@ -63,17 +63,42 @@ public class PostgresFixture : IAsyncLifetime
         }, timeout);
     }
 
-    public async Task<T> ObtenerEventoAsync<T>(
+    /// <summary>
+    /// Obtiene el primer evento del tipo indicado en el stream, sin filtrar por contenido.
+    /// </summary>
+    /// <remarks>
+    /// Issue #351: el filtro por (campoJson, valorJson) del overload de abajo compara
+    /// <c>JsonElement.ToString()</c> contra un texto -- solo sirve para campos ESCALARES. Para un
+    /// campo objeto (un VO serializado, como el Nombre de nombres_corregidos) esa comparacion nunca
+    /// coincide: mt_events.data es jsonb, y PostgreSQL no preserva ni el whitespace ni el orden de
+    /// las claves (docs 8.14.1), mientras que <c>ToString()</c> sobre un objeto devuelve el texto
+    /// crudo tal como llego. El test que necesita verificar contenido de un campo objeto usa este
+    /// overload y compara por VALOR, deserializando con las opciones reales de Marten.
+    /// Es seguro no filtrar porque cada smoke test usa una identificacion nueva: su stream contiene
+    /// un solo evento de cada tipo.
+    /// </remarks>
+    public Task<T> ObtenerEventoAsync<T>(
+        string schema, string streamId, string tipoEvento, TimeSpan timeout) =>
+        ObtenerPrimerEventoAsync<T>(schema, streamId, tipoEvento, campoJson: null, valorJson: null, timeout);
+
+    public Task<T> ObtenerEventoAsync<T>(
         string schema, string streamId, string tipoEvento,
-        string campoJson, string valorJson, TimeSpan timeout)
+        string campoJson, string valorJson, TimeSpan timeout) =>
+        ObtenerPrimerEventoAsync<T>(schema, streamId, tipoEvento, campoJson, valorJson, timeout);
+
+    private async Task<T> ObtenerPrimerEventoAsync<T>(
+        string schema, string streamId, string tipoEvento,
+        string? campoJson, string? valorJson, TimeSpan timeout)
     {
         var json = await Polling.WaitUntilAsync(async () =>
         {
             var eventos = await ObtenerEventosInternoAsync(schema, streamId, tipoEvento);
 
-            var match = eventos.FirstOrDefault(e =>
-                e.TryGetProperty(campoJson, out var prop) &&
-                prop.ToString() == valorJson);
+            var match = campoJson is null || valorJson is null
+                ? eventos.FirstOrDefault()
+                : eventos.FirstOrDefault(e =>
+                    e.TryGetProperty(campoJson, out var prop) &&
+                    prop.ToString() == valorJson);
 
             if (match.ValueKind == JsonValueKind.Undefined)
                 return null;

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/CorregirNombresFunction/CorregirNombresCommandHandlerMensajesTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/CorregirNombresFunction/CorregirNombresCommandHandlerMensajesTests.cs
@@ -1,0 +1,22 @@
+// Issue #351: guardrail de resolucion del .resx del handler (MEF-ADR-0009), gemelo de
+// TerminarVinculacionCommandHandlerMensajesTests/ReingresarColaboradorCommandHandlerMensajesTests.
+//
+// Por que existe: CorregirNombresCommandHandler.Mensajes devuelve ResourceManager.GetString(...)!
+// -- el "!" es supresion del compilador, no garantia de runtime. Si la CLAVE desaparece del .resx
+// (rename, merge que la pierde) GetString retorna null en silencio y el test del handler que
+// verifica el 404 pasa en FALSO: su asercion es WithMessage($"*{Mensajes.X}*"), que con X == null
+// se vuelve "**" y matchea cualquier excepcion.
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.CorregirNombresFunction.CommandHandler;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Tests.CorregirNombresFunction;
+
+public class CorregirNombresCommandHandlerMensajesTests
+{
+    [Fact]
+    public void Mensajes_ResuelvenTextoNoVacio_CuandoPertenecenACorregirNombresCommandHandler()
+    {
+        CorregirNombresCommandHandler.Mensajes.ColaboradorNoEncontrado.Should().NotBeNullOrWhiteSpace();
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/CorregirNombresFunction/CorregirNombresCommandHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/CorregirNombresFunction/CorregirNombresCommandHandlerTests.cs
@@ -90,6 +90,29 @@ public class CorregirNombresCommandHandlerTests : CommandHandlerAsyncTest<Correg
             StreamIdEsperado, c => c.Nombre.NombreCompleto, "Luis Alberto Barreto");
     }
 
+    // CA-1 (borde de identidad, MEF-ADR-0037): "cc" en minusculas + numero con espacios sobre un
+    // colaborador ya registrado -> la correccion alcanza el MISMO stream ("CC:79543210") y emite el
+    // evento. La normalizacion del numero la garantiza Identificacion.Crear (#348); la del codigo
+    // de tipo ("cc" -> "CC") es responsabilidad del handler en el borde, porque
+    // TipoIdentificacion.Desde es case-sensitive por diseno (#348). Sin ella el handler computaria
+    // otra clave y responderia 404 sobre un colaborador que si existe.
+    [Fact]
+    public async Task CorregirNombres_EmiteNombresCorregidos_CuandoTipoYNumeroLleganSinNormalizar()
+    {
+        DadoUnColaboradorConVinculacionAbierta();
+        var comandoSinNormalizar = ComandoConNombreDistinto() with
+        {
+            TipoIdentificacion = "cc",
+            NumeroIdentificacion = "  79543210  "
+        };
+
+        await WhenAsync(comandoSinNormalizar);
+
+        Then(StreamIdEsperado, new NombresCorregidos(NombreColaborador.Crear("Luis", "Alberto", "Barreto", null)));
+        And<ColaboradorAggregateRoot, string>(
+            StreamIdEsperado, c => c.Nombre.NombreCompleto, "Luis Alberto Barreto");
+    }
+
     // CA-2: la vinculacion vigente esta TERMINADA -> la correccion procede igual -- solo exige
     // existencia del colaborador, nunca vigencia de la vinculacion (decision de refinamiento
     // 2026-08-11: los nombres son de la PERSONA, no de la vinculacion).

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/CorregirNombresFunction/CorregirNombresCommandHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/CorregirNombresFunction/CorregirNombresCommandHandlerTests.cs
@@ -1,0 +1,156 @@
+// Issue #351: corregir los nombres de un colaborador -- cuarto comando del ciclo de vida de
+// ColaboradorAggregateRoot (desglose #348-#357) y el mas simple: sin reglas de estado.
+// CA-ADR-0030: no hay eventos de fallo -- el handler solo traduce "colaborador inexistente" a
+// KeyNotFoundException (404). El aggregate declina en SILENCIO (idempotencia por igualdad de
+// valor, decision de refinamiento 2026-08-11) cuando el nombre nuevo es igual por valor al actual.
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.CorregirNombresFunction;
+using Bitakora.ControlAsistencia.Colaboradores.CorregirNombresFunction.CommandHandler;
+using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+using Bitakora.ControlAsistencia.Colaboradores.Entities;
+using Cosmos.EventSourcing.Abstractions.Commands;
+using Cosmos.EventSourcing.Testing.Utilities;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Tests.CorregirNombresFunction;
+
+// El aggregate usa un stream ID compuesto (Identificacion.ToString(), "CC:79543210"), no el
+// GuidAggregateId del harness -- overloads explicitos de Given/Then/And (regla 18 del
+// test-writer, mismo criterio que TerminarVinculacionCommandHandlerTests/
+// ReingresarColaboradorCommandHandlerTests).
+public class CorregirNombresCommandHandlerTests : CommandHandlerAsyncTest<CorregirNombres>
+{
+    private const string NumeroValido = "79543210";
+
+    // Oraculo independiente de la clave de stream (MEF-ADR-0002 + MEF-ADR-0037): literal, no
+    // derivado de ColaboradorAggregateRoot.ComputarStreamId.
+    private const string StreamIdEsperado = "CC:79543210";
+
+    private const string CodigoVinculacionOriginal = "COL-001";
+    private static readonly DateOnly FechaInicioOriginal = new(2026, 1, 15);
+    private static readonly DateOnly FechaEfectivaTerminacion = new(2026, 6, 1);
+
+    protected override ICommandHandlerAsync<CorregirNombres> Handler =>
+        new CorregirNombresCommandHandler(EventStore);
+
+    private static Identificacion IdentificacionValida() =>
+        Identificacion.Crear(TipoIdentificacion.CC, NumeroValido);
+
+    // Nombre original del colaborador registrado -- oraculo del "actual" contra el que el
+    // aggregate compara por igualdad de valor.
+    private static NombreColaborador NombreOriginal() =>
+        NombreColaborador.Crear("Luis", "Augusto", "Barreto", null);
+
+    private static ColaboradorRegistrado ColaboradorRegistradoValido() =>
+        new(IdentificacionValida(), NombreOriginal());
+
+    private static VinculacionIniciada VinculacionIniciadaOriginal() =>
+        new(CodigoVinculacionOriginal, FechaInicioOriginal);
+
+    private static CorregirNombres ComandoConNombreDistinto() => new(
+        TipoIdentificacion: "CC",
+        NumeroIdentificacion: NumeroValido,
+        PrimerNombre: "Luis",
+        SegundoNombre: "Alberto", // distinto del original ("Augusto")
+        PrimerApellido: "Barreto",
+        SegundoApellido: null);
+
+    private static CorregirNombres ComandoConElMismoNombre() => new(
+        TipoIdentificacion: "CC",
+        NumeroIdentificacion: NumeroValido,
+        PrimerNombre: "Luis",
+        SegundoNombre: "Augusto",
+        PrimerApellido: "Barreto",
+        SegundoApellido: null);
+
+    // Precondicion: colaborador registrado con una vinculacion abierta (sin terminacion).
+    private void DadoUnColaboradorConVinculacionAbierta() =>
+        Given(StreamIdEsperado, ColaboradorRegistradoValido(), VinculacionIniciadaOriginal());
+
+    // Precondicion (CA-2): colaborador registrado con la vinculacion ya terminada.
+    private void DadoUnColaboradorConVinculacionTerminada() =>
+        Given(StreamIdEsperado,
+            ColaboradorRegistradoValido(),
+            VinculacionIniciadaOriginal(),
+            new VinculacionTerminada(FechaEfectivaTerminacion));
+
+    // CA-1: colaborador existente + comando con nombres distintos -> el stream recibe
+    // NombresCorregidos con el NombreColaborador nuevo; el aggregate rehidratado refleja el
+    // NombreCompleto corregido.
+    [Fact]
+    public async Task CorregirNombres_EmiteNombresCorregidos_CuandoElNombreEsDistintoPorValor()
+    {
+        DadoUnColaboradorConVinculacionAbierta();
+        var nombreEsperado = NombreColaborador.Crear("Luis", "Alberto", "Barreto", null);
+
+        await WhenAsync(ComandoConNombreDistinto());
+
+        Then(StreamIdEsperado, new NombresCorregidos(nombreEsperado));
+        And<ColaboradorAggregateRoot, string>(
+            StreamIdEsperado, c => c.Nombre.NombreCompleto, "Luis Alberto Barreto");
+    }
+
+    // CA-2: la vinculacion vigente esta TERMINADA -> la correccion procede igual -- solo exige
+    // existencia del colaborador, nunca vigencia de la vinculacion (decision de refinamiento
+    // 2026-08-11: los nombres son de la PERSONA, no de la vinculacion).
+    [Fact]
+    public async Task CorregirNombres_EmiteNombresCorregidos_CuandoLaVinculacionEstaTerminada()
+    {
+        DadoUnColaboradorConVinculacionTerminada();
+        var nombreEsperado = NombreColaborador.Crear("Luis", "Alberto", "Barreto", null);
+
+        await WhenAsync(ComandoConNombreDistinto());
+
+        Then(StreamIdEsperado, new NombresCorregidos(nombreEsperado));
+        And<ColaboradorAggregateRoot, string>(
+            StreamIdEsperado, c => c.Nombre.NombreCompleto, "Luis Alberto Barreto");
+        // La terminacion previa no se toca por esta correccion (Tell-don't-Ask: la correccion es
+        // ortogonal a la vinculacion, MEF-ADR-0012).
+        And<ColaboradorAggregateRoot, DateOnly?>(
+            StreamIdEsperado, c => c.FechaTerminacionVinculacionVigente, FechaEfectivaTerminacion);
+    }
+
+    // CA-3: el nombre del comando es IGUAL por valor al actual -> idempotencia silenciosa: ningun
+    // evento nuevo en el stream, el estado conserva el nombre original.
+    [Fact]
+    public async Task CorregirNombres_NoEmiteEvento_CuandoElNombreEsIgualPorValorAlActual()
+    {
+        DadoUnColaboradorConVinculacionAbierta();
+
+        await WhenAsync(ComandoConElMismoNombre());
+
+        Then(StreamIdEsperado);
+        And<ColaboradorAggregateRoot, string>(
+            StreamIdEsperado, c => c.Nombre.NombreCompleto, "Luis Augusto Barreto");
+    }
+
+    // CA-3 (variante de opcionales): un segundo apellido que llega whitespace se normaliza a
+    // ausente igual que el original (NombreColaborador.Crear, #348) -> sigue siendo "igual por
+    // valor", idempotencia silenciosa -- la comparacion ocurre DESPUES de normalizar, no sobre los
+    // primitivos crudos del comando.
+    [Fact]
+    public async Task CorregirNombres_NoEmiteEvento_CuandoElSegundoApellidoLlegaComoWhitespaceYElOriginalEsAusente()
+    {
+        DadoUnColaboradorConVinculacionAbierta();
+
+        await WhenAsync(ComandoConElMismoNombre() with { SegundoApellido = "   " });
+
+        Then(StreamIdEsperado);
+        And<ColaboradorAggregateRoot, string>(
+            StreamIdEsperado, c => c.Nombre.NombreCompleto, "Luis Augusto Barreto");
+    }
+
+    // CA-4: colaborador inexistente -> 404 (KeyNotFoundException), sin escribir nada al event
+    // store. Sin Given: el stream no existe. Then sin eventos esperados demuestra "sin escribir
+    // nada al event store" (mismo precedente que TerminarVinculacionCommandHandlerTests CA-5 /
+    // ReingresarColaboradorCommandHandlerTests CA-5).
+    [Fact]
+    public async Task CorregirNombres_LanzaKeyNotFoundException_CuandoColaboradorNoExiste()
+    {
+        var act = async () => await WhenAsync(ComandoConNombreDistinto());
+
+        await act.Should().ThrowExactlyAsync<KeyNotFoundException>()
+            .WithMessage($"*{CorregirNombresCommandHandler.Mensajes.ColaboradorNoEncontrado}*");
+        Then(StreamIdEsperado);
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/CorregirNombresFunction/CorregirNombresValidatorTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/CorregirNombresFunction/CorregirNombresValidatorTests.cs
@@ -1,0 +1,112 @@
+// Issue #351: validacion de forma del comando CorregirNombres en el borde (CA-5).
+// Patron de referencia: TerminarVinculacionValidatorTests/RegistrarColaboradorValidatorTests
+// (ValidateAsync + verificacion de PropertyName en resultado.Errors).
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.CorregirNombresFunction;
+using Bitakora.ControlAsistencia.Colaboradores.CorregirNombresFunction.CommandHandler;
+using FluentValidation.Results;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Tests.CorregirNombresFunction;
+
+public class CorregirNombresValidatorTests
+{
+    private readonly CorregirNombresValidator _validator = new();
+
+    private static CorregirNombres ComandoValido() => new(
+        TipoIdentificacion: "CC",
+        NumeroIdentificacion: "79543210",
+        PrimerNombre: "Luis",
+        SegundoNombre: "Augusto",
+        PrimerApellido: "Barreto",
+        SegundoApellido: null);
+
+    private Task<ValidationResult> Validar(CorregirNombres comando) =>
+        _validator.ValidateAsync(comando, TestContext.Current.CancellationToken);
+
+    // Camino feliz -- todos los campos correctos
+    [Fact]
+    public async Task Validar_Aprueba_CuandoTodosLosCamposSonCorrectos()
+    {
+        var resultado = await Validar(ComandoValido());
+
+        resultado.IsValid.Should().BeTrue();
+    }
+
+    // CA-5: TipoIdentificacion vacio produce 400
+    [Fact]
+    public async Task Validar_RechazaTipoIdentificacion_CuandoEstaVacio()
+    {
+        var resultado = await Validar(ComandoValido() with { TipoIdentificacion = "" });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e =>
+            e.PropertyName == nameof(CorregirNombres.TipoIdentificacion));
+    }
+
+    // CA-5: TipoIdentificacion fuera de la lista cerrada (PILA: CC/CE/TI/PA/PT) produce 400, no 500
+    [Fact]
+    public async Task Validar_RechazaTipoIdentificacion_CuandoNoEstaEnLaListaCerrada()
+    {
+        var resultado = await Validar(ComandoValido() with { TipoIdentificacion = "XX" });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e =>
+            e.PropertyName == nameof(CorregirNombres.TipoIdentificacion));
+    }
+
+    // TipoIdentificacion en minusculas ("cc") DEBE seguir siendo valido -- la normalizacion de
+    // entrada (trim+MAYUSCULAS antes de TipoIdentificacion.Desde) es responsabilidad del borde,
+    // no un rechazo (mismo criterio que TerminarVinculacionValidator/RegistrarColaboradorValidator).
+    [Fact]
+    public async Task Validar_Aprueba_CuandoTipoIdentificacionLlegaEnMinusculas()
+    {
+        var resultado = await Validar(ComandoValido() with { TipoIdentificacion = "cc" });
+
+        resultado.IsValid.Should().BeTrue();
+    }
+
+    // CA-5: NumeroIdentificacion vacio produce 400
+    [Fact]
+    public async Task Validar_RechazaNumeroIdentificacion_CuandoEstaVacio()
+    {
+        var resultado = await Validar(ComandoValido() with { NumeroIdentificacion = "" });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e =>
+            e.PropertyName == nameof(CorregirNombres.NumeroIdentificacion));
+    }
+
+    // CA-5: PrimerNombre vacio produce 400 -- minimo colombiano (NombreColaborador.Crear, #348)
+    [Fact]
+    public async Task Validar_RechazaPrimerNombre_CuandoEstaVacio()
+    {
+        var resultado = await Validar(ComandoValido() with { PrimerNombre = "" });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e =>
+            e.PropertyName == nameof(CorregirNombres.PrimerNombre));
+    }
+
+    // CA-5: PrimerApellido vacio produce 400 -- minimo colombiano (NombreColaborador.Crear, #348)
+    [Fact]
+    public async Task Validar_RechazaPrimerApellido_CuandoEstaVacio()
+    {
+        var resultado = await Validar(ComandoValido() with { PrimerApellido = "" });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e =>
+            e.PropertyName == nameof(CorregirNombres.PrimerApellido));
+    }
+
+    // SegundoNombre/SegundoApellido son OPCIONALES -- ausentes no rechazan (NombreColaborador.Crear
+    // ya los normaliza a ausente).
+    [Fact]
+    public async Task Validar_Aprueba_CuandoLosSegundosNombresYApellidosSonAusentes()
+    {
+        var resultado = await Validar(
+            ComandoValido() with { SegundoNombre = null, SegundoApellido = null });
+
+        resultado.IsValid.Should().BeTrue();
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/CorregirNombresFunction/Eventos/NombresCorregidosSerializacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/CorregirNombresFunction/Eventos/NombresCorregidosSerializacionTests.cs
@@ -1,0 +1,79 @@
+// Issue #351. Requerido por regla 16: todo evento persistido en Marten debe sobrevivir
+// Serialize -> Deserialize con las opciones REALES de Marten del dominio (regla 6d), nunca un
+// resolver armado inline. CA-6.
+
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Tests.CorregirNombresFunction.Eventos;
+
+/// <summary>
+/// Verifica que NombresCorregidos (payload rico: NombreColaborador, VO de #348 con ctor privado)
+/// sobrevive un roundtrip de serializacion STJ con las opciones reales de Marten del dominio -- y
+/// que NO sobrevive sin el registro de ese VO en el resolver.
+/// </summary>
+public class NombresCorregidosSerializacionTests
+{
+    private static readonly NombreColaborador NombreValido =
+        NombreColaborador.Crear("Luis", "Alberto", "Barreto", "Prieto");
+
+    // Usa las opciones REALES de Marten del dominio (regla 6d) -- no un resolver armado inline que
+    // solo registre este tipo. Esta eleccion es lo que convierte el RoundTrip de abajo en la
+    // barrera contra el olvido de registrar NombreColaborador dentro de
+    // ConfiguracionSerializacionColaboradores.ConfigurarResolver.
+    private static JsonSerializerOptions CrearOpcionesMarten() =>
+        ConfiguracionSerializacionColaboradores.CrearOpcionesMarten();
+
+    // CA-6: round-trip con datos completos (ambos opcionales presentes).
+    [Fact]
+    public void RoundTrip_ReconstruyeEvento_ConDatosCompletos()
+    {
+        var evento = new NombresCorregidos(NombreValido);
+        var opciones = CrearOpcionesMarten();
+
+        var json = JsonSerializer.Serialize(evento, opciones);
+        var deserializado = JsonSerializer.Deserialize<NombresCorregidos>(json, opciones);
+
+        deserializado.Should().NotBeNull();
+        deserializado!.Nombre.Should().Be(NombreValido);
+        deserializado.Nombre.NombreCompleto.Should().Be("Luis Alberto Barreto Prieto");
+    }
+
+    // CA-6: round-trip con los opcionales ausentes (segundo nombre/apellido null).
+    [Fact]
+    public void RoundTrip_ReconstruyeEvento_CuandoOpcionalesDelNombreSonAusentes()
+    {
+        var nombreSinOpcionales = NombreColaborador.Crear("Ana", null, "Gomez", null);
+        var evento = new NombresCorregidos(nombreSinOpcionales);
+        var opciones = CrearOpcionesMarten();
+
+        var json = JsonSerializer.Serialize(evento, opciones);
+        var deserializado = JsonSerializer.Deserialize<NombresCorregidos>(json, opciones);
+
+        deserializado.Should().NotBeNull();
+        deserializado!.Nombre.Should().Be(nombreSinOpcionales);
+        deserializado.Nombre.NombreCompleto.Should().Be("Ana Gomez");
+    }
+
+    // Documenta POR QUE el registro en ConfigurarResolver es obligatorio: sin el, STJ no puede
+    // invocar el ctor privado de NombreColaborador. Quien detecta el olvido son los RoundTrip_* de
+    // arriba (usan las opciones reales del dominio); este test fija el comportamiento del canal sin
+    // resolver.
+    [Fact]
+    public void Deserializar_LanzaNotSupportedException_CuandoElResolverNoRegistraElVoAnidado()
+    {
+        var evento = new NombresCorregidos(NombreValido);
+        var opcionesSinRegistro = new JsonSerializerOptions
+        {
+            TypeInfoResolver = new DefaultJsonTypeInfoResolver(),
+            PropertyNamingPolicy = null
+        };
+        var json = JsonSerializer.Serialize(evento, opcionesSinRegistro);
+
+        var act = () => JsonSerializer.Deserialize<NombresCorregidos>(json, opcionesSinRegistro);
+
+        act.Should().Throw<NotSupportedException>();
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/CorregirNombresFunction/FunctionEndpointTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/CorregirNombresFunction/FunctionEndpointTests.cs
@@ -1,0 +1,132 @@
+// Issue #351: tests del endpoint HTTP POST Colaboradores/Nombres (corregir nombres). Sin caso 409
+// (CA-ADR-0030: este comando no tiene reglas de estado) -- solo 400 (validacion), 404 (colaborador
+// inexistente) y 202 (exito, con o sin evento nuevo en el stream). Precedente:
+// TerminarVinculacionFunction.FunctionEndpoint.
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.CorregirNombresFunction;
+using Bitakora.ControlAsistencia.Colaboradores.Infraestructura;
+using Cosmos.EventSourcing.Abstractions.Commands;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Tests.CorregirNombresFunction;
+
+public class FunctionEndpointTests
+{
+    private static CorregirNombres ComandoValido() => new(
+        TipoIdentificacion: "CC",
+        NumeroIdentificacion: "79543210",
+        PrimerNombre: "Luis",
+        SegundoNombre: "Augusto",
+        PrimerApellido: "Barreto",
+        SegundoApellido: null);
+
+    private static HttpRequest FakeHttpRequest()
+    {
+        var context = new DefaultHttpContext();
+        return context.Request;
+    }
+
+    // CA-1/CA-2/CA-3: POST exitoso (con o sin evento nuevo -- la idempotencia silenciosa del
+    // aggregate no cambia el codigo HTTP) retorna 202 Accepted.
+    [Fact]
+    public async Task CorregirNombres_Retorna202_CuandoComandoEsValido()
+    {
+        var validator = new FakeCorregirNombresRequestValidator(ComandoValido());
+        var router = new FakeCorregirNombresCommandRouter();
+        var function = new FunctionEndpoint(validator, router);
+
+        var result = await function.Run(FakeHttpRequest(), CancellationToken.None);
+
+        result.Should().BeOfType<AcceptedResult>();
+    }
+
+    // CA-4: colaborador inexistente retorna 404 Not Found
+    [Fact]
+    public async Task CorregirNombres_Retorna404_CuandoColaboradorNoExiste()
+    {
+        var validator = new FakeCorregirNombresRequestValidator(ComandoValido());
+        var router = new FakeCorregirNombresCommandRouter(
+            lanzar: new KeyNotFoundException("No existe un colaborador registrado con esa identificacion"));
+        var function = new FunctionEndpoint(validator, router);
+
+        var result = await function.Run(FakeHttpRequest(), CancellationToken.None);
+
+        result.Should().BeOfType<NotFoundObjectResult>();
+    }
+
+    // CA-5: request invalida (sin primer nombre, sin primer apellido, sin identificacion, tipo
+    // fuera de la lista) retorna 400 Bad Request
+    [Fact]
+    public async Task CorregirNombres_Retorna400_CuandoRequestEsInvalido()
+    {
+        var errorDeValidacion = new BadRequestObjectResult("El body es invalido o esta malformado");
+        var validator = new FakeCorregirNombresRequestValidator(error: errorDeValidacion);
+        var router = new FakeCorregirNombresCommandRouter();
+        var function = new FunctionEndpoint(validator, router);
+
+        var result = await function.Run(FakeHttpRequest(), CancellationToken.None);
+
+        result.Should().BeOfType<BadRequestObjectResult>();
+    }
+}
+
+// ---- Fakes manuales - NO NSubstitute ----
+
+/// <summary>
+/// Fake configurable de IRequestValidator. Retorna un comando pre-configurado o un error segun lo
+/// que se le pase en el constructor.
+/// </summary>
+internal class FakeCorregirNombresRequestValidator : IRequestValidator
+{
+    private readonly CorregirNombres? _comando;
+    private readonly IActionResult? _error;
+
+    public FakeCorregirNombresRequestValidator(
+        CorregirNombres? comando = null,
+        IActionResult? error = null)
+    {
+        _comando = comando;
+        _error = error;
+    }
+
+    public Task<(T? Comando, IActionResult? Error)> ValidarAsync<T>(
+        HttpRequest req, CancellationToken ct)
+    {
+        if (_error is not null)
+            return Task.FromResult<(T?, IActionResult?)>((default, _error));
+
+        if (_comando is T resultado)
+            return Task.FromResult<(T?, IActionResult?)>((resultado, null));
+
+        return Task.FromResult<(T?, IActionResult?)>((default, null));
+    }
+}
+
+/// <summary>
+/// Fake configurable de ICommandRouter. Puede completar exitosamente o lanzar la excepcion
+/// configurada (KeyNotFoundException -> 404). Sin caso InvalidOperationException/409: este
+/// comando no tiene reglas de estado (CA-ADR-0030).
+/// </summary>
+internal class FakeCorregirNombresCommandRouter : ICommandRouter
+{
+    private readonly Exception? _excepcion;
+
+    public FakeCorregirNombresCommandRouter(Exception? lanzar = null) =>
+        _excepcion = lanzar;
+
+    public Task InvokeAsync<TCommand>(TCommand command, CancellationToken ct = default)
+        where TCommand : class
+    {
+        if (_excepcion is not null)
+            throw _excepcion;
+
+        return Task.CompletedTask;
+    }
+
+    public Task<TResult> InvokeAsync<TCommand, TResult>(
+        TCommand command, CancellationToken ct = default)
+        where TCommand : class
+        => throw new NotImplementedException();
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/Infraestructura/AliasEventosColaboradoresTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/Infraestructura/AliasEventosColaboradoresTests.cs
@@ -58,4 +58,16 @@ public class AliasEventosColaboradoresTests
 
         AliasDe<VinculacionTerminada>(options).Should().Be("vinculacion_terminada");
     }
+
+    // Issue #351 (gemela de las tres pruebas anteriores): congela el alias de NombresCorregidos,
+    // cuarto evento persistido de ColaboradorAggregateRoot (corregir nombres). Rojo esperado (fase
+    // roja, issue #351): IdentidadEventosColaboradores.TiposPersistidos sigue sin NombresCorregidos
+    // hasta que el implementer lo registre -- el implementer lo agrega ahi (no aqui, MEF-ADR-0002).
+    [Fact]
+    public void NombresCorregidos_TieneAliasNombresCorregidos()
+    {
+        var options = CrearOpcionesConEventosDeColaboradoresRegistrados();
+
+        AliasDe<NombresCorregidos>(options).Should().Be("nombres_corregidos");
+    }
 }

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/Infraestructura/ComposicionServiciosTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/Infraestructura/ComposicionServiciosTests.cs
@@ -215,7 +215,9 @@ public class ComposicionServiciosTests
     // quedara vacia.
     // Issue #349: agrega VinculacionTerminada (segundo evento persistido de la vinculacion) a la
     // lista esperada -- mismo criterio, mismo guardrail.
-    // Rojo esperado (fase roja, issue #349): TiposPersistidos todavia no incluye VinculacionTerminada.
+    // Issue #351: agrega NombresCorregidos (cuarto evento persistido, corregir nombres) a la lista
+    // esperada.
+    // Rojo esperado (fase roja, issue #351): TiposPersistidos todavia no incluye NombresCorregidos.
     [Fact]
     public async Task AgregarServiciosColaboradores_RegistraLosTiposDeEventoPersistidos_CuandoElContenedorEstaCompuesto()
     {
@@ -225,7 +227,12 @@ public class ComposicionServiciosTests
         var store = scope.ServiceProvider.GetRequiredService<IDocumentStore>();
 
         store.AssertEventosPersistidosRegistrados(
-            [typeof(ColaboradorRegistrado), typeof(VinculacionIniciada), typeof(VinculacionTerminada)]);
+            [
+                typeof(ColaboradorRegistrado),
+                typeof(VinculacionIniciada),
+                typeof(VinculacionTerminada),
+                typeof(NombresCorregidos)
+            ]);
     }
 
     // Issue #330: registrar el tipo solo sirve si el alias sigue siendo el que las filas ya
@@ -233,7 +240,8 @@ public class ComposicionServiciosTests
     // StoreOptions standalone; esta guarda lo congela sobre el store del contenedor, el unico lugar
     // donde un MapEventType o un EventNamingStyle agregados al wiring podrian cambiarlo.
     // Issue #349: agrega VinculacionTerminada -> "vinculacion_terminada" al diccionario esperado.
-    // Rojo esperado (fase roja, issue #349): VinculacionTerminada no aparece en AllKnownEventTypes().
+    // Issue #351: agrega NombresCorregidos -> "nombres_corregidos" al diccionario esperado.
+    // Rojo esperado (fase roja, issue #351): NombresCorregidos no aparece en AllKnownEventTypes().
     [Fact]
     public async Task AgregarServiciosColaboradores_DerivaElAliasDeEventoDelNombreDeClase_CuandoElContenedorEstaCompuesto()
     {
@@ -246,7 +254,8 @@ public class ComposicionServiciosTests
         {
             [typeof(ColaboradorRegistrado)] = "colaborador_registrado",
             [typeof(VinculacionIniciada)] = "vinculacion_iniciada",
-            [typeof(VinculacionTerminada)] = "vinculacion_terminada"
+            [typeof(VinculacionTerminada)] = "vinculacion_terminada",
+            [typeof(NombresCorregidos)] = "nombres_corregidos"
         });
     }
 


### PR DESCRIPTION
## Resumen

Pipeline TDD completado:
- Fase roja: tests escritos con stubs
- Fase verde: implementación completa
- Smoke tests: escritos para endpoints detectados
- Fase refactor: revisión de calidad

## Decisiones del pipeline

<details>
<summary>Test Writer (fase roja) — 11m 6s</summary>

## ES Test Writer - Decisiones (Issue #351)

### Tests creados

- `CorregirNombresFunction/CorregirNombresCommandHandlerTests.cs`: 5 tests
  - `CorregirNombres_EmiteNombresCorregidos_CuandoElNombreEsDistintoPorValor` - CA-1
  - `CorregirNombres_EmiteNombresCorregidos_CuandoLaVinculacionEstaTerminada` - CA-2
  - `CorregirNombres_NoEmiteEvento_CuandoElNombreEsIgualPorValorAlActual` - CA-3
  - `CorregirNombres_NoEmiteEvento_CuandoElSegundoApellidoLlegaComoWhitespaceYElOriginalEsAusente` - CA-3 (normalizacion antes de comparar)
  - `CorregirNombres_LanzaKeyNotFoundException_CuandoColaboradorNoExiste` - CA-4
- `CorregirNombresFunction/CorregirNombresValidatorTests.cs`: 8 tests - CA-5 (forma del comando)
- `CorregirNombresFunction/FunctionEndpointTests.cs`: 3 tests - 202/404/400 (sin 409: sin reglas de estado)
- `CorregirNombresFunction/CorregirNombresCommandHandlerMensajesTests.cs`: 1 test - guardrail .resx
- `CorregirNombresFunction/Eventos/NombresCorregidosSerializacionTests.cs`: 3 tests - CA-6 round-trip Marten + barrera sin-registro
- `Infraestructura/AliasEventosColaboradoresTests.cs` (modificado): +1 test - `NombresCorregidos_TieneAliasNombresCorregidos` (alias `nombres_corregidos`)
- `Infraestructura/ComposicionServiciosTests.cs` (modificado): agrega `NombresCorregidos` a las dos listas literales de los guardrails de composicion del contenedor real (registro de tipos + alias)

### Estructura elegida

- Una clase de test por responsabilidad (handler, validator, endpoint, mensajes, serializacion), replicando exactamente el patron ya fijado por `TerminarVinculacionFunction`/`ReingresarColaboradorFunction` (#349/#350) en el mismo dominio.
- Sin nested classes: un solo comando en este issue, no hay estado compartido entre multiples handlers que justifique agruparlos.
- Sin tests directos del aggregate: se prueba indirectamente via el handler con el DSL `Given/WhenAsync/Then/And<>` (CommandHandlerAsyncTest), mismo criterio que los tres comandos previos del ciclo de vida (#330/#349/#350) -- ninguno tiene tests unitarios "puros" del aggregate por fuera del handler.

### Stubs creados

- `NombresCorregidos.cs` (Colaboradores.DomainEvents) - evento record `NombresCorregidos(NombreColaborador Nombre)`, sin ctor/logica propia (mismo patron que `ColaboradorRegistrado`).
- `ColaboradorAggregateRoot.CorregirNombres(NombreColaborador nombre)` - stub `internal`, `throw new NotImplementedException()`.
- `ColaboradorAggregateRoot.Apply(NombresCorregidos e)` - stub publico, `throw new NotImplementedException()`.
- `CorregirNombres.cs` (comando, record con 6 primitivos) - `CorregirNombresFunction/`.
- `CorregirNombresCommandHandler` - stub `HandleAsync` con `throw new NotImplementedException()`; `partial class` con `.Mensajes.cs` + `.resx` (clave `ColaboradorNoEncontrado`, contenido real de texto porque es un recurso, no logica).
- `CorregirNombresValidator` - `AbstractValidator<CorregirNombres>` sin reglas (constructor vacio): stub minimo, el implementer agrega las reglas de forma (CA-5).
- `FunctionEndpoint` - `Run` con `throw new NotImplementedException()`.

### Decisiones de diseno

- **No se toco `IdentidadEventosColaboradores.TiposPersistidos`.** La sección 6f del rol es explicita: "tu no tocas esa lista" -- el registro del evento en el `EventGraph` es responsabilidad del implementer. El guardrail de alias (`AliasEventosColaboradoresTests.NombresCorregidos_TieneAliasNombresCorregidos`) queda deliberadamente ROJO en esta fase, igual que ocurrio con `VinculacionTerminada` en #349 (comentario preservado en el propio test).
- **Si se actualizaron las listas literales de `ComposicionServiciosTests.cs`** (registro de tipos + alias derivado), porque en este proyecto ese archivo usa oraculos literales escritos a mano (no una guarda derivada por reflexion) -- mismo patron que el commit de #349 aplico sobre el mismo archivo. Es una extension del guardrail 6f, no una modificacion de comportamiento de test existente.
- El aggregate compara nombres por igualdad de valor (`NombreColaborador.Equals`, #348) -- la normalizacion de opcionales (whitespace -> ausente) ocurre en `NombreColaborador.Crear` ANTES de comparar, cubierto explicitamente por un test dedicado.
- Sin caso 409 en ningun archivo (handler/endpoint): CA-ADR-0030 + la decision 1 del issue ("no hay reglas de estado que violar") lo descartan explicitamente.

### Cobertura de criterios

| Criterio de aceptacion | Test(s) |
|---|---|
| CA-1: nombres distintos -> 202 + evento + estado nuevo | `CorregirNombres_EmiteNombresCorregidos_CuandoElNombreEsDistintoPorValor` |
| CA-2: vinculacion terminada -> procede igual | `CorregirNombres_EmiteNombresCorregidos_CuandoLaVinculacionEstaTerminada` |
| CA-3: nombres iguales -> 202 sin evento | `CorregirNombres_NoEmiteEvento_CuandoElNombreEsIgualPorValorAlActual`, `..._CuandoElSegundoApellidoLlegaComoWhitespaceYElOriginalEsAusente` |
| CA-4: inexistente -> 404 | `CorregirNombres_LanzaKeyNotFoundException_CuandoColaboradorNoExiste`, `FunctionEndpointTests.CorregirNombres_Retorna404_CuandoColaboradorNoExiste` |
| CA-5: request invalida -> 400 | `CorregirNombresValidatorTests.*` (8 tests), `FunctionEndpointTests.CorregirNombres_Retorna400_CuandoRequestEsInvalido` |
| CA-6: registro + round-trip | `AliasEventosColaboradoresTests.NombresCorregidos_TieneAliasNombresCorregidos`, `ComposicionServiciosTests.*` (2 tests modificados), `NombresCorregidosSerializacionTests.*` (3 tests) |

### Desviaciones del plan del planner

| Sugerencia del issue | Desviacion aplicada | Razon tecnica | Consecuencia |
|---|---|---|---|
| "Impacto esperado" sugiere carpeta `CorregirNombres/` (sin sufijo) | Carpeta `CorregirNombresFunction/` | MEF-ADR-0006 + convencion real del dominio (ver comentario en `TerminarVinculacionFunction/FunctionEndpoint.cs`): las carpetas de COMANDOS llevan sufijo "Function" porque el record del comando es homonimo del feature folder; solo las queries GET sin ese conflicto omiten el sufijo. Los tres comandos previos del mismo dominio (`RegistrarColaboradorFunction`, `TerminarVinculacionFunction`, `ReingresarColaboradorFunction`) siguen ese patron. | Ningun CA afectado; solo cambia la ruta del namespace/carpeta. |
| "Impacto esperado" sugiere modificar `IdentidadEventosColaboradores.cs` para agregar `NombresCorregidos` | No se modifico ese archivo en esta fase | Regla explicita de la seccion 6f del rol de test-writer: el registro en `TiposPersistidos` es responsabilidad del implementer; el test-writer solo agrega el evento como tipo y el guardrail de alias que debe quedar ROJO. Mismo patron seguido por #349 (VinculacionTerminada) segun el comentario historico ya presente en `AliasEventosColaboradoresTests.cs`. | El guardrail de alias (`NombresCorregidos_TieneAliasNombresCorregidos`) y los dos tests modificados de `ComposicionServiciosTests.cs` quedan en rojo hasta que el implementer registre el tipo -- consistente con el principio "los tests deben fallar". |

</details>

<details>
<summary>Implementer (fase verde) — 4m 3s</summary>

## ES Implementer - Decisiones

### Enfoque de implementacion
Issue #351 es el comando mas simple del ciclo de vida de `ColaboradorAggregateRoot`: sin reglas
de estado, sin eventos de fallo. El test-writer dejo todo el andamiaje (comando, endpoint,
handler, validator, .resx, evento persistido) con `throw new NotImplementedException()` en los
puntos exactos que definen el contrato. Se siguio al pie de la letra el molde de
`TerminarVinculacionFunction`/`ReingresarColaboradorFunction` (comentarios del propio test-writer
en cada stub apuntaban a ese precedente), reemplazando cada stub por su implementacion minima:

1. `ColaboradorAggregateRoot.Apply(NombresCorregidos)`: reemplaza `_nombre` -- una linea, nunca
   lanza (MEF-ADR-0004 capa 4).
2. `ColaboradorAggregateRoot.CorregirNombres(NombreColaborador nombre)`: compara por igualdad de
   valor contra `_nombre` (`NombreColaborador.Equals`, ya implementado en #348); si es igual,
   declina en silencio (no appendea nada); si es distinto, appendea y aplica `NombresCorregidos`.
   Patron "declinar silencioso" (precedente `ControlDiarioAggregateRoot.AdicionarMarcacion`,
   citado explicitamente en el comentario del stub).
3. `IdentidadEventosColaboradores.TiposPersistidos`: alta de `NombresCorregidos` (cuarta entrada).
4. `CorregirNombresCommandHandler.HandleAsync`: parseo tipado unico del borde
   (`TipoIdentificacion.Desde` + `Identificacion.Crear` + `NombreColaborador.Crear`) ->
   `ComputarStreamId` -> `GetAggregateRootAsync` -> `KeyNotFoundException` si no existe (404) ->
   `colaborador.CorregirNombres(nombre)`. Sin publicacion a bus (event-sourcing puro).
5. `CorregirNombresValidator`: `TipoIdentificacion` (NotEmpty + `Must` contra la lista cerrada,
   `Cascade(Stop)`), `NumeroIdentificacion`/`PrimerNombre`/`PrimerApellido` NotEmpty. Segundos
   nombre/apellido sin regla (opcionales, `NombreColaborador.Crear` ya los normaliza).
6. `FunctionEndpoint.Run`: valida (400) -> despacha comando -> `KeyNotFoundException` -> 404;
   exito -> 202. Sin catch de `InvalidOperationException`/409 -- este comando no tiene reglas de
   estado (CA-ADR-0030).

### Decisiones de diseno
- No se agrego ningun caso 409: el issue y los tests son explicitos en que este comando "ni
  siquiera tiene caso 409" (sin reglas de estado que violar).
- La comparacion de idempotencia ocurre DESPUES de que `NombreColaborador.Crear` normaliza los
  4 componentes (trim, ausencia de opcionales) -- se logra automaticamente al construir el VO
  antes de invocar `CorregirNombres`, sin logica adicional en el aggregate (el VO ya encapsula
  su propia normalizacion, Tell-don't-Ask).
- `CorregirNombres` en el aggregate no valida vigencia de la vinculacion -- ninguna lectura de
  `_fechaTerminacionVinculacionVigente` en el metodo, coherente con la decision de refinamiento
  ("los nombres son de la PERSONA, no de la vinculacion").

### ADRs consultados
- CA-ADR-0030: 404 sincrono para inexistente, sin eventos de fallo persistidos para este flujo.
- MEF-ADR-0012: Tell-don't-Ask -- el aggregate compara con su propio estado (`_nombre`) y decide;
  el handler nunca lee estado del aggregate para decidir.
- CA-ADR-0029 / MEF-ADR-0039: `NombresCorregidos` vive en la isla `DomainEvents` con payload rico
  (`NombreColaborador`), registrado en `TiposPersistidos`.
- MEF-ADR-0037: `ComputarStreamId` como unico punto de conversion de la clave del stream (ya
  existente, reutilizado sin cambios).
- MEF-ADR-0006: naming `[Function("CorregirNombres")]`, Route `Colaboradores/Nombres`.
- MEF-ADR-0009: mensaje 404 en `.resx` (ya provisto por el test-writer, sin cambios).
- CA-ADR-0027, MEF-ADR-0002, MEF-ADR-0016, MEF-ADR-0005: sin impacto directo en la
  implementacion -- ya satisfechos por el andamiaje del test-writer.

### Desviaciones de ADRs
Ninguna desviacion -- todos los ADRs aplicados al pie de la letra.

### Desviaciones del plan del planner
Ninguna desviacion -- la interfaz publica propuesta por el planner (firma de `CorregirNombres`,
`Apply(NombresCorregidos)`, ruta del validator/handler/endpoint) coincidio exactamente con el
andamiaje que dejo el test-writer, y se implemento tal cual.

### Precedentes consultados
- `TerminarVinculacionFunction` (issue #349) y `ReingresarColaboradorFunction` (issue #350):
  alineados con CA-ADR-0030/MEF-ADR-0004 -- replicados sin modificacion de patron.
- `ControlDiarioAggregateRoot.AdicionarMarcacion`: precedente del patron "declinar silencioso"
  citado por el propio comentario del stub -- alineado con MEF-ADR-0012 (decision interna del
  aggregate, sin excepcion ni evento de fallo).

### Infraestructura modificada
Ninguna. El comando no publica eventos a ningun bus (event-sourcing puro, sin consumidores) --
no aplica `topics_config` de Service Bus.

### Complejidad encontrada
Ninguna. El andamiaje del test-writer dejaba el contrato completamente especificado (comentarios
detallados en cada stub con el flujo esperado paso a paso); la implementacion fue directa desde
la primera pasada, sin iteraciones fallidas.

### Resultado
- Tests del dominio Colaboradores: 188/188 en verde.
- Suite completa del repo: 1032 correctos, 26 omitidos (smoke tests que requieren Postgres/Service
  Bus locales, comportamiento esperado sin infra), 0 errores.

</details>
<details>
<summary>Smoke Test Writer — 12m 50s</summary>

_(El agente no generó resumen)_

</details>
<details>
<summary>Reviewer (fase refactor) — 15m 53s</summary>

## ES Reviewer - Revision

### Evaluacion general
- Calidad: **buena**
- Cambios realizados: **si** (commit `2d3216b`)

Baseline verde en el gate pre-merge (los 6 proyectos `*.Tests`, 982 tests): antes y despues de
cada cambio. Los 4 rojos de `Colaboradores.SmokeTests` NO son un bloqueo del pipeline -- ver
"Smoke tests rojos hasta el despliegue" mas abajo.

### Cumplimiento de ADRs aplicables

| ADR | Cumplimiento | Observacion |
|---|---|---|
| CA-ADR-0030: fallos sincronos sin consumidores downstream | ok | 404 via `KeyNotFoundException` con mensaje `.resx`; cero eventos de fallo persistidos; sin caso 409 (este comando no tiene reglas de estado que violar, tal como fija el issue). El endpoint no cablea `catch (InvalidOperationException)` -- correcto, no hay razon que traducir |
| MEF-ADR-0012: Tell-don't-Ask y modelado | ok | `CorregirNombres` compara contra SU `_nombre`; el handler nunca interroga estado del aggregate. Cero propiedades publicas nuevas, cero clase estatica sobre datos crudos del VO, cero `[JsonConstructor]`, cero `InternalsVisibleTo` desde el ensamblado de eventos. `record` para evento sin invariantes (el VO es dueno de las suyas). Recorrido explicito de los 7 antipatrones: ninguno presente |
| CA-ADR-0029 / MEF-ADR-0039: ensamblados de eventos por rol | ok | `NombresCorregidos` nace en la isla `Colaboradores.DomainEvents` con payload rico y alta en `TiposPersistidos`. El comando `CorregirNombres` es primitivo puro (no reusa el VO como campo del payload de entrada). El diff no toca **ningun** `.csproj` (verificado con `git diff main...HEAD -- '**/*.csproj'`: vacio) |
| MEF-ADR-0037: identidad de stream | ok tras refactor | `ComputarStreamId` como punto unico; `ToString()` sin formato explicito. **El `Trim()/ToUpperInvariant()` del borde no tenia ningun test que lo ejercitara** -- agregado en esta fase (mismo hueco que se cerro en #350) |
| MEF-ADR-0006: naming de funciones Azure | ok | `[Function("CorregirNombres")]`, feature folder `CorregirNombresFunction/`, `FunctionEndpoint.cs`, subcarpeta `CommandHandler/`. Route `Colaboradores/Nombres` con identificacion en el body (la clave contiene `:`) |
| MEF-ADR-0009: mensajes en `.resx` | ok | `.resx` por handler + guardrail `CorregirNombresCommandHandlerMensajesTests` que impide el falso verde del `WithMessage($"*{null}*")` |
| CA-ADR-0027: tenancy | ok | Sin impacto: el comando no toca resolucion de tenant |
| MEF-ADR-0002 / MEF-ADR-0016: testing y naming | ok | DSL Given/WhenAsync/Then/And con overloads de stream compuesto; solo `[Fact]`; oraculo de la clave literal (`"CC:79543210"`), no derivado de `ComputarStreamId`; naming `<Sujeto>_<LoQuePasa>_Cuando<Condicion>` con el comando como sujeto |
| MEF-ADR-0005: naming y versionado de eventos | ok | Nombre en pasado que cuenta un hecho de dominio; alias `nombres_corregidos` congelado por dos guardrails (`AliasEventosColaboradoresTests` y `ComposicionServiciosTests`). Tipo **nuevo**, no un rename: el protocolo de dos despliegues de MEF-ADR-0036 seccion 5 no aplica |

### Desviaciones de ADRs

**Desviaciones declaradas por el implementer**: ninguna (su resumen declara "Ninguna desviacion").

**Desviaciones detectadas por el reviewer (NO declaradas por el implementer)**: ninguna a nivel de
ADR. La unica divergencia frente al issue es de nomenclatura de carpeta y va en la direccion
correcta:

#### Divergencia menor: nombre del feature folder (no es desviacion de ADR)
- **Lo que decia el issue**: "carpeta `CorregirNombres/`" (seccion "Investigacion del planner").
- **Lo implementado**: `CorregirNombresFunction/`.
- **Evaluacion del reviewer**: correcto tal como esta. La convencion del pipeline es sufijo
  `Function` en el feature folder de un trigger HTTP, y los tres hermanos del dominio la siguen.
  Era el issue el impreciso. Sin accion.

**Conclusion: ninguna desviacion de ADR -- todos los ADRs aplicables se cumplen.**

### Precedentes consultados por el implementer

| Precedente | ADR aplicable | Veredicto |
|---|---|---|
| `TerminarVinculacionFunction` (#349) | CA-ADR-0030, MEF-ADR-0004, MEF-ADR-0037 | alineado |
| `ReingresarColaboradorFunction` (#350) | CA-ADR-0030, MEF-ADR-0004 | alineado |
| `ControlDiarioAggregateRoot.AdicionarMarcacion` | MEF-ADR-0012, CA-ADR-0030 ("declinar sin emitir") | alineado -- es el precedente que el propio CA-ADR-0030 cita |
| `ColaboradorRegistrado` (payload rico con VO) | MEF-ADR-0012 (frontera event store vs bus) | alineado: el evento no lleva marker de bus, asi que el payload rico es legitimo |

Nota sobre un precedente **no** citado y que si arrastra deuda: `TerminarVinculacionCommandHandler`
conserva su comentario `// STUB (fase roja, issue #349)`. Fuera del alcance de este PR (regla 4),
reportado abajo como hallazgo cosmetico.

### Convenciones del pipeline (no ADRs)

| Convencion | Estado | Observacion |
|---|---|---|
| Cada test con `Then()` + `And<>()` | ok | Unica excepcion: `CorregirNombres_LanzaKeyNotFoundException_CuandoColaboradorNoExiste` usa `Then(streamId)` sin `And<>()`, porque el stream no existe y no hay aggregate que rehidratar. Identico al precedente de #349/#350 |
| Overloads correctos para stream IDs compuestos | ok | `Given(streamId, ...)`, `Then(streamId, ...)`, `And<T,P>(streamId, ...)` en todos los tests |
| Fakes manuales (no NSubstitute) | ok | `FakeCorregirNombresRequestValidator` / `FakeCorregirNombresCommandRouter`, clases concretas |
| Feature folders (produccion y tests) | ok | Espejo exacto; un archivo por responsabilidad (handler, validator, endpoint, mensajes, serializacion del evento en `Eventos/`) |
| Smoke tests: SkipWhen, secrets, cobertura | ok tras refactor | `Assert.SkipWhen` en los 3 tests que dependen de Postgres; `appsettings.json` sin secrets; cobertura de **todos** los efectos del handler (no publica a bus -- `IPublicEventSender`/`IPrivateEventSender` no aparecen en el handler, verificado leyendolo, asi que la persistencia en `mt_events` es el unico efecto y esta cubierto). Un archivo por comando. **Se corrigio el assert de CA-1/CA-2** (ver hallazgo mayor #1) |
| Proyecciones read-side (partial, inmutabilidad, read APIs, naming, cuarta isla) | n/a | El diff no toca `ReadModels` ni `Projections` ni ninguna Function GET |
| Antipatrones de habilitacion (MEF-ADR-0039) | ok | El diff no toca ningun `.csproj` y el unico tipo nuevo (`NombresCorregidos`) no es homonimo de nada en `PublicEvents`/`PrivateEvents` |
| Compatibilidad Marten write-side/read-side | falla (parcial: no verificada por falta de herramienta) | El gate **aplica** (el diff toca `IdentidadEventosColaboradores.cs`). La unica fila que este diff puede mover es "Tipos de evento registrados (`AddEventTypes`)", y esta verificada por lectura de fuente: `ConfiguracionMartenProjectionsColaboradores.cs:81` hace `opts.Events.AddEventTypes(IdentidadEventosColaboradores.TiposPersistidos)` -- **la misma lista** que consume el write-side, asi que no pueden divergir. Las demas filas (schema, `StreamIdentity`, `EventNamingStyle`, `TenancyStyle`, `MetadataConfig`, serializador) no las toca el diff. La verificacion **completa** por decompilacion no se pudo correr: `ilspycmd` no esta instalado. Para habilitarla: `dotnet tool install -g ilspycmd` |
| Identidad de stream (MEF-ADR-0037) | ok | `ToString()` sin especificador; cero reconstruccion manual de la clave en handler/endpoint; sin GET de consulta en el diff. La interpolacion `$"{TipoIdentificacionCc}:{numero}"` del smoke test es el oraculo black-box independiente (ese proyecto no referencia el Function App), no una segunda via de conversion de produccion |
| Control de volumen de telemetria (MEF-ADR-0038) | n/a | El diff no toca `ComposicionServicios*`, `ConfiguracionObservabilidad*` ni el callback de Wolverine |
| Tests via ToString/comportamiento | ok | Se verifica `c.Nombre.NombreCompleto` (composicion canonica del VO), nunca los 4 componentes privados |
| Sin numeros magicos | ok tras refactor | Se nombro el `TimeSpan.FromSeconds(5)` suelto del smoke test como `TimeoutLecturaConfirmada` |
| Condiciones en positivo (guardas if/else afirmativas) | ok | `if (nombre.Equals(_nombre)) return;` y `if (colaborador is null) throw ...` son early-returns/guard clauses, no bifurcaciones `if`/`else` en negativo |

### Elegancia del codigo

La implementacion de produccion ya era compacta e idiomatica: `CorregirNombres` son 6 lineas de
cuerpo, `Apply` es una expresion, el handler es lineal sin ramas superfluas y el `record` del
comando es primitivo puro. Lo unico que sobraba era **texto**, no codigo:

- **Compacidad**: el cruft de fase roja (`// STUB (fase roja, issue #351)` en 3 archivos, mas el
  "Flujo esperado" numerado 1-4 que narraba paso a paso lo que el metodo ya dice) sobrevivio a la
  fase verde. Eliminado -- mismo tratamiento que el reviewer de #350 aplico a los suyos.
- **Legibilidad**: los comentarios que quedan ahora explican el **porque** (por que no hay 409, por
  que la comparacion ocurre despues de construir el VO, por que no se mira la vigencia) en vez de
  repetir el **que**.
- **Robustez/eficiencia**: sin hallazgos. Cero excepciones tragadas en produccion, cero loops,
  cero asignaciones evitables.
- **Limpieza**: build de la solucion completa sin advertencias nuevas (las 4 `NU1902` de
  `OpenTelemetry.Api` son preexistentes y viven en `Programacion`). `dotnet format
  --verify-no-changes` da el mismo exit code con y sin este diff (comprobado con `git stash`):
  los `IDE0005` que reporta son preexistentes en `ControlHoras.Tests`. Cero `─` (U+2500).

### Criticas y hallazgos

**1. [MAYOR - corregido] Los smoke tests CA-1 y CA-2 eran un falso rojo garantizado.**
Filtraban el evento pasando `campoJson: "Nombre", valorJson: JsonSerializer.Serialize(nombre,
OpcionesMarten)`. Ese filtro compara `JsonElement.ToString()` contra un texto, y para un campo
**objeto** (no escalar como el `FechaEfectiva` de los hermanos, que si funciona) `ToString()`
devuelve el JSON **crudo** tal como llego de la base. `mt_events.data` es `jsonb`, y PostgreSQL no
preserva ni el whitespace ni el orden de las claves (docs 8.14.1), asi que la igualdad de texto no
podia coincidir nunca. Verificado empiricamente contra el `NombreColaborador` real y sus opciones
de Marten: la comparacion vieja da `False` incluso con los datos correctos; la nueva da `True`
aunque el payload llegue con claves reordenadas y espacios. Ademas el `ObtenerEventoAsync`
subsiguiente habria muerto con `TimeoutException` a los 5s, no con una asercion legible.
**Correccion**: el assert ahora deserializa el campo con las opciones reales de Marten y compara
por igualdad de valor (`NombreColaborador.Equals`) -- exactamente lo que el encabezado del propio
archivo declaraba como intencion ("nunca comparando texto JSON crudo a mano") y que la
implementacion contradecia. CA-2 gano de paso la verificacion de contenido que no tenia (solo
comprobaba que existiera *algun* `nombres_corregidos`). Se extrajo el assert compartido a
`ElStreamRecibioElNombreAsync`.

**2. [MENOR - corregido] El `Trim()/ToUpperInvariant()` del borde no tenia test.**
Es la misma linea cuya ausencia haria que un `"cc"` en minusculas computara otra clave de stream y
devolviera 404 sobre un colaborador que si existe (MEF-ADR-0037). Ningun test del handler la
ejercitaba. Agregado `CorregirNombres_EmiteNombresCorregidos_CuandoTipoYNumeroLleganSinNormalizar`,
gemelo del que el reviewer de #350 agrego para el reingreso.

**3. [MENOR - no corregido, se propone issue] Cuarta copia de `EsTipoIdentificacionReconocido`.**
Los 4 validators del dominio repiten el mismo predicado que consulta la lista cerrada **capturando
una excepcion** (`try { TipoIdentificacion.Desde(...) } catch (ArgumentException) { return false; }`).
Es control de flujo por excepcion en un camino esperado (un 400 normal), y existe porque
`TipoIdentificacion` no expone la consulta -- el reverso de "aprovechar la superficie del dominio"
de MEF-ADR-0012. La forma correcta seria un `TipoIdentificacion.EsReconocido(codigo)` (o
`TryDesde`) en el VO y los 4 validators consumiendolo. **No lo corrijo aqui** por dos razones
explicitas: MEF-ADR-0018 fija que "el reviewer no debe pedir extraccion si el implementer no la
ofrece", y el arreglo toca un tipo de `DomainEvents` mas 3 archivos fuera del alcance de este issue
(regla 4). **Recomendacion al planner**: issue de limpieza transversal del dominio Colaboradores.

**4. [COSMETICO - no corregido] Cruft heredado en `TerminarVinculacionCommandHandler`.**
Conserva `// STUB (fase roja, issue #349)`. Fuera del diff de este issue; se arrastra desde #349.
Candidato al mismo issue de limpieza del hallazgo 3.

**5. [COSMETICO - no corregido] `DebeEstarDisponible_CuandoSeConsultaHealthCheck` cuadruplicado.**
El health check se prueba en `HealthSmokeTests` y ademas se replica en cada clase de smoke tests
(ahora 4 veces en el mismo ensamblado), pese a que `ApiFixture.InitializeAsync` ya falla duro si
`/api/health` no responde `200`. Ademas su nombre es el patron `Debe...` que MEF-ADR-0016
reemplazo. Es la plantilla del `smoke-test-writer`, no una decision de este issue: corregirlo solo
en el archivo nuevo rompe la simetria con los hermanos. **Recomendacion**: issue sobre la plantilla
del agente, no parche local.

### Smoke tests rojos hasta el despliegue (no es bloqueo)

`dotnet test` sobre **toda** la solucion reporta 4 errores, los 4 en
`CorregirNombresSmokeTests` (los casos de 400). No son un defecto del codigo:

- Verificado con `curl` contra dev: `POST /api/Colaboradores/Nombres` responde **404** para
  cualquier payload, mientras que `POST /api/Colaboradores/Terminaciones` responde **400** con un
  payload invalido. La ruta nueva **todavia no esta desplegada**.
- Es el estado esperado pre-merge por diseno de MEF-ADR-0013: los smoke tests corren en un job
  posterior al deploy, y el gate pre-merge (`ci.yml` y `deploy-colaboradores.yml`) itera unicamente
  sobre `tests/Bitakora.ControlAsistencia.*.Tests/`, que estan **todos en verde** (982 tests).
- Efecto colateral a tener presente: `CorregirNombres_Retorna404_CuandoColaboradorNoExiste` pasa
  hoy **por la razon equivocada** (404 de ruta inexistente, no de colaborador inexistente). Se
  volvera significativo con el despliegue.

No se creo `blockage-report.md`: no hay ningun test bloqueado por un defecto del codigo.

### Refactorings aplicados

1. Cruft de fase roja eliminado en `CorregirNombresCommandHandler`, `CorregirNombresValidator`,
   `FunctionEndpoint`, `NombresCorregidos` y `ColaboradorAggregateRoot.CorregirNombres`
   (comentarios dirigidos al implementer + narracion paso a paso que el codigo ya expresa).
   Justificacion: precedente directo del reviewer de #350 (commit `a312bca`).
2. Assert de contenido de los smoke tests CA-1/CA-2 reescrito para comparar por valor de dominio
   en vez de por texto JSON crudo, con el assert compartido extraido a un helper privado.
   Justificacion: hallazgo mayor #1.
3. `PostgresFixture.ObtenerEventoAsync`: overload aditivo sin filtro por campo (delegan ambos en un
   privado comun). Justificacion: el filtro por texto solo es valido para campos escalares; el
   nuevo overload es lo que permite verificar un campo objeto. Cero impacto en los call sites
   existentes de los hermanos.
4. `TimeSpan.FromSeconds(5)` suelto -> constante `TimeoutLecturaConfirmada` con su porque.

Cada paso se verifico con la suite de `*.Tests` en verde; ninguno hubo que revertir.

### Cobertura de criterios de aceptacion

| Criterio | Estado | Test(s) |
|---|---|---|
| CA-1: existente + POST valido con nombres distintos -> 202, `NombresCorregidos` en el stream, aggregate rehidratado con el `NombreCompleto` nuevo | cubierto | `CorregirNombres_EmiteNombresCorregidos_CuandoElNombreEsDistintoPorValor`, `CorregirNombres_EmiteNombresCorregidos_CuandoTipoYNumeroLleganSinNormalizar` (nuevo), `CorregirNombres_Retorna202_CuandoComandoEsValido`, smoke `CorregirNombres_Retorna202YPersisteNombresCorregidos_CuandoNombreEsDistintoPorValor` |
| CA-2: vinculacion TERMINADA -> la correccion procede igual | cubierto | `CorregirNombres_EmiteNombresCorregidos_CuandoLaVinculacionEstaTerminada` (con `And<>` que prueba ademas que la terminacion previa no se toca), smoke `..._CuandoVinculacionEstaTerminada` |
| CA-3: nombres iguales por valor -> 202 sin evento nuevo | cubierto | `CorregirNombres_NoEmiteEvento_CuandoElNombreEsIgualPorValorAlActual`, `..._CuandoElSegundoApellidoLlegaComoWhitespaceYElOriginalEsAusente` (la igualdad se evalua tras normalizar, no sobre los primitivos crudos), smoke `CorregirNombres_Retorna202SinNuevoEvento_...` |
| CA-4: inexistente -> 404 con mensaje `.resx`, sin escribir al event store | cubierto | `CorregirNombres_LanzaKeyNotFoundException_CuandoColaboradorNoExiste` (el `Then(streamId)` sin eventos prueba el "sin escribir nada"), `CorregirNombres_Retorna404_CuandoColaboradorNoExiste`, `Mensajes_ResuelvenTextoNoVacio_...` |
| CA-5: request invalida -> 400 sin tocar el event store | cubierto | 6 tests de `CorregirNombresValidatorTests` (vacio y fuera de lista para tipo, numero, primer nombre, primer apellido; mas los dos casos que **deben** aprobar: minusculas y opcionales ausentes), `CorregirNombres_Retorna400_CuandoRequestEsInvalido`, 4 smoke |
| CA-6: `NombresCorregidos` en `TiposPersistidos` + round-trip con el resolver | cubierto | `NombresCorregidos_TieneAliasNombresCorregidos`, `AgregarServiciosColaboradores_RegistraLosTiposDeEventoPersistidos_...`, `AgregarServiciosColaboradores_DerivaElAliasDeEventoDelNombreDeClase_...`, `NombresCorregidosSerializacionTests` (3 tests: datos completos, opcionales ausentes, y el que documenta el fallo sin resolver) |

Sin casos borde relevantes sin cubrir. No aplica el guardrail de round-trip con serializador **por
defecto** (test-writer 6e): `NombresCorregidos` no lleva marker de bus y no cruza ningun bus -- su
payload rico es legitimo justamente por eso.

### Tests agregados
- `CorregirNombres_EmiteNombresCorregidos_CuandoTipoYNumeroLleganSinNormalizar` -- cubre el
  `Trim()/ToUpperInvariant()` del borde (MEF-ADR-0037), que no tenia ningun test.
- Tests de contrato de igualdad (`IgualdadTestBase<T>`) y de serializacion round-trip: **no se
  agregaron porque ya existen** -- `NombreColaboradorIgualdadTests` y
  `NombreColaboradorSerializacionTests` (#348) cubren el unico VO del diff, y el evento nuevo trae
  su propio `NombresCorregidosSerializacionTests`.

</details>

## Commits

2d3216b refactor(hu-351): limpia cruft de fase roja, cubre el borde de identidad y corrige el assert del smoke test
1fa0e54 test(hu-351): smoke tests para corregir los nombres de un colaborador
fb350fc feat(hu-351): implementacion de corregir los nombres de un colaborador (fase verde)
32ac153 test(issue-351): tests para corregir nombres de un colaborador (fase roja)

Closes #351