### PR TITLE
Corregir la fecha de inicio de la vinculacion vigente

### DIFF
--- a/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/FechaInicioVinculacionCorregida.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/FechaInicioVinculacionCorregida.cs
@@ -1,0 +1,19 @@
+namespace Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+
+/// <summary>
+/// Evento de event sourcing que registra la correccion de la fecha de inicio de la ULTIMA
+/// vinculacion de un colaborador (tenga o no terminacion registrada). Se persiste en el stream de
+/// ColaboradorAggregateRoot.
+/// </summary>
+/// <remarks>
+/// Issue #352: payload plano (DateOnly) -- mismo criterio que VinculacionTerminada. Nombre propio
+/// ("FechaInicioVinculacionCorregida"), no una reutilizacion de VinculacionIniciada: a diferencia
+/// del reingreso (#350, mismo hecho que el registro), esta es una ENMIENDA de un dato que ya
+/// existia, no el nacimiento de una vinculacion nueva -- amerita su propio tipo (CA-ADR-0029: un
+/// evento no conoce su comando, pero tampoco disfraza un hecho distinto bajo un tipo existente).
+/// No necesita ConfigurarSerializacion: tipo primitivo (DateOnly), STJ lo reconstruye sin ayuda --
+/// mismo criterio que VinculacionTerminada/VinculacionIniciada.
+/// No cruza el bus (sin marker IPrivateEvent/IPublicEvent): event-sourcing puro, sin consumidores
+/// (issue #352 "Consumidores: ninguno").
+/// </remarks>
+public sealed record FechaInicioVinculacionCorregida(DateOnly FechaInicio);

--- a/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/IdentidadEventosColaboradores.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/IdentidadEventosColaboradores.cs
@@ -19,5 +19,6 @@ public static class IdentidadEventosColaboradores
         typeof(VinculacionIniciada),
         typeof(VinculacionTerminada),
         typeof(NombresCorregidos),
+        typeof(FechaInicioVinculacionCorregida),
     ];
 }

--- a/src/Bitakora.ControlAsistencia.Colaboradores/CorregirFechaInicioVinculacionFunction/CommandHandler/CorregirFechaInicioVinculacionCommandHandler.Mensajes.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/CorregirFechaInicioVinculacionFunction/CommandHandler/CorregirFechaInicioVinculacionCommandHandler.Mensajes.cs
@@ -1,0 +1,24 @@
+using System.Resources;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.CorregirFechaInicioVinculacionFunction.CommandHandler;
+
+// MEF-ADR-0009: mensajes del handler en .resx separado.
+// internal: accesible desde tests via InternalsVisibleTo en el .csproj.
+public partial class CorregirFechaInicioVinculacionCommandHandler
+{
+    private static readonly ResourceManager ResourceManager = new(
+        "Bitakora.ControlAsistencia.Colaboradores.CorregirFechaInicioVinculacionFunction.CommandHandler.CorregirFechaInicioVinculacionCommandHandlerMensajes",
+        typeof(CorregirFechaInicioVinculacionCommandHandler).Assembly);
+
+    internal static class Mensajes
+    {
+        public static string ColaboradorNoEncontrado =>
+            ResourceManager.GetString(nameof(ColaboradorNoEncontrado))!;
+
+        public static string FechaPosteriorATerminacionPropia =>
+            ResourceManager.GetString(nameof(FechaPosteriorATerminacionPropia))!;
+
+        public static string FechaSolapaVinculacionAnterior =>
+            ResourceManager.GetString(nameof(FechaSolapaVinculacionAnterior))!;
+    }
+}

--- a/src/Bitakora.ControlAsistencia.Colaboradores/CorregirFechaInicioVinculacionFunction/CommandHandler/CorregirFechaInicioVinculacionCommandHandler.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/CorregirFechaInicioVinculacionFunction/CommandHandler/CorregirFechaInicioVinculacionCommandHandler.cs
@@ -1,0 +1,37 @@
+using Cosmos.EventSourcing.Abstractions.Commands;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.CorregirFechaInicioVinculacionFunction.CommandHandler;
+
+// Issue #352: handler del comando CorregirFechaInicioVinculacion. Combina el flujo de
+// ReingresarColaboradorCommandHandler (dos razones de rechazo -> 409) con el de
+// CorregirNombresCommandHandler (idempotencia silenciosa, sin excepcion).
+// Flujo esperado (MEF-ADR-0004 capa 2 -- CA-ADR-0030):
+//   1. Normalizar y parsear TipoIdentificacion -> TipoIdentificacion.Desde(...) (borde HTTP:
+//      normalizar trim+MAYUSCULAS ANTES de Desde, mismo criterio que los handlers hermanos).
+//   2. Identificacion.Crear(tipo, command.NumeroIdentificacion) -- normaliza el numero.
+//   3. ComputarStreamId(identificacion) -> GetAggregateRootAsync<ColaboradorAggregateRoot> -- si
+//      es null, throw KeyNotFoundException(Mensajes.ColaboradorNoEncontrado) (-> 404).
+//   4. colaborador.CorregirFechaInicio(command.FechaCorregida) -- el aggregate declina con
+//      resultado o en silencio (nunca lanza, nunca emite evento de fallo persistido):
+//        - ResultadoCorreccionFechaInicioVinculacion.FechaPosteriorATerminacionPropia -> throw
+//          InvalidOperationException(Mensajes.FechaPosteriorATerminacionPropia) (-> 409).
+//        - ResultadoCorreccionFechaInicioVinculacion.FechaSolapaVinculacionAnterior -> throw
+//          InvalidOperationException(Mensajes.FechaSolapaVinculacionAnterior) (-> 409).
+//        - ResultadoCorreccionFechaInicioVinculacion.SinCambios -> no hace nada (idempotencia
+//          silenciosa, patron CorregirNombresCommandHandler).
+//        - ResultadoCorreccionFechaInicioVinculacion.Exitosa -> el aggregate ya agrego
+//          FechaInicioVinculacionCorregida a _uncommittedEvents; WhenAsync/el middleware persiste
+//          via SaveChanges.
+// Sin publicacion a bus (event-sourcing puro, issue #352 "Consumidores: ninguno").
+// STUB (fase roja, issue #352): el cuerpo completo queda para el implementer.
+public partial class CorregirFechaInicioVinculacionCommandHandler
+    : ICommandHandlerAsync<CorregirFechaInicioVinculacion>
+{
+    private readonly IEventStore _eventStore;
+
+    public CorregirFechaInicioVinculacionCommandHandler(IEventStore eventStore) =>
+        _eventStore = eventStore;
+
+    public Task HandleAsync(CorregirFechaInicioVinculacion command, CancellationToken ct = default) =>
+        throw new NotImplementedException();
+}

--- a/src/Bitakora.ControlAsistencia.Colaboradores/CorregirFechaInicioVinculacionFunction/CommandHandler/CorregirFechaInicioVinculacionCommandHandler.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/CorregirFechaInicioVinculacionFunction/CommandHandler/CorregirFechaInicioVinculacionCommandHandler.cs
@@ -1,3 +1,5 @@
+using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+using Bitakora.ControlAsistencia.Colaboradores.Entities;
 using Cosmos.EventSourcing.Abstractions.Commands;
 
 namespace Bitakora.ControlAsistencia.Colaboradores.CorregirFechaInicioVinculacionFunction.CommandHandler;
@@ -23,7 +25,6 @@ namespace Bitakora.ControlAsistencia.Colaboradores.CorregirFechaInicioVinculacio
 //          FechaInicioVinculacionCorregida a _uncommittedEvents; WhenAsync/el middleware persiste
 //          via SaveChanges.
 // Sin publicacion a bus (event-sourcing puro, issue #352 "Consumidores: ninguno").
-// STUB (fase roja, issue #352): el cuerpo completo queda para el implementer.
 public partial class CorregirFechaInicioVinculacionCommandHandler
     : ICommandHandlerAsync<CorregirFechaInicioVinculacion>
 {
@@ -32,6 +33,25 @@ public partial class CorregirFechaInicioVinculacionCommandHandler
     public CorregirFechaInicioVinculacionCommandHandler(IEventStore eventStore) =>
         _eventStore = eventStore;
 
-    public Task HandleAsync(CorregirFechaInicioVinculacion command, CancellationToken ct = default) =>
-        throw new NotImplementedException();
+    public async Task HandleAsync(CorregirFechaInicioVinculacion command, CancellationToken ct = default)
+    {
+        // Parseo tipado unico del borde (MEF-ADR-0037 seccion 2), mismo criterio que
+        // ReingresarColaboradorCommandHandler/TerminarVinculacionCommandHandler.
+        var tipo = TipoIdentificacion.Desde(command.TipoIdentificacion.Trim().ToUpperInvariant());
+        var identificacion = Identificacion.Crear(tipo, command.NumeroIdentificacion);
+
+        var streamId = ColaboradorAggregateRoot.ComputarStreamId(identificacion);
+        var colaborador = await _eventStore.GetAggregateRootAsync<ColaboradorAggregateRoot>(streamId, ct);
+        if (colaborador is null)
+            throw new KeyNotFoundException(Mensajes.ColaboradorNoEncontrado);
+
+        var resultado = colaborador.CorregirFechaInicio(command.FechaCorregida);
+        switch (resultado)
+        {
+            case ResultadoCorreccionFechaInicioVinculacion.FechaPosteriorATerminacionPropia:
+                throw new InvalidOperationException(Mensajes.FechaPosteriorATerminacionPropia);
+            case ResultadoCorreccionFechaInicioVinculacion.FechaSolapaVinculacionAnterior:
+                throw new InvalidOperationException(Mensajes.FechaSolapaVinculacionAnterior);
+        }
+    }
 }

--- a/src/Bitakora.ControlAsistencia.Colaboradores/CorregirFechaInicioVinculacionFunction/CommandHandler/CorregirFechaInicioVinculacionCommandHandler.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/CorregirFechaInicioVinculacionFunction/CommandHandler/CorregirFechaInicioVinculacionCommandHandler.cs
@@ -4,27 +4,14 @@ using Cosmos.EventSourcing.Abstractions.Commands;
 
 namespace Bitakora.ControlAsistencia.Colaboradores.CorregirFechaInicioVinculacionFunction.CommandHandler;
 
-// Issue #352: handler del comando CorregirFechaInicioVinculacion. Combina el flujo de
-// ReingresarColaboradorCommandHandler (dos razones de rechazo -> 409) con el de
-// CorregirNombresCommandHandler (idempotencia silenciosa, sin excepcion).
-// Flujo esperado (MEF-ADR-0004 capa 2 -- CA-ADR-0030):
-//   1. Normalizar y parsear TipoIdentificacion -> TipoIdentificacion.Desde(...) (borde HTTP:
-//      normalizar trim+MAYUSCULAS ANTES de Desde, mismo criterio que los handlers hermanos).
-//   2. Identificacion.Crear(tipo, command.NumeroIdentificacion) -- normaliza el numero.
-//   3. ComputarStreamId(identificacion) -> GetAggregateRootAsync<ColaboradorAggregateRoot> -- si
-//      es null, throw KeyNotFoundException(Mensajes.ColaboradorNoEncontrado) (-> 404).
-//   4. colaborador.CorregirFechaInicio(command.FechaCorregida) -- el aggregate declina con
-//      resultado o en silencio (nunca lanza, nunca emite evento de fallo persistido):
-//        - ResultadoCorreccionFechaInicioVinculacion.FechaPosteriorATerminacionPropia -> throw
-//          InvalidOperationException(Mensajes.FechaPosteriorATerminacionPropia) (-> 409).
-//        - ResultadoCorreccionFechaInicioVinculacion.FechaSolapaVinculacionAnterior -> throw
-//          InvalidOperationException(Mensajes.FechaSolapaVinculacionAnterior) (-> 409).
-//        - ResultadoCorreccionFechaInicioVinculacion.SinCambios -> no hace nada (idempotencia
-//          silenciosa, patron CorregirNombresCommandHandler).
-//        - ResultadoCorreccionFechaInicioVinculacion.Exitosa -> el aggregate ya agrego
-//          FechaInicioVinculacionCorregida a _uncommittedEvents; WhenAsync/el middleware persiste
-//          via SaveChanges.
-// Sin publicacion a bus (event-sourcing puro, issue #352 "Consumidores: ninguno").
+// Issue #352: handler del comando CorregirFechaInicioVinculacion. Combina los dos mecanismos que
+// el ciclo de vida ya usa (CA-ADR-0030): el aggregate declina CON RESULTADO las dos reglas de
+// estado -- que este handler traduce a InvalidOperationException/409 con mensaje .resx -- y declina
+// EN SILENCIO la idempotencia (SinCambios), que no es un rechazo: el borde responde 202 igual, como
+// en CorregirNombresCommandHandler. El 404 es precondicion de orquestacion (MEF-ADR-0004 capa 2),
+// no regla del aggregate. En el camino de exito el aggregate ya dejo FechaInicioVinculacionCorregida
+// en _uncommittedEvents -- el middleware persiste via SaveChanges. Sin publicacion a bus
+// (event-sourcing puro, issue #352 "Consumidores: ninguno").
 public partial class CorregirFechaInicioVinculacionCommandHandler
     : ICommandHandlerAsync<CorregirFechaInicioVinculacion>
 {

--- a/src/Bitakora.ControlAsistencia.Colaboradores/CorregirFechaInicioVinculacionFunction/CommandHandler/CorregirFechaInicioVinculacionCommandHandlerMensajes.resx
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/CorregirFechaInicioVinculacionFunction/CommandHandler/CorregirFechaInicioVinculacionCommandHandlerMensajes.resx
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" msdata:Ordinal="0" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter</value></resheader>
+  <data name="ColaboradorNoEncontrado" xml:space="preserve">
+    <value>No existe un colaborador registrado con esa identificacion</value>
+  </data>
+  <data name="FechaPosteriorATerminacionPropia" xml:space="preserve">
+    <value>La fecha de inicio corregida no puede ser posterior a la fecha efectiva de terminacion de la vinculacion</value>
+  </data>
+  <data name="FechaSolapaVinculacionAnterior" xml:space="preserve">
+    <value>La fecha de inicio corregida debe ser estrictamente posterior a la fecha efectiva de terminacion de la vinculacion anterior</value>
+  </data>
+</root>

--- a/src/Bitakora.ControlAsistencia.Colaboradores/CorregirFechaInicioVinculacionFunction/CommandHandler/CorregirFechaInicioVinculacionValidator.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/CorregirFechaInicioVinculacionFunction/CommandHandler/CorregirFechaInicioVinculacionValidator.cs
@@ -1,0 +1,16 @@
+using FluentValidation;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.CorregirFechaInicioVinculacionFunction.CommandHandler;
+
+// Issue #352: validacion de forma del comando CorregirFechaInicioVinculacion en el borde
+// (MEF-ADR-0004 capa 1 -> 400 BadRequest). CA-6: TipoIdentificacion (requerido + en la lista
+// cerrada -- normalizar trim+MAYUSCULAS antes de TipoIdentificacion.Desde, mismo criterio de
+// normalizacion de entrada que los demas validators del dominio), NumeroIdentificacion y
+// FechaCorregida requeridos.
+// Se descubre via el AddValidatorsFromAssemblyContaining que ComposicionServicios ya configura: no
+// requiere tocar el wiring de DI.
+// STUB (fase roja, issue #352): sin reglas todavia -- el implementer las agrega (precedente
+// TerminarVinculacionValidator, issue #349).
+public class CorregirFechaInicioVinculacionValidator : AbstractValidator<CorregirFechaInicioVinculacion>
+{
+}

--- a/src/Bitakora.ControlAsistencia.Colaboradores/CorregirFechaInicioVinculacionFunction/CommandHandler/CorregirFechaInicioVinculacionValidator.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/CorregirFechaInicioVinculacionFunction/CommandHandler/CorregirFechaInicioVinculacionValidator.cs
@@ -1,3 +1,4 @@
+using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
 using FluentValidation;
 
 namespace Bitakora.ControlAsistencia.Colaboradores.CorregirFechaInicioVinculacionFunction.CommandHandler;
@@ -9,8 +10,38 @@ namespace Bitakora.ControlAsistencia.Colaboradores.CorregirFechaInicioVinculacio
 // FechaCorregida requeridos.
 // Se descubre via el AddValidatorsFromAssemblyContaining que ComposicionServicios ya configura: no
 // requiere tocar el wiring de DI.
-// STUB (fase roja, issue #352): sin reglas todavia -- el implementer las agrega (precedente
-// TerminarVinculacionValidator, issue #349).
 public class CorregirFechaInicioVinculacionValidator : AbstractValidator<CorregirFechaInicioVinculacion>
 {
+    public CorregirFechaInicioVinculacionValidator()
+    {
+        // Cascade(Stop) evita que Must evalue un valor vacio que NotEmpty ya rechazo -- mismo
+        // criterio que ReingresarColaboradorValidator/TerminarVinculacionValidator.
+        RuleFor(x => x.TipoIdentificacion)
+            .Cascade(CascadeMode.Stop)
+            .NotEmpty()
+            .Must(EsTipoIdentificacionReconocido)
+            .WithMessage("El tipo de identificacion no es uno de los reconocidos");
+
+        RuleFor(x => x.NumeroIdentificacion).NotEmpty();
+
+        // FechaCorregida es REQUERIDA -- el default de DateOnly (0001-01-01) equivale a "no llego"
+        // (doctrina bitemporal del BC: el tiempo de los hechos viene del cliente).
+        RuleFor(x => x.FechaCorregida).NotEqual(default(DateOnly));
+    }
+
+    // Consulta la lista cerrada (#348) sin propagar la excepcion de dominio al boundary de
+    // validacion -- un codigo fuera de la lista debe traducirse en un error de FluentValidation
+    // (400), no en una excepcion no controlada.
+    private static bool EsTipoIdentificacionReconocido(string tipo)
+    {
+        try
+        {
+            TipoIdentificacion.Desde(tipo.Trim().ToUpperInvariant());
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+    }
 }

--- a/src/Bitakora.ControlAsistencia.Colaboradores/CorregirFechaInicioVinculacionFunction/CorregirFechaInicioVinculacion.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/CorregirFechaInicioVinculacionFunction/CorregirFechaInicioVinculacion.cs
@@ -1,0 +1,20 @@
+namespace Bitakora.ControlAsistencia.Colaboradores.CorregirFechaInicioVinculacionFunction;
+
+// Issue #352: comando para corregir la fecha de inicio de la ULTIMA vinculacion de un colaborador
+// (tenga o no terminacion registrada, decision de refinamiento 2026-08-11) -- quinto comando del
+// ciclo de vida de ColaboradorAggregateRoot (desglose #348-#357). La fecha de inicio es un dato
+// requerido que puede nacer errado (caso real: se registro ayer con la fecha mal) y necesita su
+// enmienda.
+// Trigger: HTTP POST, Route: Colaboradores/FechasInicio (el recurso que se reemplaza, gemelo de
+// Colaboradores/Nombres #351; la identificacion viaja en el body porque su representacion
+// "CC:79543210" contiene ":", hostil como segmento de URL).
+// Payload primitivo -- igual que los demas comandos del ciclo de vida (MEF-ADR-0039 decision 6,
+// payload por rol): NUNCA reusa un tipo de Colaboradores.DomainEvents como campo. El handler
+// construye TipoIdentificacion/Identificacion a partir de estos primitivos (parseo tipado unico en
+// el borde, MEF-ADR-0037 seccion 2).
+// FechaCorregida es REQUERIDA (DateOnly, sin default del servidor) -- doctrina bitemporal del BC:
+// el tiempo de los hechos viene del cliente, nunca del reloj del servidor.
+public record CorregirFechaInicioVinculacion(
+    string TipoIdentificacion,
+    string NumeroIdentificacion,
+    DateOnly FechaCorregida);

--- a/src/Bitakora.ControlAsistencia.Colaboradores/CorregirFechaInicioVinculacionFunction/FunctionEndpoint.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/CorregirFechaInicioVinculacionFunction/FunctionEndpoint.cs
@@ -1,0 +1,46 @@
+using Bitakora.ControlAsistencia.Colaboradores.Infraestructura;
+using Cosmos.EventSourcing.Abstractions.Commands;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.CorregirFechaInicioVinculacionFunction;
+
+// Issue #352: endpoint HTTP POST para corregir la fecha de inicio de la ultima vinculacion de un
+// colaborador. MEF-ADR-0006: [Function("CorregirFechaInicioVinculacion")]; carpeta CON sufijo
+// "Function" -- mismo criterio que los demas comandos del ciclo de vida: el record del comando es
+// homonimo del feature folder.
+// Route = "Colaboradores/FechasInicio": el recurso que se reemplaza, gemelo de
+// Colaboradores/Nombres (#351) -- identificacion en el body porque su representacion
+// ("CC:79543210") contiene ":", hostil como segmento de URL.
+// CA-ADR-0030 / MEF-ADR-0004 (precedente ReingresarColaboradorFunction.FunctionEndpoint): validar
+// request (400 via IRequestValidator) -> despachar comando -> InvalidOperationException -> 409
+// Conflict, KeyNotFoundException -> 404 NotFound; exito -> 202 Accepted.
+public class FunctionEndpoint(IRequestValidator requestValidator, ICommandRouter commandRouter)
+{
+    [Function("CorregirFechaInicioVinculacion")]
+    public async Task<IActionResult> Run(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "Colaboradores/FechasInicio")]
+        HttpRequest req,
+        CancellationToken ct)
+    {
+        var (comando, error) = await requestValidator.ValidarAsync<CorregirFechaInicioVinculacion>(req, ct);
+        if (error is not null)
+            return error;
+
+        try
+        {
+            await commandRouter.InvokeAsync(comando!, ct);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return new ConflictObjectResult(ex.Message);
+        }
+        catch (KeyNotFoundException ex)
+        {
+            return new NotFoundObjectResult(ex.Message);
+        }
+
+        return new AcceptedResult();
+    }
+}

--- a/src/Bitakora.ControlAsistencia.Colaboradores/Entities/ColaboradorAggregateRoot.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/Entities/ColaboradorAggregateRoot.cs
@@ -69,6 +69,11 @@ public partial class ColaboradorAggregateRoot : AggregateRoot
     // Issue #351: reemplaza el nombre de la persona. Nunca lanza (MEF-ADR-0004 capa 4).
     public void Apply(NombresCorregidos e) => _nombre = e.Nombre;
 
+    // Issue #352: reemplaza la fecha de inicio de la ULTIMA vinculacion (tenga o no terminacion
+    // registrada). Nunca lanza (MEF-ADR-0004 capa 4).
+    // STUB (fase roja, issue #352): el cuerpo completo queda para el implementer.
+    public void Apply(FechaInicioVinculacionCorregida e) => throw new NotImplementedException();
+
     // Issue #349: mecanismo "declinar con resultado" (CA-ADR-0030) -- nunca lanza, nunca emite un
     // evento de fallo persistido. Dos razones de rechazo evaluables solo con la historia del
     // stream, sin reloj (decision de refinamiento):
@@ -144,6 +149,28 @@ public partial class ColaboradorAggregateRoot : AggregateRoot
         _uncommittedEvents.Add(evento);
         Apply(evento);
     }
+
+    // Issue #352: mecanismo combinado (CA-ADR-0030) -- "declinar con resultado" para las dos
+    // reglas de estado y "declinar en silencio" (precedente CorregirNombres #351) para la
+    // idempotencia. Tres reglas evaluables solo con la historia del stream, sin reloj (decision de
+    // refinamiento 2026-08-11):
+    //   - SinCambios (idempotencia, se evalua PRIMERO): fechaCorregida == _fechaInicioVinculacionVigente
+    //     -> ningun evento, sin excepcion (patron #351: la idempotencia no consulta las demas reglas).
+    //   - FechaPosteriorATerminacionPropia: la ULTIMA vinculacion tiene terminacion registrada
+    //     (_fechaTerminacionVinculacionVigente is not null) y fechaCorregida >
+    //     _fechaTerminacionVinculacionVigente.Value (fechaCorregida == la propia terminacion es
+    //     valida: vinculacion de un solo dia, consistente con TerminarVinculacion #349).
+    //   - FechaSolapaVinculacionAnterior: no-solape hacia atras, solo ejercitable cuando existe una
+    //     vinculacion anterior (tras un reingreso, #350) -- fechaCorregida es igual o anterior a la
+    //     FechaEfectiva de esa vinculacion anterior (misma frontera que Reingresar #350: el dia de
+    //     la fecha efectiva pertenece a la vinculacion que termino).
+    // Exito: appendea FechaInicioVinculacionCorregida a _uncommittedEvents y lo aplica.
+    // internal: mismo criterio de visibilidad que TerminarVinculacion/Reingresar/CorregirNombres --
+    // el unico llamador es el handler del mismo ensamblado (los tests lo alcanzan via
+    // InternalsVisibleTo).
+    // STUB (fase roja, issue #352): el cuerpo completo queda para el implementer.
+    internal ResultadoCorreccionFechaInicioVinculacion CorregirFechaInicio(DateOnly fechaCorregida) =>
+        throw new NotImplementedException();
 
     // Factory interno: agrega los DOS eventos del commit a _uncommittedEvents y los aplica -- patron
     // RegistroDeMarcacionAggregateRoot.Iniciar, generalizado a dos eventos en el mismo commit.

--- a/src/Bitakora.ControlAsistencia.Colaboradores/Entities/ColaboradorAggregateRoot.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/Entities/ColaboradorAggregateRoot.cs
@@ -27,6 +27,15 @@ public partial class ColaboradorAggregateRoot : AggregateRoot
     private DateOnly _fechaInicioVinculacionVigente;
     private DateOnly? _fechaTerminacionVinculacionVigente;
 
+    // Issue #352: fecha efectiva de terminacion de la vinculacion ANTERIOR a la vigente (la que
+    // Apply(VinculacionIniciada) desplaza al reabrir con un reingreso). A diferencia de
+    // _fechaTerminacionVinculacionVigente (que Apply(VinculacionIniciada) resetea a null al
+    // reabrir), este campo sobrevive el reingreso: es el unico dato que permite evaluar la
+    // no-solape hacia atras (CorregirFechaInicio) despues de que la vinculacion anterior dejo de
+    // ser la vigente. null cuando nunca hubo una vinculacion anterior (colaborador en su primera
+    // vinculacion).
+    private DateOnly? _fechaTerminacionVinculacionAnterior;
+
     internal Identificacion Identificacion => _identificacion!;
     internal NombreColaborador Nombre => _nombre!;
     internal string CodigoVinculacionVigente => _codigoVinculacionVigente!;
@@ -55,8 +64,13 @@ public partial class ColaboradorAggregateRoot : AggregateRoot
     // Issue #350: reabre la vinculacion al re-aplicarse -- una segunda VinculacionIniciada en el
     // mismo stream (reingreso) deja limpia la terminacion de la vinculacion anterior, sin lo cual
     // el reingreso rehidratado quedaria "ya terminado" heredando la terminacion previa.
+    // Issue #352: antes de resetear, conserva en _fechaTerminacionVinculacionAnterior la
+    // terminacion de la vinculacion que este reingreso desplaza -- es el unico rastro que
+    // CorregirFechaInicio tiene para evaluar la no-solape hacia atras una vez que
+    // _fechaTerminacionVinculacionVigente ya se reseteo a null.
     public void Apply(VinculacionIniciada e)
     {
+        _fechaTerminacionVinculacionAnterior = _fechaTerminacionVinculacionVigente;
         _codigoVinculacionVigente = e.Codigo;
         _fechaInicioVinculacionVigente = e.FechaInicio;
         _fechaTerminacionVinculacionVigente = null;
@@ -71,8 +85,7 @@ public partial class ColaboradorAggregateRoot : AggregateRoot
 
     // Issue #352: reemplaza la fecha de inicio de la ULTIMA vinculacion (tenga o no terminacion
     // registrada). Nunca lanza (MEF-ADR-0004 capa 4).
-    // STUB (fase roja, issue #352): el cuerpo completo queda para el implementer.
-    public void Apply(FechaInicioVinculacionCorregida e) => throw new NotImplementedException();
+    public void Apply(FechaInicioVinculacionCorregida e) => _fechaInicioVinculacionVigente = e.FechaInicio;
 
     // Issue #349: mecanismo "declinar con resultado" (CA-ADR-0030) -- nunca lanza, nunca emite un
     // evento de fallo persistido. Dos razones de rechazo evaluables solo con la historia del
@@ -168,9 +181,25 @@ public partial class ColaboradorAggregateRoot : AggregateRoot
     // internal: mismo criterio de visibilidad que TerminarVinculacion/Reingresar/CorregirNombres --
     // el unico llamador es el handler del mismo ensamblado (los tests lo alcanzan via
     // InternalsVisibleTo).
-    // STUB (fase roja, issue #352): el cuerpo completo queda para el implementer.
-    internal ResultadoCorreccionFechaInicioVinculacion CorregirFechaInicio(DateOnly fechaCorregida) =>
-        throw new NotImplementedException();
+    internal ResultadoCorreccionFechaInicioVinculacion CorregirFechaInicio(DateOnly fechaCorregida)
+    {
+        if (fechaCorregida == _fechaInicioVinculacionVigente)
+            return ResultadoCorreccionFechaInicioVinculacion.SinCambios;
+
+        if (_fechaTerminacionVinculacionVigente is not null &&
+            fechaCorregida > _fechaTerminacionVinculacionVigente.Value)
+            return ResultadoCorreccionFechaInicioVinculacion.FechaPosteriorATerminacionPropia;
+
+        if (_fechaTerminacionVinculacionAnterior is not null &&
+            fechaCorregida <= _fechaTerminacionVinculacionAnterior.Value)
+            return ResultadoCorreccionFechaInicioVinculacion.FechaSolapaVinculacionAnterior;
+
+        var evento = new FechaInicioVinculacionCorregida(fechaCorregida);
+        _uncommittedEvents.Add(evento);
+        Apply(evento);
+
+        return ResultadoCorreccionFechaInicioVinculacion.Exitosa;
+    }
 
     // Factory interno: agrega los DOS eventos del commit a _uncommittedEvents y los aplica -- patron
     // RegistroDeMarcacionAggregateRoot.Iniciar, generalizado a dos eventos en el mismo commit.

--- a/src/Bitakora.ControlAsistencia.Colaboradores/Entities/ResultadoCorreccionFechaInicioVinculacion.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/Entities/ResultadoCorreccionFechaInicioVinculacion.cs
@@ -1,0 +1,20 @@
+namespace Bitakora.ControlAsistencia.Colaboradores.Entities;
+
+// Issue #352: resultado de ColaboradorAggregateRoot.CorregirFechaInicio. Combina los dos
+// mecanismos que el ciclo de vida ya usa (CA-ADR-0030):
+//   - "declinar con resultado" (ResultadoTerminacionVinculacion #349 / ResultadoReingresoColaborador
+//     #350): las dos razones de rechazo (coherencia interna, no-solape hacia atras) que el handler
+//     traduce a InvalidOperationException/409 con mensaje .resx.
+//   - "declinar en silencio" (ColaboradorAggregateRoot.CorregirNombres #351): SinCambios es la
+//     variante de EXITO silenciosa -- la fecha corregida es igual a la fecha de inicio actual, no
+//     hay nada que corregir, ningun evento nuevo y ninguna excepcion.
+// internal: mismo criterio de visibilidad que ResultadoTerminacionVinculacion/
+// ResultadoReingresoColaborador -- vive en el mismo ensamblado que el handler que lo consume
+// (Entities/ y CommandHandler/ en el mismo proyecto Function App).
+internal enum ResultadoCorreccionFechaInicioVinculacion
+{
+    Exitosa,
+    SinCambios,
+    FechaPosteriorATerminacionPropia,
+    FechaSolapaVinculacionAnterior
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/CorregirFechaInicioVinculacionFunction/CorregirFechaInicioVinculacionSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/CorregirFechaInicioVinculacionFunction/CorregirFechaInicioVinculacionSmokeTests.cs
@@ -25,7 +25,6 @@
 using System.Globalization;
 using System.Net;
 using System.Net.Http.Json;
-using System.Text.Json;
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.Colaboradores.SmokeTests.Fixtures;
 
@@ -47,10 +46,6 @@ public class CorregirFechaInicioVinculacionSmokeTests(ApiFixture api, PostgresFi
     // CA-4: la ausencia de evento es sincrona (sin proyeccion downstream) -- un timeout corto
     // alcanza para probarla sin alargar la suite esperando los 30s estandar sin ganar senal.
     private static readonly TimeSpan TimeoutAusencia = TimeSpan.FromSeconds(3);
-
-    // Segunda lectura del mismo evento que ExisteEventoAsync ya espero: si el primer polling
-    // termino, el evento esta -- no hay nada mas que esperar.
-    private static readonly TimeSpan TimeoutLecturaConfirmada = TimeSpan.FromSeconds(5);
 
     // Numero unico por test -- evita colisiones entre ejecuciones repetidas del smoke test: la
     // identidad del stream es Identificacion.ToString() ("CC:<numero>"), no un Guid nuevo por
@@ -171,18 +166,17 @@ public class CorregirFechaInicioVinculacionSmokeTests(ApiFixture api, PostgresFi
 
         var streamId = ComputarStreamId(numeroIdentificacion);
 
+        // El filtro (campoJson, valorJson) de ExisteEventoAsync ya compara el valor persistido de
+        // FechaInicio contra el esperado -- releerlo con ObtenerEventoAsync usando el MISMO filtro
+        // solo repetiria la consulta para afirmar lo que el filtro ya garantizo. El overload sin
+        // filtro sigue siendo necesario en #351 (campo objeto: el Nombre exige comparar por valor
+        // deserializado), no aqui: FechaInicio es escalar.
         var existe = await postgres.ExisteEventoAsync(
             SchemaColaboradores, streamId, TipoEventoFechaInicioVinculacionCorregida, Timeout,
             campoJson: "FechaInicio", valorJson: FormatearFecha(fechaCorregida));
 
         existe.Should().BeTrue(
             $"el evento {TipoEventoFechaInicioVinculacionCorregida} deberia existir en el stream {streamId} con FechaInicio {FormatearFecha(fechaCorregida)}");
-
-        var eventoPersistido = await postgres.ObtenerEventoAsync<JsonElement>(
-            SchemaColaboradores, streamId, TipoEventoFechaInicioVinculacionCorregida,
-            campoJson: "FechaInicio", valorJson: FormatearFecha(fechaCorregida), TimeoutLecturaConfirmada);
-
-        eventoPersistido.GetProperty("FechaInicio").GetString().Should().Be(FormatearFecha(fechaCorregida));
     }
 
     // CA-2 (borde valido): la ultima vinculacion esta TERMINADA y FechaCorregida == FechaEfectiva

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/CorregirFechaInicioVinculacionFunction/CorregirFechaInicioVinculacionSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/CorregirFechaInicioVinculacionFunction/CorregirFechaInicioVinculacionSmokeTests.cs
@@ -1,0 +1,356 @@
+// Issue #352: smoke tests del endpoint POST Colaboradores/FechasInicio (corregir la fecha de
+// inicio de la ULTIMA vinculacion de un colaborador, tenga o no terminacion registrada). Quinto
+// comando del ciclo de vida de ColaboradorAggregateRoot (desglose #348-#357). Molde:
+// CorregirNombresSmokeTests (#351) + ReingresarColaboradorSmokeTests (#350) -- mismo comando
+// event-sourcing puro sin consumidores downstream (CA-ADR-0030): sin ServiceBusFixture, la unica
+// verificacion black-box de los efectos del handler es leer mt_events via PostgresFixture.
+//
+// Arrange: CorregirFechaInicioVinculacion exige un ColaboradorAggregateRoot existente -- el
+// arrange de cada test registra el colaborador y, cuando aplica, termina su vinculacion y/o lo
+// reingresa via los mismos comandos que los originan (#330, #349, #350), nunca sembrando datos por
+// fuera del API.
+//
+// CA-1 (camino feliz, vinculacion abierta): 202 + el stream recibe FechaInicioVinculacionCorregida
+// con la FechaInicio exacta del request.
+// CA-2 (coherencia interna, ultima vinculacion con terminacion registrada): FechaCorregida ==
+// FechaEfectiva propia -> 202 (vinculacion de un solo dia, valida); FechaCorregida > FechaEfectiva
+// -> 409 con .resx, sin evento.
+// CA-3 (no-solape hacia atras, tras un reingreso): FechaCorregida igual a la FechaEfectiva de la
+// vinculacion anterior -> 409, sin evento.
+// CA-4 (idempotencia silenciosa): FechaCorregida igual a la fecha de inicio actual -> 202 sin
+// evento nuevo (mecanismo "declinar en silencio", precedente CorregirNombres #351).
+// CA-5: colaborador inexistente -> 404, sin escribir nada al event store.
+// CA-6: request invalida (sin FechaCorregida, sin identificacion, tipo fuera de la lista) -> 400,
+// sin tocar el event store.
+using System.Globalization;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.SmokeTests.Fixtures;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.SmokeTests.CorregirFechaInicioVinculacionFunction;
+
+public class CorregirFechaInicioVinculacionSmokeTests(ApiFixture api, PostgresFixture postgres)
+{
+    private readonly HttpClient _client = api.Client;
+
+    private const string RutaRegistrar = "/api/Colaboradores";
+    private const string RutaTerminaciones = "/api/Colaboradores/Terminaciones";
+    private const string RutaReingresos = "/api/Colaboradores/Reingresos";
+    private const string RutaFechasInicio = "/api/Colaboradores/FechasInicio";
+    private const string SchemaColaboradores = "colaboradores";
+    private const string TipoEventoFechaInicioVinculacionCorregida = "fecha_inicio_vinculacion_corregida";
+    private const string TipoIdentificacionCc = "CC";
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
+
+    // CA-4: la ausencia de evento es sincrona (sin proyeccion downstream) -- un timeout corto
+    // alcanza para probarla sin alargar la suite esperando los 30s estandar sin ganar senal.
+    private static readonly TimeSpan TimeoutAusencia = TimeSpan.FromSeconds(3);
+
+    // Segunda lectura del mismo evento que ExisteEventoAsync ya espero: si el primer polling
+    // termino, el evento esta -- no hay nada mas que esperar.
+    private static readonly TimeSpan TimeoutLecturaConfirmada = TimeSpan.FromSeconds(5);
+
+    // Numero unico por test -- evita colisiones entre ejecuciones repetidas del smoke test: la
+    // identidad del stream es Identificacion.ToString() ("CC:<numero>"), no un Guid nuevo por
+    // llamada, asi que reusar un numero fijo haria que el arrange (RegistrarColaborador) choque con
+    // 409 en la segunda corrida.
+    private static string NuevoNumeroIdentificacion() => Guid.CreateVersion7().ToString("N").ToUpperInvariant();
+
+    private static string NuevoCodigoColaborador() => $"[TEST]-{Guid.CreateVersion7()}";
+
+    private static string ComputarStreamId(string numeroIdentificacion) =>
+        $"{TipoIdentificacionCc}:{numeroIdentificacion}";
+
+    private static string FormatearFecha(DateOnly fecha) =>
+        fecha.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+
+    private static object PayloadRegistro(string numeroIdentificacion, DateOnly fechaInicio) => new
+    {
+        tipoIdentificacion = TipoIdentificacionCc,
+        numeroIdentificacion,
+        primerNombre = "[TEST]",
+        segundoNombre = (string?)null,
+        primerApellido = "Smoke",
+        segundoApellido = (string?)null,
+        codigoColaborador = NuevoCodigoColaborador(),
+        fechaInicio
+    };
+
+    private static object PayloadTerminacion(string numeroIdentificacion, DateOnly fechaEfectiva) => new
+    {
+        tipoIdentificacion = TipoIdentificacionCc,
+        numeroIdentificacion,
+        fechaEfectiva
+    };
+
+    private static object PayloadReingreso(string numeroIdentificacion, DateOnly fechaInicio) => new
+    {
+        tipoIdentificacion = TipoIdentificacionCc,
+        numeroIdentificacion,
+        codigoColaborador = NuevoCodigoColaborador(),
+        fechaInicio
+    };
+
+    private static object PayloadCorreccion(
+        string numeroIdentificacion, DateOnly fechaCorregida, string tipoIdentificacion = TipoIdentificacionCc) => new
+        {
+            tipoIdentificacion,
+            numeroIdentificacion,
+            fechaCorregida
+        };
+
+    // Arrange comun: registra un colaborador con una vinculacion abierta -- via el comando que la
+    // origina (#330), nunca sembrando el event store por fuera del API.
+    private async Task RegistrarColaboradorAsync(
+        string numeroIdentificacion, DateOnly fechaInicio, CancellationToken ct)
+    {
+        var response = await _client.PostAsJsonAsync(
+            RutaRegistrar, PayloadRegistro(numeroIdentificacion, fechaInicio), ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted,
+            "el arrange de este smoke test depende de que RegistrarColaborador funcione");
+    }
+
+    // Arrange comun: cierra la vinculacion vigente -- via el comando que la origina (#349), nunca
+    // sembrando el event store por fuera del API.
+    private async Task TerminarVinculacionAsync(
+        string numeroIdentificacion, DateOnly fechaEfectiva, CancellationToken ct)
+    {
+        var response = await _client.PostAsJsonAsync(
+            RutaTerminaciones, PayloadTerminacion(numeroIdentificacion, fechaEfectiva), ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted,
+            "el arrange de este smoke test depende de que TerminarVinculacion funcione");
+    }
+
+    // Arrange comun (CA-3): reingresa al colaborador tras una terminacion -- via el comando que lo
+    // origina (#350), nunca sembrando el event store por fuera del API.
+    private async Task ReingresarColaboradorAsync(
+        string numeroIdentificacion, DateOnly fechaInicio, CancellationToken ct)
+    {
+        var response = await _client.PostAsJsonAsync(
+            RutaReingresos, PayloadReingreso(numeroIdentificacion, fechaInicio), ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted,
+            "el arrange de este smoke test depende de que ReingresarColaborador funcione");
+    }
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task DebeEstarDisponible_CuandoSeConsultaHealthCheck()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var response = await _client.GetAsync("/api/health", ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    // CA-1: camino feliz -- colaborador con vinculacion abierta + FechaCorregida distinta valida ->
+    // 202 y el stream recibe FechaInicioVinculacionCorregida con la FechaInicio exacta del request.
+    // Sin Service Bus (event-sourcing puro): mt_events es la unica ventana black-box a lo que quedo
+    // grabado.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task CorregirFechaInicioVinculacion_Retorna202YPersisteFechaInicioVinculacionCorregida_CuandoUltimaVinculacionEstaAbierta()
+    {
+        Assert.SkipWhen(!postgres.IsConfigured, postgres.SkipReason ?? "Postgres no disponible.");
+
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion();
+        var fechaInicioOriginal = new DateOnly(2026, 1, 15);
+        var fechaCorregida = new DateOnly(2026, 1, 10);
+
+        await RegistrarColaboradorAsync(numeroIdentificacion, fechaInicioOriginal, ct);
+
+        var response = await _client.PostAsJsonAsync(
+            RutaFechasInicio, PayloadCorreccion(numeroIdentificacion, fechaCorregida), ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+
+        var streamId = ComputarStreamId(numeroIdentificacion);
+
+        var existe = await postgres.ExisteEventoAsync(
+            SchemaColaboradores, streamId, TipoEventoFechaInicioVinculacionCorregida, Timeout,
+            campoJson: "FechaInicio", valorJson: FormatearFecha(fechaCorregida));
+
+        existe.Should().BeTrue(
+            $"el evento {TipoEventoFechaInicioVinculacionCorregida} deberia existir en el stream {streamId} con FechaInicio {FormatearFecha(fechaCorregida)}");
+
+        var eventoPersistido = await postgres.ObtenerEventoAsync<JsonElement>(
+            SchemaColaboradores, streamId, TipoEventoFechaInicioVinculacionCorregida,
+            campoJson: "FechaInicio", valorJson: FormatearFecha(fechaCorregida), TimeoutLecturaConfirmada);
+
+        eventoPersistido.GetProperty("FechaInicio").GetString().Should().Be(FormatearFecha(fechaCorregida));
+    }
+
+    // CA-2 (borde valido): la ultima vinculacion esta TERMINADA y FechaCorregida == FechaEfectiva
+    // propia -> 202 (vinculacion de un solo dia, consistente con TerminarVinculacion #349).
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task CorregirFechaInicioVinculacion_Retorna202YPersisteFechaInicioVinculacionCorregida_CuandoFechaCorregidaEsIgualALaFechaEfectivaPropia()
+    {
+        Assert.SkipWhen(!postgres.IsConfigured, postgres.SkipReason ?? "Postgres no disponible.");
+
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion();
+        var fechaInicioOriginal = new DateOnly(2026, 2, 1);
+        var fechaEfectivaTerminacion = new DateOnly(2026, 3, 1);
+
+        await RegistrarColaboradorAsync(numeroIdentificacion, fechaInicioOriginal, ct);
+        await TerminarVinculacionAsync(numeroIdentificacion, fechaEfectivaTerminacion, ct);
+
+        var response = await _client.PostAsJsonAsync(
+            RutaFechasInicio, PayloadCorreccion(numeroIdentificacion, fechaEfectivaTerminacion), ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+
+        var streamId = ComputarStreamId(numeroIdentificacion);
+
+        var existe = await postgres.ExisteEventoAsync(
+            SchemaColaboradores, streamId, TipoEventoFechaInicioVinculacionCorregida, Timeout,
+            campoJson: "FechaInicio", valorJson: FormatearFecha(fechaEfectivaTerminacion));
+
+        existe.Should().BeTrue(
+            "una FechaCorregida igual a la FechaEfectiva propia deberia aceptarse (vinculacion de un solo dia)");
+    }
+
+    // CA-2 (borde invalido): FechaCorregida POSTERIOR a la FechaEfectiva propia de la ultima
+    // vinculacion (ya terminada) -> 409. No requiere Postgres: el status code ya prueba que el
+    // aggregate declino con resultado y el handler lo tradujo (CA-ADR-0030).
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task CorregirFechaInicioVinculacion_Retorna409_CuandoFechaCorregidaEsPosteriorALaFechaEfectivaPropia()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion();
+        var fechaInicioOriginal = new DateOnly(2026, 2, 1);
+        var fechaEfectivaTerminacion = new DateOnly(2026, 3, 1);
+
+        await RegistrarColaboradorAsync(numeroIdentificacion, fechaInicioOriginal, ct);
+        await TerminarVinculacionAsync(numeroIdentificacion, fechaEfectivaTerminacion, ct);
+
+        var response = await _client.PostAsJsonAsync(
+            RutaFechasInicio,
+            PayloadCorreccion(numeroIdentificacion, fechaEfectivaTerminacion.AddDays(1)),
+            ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    // CA-3: tras un reingreso, FechaCorregida IGUAL a la FechaEfectiva de la vinculacion anterior ->
+    // 409 por no-solape (el mismo dia se rechaza -- el dia de la fecha efectiva pertenece a la
+    // vinculacion que termino, misma frontera que Reingresar #350).
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task CorregirFechaInicioVinculacion_Retorna409_CuandoFechaCorregidaSolapaLaVinculacionAnteriorTrasUnReingreso()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion();
+        var fechaInicioOriginal = new DateOnly(2026, 1, 1);
+        var fechaEfectivaTerminacion = new DateOnly(2026, 3, 1);
+        var fechaReingreso = new DateOnly(2026, 3, 15);
+
+        await RegistrarColaboradorAsync(numeroIdentificacion, fechaInicioOriginal, ct);
+        await TerminarVinculacionAsync(numeroIdentificacion, fechaEfectivaTerminacion, ct);
+        await ReingresarColaboradorAsync(numeroIdentificacion, fechaReingreso, ct);
+
+        var response = await _client.PostAsJsonAsync(
+            RutaFechasInicio,
+            PayloadCorreccion(numeroIdentificacion, fechaEfectivaTerminacion),
+            ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    // CA-4: FechaCorregida igual a la fecha de inicio actual -> 202 sin evento nuevo en el stream
+    // (idempotencia silenciosa). Verificacion de ausencia con timeout corto -- ver el porque en el
+    // comentario de TimeoutAusencia (arriba).
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task CorregirFechaInicioVinculacion_Retorna202SinNuevoEvento_CuandoFechaCorregidaEsIgualALaActual()
+    {
+        Assert.SkipWhen(!postgres.IsConfigured, postgres.SkipReason ?? "Postgres no disponible.");
+
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion();
+        var fechaInicio = new DateOnly(2026, 4, 1);
+
+        await RegistrarColaboradorAsync(numeroIdentificacion, fechaInicio, ct);
+
+        var response = await _client.PostAsJsonAsync(
+            RutaFechasInicio, PayloadCorreccion(numeroIdentificacion, fechaInicio), ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+
+        var existe = await postgres.ExisteEventoAsync(
+            SchemaColaboradores, ComputarStreamId(numeroIdentificacion),
+            TipoEventoFechaInicioVinculacionCorregida, TimeoutAusencia);
+
+        existe.Should().BeFalse(
+            "una FechaCorregida igual a la actual no deberia persistir un evento nuevo (idempotencia silenciosa)");
+    }
+
+    // CA-5: colaborador inexistente -> 404, sin escribir nada al event store (no hay stream para
+    // consultar: la ausencia de escritura la garantiza el propio 404 -- el handler lanza antes de
+    // llegar al aggregate).
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task CorregirFechaInicioVinculacion_Retorna404_CuandoColaboradorNoExiste()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion(); // nunca registrado
+
+        var response = await _client.PostAsJsonAsync(
+            RutaFechasInicio, PayloadCorreccion(numeroIdentificacion, new DateOnly(2026, 5, 1)), ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    // CA-6: FechaCorregida vacia (default de DateOnly, "no llego" segun la doctrina bitemporal del
+    // BC) -> 400.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task CorregirFechaInicioVinculacion_Retorna400_CuandoFechaCorregidaEsVacia()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var payload = new
+        {
+            tipoIdentificacion = TipoIdentificacionCc,
+            numeroIdentificacion = NuevoNumeroIdentificacion(),
+            fechaCorregida = default(DateOnly)
+        };
+
+        var response = await _client.PostAsJsonAsync(RutaFechasInicio, payload, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    // CA-6: NumeroIdentificacion vacio -> 400.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task CorregirFechaInicioVinculacion_Retorna400_CuandoNumeroIdentificacionEsVacio()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var payload = PayloadCorreccion(numeroIdentificacion: "", new DateOnly(2026, 5, 1));
+
+        var response = await _client.PostAsJsonAsync(RutaFechasInicio, payload, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    // CA-6: TipoIdentificacion fuera de la lista cerrada (PILA: CC, CE, TI, PA, PT) -> 400.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task CorregirFechaInicioVinculacion_Retorna400_CuandoTipoIdentificacionNoEsReconocido()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var payload = PayloadCorreccion(
+            NuevoNumeroIdentificacion(), new DateOnly(2026, 5, 1), tipoIdentificacion: "XX");
+
+        var response = await _client.PostAsJsonAsync(RutaFechasInicio, payload, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/CorregirFechaInicioVinculacionFunction/CorregirFechaInicioVinculacionCommandHandlerMensajesTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/CorregirFechaInicioVinculacionFunction/CorregirFechaInicioVinculacionCommandHandlerMensajesTests.cs
@@ -1,0 +1,27 @@
+// Issue #352: guardrail de resolucion del .resx del handler (MEF-ADR-0009), gemelo del que
+// ReingresarColaboradorCommandHandlerMensajesTests.cs aplica.
+//
+// Por que existe: CorregirFechaInicioVinculacionCommandHandler.Mensajes devuelve
+// ResourceManager.GetString(...)! -- el "!" es supresion del compilador, no garantia de runtime. Si
+// la CLAVE desaparece del .resx (rename, merge que la pierde) GetString retorna null en silencio y
+// los tests del handler pasan en FALSO: sus aserciones son WithMessage($"*{Mensajes.X}*"), que con
+// X == null se vuelve "**" y matchea cualquier excepcion.
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.CorregirFechaInicioVinculacionFunction.CommandHandler;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Tests.CorregirFechaInicioVinculacionFunction;
+
+public class CorregirFechaInicioVinculacionCommandHandlerMensajesTests
+{
+    [Fact]
+    public void Mensajes_ResuelvenTextoNoVacio_CuandoPertenecenACorregirFechaInicioVinculacionCommandHandler()
+    {
+        CorregirFechaInicioVinculacionCommandHandler.Mensajes.ColaboradorNoEncontrado
+            .Should().NotBeNullOrWhiteSpace();
+        CorregirFechaInicioVinculacionCommandHandler.Mensajes.FechaPosteriorATerminacionPropia
+            .Should().NotBeNullOrWhiteSpace();
+        CorregirFechaInicioVinculacionCommandHandler.Mensajes.FechaSolapaVinculacionAnterior
+            .Should().NotBeNullOrWhiteSpace();
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/CorregirFechaInicioVinculacionFunction/CorregirFechaInicioVinculacionCommandHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/CorregirFechaInicioVinculacionFunction/CorregirFechaInicioVinculacionCommandHandlerTests.cs
@@ -1,0 +1,265 @@
+// Issue #352: corregir la fecha de inicio de la ULTIMA vinculacion de un colaborador (tenga o no
+// terminacion registrada) -- quinto comando del ciclo de vida de ColaboradorAggregateRoot
+// (desglose #348-#357). CA-ADR-0030: el aggregate combina "declinar con resultado" (dos razones
+// 409: coherencia interna, no-solape hacia atras) con "declinar en silencio" (idempotencia,
+// precedente CorregirNombres #351). Depende de #350 (reingresar): la no-solape hacia atras solo es
+// ejercitable cuando existe una vinculacion anterior.
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.CorregirFechaInicioVinculacionFunction;
+using Bitakora.ControlAsistencia.Colaboradores.CorregirFechaInicioVinculacionFunction.CommandHandler;
+using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+using Bitakora.ControlAsistencia.Colaboradores.Entities;
+using Cosmos.EventSourcing.Abstractions.Commands;
+using Cosmos.EventSourcing.Testing.Utilities;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Tests.CorregirFechaInicioVinculacionFunction;
+
+// El aggregate usa un stream ID compuesto (Identificacion.ToString(), "CC:79543210"), no el
+// GuidAggregateId del harness -- overloads explicitos de Given/Then/And (regla 18 del
+// test-writer, mismo criterio que TerminarVinculacionCommandHandlerTests/
+// ReingresarColaboradorCommandHandlerTests/CorregirNombresCommandHandlerTests).
+public class CorregirFechaInicioVinculacionCommandHandlerTests
+    : CommandHandlerAsyncTest<CorregirFechaInicioVinculacion>
+{
+    private const string NumeroValido = "79543210";
+
+    // Oraculo independiente de la clave de stream (MEF-ADR-0002 + MEF-ADR-0037): literal, no
+    // derivado de ColaboradorAggregateRoot.ComputarStreamId.
+    private const string StreamIdEsperado = "CC:79543210";
+
+    private const string CodigoVinculacionOriginal = "COL-001";
+    private const string CodigoReingreso = "COL-002";
+    private static readonly DateOnly FechaInicioOriginal = new(2026, 1, 15);
+    private static readonly DateOnly FechaEfectivaTerminacionOriginal = new(2026, 6, 1);
+    private static readonly DateOnly FechaInicioReingreso =
+        FechaEfectivaTerminacionOriginal.AddDays(1); // 2026-06-02
+
+    protected override ICommandHandlerAsync<CorregirFechaInicioVinculacion> Handler =>
+        new CorregirFechaInicioVinculacionCommandHandler(EventStore);
+
+    private static CorregirFechaInicioVinculacion ComandoCon(DateOnly fechaCorregida) => new(
+        TipoIdentificacion: "CC",
+        NumeroIdentificacion: NumeroValido,
+        FechaCorregida: fechaCorregida);
+
+    private static Identificacion IdentificacionValida() =>
+        Identificacion.Crear(TipoIdentificacion.CC, NumeroValido);
+
+    private static NombreColaborador NombreValido() =>
+        NombreColaborador.Crear("Luis", "Augusto", "Barreto", null);
+
+    private static ColaboradorRegistrado ColaboradorRegistradoValido() =>
+        new(IdentificacionValida(), NombreValido());
+
+    private static VinculacionIniciada VinculacionIniciadaOriginal() =>
+        new(CodigoVinculacionOriginal, FechaInicioOriginal);
+
+    // Precondicion: colaborador registrado con una vinculacion abierta (sin terminacion) -- base
+    // de CA-1 y CA-4.
+    private void DadoUnColaboradorConVinculacionAbierta() =>
+        Given(StreamIdEsperado, ColaboradorRegistradoValido(), VinculacionIniciadaOriginal());
+
+    // Precondicion: colaborador registrado con la vinculacion original ya terminada -- base de
+    // CA-2.
+    private void DadoUnColaboradorConVinculacionTerminada() =>
+        Given(StreamIdEsperado,
+            ColaboradorRegistradoValido(),
+            VinculacionIniciadaOriginal(),
+            new VinculacionTerminada(FechaEfectivaTerminacionOriginal));
+
+    // Precondicion (CA-3): colaborador con la vinculacion original terminada y un reingreso
+    // posterior sin terminar -- la ULTIMA vinculacion (la del reingreso) es la que se corrige; la
+    // original es la "vinculacion anterior" contra la que se ejerce la no-solape hacia atras.
+    private void DadoUnColaboradorConVinculacionAnteriorYReingresoAbierto() =>
+        Given(StreamIdEsperado,
+            ColaboradorRegistradoValido(),
+            VinculacionIniciadaOriginal(),
+            new VinculacionTerminada(FechaEfectivaTerminacionOriginal),
+            new VinculacionIniciada(CodigoReingreso, FechaInicioReingreso));
+
+    // CA-1: la ultima vinculacion esta ABIERTA + FechaCorregida distinta valida -> el stream
+    // recibe FechaInicioVinculacionCorregida; el aggregate rehidratado refleja la fecha nueva.
+    [Fact]
+    public async Task CorregirFechaInicioVinculacion_EmiteFechaInicioVinculacionCorregida_CuandoLaUltimaVinculacionEstaAbierta()
+    {
+        DadoUnColaboradorConVinculacionAbierta();
+        var fechaCorregida = FechaInicioOriginal.AddDays(-5);
+
+        await WhenAsync(ComandoCon(fechaCorregida));
+
+        Then(StreamIdEsperado, new FechaInicioVinculacionCorregida(fechaCorregida));
+        And<ColaboradorAggregateRoot, DateOnly>(
+            StreamIdEsperado, c => c.FechaInicioVinculacionVigente, fechaCorregida);
+    }
+
+    // CA-1 (borde de identidad, MEF-ADR-0037): "cc" en minusculas + numero con espacios sobre un
+    // colaborador ya registrado -> la correccion alcanza el MISMO stream ("CC:79543210") y emite
+    // el evento. La normalizacion del numero la garantiza Identificacion.Crear (#348); la del
+    // codigo de tipo ("cc" -> "CC") es responsabilidad del handler en el borde, porque
+    // TipoIdentificacion.Desde es case-sensitive por diseno (#348).
+    [Fact]
+    public async Task CorregirFechaInicioVinculacion_EmiteFechaInicioVinculacionCorregida_CuandoTipoYNumeroLleganSinNormalizar()
+    {
+        DadoUnColaboradorConVinculacionAbierta();
+        var fechaCorregida = FechaInicioOriginal.AddDays(-5);
+        var comandoSinNormalizar = ComandoCon(fechaCorregida) with
+        {
+            TipoIdentificacion = "cc",
+            NumeroIdentificacion = "  79543210  "
+        };
+
+        await WhenAsync(comandoSinNormalizar);
+
+        Then(StreamIdEsperado, new FechaInicioVinculacionCorregida(fechaCorregida));
+        And<ColaboradorAggregateRoot, DateOnly>(
+            StreamIdEsperado, c => c.FechaInicioVinculacionVigente, fechaCorregida);
+    }
+
+    // CA-2 (primera direccion): la ultima vinculacion tiene terminacion registrada y
+    // FechaCorregida es estrictamente ANTERIOR a esa FechaEfectiva -> exito. La terminacion previa
+    // no se toca por esta correccion (Tell-don't-Ask: la correccion es ortogonal a la vigencia,
+    // MEF-ADR-0012).
+    [Fact]
+    public async Task CorregirFechaInicioVinculacion_EmiteFechaInicioVinculacionCorregida_CuandoFechaCorregidaEsAnteriorALaFechaEfectivaPropia()
+    {
+        DadoUnColaboradorConVinculacionTerminada();
+        var fechaCorregida = FechaInicioOriginal.AddDays(-5);
+
+        await WhenAsync(ComandoCon(fechaCorregida));
+
+        Then(StreamIdEsperado, new FechaInicioVinculacionCorregida(fechaCorregida));
+        And<ColaboradorAggregateRoot, DateOnly>(
+            StreamIdEsperado, c => c.FechaInicioVinculacionVigente, fechaCorregida);
+        And<ColaboradorAggregateRoot, DateOnly?>(
+            StreamIdEsperado, c => c.FechaTerminacionVinculacionVigente, FechaEfectivaTerminacionOriginal);
+    }
+
+    // CA-2 (segunda direccion, borde valido): FechaCorregida IGUAL a la FechaEfectiva propia ->
+    // exito -- vinculacion de un solo dia, consistente con TerminarVinculacion (#349).
+    [Fact]
+    public async Task CorregirFechaInicioVinculacion_EmiteFechaInicioVinculacionCorregida_CuandoFechaCorregidaEsIgualALaFechaEfectivaPropia()
+    {
+        DadoUnColaboradorConVinculacionTerminada();
+
+        await WhenAsync(ComandoCon(FechaEfectivaTerminacionOriginal));
+
+        Then(StreamIdEsperado, new FechaInicioVinculacionCorregida(FechaEfectivaTerminacionOriginal));
+        And<ColaboradorAggregateRoot, DateOnly>(
+            StreamIdEsperado, c => c.FechaInicioVinculacionVigente, FechaEfectivaTerminacionOriginal);
+    }
+
+    // CA-2 (borde invalido): FechaCorregida POSTERIOR a la FechaEfectiva propia -> 409, ningun
+    // evento nuevo, el estado conserva la fecha de inicio original.
+    [Fact]
+    public async Task CorregirFechaInicioVinculacion_LanzaInvalidOperationException_CuandoFechaCorregidaEsPosteriorALaFechaEfectivaPropia()
+    {
+        DadoUnColaboradorConVinculacionTerminada();
+
+        var act = async () => await WhenAsync(
+            ComandoCon(FechaEfectivaTerminacionOriginal.AddDays(1)));
+
+        await act.Should().ThrowExactlyAsync<InvalidOperationException>()
+            .WithMessage(
+                $"*{CorregirFechaInicioVinculacionCommandHandler.Mensajes.FechaPosteriorATerminacionPropia}*");
+        Then(StreamIdEsperado);
+        And<ColaboradorAggregateRoot, DateOnly>(
+            StreamIdEsperado, c => c.FechaInicioVinculacionVigente, FechaInicioOriginal);
+    }
+
+    // CA-1 (variante tras reingreso, dependencia #350): la ULTIMA vinculacion es la del reingreso
+    // y esta abierta; FechaCorregida estrictamente posterior a la FechaEfectiva de la vinculacion
+    // anterior y distinta de la actual -> exito. Ejercita el Apply(VinculacionIniciada)
+    // re-aplicado que #350 construyo.
+    [Fact]
+    public async Task CorregirFechaInicioVinculacion_EmiteFechaInicioVinculacionCorregida_CuandoLaUltimaVinculacionEsUnReingresoAbierto()
+    {
+        DadoUnColaboradorConVinculacionAnteriorYReingresoAbierto();
+        var fechaCorregida = FechaEfectivaTerminacionOriginal.AddDays(2); // 2026-06-03
+
+        await WhenAsync(ComandoCon(fechaCorregida));
+
+        Then(StreamIdEsperado, new FechaInicioVinculacionCorregida(fechaCorregida));
+        And<ColaboradorAggregateRoot, DateOnly>(
+            StreamIdEsperado, c => c.FechaInicioVinculacionVigente, fechaCorregida);
+    }
+
+    // CA-3 (primera direccion, borde): tras un reingreso, FechaCorregida IGUAL a la FechaEfectiva
+    // de la vinculacion anterior -> 409 por no-solape (el mismo dia se rechaza -- el dia de la
+    // fecha efectiva pertenece a la vinculacion que termino, misma frontera que Reingresar #350).
+    [Fact]
+    public async Task CorregirFechaInicioVinculacion_LanzaInvalidOperationException_CuandoFechaCorregidaEsIgualALaFechaEfectivaDeLaVinculacionAnterior()
+    {
+        DadoUnColaboradorConVinculacionAnteriorYReingresoAbierto();
+
+        var act = async () => await WhenAsync(ComandoCon(FechaEfectivaTerminacionOriginal));
+
+        await act.Should().ThrowExactlyAsync<InvalidOperationException>()
+            .WithMessage(
+                $"*{CorregirFechaInicioVinculacionCommandHandler.Mensajes.FechaSolapaVinculacionAnterior}*");
+        Then(StreamIdEsperado);
+        And<ColaboradorAggregateRoot, DateOnly>(
+            StreamIdEsperado, c => c.FechaInicioVinculacionVigente, FechaInicioReingreso);
+    }
+
+    // CA-3 (segunda direccion, mayor margen): FechaCorregida ANTERIOR a la FechaEfectiva de la
+    // vinculacion anterior -> 409 igual.
+    [Fact]
+    public async Task CorregirFechaInicioVinculacion_LanzaInvalidOperationException_CuandoFechaCorregidaEsAnteriorALaFechaEfectivaDeLaVinculacionAnterior()
+    {
+        DadoUnColaboradorConVinculacionAnteriorYReingresoAbierto();
+
+        var act = async () => await WhenAsync(
+            ComandoCon(FechaEfectivaTerminacionOriginal.AddDays(-1)));
+
+        await act.Should().ThrowExactlyAsync<InvalidOperationException>()
+            .WithMessage(
+                $"*{CorregirFechaInicioVinculacionCommandHandler.Mensajes.FechaSolapaVinculacionAnterior}*");
+        Then(StreamIdEsperado);
+        And<ColaboradorAggregateRoot, DateOnly>(
+            StreamIdEsperado, c => c.FechaInicioVinculacionVigente, FechaInicioReingreso);
+    }
+
+    // CA-4: FechaCorregida IGUAL a la fecha de inicio actual (vinculacion abierta) -> idempotencia
+    // silenciosa: ningun evento nuevo en el stream, el estado conserva la fecha original.
+    [Fact]
+    public async Task CorregirFechaInicioVinculacion_NoEmiteEvento_CuandoFechaCorregidaEsIgualALaActual()
+    {
+        DadoUnColaboradorConVinculacionAbierta();
+
+        await WhenAsync(ComandoCon(FechaInicioOriginal));
+
+        Then(StreamIdEsperado);
+        And<ColaboradorAggregateRoot, DateOnly>(
+            StreamIdEsperado, c => c.FechaInicioVinculacionVigente, FechaInicioOriginal);
+    }
+
+    // CA-4 (variante con terminacion registrada): la idempotencia se evalua ANTES que las demas
+    // reglas -- una FechaCorregida igual a la actual no dispara la validacion de coherencia
+    // interna aunque la ultima vinculacion ya este terminada.
+    [Fact]
+    public async Task CorregirFechaInicioVinculacion_NoEmiteEvento_CuandoFechaCorregidaEsIgualALaActualYLaVinculacionEstaTerminada()
+    {
+        DadoUnColaboradorConVinculacionTerminada();
+
+        await WhenAsync(ComandoCon(FechaInicioOriginal));
+
+        Then(StreamIdEsperado);
+        And<ColaboradorAggregateRoot, DateOnly>(
+            StreamIdEsperado, c => c.FechaInicioVinculacionVigente, FechaInicioOriginal);
+    }
+
+    // CA-5: colaborador inexistente -> 404 (KeyNotFoundException), sin escribir nada al event
+    // store. Sin Given: el stream no existe. Then sin eventos esperados demuestra "sin escribir
+    // nada al event store" (mismo precedente que TerminarVinculacionCommandHandlerTests CA-5 /
+    // ReingresarColaboradorCommandHandlerTests CA-5 / CorregirNombresCommandHandlerTests CA-4).
+    [Fact]
+    public async Task CorregirFechaInicioVinculacion_LanzaKeyNotFoundException_CuandoColaboradorNoExiste()
+    {
+        var act = async () => await WhenAsync(ComandoCon(FechaInicioOriginal));
+
+        await act.Should().ThrowExactlyAsync<KeyNotFoundException>()
+            .WithMessage($"*{CorregirFechaInicioVinculacionCommandHandler.Mensajes.ColaboradorNoEncontrado}*");
+        Then(StreamIdEsperado);
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/CorregirFechaInicioVinculacionFunction/CorregirFechaInicioVinculacionCommandHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/CorregirFechaInicioVinculacionFunction/CorregirFechaInicioVinculacionCommandHandlerTests.cs
@@ -30,10 +30,14 @@ public class CorregirFechaInicioVinculacionCommandHandlerTests
 
     private const string CodigoVinculacionOriginal = "COL-001";
     private const string CodigoReingreso = "COL-002";
+    private const string CodigoSegundoReingreso = "COL-003";
     private static readonly DateOnly FechaInicioOriginal = new(2026, 1, 15);
     private static readonly DateOnly FechaEfectivaTerminacionOriginal = new(2026, 6, 1);
     private static readonly DateOnly FechaInicioReingreso =
         FechaEfectivaTerminacionOriginal.AddDays(1); // 2026-06-02
+    private static readonly DateOnly FechaEfectivaTerminacionReingreso = new(2026, 9, 1);
+    private static readonly DateOnly FechaInicioSegundoReingreso =
+        FechaEfectivaTerminacionReingreso.AddDays(1); // 2026-09-02
 
     protected override ICommandHandlerAsync<CorregirFechaInicioVinculacion> Handler =>
         new CorregirFechaInicioVinculacionCommandHandler(EventStore);
@@ -77,6 +81,28 @@ public class CorregirFechaInicioVinculacionCommandHandlerTests
             VinculacionIniciadaOriginal(),
             new VinculacionTerminada(FechaEfectivaTerminacionOriginal),
             new VinculacionIniciada(CodigoReingreso, FechaInicioReingreso));
+
+    // Precondicion: la ULTIMA vinculacion es un reingreso que ya tiene su propia terminacion
+    // registrada -- unico estado en que las DOS reglas de estado acotan la fecha a la vez
+    // (ventana abierta-cerrada: FechaEfectivaTerminacionOriginal < fecha <= FechaEfectivaTerminacionReingreso).
+    private void DadoUnColaboradorConReingresoYaTerminado() =>
+        Given(StreamIdEsperado,
+            ColaboradorRegistradoValido(),
+            VinculacionIniciadaOriginal(),
+            new VinculacionTerminada(FechaEfectivaTerminacionOriginal),
+            new VinculacionIniciada(CodigoReingreso, FechaInicioReingreso),
+            new VinculacionTerminada(FechaEfectivaTerminacionReingreso));
+
+    // Precondicion: dos reingresos encadenados -- la "vinculacion anterior" a la ultima es la del
+    // PRIMER reingreso (terminada en FechaEfectivaTerminacionReingreso), no la original.
+    private void DadoUnColaboradorConDosReingresos() =>
+        Given(StreamIdEsperado,
+            ColaboradorRegistradoValido(),
+            VinculacionIniciadaOriginal(),
+            new VinculacionTerminada(FechaEfectivaTerminacionOriginal),
+            new VinculacionIniciada(CodigoReingreso, FechaInicioReingreso),
+            new VinculacionTerminada(FechaEfectivaTerminacionReingreso),
+            new VinculacionIniciada(CodigoSegundoReingreso, FechaInicioSegundoReingreso));
 
     // CA-1: la ultima vinculacion esta ABIERTA + FechaCorregida distinta valida -> el stream
     // recibe FechaInicioVinculacionCorregida; el aggregate rehidratado refleja la fecha nueva.
@@ -218,6 +244,50 @@ public class CorregirFechaInicioVinculacionCommandHandlerTests
         Then(StreamIdEsperado);
         And<ColaboradorAggregateRoot, DateOnly>(
             StreamIdEsperado, c => c.FechaInicioVinculacionVigente, FechaInicioReingreso);
+    }
+
+    // CA-2 + CA-3 combinados: la ULTIMA vinculacion es un reingreso que YA tiene terminacion
+    // propia, unico estado en que las dos reglas de estado acotan la fecha a la vez. Una fecha
+    // dentro de la ventana valida (posterior a la terminacion ANTERIOR, anterior o igual a la
+    // PROPIA) se acepta, y la terminacion propia sigue intacta -- la correccion es ortogonal a la
+    // vigencia (MEF-ADR-0012).
+    [Fact]
+    public async Task CorregirFechaInicioVinculacion_EmiteFechaInicioVinculacionCorregida_CuandoLaFechaCaeEntreLaTerminacionAnteriorYLaPropia()
+    {
+        DadoUnColaboradorConReingresoYaTerminado();
+        // 2026-06-11: dentro de (2026-06-01, 2026-09-01] y distinta de la actual (2026-06-02), que
+        // seria idempotencia y no ejercitaria ninguna de las dos reglas.
+        var fechaCorregida = FechaEfectivaTerminacionOriginal.AddDays(10);
+
+        await WhenAsync(ComandoCon(fechaCorregida));
+
+        Then(StreamIdEsperado, new FechaInicioVinculacionCorregida(fechaCorregida));
+        And<ColaboradorAggregateRoot, DateOnly>(
+            StreamIdEsperado, c => c.FechaInicioVinculacionVigente, fechaCorregida);
+        And<ColaboradorAggregateRoot, DateOnly?>(
+            StreamIdEsperado, c => c.FechaTerminacionVinculacionVigente, FechaEfectivaTerminacionReingreso);
+    }
+
+    // CA-3 (cadena larga): con DOS reingresos encadenados, la no-solape se evalua contra la
+    // terminacion de la vinculacion INMEDIATAMENTE anterior (la del primer reingreso,
+    // 2026-09-01), no contra la de la vinculacion original (2026-06-01). Una fecha posterior a la
+    // terminacion original pero anterior a la del primer reingreso debe rechazarse: si la
+    // terminacion anterior se congelara en la primera, este comando pasaria y dejaria dos
+    // vinculaciones solapadas en el stream.
+    [Fact]
+    public async Task CorregirFechaInicioVinculacion_LanzaInvalidOperationException_CuandoFechaCorregidaSolapaElReingresoPrevioYNoLaVinculacionOriginal()
+    {
+        DadoUnColaboradorConDosReingresos();
+        var fechaCorregida = new DateOnly(2026, 7, 1); // > 2026-06-01 pero < 2026-09-01
+
+        var act = async () => await WhenAsync(ComandoCon(fechaCorregida));
+
+        await act.Should().ThrowExactlyAsync<InvalidOperationException>()
+            .WithMessage(
+                $"*{CorregirFechaInicioVinculacionCommandHandler.Mensajes.FechaSolapaVinculacionAnterior}*");
+        Then(StreamIdEsperado);
+        And<ColaboradorAggregateRoot, DateOnly>(
+            StreamIdEsperado, c => c.FechaInicioVinculacionVigente, FechaInicioSegundoReingreso);
     }
 
     // CA-4: FechaCorregida IGUAL a la fecha de inicio actual (vinculacion abierta) -> idempotencia

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/CorregirFechaInicioVinculacionFunction/CorregirFechaInicioVinculacionValidatorTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/CorregirFechaInicioVinculacionFunction/CorregirFechaInicioVinculacionValidatorTests.cs
@@ -1,0 +1,98 @@
+// Issue #352: validacion de forma del comando CorregirFechaInicioVinculacion en el borde (CA-6).
+// Patron de referencia: ReingresarColaboradorValidatorTests (ValidateAsync + verificacion de
+// PropertyName en resultado.Errors).
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.CorregirFechaInicioVinculacionFunction;
+using Bitakora.ControlAsistencia.Colaboradores.CorregirFechaInicioVinculacionFunction.CommandHandler;
+using FluentValidation.Results;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Tests.CorregirFechaInicioVinculacionFunction;
+
+public class CorregirFechaInicioVinculacionValidatorTests
+{
+    private readonly CorregirFechaInicioVinculacionValidator _validator = new();
+
+    private static CorregirFechaInicioVinculacion ComandoValido() => new(
+        TipoIdentificacion: "CC",
+        NumeroIdentificacion: "79543210",
+        FechaCorregida: new DateOnly(2026, 1, 10));
+
+    private Task<ValidationResult> Validar(CorregirFechaInicioVinculacion comando) =>
+        _validator.ValidateAsync(comando, TestContext.Current.CancellationToken);
+
+    // Camino feliz -- todos los campos correctos
+    [Fact]
+    public async Task Validar_Aprueba_CuandoTodosLosCamposSonCorrectos()
+    {
+        var resultado = await Validar(ComandoValido());
+
+        resultado.IsValid.Should().BeTrue();
+    }
+
+    // CA-6: TipoIdentificacion vacio produce 400
+    [Fact]
+    public async Task Validar_RechazaTipoIdentificacion_CuandoEstaVacio()
+    {
+        var resultado = await Validar(ComandoValido() with { TipoIdentificacion = "" });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e =>
+            e.PropertyName == nameof(CorregirFechaInicioVinculacion.TipoIdentificacion));
+    }
+
+    // CA-6: TipoIdentificacion fuera de la lista cerrada (PILA: CC/CE/TI/PA/PT) produce 400, no 500
+    [Fact]
+    public async Task Validar_RechazaTipoIdentificacion_CuandoNoEstaEnLaListaCerrada()
+    {
+        var resultado = await Validar(ComandoValido() with { TipoIdentificacion = "XX" });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e =>
+            e.PropertyName == nameof(CorregirFechaInicioVinculacion.TipoIdentificacion));
+    }
+
+    // TipoIdentificacion en minusculas ("cc") DEBE seguir siendo valido -- la normalizacion de
+    // entrada (trim+MAYUSCULAS antes de TipoIdentificacion.Desde) es responsabilidad del borde, no
+    // un rechazo (mismo criterio que los demas validators del dominio).
+    [Fact]
+    public async Task Validar_Aprueba_CuandoTipoIdentificacionLlegaEnMinusculas()
+    {
+        var resultado = await Validar(ComandoValido() with { TipoIdentificacion = "cc" });
+
+        resultado.IsValid.Should().BeTrue();
+    }
+
+    // CA-6: NumeroIdentificacion vacio produce 400
+    [Fact]
+    public async Task Validar_RechazaNumeroIdentificacion_CuandoEstaVacio()
+    {
+        var resultado = await Validar(ComandoValido() with { NumeroIdentificacion = "" });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e =>
+            e.PropertyName == nameof(CorregirFechaInicioVinculacion.NumeroIdentificacion));
+    }
+
+    // CA-6: FechaCorregida con el valor default de DateOnly produce 400 -- REQUERIDA, sin default
+    // del servidor (doctrina bitemporal del BC: el tiempo de los hechos viene del cliente).
+    [Fact]
+    public async Task Validar_RechazaFechaCorregida_CuandoEsDefault()
+    {
+        var resultado = await Validar(ComandoValido() with { FechaCorregida = default });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e =>
+            e.PropertyName == nameof(CorregirFechaInicioVinculacion.FechaCorregida));
+    }
+
+    // FechaCorregida futura o pasada DEBE seguir siendo valida en la capa de forma -- las reglas
+    // de coherencia interna y no-solape son del aggregate (CA-2/CA-3), nunca del validator.
+    [Fact]
+    public async Task Validar_Aprueba_CuandoFechaCorregidaEsFutura()
+    {
+        var resultado = await Validar(ComandoValido() with { FechaCorregida = new DateOnly(2030, 1, 1) });
+
+        resultado.IsValid.Should().BeTrue();
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/CorregirFechaInicioVinculacionFunction/Eventos/FechaInicioVinculacionCorregidaSerializacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/CorregirFechaInicioVinculacionFunction/Eventos/FechaInicioVinculacionCorregidaSerializacionTests.cs
@@ -1,0 +1,52 @@
+// Issue #352. Requerido por regla 16: todo evento persistido en Marten debe sobrevivir
+// Serialize -> Deserialize con las opciones REALES de Marten del dominio (regla 6d). Sin marker de
+// bus (issue #352 "Consumidores: ninguno") -- no aplica el test de portabilidad de la regla 21
+// (seccion 6e).
+
+using System.Text.Json;
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Tests.CorregirFechaInicioVinculacionFunction.Eventos;
+
+/// <summary>
+/// Verifica que FechaInicioVinculacionCorregida (payload plano: DateOnly, sin VOs anidados)
+/// sobrevive un roundtrip de serializacion STJ con las opciones reales de Marten del dominio.
+/// Igual que VinculacionTerminada/VinculacionIniciada, este evento NO necesita
+/// ConfigurarSerializacion propio (ctor publico, tipo primitivo) -- no hay un test "sin registro
+/// falla": no hay ningun registro que proteger.
+/// </summary>
+public class FechaInicioVinculacionCorregidaSerializacionTests
+{
+    private static JsonSerializerOptions CrearOpcionesMarten() =>
+        ConfiguracionSerializacionColaboradores.CrearOpcionesMarten();
+
+    // CA-1: FechaInicioVinculacionCorregida persiste FechaInicio tal como llego (sin default del
+    // servidor) y sobrevive el roundtrip completo.
+    [Fact]
+    public void RoundTrip_ReconstruyeEvento_ConDatosCompletos()
+    {
+        var evento = new FechaInicioVinculacionCorregida(new DateOnly(2026, 1, 10));
+        var opciones = CrearOpcionesMarten();
+
+        var json = JsonSerializer.Serialize(evento, opciones);
+        var deserializado = JsonSerializer.Deserialize<FechaInicioVinculacionCorregida>(json, opciones);
+
+        deserializado.Should().NotBeNull();
+        deserializado!.FechaInicio.Should().Be(new DateOnly(2026, 1, 10));
+    }
+
+    // CA-1 (variante): una fecha corregida distante en el pasado sobrevive el roundtrip igual.
+    [Fact]
+    public void RoundTrip_ReconstruyeEvento_ConFechaDistanteEnElPasado()
+    {
+        var evento = new FechaInicioVinculacionCorregida(new DateOnly(2015, 3, 1));
+        var opciones = CrearOpcionesMarten();
+
+        var json = JsonSerializer.Serialize(evento, opciones);
+        var deserializado = JsonSerializer.Deserialize<FechaInicioVinculacionCorregida>(json, opciones);
+
+        deserializado.Should().NotBeNull();
+        deserializado!.FechaInicio.Should().Be(new DateOnly(2015, 3, 1));
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/CorregirFechaInicioVinculacionFunction/FunctionEndpointTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/CorregirFechaInicioVinculacionFunction/FunctionEndpointTests.cs
@@ -1,0 +1,143 @@
+// Issue #352: tests del endpoint HTTP POST Colaboradores/FechasInicio (corregir la fecha de
+// inicio de la ultima vinculacion de un colaborador). CA-ADR-0030 / MEF-ADR-0004:
+// InvalidOperationException -> 409, KeyNotFoundException -> 404, exito -> 202. Precedente:
+// ReingresarColaboradorFunction.FunctionEndpoint.
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.CorregirFechaInicioVinculacionFunction;
+using Bitakora.ControlAsistencia.Colaboradores.Infraestructura;
+using Cosmos.EventSourcing.Abstractions.Commands;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Tests.CorregirFechaInicioVinculacionFunction;
+
+public class FunctionEndpointTests
+{
+    private static CorregirFechaInicioVinculacion ComandoValido() => new(
+        TipoIdentificacion: "CC",
+        NumeroIdentificacion: "79543210",
+        FechaCorregida: new DateOnly(2026, 1, 10));
+
+    private static HttpRequest FakeHttpRequest()
+    {
+        var context = new DefaultHttpContext();
+        return context.Request;
+    }
+
+    // CA-1/CA-2/CA-4: POST exitoso retorna 202 Accepted
+    [Fact]
+    public async Task CorregirFechaInicioVinculacion_Retorna202_CuandoComandoEsValido()
+    {
+        var validator = new FakeCorregirFechaInicioVinculacionRequestValidator(ComandoValido());
+        var router = new FakeCorregirFechaInicioVinculacionCommandRouter();
+        var function = new FunctionEndpoint(validator, router);
+
+        var result = await function.Run(FakeHttpRequest(), CancellationToken.None);
+
+        result.Should().BeOfType<AcceptedResult>();
+    }
+
+    // CA-2/CA-3: violacion de una regla de estado (coherencia interna / no-solape hacia atras)
+    // retorna 409 Conflict.
+    [Fact]
+    public async Task CorregirFechaInicioVinculacion_Retorna409_CuandoLaFechaCorregidaVulneraUnaRegla()
+    {
+        var validator = new FakeCorregirFechaInicioVinculacionRequestValidator(ComandoValido());
+        var router = new FakeCorregirFechaInicioVinculacionCommandRouter(
+            lanzar: new InvalidOperationException(
+                "La fecha de inicio corregida no puede ser posterior a la fecha efectiva de terminacion de la vinculacion"));
+        var function = new FunctionEndpoint(validator, router);
+
+        var result = await function.Run(FakeHttpRequest(), CancellationToken.None);
+
+        result.Should().BeOfType<ConflictObjectResult>();
+    }
+
+    // CA-5: colaborador inexistente retorna 404 Not Found
+    [Fact]
+    public async Task CorregirFechaInicioVinculacion_Retorna404_CuandoColaboradorNoExiste()
+    {
+        var validator = new FakeCorregirFechaInicioVinculacionRequestValidator(ComandoValido());
+        var router = new FakeCorregirFechaInicioVinculacionCommandRouter(
+            lanzar: new KeyNotFoundException("No existe un colaborador registrado con esa identificacion"));
+        var function = new FunctionEndpoint(validator, router);
+
+        var result = await function.Run(FakeHttpRequest(), CancellationToken.None);
+
+        result.Should().BeOfType<NotFoundObjectResult>();
+    }
+
+    // CA-6: request invalida (sin FechaCorregida, sin identificacion, tipo fuera de la lista
+    // cerrada) retorna 400 Bad Request
+    [Fact]
+    public async Task CorregirFechaInicioVinculacion_Retorna400_CuandoRequestEsInvalido()
+    {
+        var errorDeValidacion = new BadRequestObjectResult("El body es invalido o esta malformado");
+        var validator = new FakeCorregirFechaInicioVinculacionRequestValidator(error: errorDeValidacion);
+        var router = new FakeCorregirFechaInicioVinculacionCommandRouter();
+        var function = new FunctionEndpoint(validator, router);
+
+        var result = await function.Run(FakeHttpRequest(), CancellationToken.None);
+
+        result.Should().BeOfType<BadRequestObjectResult>();
+    }
+}
+
+// ---- Fakes manuales - NO NSubstitute ----
+
+/// <summary>
+/// Fake configurable de IRequestValidator. Retorna un comando pre-configurado o un error segun lo
+/// que se le pase en el constructor.
+/// </summary>
+internal class FakeCorregirFechaInicioVinculacionRequestValidator : IRequestValidator
+{
+    private readonly CorregirFechaInicioVinculacion? _comando;
+    private readonly IActionResult? _error;
+
+    public FakeCorregirFechaInicioVinculacionRequestValidator(
+        CorregirFechaInicioVinculacion? comando = null,
+        IActionResult? error = null)
+    {
+        _comando = comando;
+        _error = error;
+    }
+
+    public Task<(T? Comando, IActionResult? Error)> ValidarAsync<T>(
+        HttpRequest req, CancellationToken ct)
+    {
+        if (_error is not null)
+            return Task.FromResult<(T?, IActionResult?)>((default, _error));
+
+        if (_comando is T resultado)
+            return Task.FromResult<(T?, IActionResult?)>((resultado, null));
+
+        return Task.FromResult<(T?, IActionResult?)>((default, null));
+    }
+}
+
+/// <summary>
+/// Fake configurable de ICommandRouter. Puede completar exitosamente o lanzar la excepcion
+/// configurada (InvalidOperationException -> 409, KeyNotFoundException -> 404).
+/// </summary>
+internal class FakeCorregirFechaInicioVinculacionCommandRouter : ICommandRouter
+{
+    private readonly Exception? _excepcion;
+
+    public FakeCorregirFechaInicioVinculacionCommandRouter(Exception? lanzar = null) =>
+        _excepcion = lanzar;
+
+    public Task InvokeAsync<TCommand>(TCommand command, CancellationToken ct = default)
+        where TCommand : class
+    {
+        if (_excepcion is not null)
+            throw _excepcion;
+
+        return Task.CompletedTask;
+    }
+
+    public Task<TResult> InvokeAsync<TCommand, TResult>(
+        TCommand command, CancellationToken ct = default)
+        where TCommand : class
+        => throw new NotImplementedException();
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/Infraestructura/AliasEventosColaboradoresTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/Infraestructura/AliasEventosColaboradoresTests.cs
@@ -70,4 +70,18 @@ public class AliasEventosColaboradoresTests
 
         AliasDe<NombresCorregidos>(options).Should().Be("nombres_corregidos");
     }
+
+    // Issue #352 (gemela de las cuatro pruebas anteriores): congela el alias de
+    // FechaInicioVinculacionCorregida, quinto evento persistido de ColaboradorAggregateRoot
+    // (corregir la fecha de inicio de la ultima vinculacion). Rojo esperado (fase roja, issue
+    // #352): IdentidadEventosColaboradores.TiposPersistidos sigue sin
+    // FechaInicioVinculacionCorregida hasta que el implementer lo registre -- el implementer lo
+    // agrega ahi (no aqui, MEF-ADR-0002).
+    [Fact]
+    public void FechaInicioVinculacionCorregida_TieneAliasFechaInicioVinculacionCorregida()
+    {
+        var options = CrearOpcionesConEventosDeColaboradoresRegistrados();
+
+        AliasDe<FechaInicioVinculacionCorregida>(options).Should().Be("fecha_inicio_vinculacion_corregida");
+    }
 }

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/Infraestructura/ComposicionServiciosTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/Infraestructura/ComposicionServiciosTests.cs
@@ -218,6 +218,10 @@ public class ComposicionServiciosTests
     // Issue #351: agrega NombresCorregidos (cuarto evento persistido, corregir nombres) a la lista
     // esperada.
     // Rojo esperado (fase roja, issue #351): TiposPersistidos todavia no incluye NombresCorregidos.
+    // Issue #352: agrega FechaInicioVinculacionCorregida (quinto evento persistido, corregir la
+    // fecha de inicio de la ultima vinculacion) a la lista esperada.
+    // Rojo esperado (fase roja, issue #352): TiposPersistidos todavia no incluye
+    // FechaInicioVinculacionCorregida.
     [Fact]
     public async Task AgregarServiciosColaboradores_RegistraLosTiposDeEventoPersistidos_CuandoElContenedorEstaCompuesto()
     {
@@ -231,7 +235,8 @@ public class ComposicionServiciosTests
                 typeof(ColaboradorRegistrado),
                 typeof(VinculacionIniciada),
                 typeof(VinculacionTerminada),
-                typeof(NombresCorregidos)
+                typeof(NombresCorregidos),
+                typeof(FechaInicioVinculacionCorregida)
             ]);
     }
 
@@ -242,6 +247,10 @@ public class ComposicionServiciosTests
     // Issue #349: agrega VinculacionTerminada -> "vinculacion_terminada" al diccionario esperado.
     // Issue #351: agrega NombresCorregidos -> "nombres_corregidos" al diccionario esperado.
     // Rojo esperado (fase roja, issue #351): NombresCorregidos no aparece en AllKnownEventTypes().
+    // Issue #352: agrega FechaInicioVinculacionCorregida -> "fecha_inicio_vinculacion_corregida"
+    // al diccionario esperado.
+    // Rojo esperado (fase roja, issue #352): FechaInicioVinculacionCorregida no aparece en
+    // AllKnownEventTypes().
     [Fact]
     public async Task AgregarServiciosColaboradores_DerivaElAliasDeEventoDelNombreDeClase_CuandoElContenedorEstaCompuesto()
     {
@@ -255,7 +264,8 @@ public class ComposicionServiciosTests
             [typeof(ColaboradorRegistrado)] = "colaborador_registrado",
             [typeof(VinculacionIniciada)] = "vinculacion_iniciada",
             [typeof(VinculacionTerminada)] = "vinculacion_terminada",
-            [typeof(NombresCorregidos)] = "nombres_corregidos"
+            [typeof(NombresCorregidos)] = "nombres_corregidos",
+            [typeof(FechaInicioVinculacionCorregida)] = "fecha_inicio_vinculacion_corregida"
         });
     }
 


### PR DESCRIPTION
## Resumen

Pipeline TDD completado:
- Fase roja: tests escritos con stubs
- Fase verde: implementación completa
- Smoke tests: escritos para endpoints detectados
- Fase refactor: revisión de calidad

## Decisiones del pipeline

<details>
<summary>Test Writer (fase roja) — 0m 0s</summary>

_(El agente no generó resumen)_

</details>

<details>
<summary>Implementer (fase verde) — 6m 19s</summary>

## ES Implementer - Decisiones

### Enfoque de implementacion
El test-writer ya habia dejado el molde completo (evento, comando, validator vacio, handler stub,
FunctionEndpoint terminado, resultado enum, mensajes .resx) siguiendo el precedente de #349/#350/#351.
El trabajo de esta fase se concentro en tres piezas:

1. **`ColaboradorAggregateRoot.CorregirFechaInicio`**: combina el mecanismo "declinar con resultado"
   (dos razones 409: `FechaPosteriorATerminacionPropia`, `FechaSolapaVinculacionAnterior`) con el
   mecanismo "declinar en silencio" (idempotencia `SinCambios`, evaluada primero), replicando
   CA-ADR-0030 tal como ya lo hacen `TerminarVinculacion`/`Reingresar`/`CorregirNombres`.
2. **Un campo nuevo en el aggregate**: `_fechaTerminacionVinculacionAnterior`, necesario para que la
   regla de no-solape hacia atras sobreviva un reingreso (ver "Complejidad encontrada").
3. **Handler y validator**: mismo patron literal que `ReingresarColaboradorCommandHandler`/
   `ReingresarColaboradorValidator` (parseo tipado unico en el borde, lista cerrada de
   `TipoIdentificacion`, `switch` sobre el resultado del aggregate que traduce a excepcion).

`FunctionEndpoint.cs`, el comando `CorregirFechaInicioVinculacion.cs`, el evento
`FechaInicioVinculacionCorregida.cs` y los `.resx`/`Mensajes.cs` ya venian completos del test-writer
-- no requirieron cambios.

### Decisiones de diseno
- **Orden de evaluacion en `CorregirFechaInicio`**: idempotencia (`SinCambios`) primero, coherencia
  interna (`FechaPosteriorATerminacionPropia`) segundo, no-solape (`FechaSolapaVinculacionAnterior`)
  tercero. El orden lo fija el test CA-4 variante ("la idempotencia se evalua ANTES que las demas
  reglas") -- una fecha corregida igual a la actual no dispara ninguna otra validacion aunque la
  vinculacion ya este terminada.
- **`_fechaTerminacionVinculacionAnterior`**: campo privado nuevo, poblado en
  `Apply(VinculacionIniciada)` guardando el valor de `_fechaTerminacionVinculacionVigente` ANTES de
  resetearlo a null. Es el unico dato que sobrevive un reingreso para poder evaluar la no-solape
  hacia atras contra la vinculacion anterior (ver "Complejidad encontrada").
- **Fronteras de igualdad**: `fechaCorregida == terminacionPropia` es valida (vinculacion de un solo
  dia); `fechaCorregida <= terminacionAnterior` se rechaza (el dia de la fecha efectiva pertenece a
  la vinculacion que termino) -- ambas coherentes con las fronteras ya fijadas por
  `TerminarVinculacion`/`Reingresar` en #349/#350.

### ADRs consultados
- CA-ADR-0030 (fallos sincronos para comandos HTTP sin consumidores downstream): mecanismo
  "declinar con resultado, nunca lanza" aplicado integramente; el handler traduce el resultado del
  aggregate a `InvalidOperationException`/`KeyNotFoundException`.
- MEF-ADR-0012 (Tell-don't-Ask): el aggregate evalua las tres reglas contra su propia historia
  (campos privados); el handler nunca interroga estado interno, solo consume el enum de resultado.
- MEF-ADR-0037 (identidad del stream): parseo tipado unico en el borde del handler
  (`TipoIdentificacion.Desde` + `Identificacion.Crear` + `ComputarStreamId`), replicado tal cual de
  `ReingresarColaboradorCommandHandler`.
- CA-ADR-0029 / MEF-ADR-0039 (payload por rol, tres islas): `FechaInicioVinculacionCorregida` vive
  en `Colaboradores.DomainEvents`, payload plano (`DateOnly`), sin marker de bus (evento sin
  consumidores). Registrado en `IdentidadEventosColaboradores.TiposPersistidos`.
- MEF-ADR-0009 (mensajes .resx): ya provistos por el test-writer, consumidos tal cual desde el
  handler (`Mensajes.ColaboradorNoEncontrado`, `Mensajes.FechaPosteriorATerminacionPropia`,
  `Mensajes.FechaSolapaVinculacionAnterior`).
- MEF-ADR-0006 (naming): `[Function("CorregirFechaInicioVinculacion")]`, Route
  `Colaboradores/FechasInicio` -- ya provisto por el test-writer.

### Desviaciones de ADRs
Ninguna desviacion -- todos los ADRs aplicados al pie de la letra.

### Precedentes consultados
- `ReingresarColaboradorCommandHandler`/`ReingresarColaboradorValidator` (#350): patron replicado
  literalmente para el handler y el validator de este issue -- alineado con CA-ADR-0030 y
  MEF-ADR-0037.
- `ColaboradorAggregateRoot.Reingresar`/`TerminarVinculacion`/`CorregirNombres` (#349/#350/#351):
  molde de "declinar con resultado" / "declinar en silencio" replicado para `CorregirFechaInicio`.
- No se detecto ningun precedente que violara un ADR aplicable a este issue.

### Infraestructura modificada
Ninguna. El comando es event-sourcing puro sin consumidores downstream (issue: "Consumidores:
ninguno") -- no publica a ningun bus, no requiere topics ni subscriptions.

### Complejidad encontrada
La unica pieza no trivial fue CA-3 (no-solape hacia atras tras un reingreso). El aggregate solo
trackeaba `_fechaTerminacionVinculacionVigente`, que `Apply(VinculacionIniciada)` resetea a `null`
al reabrir la vinculacion (mecanismo ya construido por #350 para que el reingreso rehidratado no
quede "ya terminado"). Eso significa que, tras un reingreso, la fecha de terminacion de la
vinculacion ANTERIOR (necesaria para la regla de no-solape de este issue) ya no estaba disponible
en ningun campo del aggregate.

Se resolvio agregando `_fechaTerminacionVinculacionAnterior`, poblado en
`Apply(VinculacionIniciada)` con el valor de `_fechaTerminacionVinculacionVigente` justo ANTES de
resetearlo. Este campo es `null` mientras el colaborador esta en su primera vinculacion (nunca hubo
un reingreso) y toma valor la primera vez que se reingresa, conservandose estable en reingresos
subsecuentes (no se sobreescribe con `null` en el segundo reingreso porque para entonces la
vinculacion previa ya tiene su propia terminacion registrada antes del siguiente
`Apply(VinculacionIniciada)`). Verificado contra los 4 tests de CA-1 variante/CA-3 (ambas
direcciones) del CommandHandlerTests -- todos en verde.

### Resultado
- Tests del dominio Colaboradores: 215/215 pasando.
- Suite completa del repositorio: 1065 correcto, 0 error, 29 omitido (smoke tests que requieren
  Postgres/ServiceBus local, sin relacion con este cambio).

</details>
<details>
<summary>Smoke Test Writer — 2m 57s</summary>

_(El agente no generó resumen)_

</details>
<details>
<summary>Reviewer (fase refactor) — 15m 20s</summary>

## ES Reviewer - Revision

### Evaluacion general
- Calidad: **buena**
- Cambios realizados: **si** (commit `959906b` -- 2 tests de borde, 2 limpiezas de cruft; sin cambios de comportamiento)

**Estado de la suite**: 1069 correcto / 32 omitido / **5 error**. Los 5 rojos son smoke tests del
endpoint nuevo corriendo contra dev, que devuelve `404` porque `POST /api/Colaboradores/FechasInicio`
**todavia no esta desplegado** (`Expected ... BadRequest/Conflict, but found NotFound`). No son
defectos del codigo: los smoke tests de los slices hermanos (#349/#350/#351), cuyos endpoints si
estan desplegados, pasan en la misma corrida. Baseline identico antes y despues de mis cambios
(mismos 5 tests, misma causa); no introduje ningun rojo. No existe `blockage-report.md` ni hizo
falta crearlo.

### Cumplimiento de ADRs aplicables

| ADR | Cumplimiento | Observacion |
|---|---|---|
| CA-ADR-0030: fallos sincronos sin consumidores downstream | ok | El aggregate declina con resultado (`ResultadoCorreccionFechaInicioVinculacion`) y nunca lanza ni persiste evento de fallo; el handler traduce a `InvalidOperationException`->409 y `KeyNotFoundException`->404 con `.resx`. Aplica ademas el "declinar en silencio" del ADR (variante `SinCambios` -> 202 sin evento), correctamente identificado como **exito silencioso**, no rechazo |
| MEF-ADR-0012: modelado, Tell-don't-Ask, serializacion | ok | Las tres reglas se evaluan **dentro** del aggregate contra su propia historia; el handler solo consume el enum, nunca interroga estado. Sin propiedades/getters publicos nuevos: `_fechaTerminacionVinculacionAnterior` es privado. `FechaInicioVinculacionCorregida` = `record` sin invariantes (fila correcta de la tabla del ADR) |
| MEF-ADR-0037: identidad de stream | ok | Punto unico de conversion respetado: el handler llama `ColaboradorAggregateRoot.ComputarStreamId(identificacion)`; no hay concatenacion paralela ni `ToString(<formato>)`. Parseo tipado unico en el borde (`TipoIdentificacion.Desde` + `Identificacion.Crear`) antes de tocar el store. Sin componentes `Guid` en la clave |
| CA-ADR-0029 / MEF-ADR-0039: composicion por rol del evento | ok | Evento en la isla `Colaboradores.DomainEvents`, payload plano (`DateOnly`), sin marker de bus, alta en `TiposPersistidos`. El diff **no toca ningun `.csproj`**: cero `ProjectReference`/`PackageReference` nuevas. Sin tipo homonimo en `PublicEvents`/`PrivateEvents` (verificado por grep) |
| MEF-ADR-0006: naming de funciones Azure | ok | `[Function("CorregirFechaInicioVinculacion")]`, feature folder `CorregirFechaInicioVinculacionFunction/` con sufijo `Function` (HTTP), clase `FunctionEndpoint.cs`, subcarpeta `CommandHandler/`, `Route` explicito con verbo `"post"` declarado |
| MEF-ADR-0009: mensajes `.resx` por handler | ok | `.resx` junto al handler + partial `Mensajes` + guardrail `...MensajesTests` que evita el falso verde del `WithMessage("**")` cuando una clave desaparece |
| CA-ADR-0027: tenancy | ok | Sin manejo explicito: el `IEventStore` del paquete resuelve el tenant, igual que los tres slices hermanos |
| MEF-ADR-0002 / MEF-ADR-0016: testing y naming | ok | DSL Given/WhenAsync/Then/And con overloads de stream compuesto; solo `[Fact]`; `<Sujeto>_<LoQuePasa>_Cuando<Condicion>` con el **nombre del comando** como sujeto. Oraculo de stream literal (`"CC:79543210"`), no derivado de `ComputarStreamId` |
| MEF-ADR-0005: naming/versionado de eventos | ok | `FechaInicioVinculacionCorregida`: hecho en pasado, nombre propio y no reutilizacion de `VinculacionIniciada` (decision correcta: enmienda != nacimiento) |
| MEF-ADR-0036: identidad del evento persistido | ok (colateral) | Tipo **nuevo**, no un rename: no aplica el protocolo de dos despliegues. Alias congelado por `AliasEventosColaboradoresTests` (`fecha_inicio_vinculacion_corregida`) y por los dos tests de `ComposicionServiciosTests` |
| MEF-ADR-0018: Rule of Three / autoridad de extraccion | ok | Ver "Criticas y hallazgos" #3: hay cuarta copia mecanica del validator, pero el ADR reserva la iniciativa de extraccion al implementer -- no la impongo |

### Desviaciones de ADRs

**Ninguna desviacion** -- todos los ADRs aplicables se cumplen.

El implementer declaro "ninguna desviacion" en `stage-2-implementer.md`; lo verifique contra el diff
ADR por ADR y **no encontre desviaciones no declaradas**. Recorri explicitamente los 7 antipatrones
de MEF-ADR-0012 (propiedad publica para consumidor externo, clase estatica sobre datos crudos,
getter solo-para-tests, `InternalsVisibleTo` desde una isla de eventos, `[JsonConstructor]`,
`record` con `IReadOnlyList`, marker de bus con payload rico): ninguno aplica a este diff.

### Precedentes consultados por el implementer

| Precedente | ADR aplicable | Veredicto |
|---|---|---|
| `ReingresarColaboradorCommandHandler` / `ReingresarColaboradorValidator` (#350) | CA-ADR-0030, MEF-ADR-0037 | alineado |
| `ColaboradorAggregateRoot.TerminarVinculacion` / `.Reingresar` (#349/#350) | CA-ADR-0030, MEF-ADR-0012 | alineado |
| `ColaboradorAggregateRoot.CorregirNombres` (#351) | CA-ADR-0030 ("declinar en silencio") | alineado |
| `CorregirNombresSmokeTests` / `ReingresarColaboradorSmokeTests` | MEF-ADR-0013 | alineado |

Ningun precedente citado viola un ADR.

### Convenciones del pipeline (no ADRs)

| Convencion | Estado | Observacion |
|---|---|---|
| Cada test con `Then()` + `And<>()` | ok | 12 de 13 tests del handler cumplen. La excepcion es CA-5 (`...CuandoColaboradorNoExiste`): sin stream, no hay aggregate que rehidratar y `And<>` no tiene sujeto -- justificado y con precedente literal en #349/#350/#351 |
| Overloads correctos para stream IDs compuestos | ok | `Given(streamId, ...)`, `Then(streamId, ...)`, `And<T,P>(streamId, ...)` en todos los tests |
| Fakes manuales (no NSubstitute) | ok | `FakeCorregirFechaInicioVinculacionRequestValidator` / `...CommandRouter`, clases concretas |
| Feature folders (produccion y tests) | ok | Espejo exacto; un archivo por responsabilidad (handler / validator / endpoint / mensajes / serializacion del evento) |
| Smoke tests: SkipWhen, secrets, cobertura | ok | `Assert.SkipWhen` (xUnit v3) en los 3 tests que dependen de Postgres; identificacion unica por test (sin colisiones); cobertura del unico efecto secundario del handler (persistencia). Sin `ServiceBusFixture` porque el comando no publica nada -- correctamente `n/a`, no un efecto omitido. Un solo archivo por comando; sin secrets en el diff |
| Proyecciones read-side (MEF-ADR-0035/0041) | n/a | El diff no toca `ReadModels`/`Projections` ni ninguna Function GET |
| Antipatrones de habilitacion (MEF-ADR-0039) | n/a | El diff no toca ningun `.csproj` (verificado con `git diff main...HEAD -- '**/*.csproj'`, vacio); el tipo de evento nuevo no lleva marker de bus ni es homonimo de ninguno existente |
| Compatibilidad Marten write-side/read-side | n/a | El diff no toca version del paquete ni configuracion de Marten (`ComposicionServicios*`, `ConfiguracionSerializacion*`, `opts.Events.*`, serializador). Solo se sumo un tipo a `TiposPersistidos`, cuyo efecto en `AddEventTypes` ya lo congela `ComposicionServiciosTests` |
| Identidad de stream (MEF-ADR-0037) | ok | Ver la tabla de ADRs. La reconstruccion `$"CC:{numero}"` del smoke test **no** es hallazgo: es un oraculo black-box deliberado en un proyecto que solo referencia `Colaboradores.DomainEvents` y no alcanza `ComputarStreamId` |
| Control de volumen de telemetria (MEF-ADR-0038) | n/a | El diff no toca los seams de observabilidad ni el callback de Wolverine |
| Tests via ToString/comportamiento | ok | Sin getters nuevos; los `And<>` usan observables `internal` que ya existian desde #330/#349 |
| Sin numeros magicos | ok | Fechas y codigos como constantes con nombre (`FechaEfectivaTerminacionReingreso`, `CodigoSegundoReingreso`, ...) |
| Condiciones en positivo (guardas if/else afirmativas) | ok | Las tres guardas de `CorregirFechaInicio` son early-returns que expresan la precondicion de salida; sin `if/else` en negativo |

### Elegancia del codigo
- **Compacidad**: el unico exceso real era el comentario del `CommandHandler` -- 21 lineas que
  narraban paso a paso el mismo flujo que las 20 lineas de codigo de abajo (cruft del stub de fase
  roja). Compactado a 8 lineas que explican el **porque** (los dos mecanismos de CA-ADR-0030), al
  estilo de los handlers hermanos. Segundo exceso, en el smoke test: relectura tautologica del
  mismo evento (ver Refactorings).
- **Legibilidad**: buena. Los factory methods `DadoUnColaboradorCon...` nombran el estado del
  stream, no la secuencia de eventos -- el test se lee como especificacion.
- **Idiomatismo**: correcto. `record` para evento y comando, `switch` sobre enum, `with` para
  variar el comando en los tests. La guarda `_fechaTerminacionVinculacionVigente is not null && fecha > ....Value`
  podria comprimirse al operador lifted (`fecha > _fechaTerminacionVinculacionVigente`), pero la
  forma explicita es mas legible y evita el foot-gun clasico de las comparaciones nullable: **no lo
  toque, es la eleccion correcta**.
- **Robustez**: los boundaries estan cubiertos (validator -> 400, handler -> 404/409); ninguna
  excepcion se traga en silencio.
- **Eficiencia**: n/a -- tres comparaciones de `DateOnly`, sin loops ni colecciones.
- **Limpieza**: 0 warnings del compilador, 0 hallazgos de `dotnet format` en archivos de
  Colaboradores (los 4 IDE0005 que reporta la solucion son preexistentes en `ControlHoras.Tests`,
  fuera del alcance de esta HU), sin `Console.WriteLine` ni caracteres U+2500.

### Criticas y hallazgos

1. **[menor -- corregido]** Cruft de fase roja en `CorregirFechaInicioVinculacionCommandHandler.cs`:
   el comentario de cabecera enumeraba los 4 pasos del metodo con sus tipos y excepciones exactas.
   Un comentario que repite el codigo se desincroniza en el primer cambio. Corregido.

2. **[menor -- corregido]** Verificacion tautologica en el smoke test CA-1: se llamaba
   `ExisteEventoAsync(campoJson: "FechaInicio", valorJson: X)` y despues `ObtenerEventoAsync` **con
   el mismo filtro** para afirmar que `FechaInicio == X`. Leido `PostgresFixture`, el filtro compara
   `prop.ToString() == valorJson`: la segunda consulta no podia fallar si la primera pasaba. El
   overload sin filtro si es necesario en #351 (campo objeto, comparacion por valor deserializado),
   pero aqui `FechaInicio` es escalar. Corregido.

3. **[menor -- NO corregido, deliberado]** Cuarta copia literal de
   `EsTipoIdentificacionReconocido` (try/catch de `ArgumentException` para decidir un booleano) en
   los validators del dominio. Es control de flujo por excepcion y, por Tell-don't-Ask, la lista
   cerrada deberia poder responder `TipoIdentificacion.EsReconocido(codigo)` sin lanzar. **No lo
   extraigo**: MEF-ADR-0018 ("Autoridad de extraccion") reserva la iniciativa al implementer salvo
   evidencia de evolucion conjunta, y hacerlo tocaria el VO (#348) y tres validators fuera del
   diff. **Recomendacion: issue de refactor** que agregue el metodo al VO y migre los cuatro
   validators de una vez.

4. **[menor -- NO corregido]** El smoke test CA-5 (`...Retorna404_CuandoColaboradorNoExiste`)
   **pasa hoy por la razon equivocada**: dev responde 404 porque la ruta no existe todavia, no
   porque el colaborador falte. Post-deploy la ambiguedad desaparece, y los otros 5 tests del mismo
   archivo ya delatan la situacion, asi que el falso verde no es silencioso. Reforzarlo (assert
   sobre el mensaje del body) sumaria un rojo mas al baseline pre-deploy y se desviaria del
   precedente de #349/#350/#351. **Recomendacion**: si se decide reforzarlo, hacerlo en los cuatro
   smoke tests de la cadena a la vez, en un issue propio.

5. **[cosmetico -- NO corregido]** Deuda de lenguaje ubicuo preexistente: el estado se llama
   `_fechaInicioVinculacionVigente`/`FechaInicioVinculacionVigente`, pero el alcance que este issue
   fijo es "la **ULTIMA** vinculacion, tenga o no terminacion registrada" -- y el refinamiento
   constata que "vigente" no existe como estado en el modelo sin reloj. El nombre viene de #330 y
   renombrarlo tocaria los cuatro slices; fuera del alcance (regla 4). **Recomendacion**: incluirlo
   en el issue de cierre de la cadena (#357) o en uno de limpieza.

6. **[cosmetico -- NO corregido]** Los comentarios `// Rojo esperado (fase roja, issue #NNN): ...`
   se acumulan en `ComposicionServiciosTests.cs` y `AliasEventosColaboradoresTests.cs` (ya van
   #330, #349, #351, #352) y describen un estado que dejo de existir al mergear cada slice. Limpiar
   solo el de #352 dejaria el bloque inconsistente; limpiarlos todos es refactor fuera de la HU.
   **Recomendacion**: issue de limpieza transversal.

7. **[observacion, sin accion]** `ObjectDisposedException` deriva de `InvalidOperationException`,
   asi que un fallo de infraestructura en el endpoint se traduciria a 409 en vez de 500. Es una
   propiedad del patron de traduccion de todo el marco (identica en los cuatro endpoints del
   dominio), no algo que este PR introduzca. No corresponde arreglarlo aqui.

### Refactorings aplicados

1. **Comentario del `CommandHandler` compactado** (21 -> 8 lineas): se conserva el porque (los dos
   mecanismos de CA-ADR-0030 y la razon de que `SinCambios` sea exito y no rechazo) y se elimina la
   narracion del flujo. `dotnet test` verde despues del cambio.
2. **Relectura tautologica eliminada del smoke test CA-1**, junto con la constante
   `TimeoutLecturaConfirmada` y el `using System.Text.Json` que solo esa relectura usaba. Compila
   sin warnings; el test sigue verificando el mismo hecho (evento persistido **con** la fecha
   exacta).

Ningun refactor rompio un test; no hubo nada que revertir.

### Cobertura de criterios de aceptacion

| Criterio | Estado | Test(s) |
|---|---|---|
| CA-1: ultima vinculacion abierta + fecha valida distinta -> 202, evento en el stream, aggregate rehidratado con la fecha nueva, tipo registrado | cubierto | `CorregirFechaInicioVinculacion_EmiteFechaInicioVinculacionCorregida_CuandoLaUltimaVinculacionEstaAbierta`; `..._CuandoTipoYNumeroLleganSinNormalizar`; `..._CuandoLaUltimaVinculacionEsUnReingresoAbierto`; alta en `TiposPersistidos` congelada por `AgregarServiciosColaboradores_RegistraLosTiposDeEventoPersistidos_...` + `..._DerivaElAliasDeEventoDelNombreDeClase_...` + `FechaInicioVinculacionCorregida_TieneAliasFechaInicioVinculacionCorregida`; smoke `..._Retorna202YPersiste..._CuandoUltimaVinculacionEstaAbierta` |
| CA-2: con terminacion registrada, `<=` propia -> 202 (`==` valido); `>` -> 409 con `.resx`, sin evento | cubierto | `..._CuandoFechaCorregidaEsAnteriorALaFechaEfectivaPropia`; `..._CuandoFechaCorregidaEsIgualALaFechaEfectivaPropia`; `..._LanzaInvalidOperationException_CuandoFechaCorregidaEsPosteriorALaFechaEfectivaPropia`; smoke 202 y 409 |
| CA-3: tras un reingreso, fecha igual o anterior a la terminacion de la vinculacion anterior -> 409, sin evento | cubierto | `..._CuandoFechaCorregidaEsIgualALaFechaEfectivaDeLaVinculacionAnterior`; `..._CuandoFechaCorregidaEsAnteriorALaFechaEfectivaDeLaVinculacionAnterior`; **agregado**: `..._CuandoFechaCorregidaSolapaElReingresoPrevioYNoLaVinculacionOriginal`; smoke `..._Retorna409_...TrasUnReingreso` |
| CA-4: fecha igual a la actual -> 202 sin evento nuevo | cubierto | `..._NoEmiteEvento_CuandoFechaCorregidaEsIgualALaActual`; `..._NoEmiteEvento_...YLaVinculacionEstaTerminada` (congela que la idempotencia se evalua **antes** que las demas reglas); smoke `..._Retorna202SinNuevoEvento_...` |
| CA-5: colaborador inexistente -> 404 con `.resx`, sin escribir nada | cubierto | `..._LanzaKeyNotFoundException_CuandoColaboradorNoExiste` (con `Then(streamId)` vacio probando la no-escritura); `FunctionEndpointTests...Retorna404...`; smoke 404 (ver hallazgo #4) |
| CA-6: request invalida -> 400 sin tocar el event store | cubierto | 5 tests de `CorregirFechaInicioVinculacionValidatorTests` (tipo vacio / fuera de lista / minusculas valido / numero vacio / fecha default) + 2 de no-rechazo indebido; `FunctionEndpointTests...Retorna400...`; 3 smoke tests de 400 |

Cobertura adicional no exigida por los CAs pero necesaria: round-trip de serializacion del evento
con las opciones reales de Marten (`FechaInicioVinculacionCorregidaSerializacionTests`) y guardrail
de resolucion del `.resx`.

### Tests agregados

Dos casos borde sobre `_fechaTerminacionVinculacionAnterior` -- el campo nuevo que el implementer
introdujo y la pieza mas fragil del slice, porque su correccion depende de un **orden de asignacion**
dentro de `Apply(VinculacionIniciada)` que ningun test cubria mas alla del primer reingreso:

1. `CorregirFechaInicioVinculacion_EmiteFechaInicioVinculacionCorregida_CuandoLaFechaCaeEntreLaTerminacionAnteriorYLaPropia`
   -- la ultima vinculacion es un reingreso **ya terminado**: unico estado en que las dos reglas de
   CA-2 y CA-3 acotan la fecha a la vez (ventana `(terminacionAnterior, terminacionPropia]`).
   Verifica ademas que la terminacion propia queda intacta tras la correccion.
2. `CorregirFechaInicioVinculacion_LanzaInvalidOperationException_CuandoFechaCorregidaSolapaElReingresoPrevioYNoLaVinculacionOriginal`
   -- con **dos** reingresos encadenados, la no-solape debe evaluarse contra la terminacion
   inmediatamente anterior, no contra la original. Verifique que el test no es vacuo: si el campo se
   congelara en la primera terminacion, la fecha del test (2026-07-01) pasaria el filtro y el
   aggregate emitiria el evento, fallando tanto el `ThrowExactlyAsync` como el `Then` vacio.

Ambos pasan contra la implementacion actual (217/217 en `Colaboradores.Tests`, antes 215): confirman
que el razonamiento del implementer sobre la cadena larga era correcto y lo dejan congelado.

No hicieron falta tests de contrato de igualdad ni de portabilidad por bus: el evento es un `record`
plano sin `IEquatable` manual, sin `ConfigurarSerializacion` y sin marker de bus.

</details>

## Commits

959906b refactor(hu-352): cubre la cadena larga de reingresos y limpia cruft de fase roja
90e5208 Agrega smoke tests para CorregirFechaInicioVinculacion (issue #352)
8996cca feat(issue-352): implementacion de corregir la fecha de inicio de la ultima vinculacion (fase verde)
7ee58ed test(issue-352): tests para corregir la fecha de inicio de la ultima vinculacion (fase roja)

Closes #352