### PR TITLE
Anular la terminacion de una vinculacion

### DIFF
--- a/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/IdentidadEventosColaboradores.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/IdentidadEventosColaboradores.cs
@@ -20,5 +20,6 @@ public static class IdentidadEventosColaboradores
         typeof(VinculacionTerminada),
         typeof(NombresCorregidos),
         typeof(FechaInicioVinculacionCorregida),
+        typeof(TerminacionAnulada),
     ];
 }

--- a/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/TerminacionAnulada.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/TerminacionAnulada.cs
@@ -1,0 +1,19 @@
+namespace Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+
+/// <summary>
+/// Evento de event sourcing que anula la terminacion registrada de la ULTIMA vinculacion de un
+/// colaborador, reabriendola con su codigo y fecha de inicio originales intactos. Se persiste en
+/// el stream de ColaboradorAggregateRoot.
+/// </summary>
+/// <remarks>
+/// Issue #354: sin payload -- el hecho es el evento mismo. No hay dato adicional que registrar: la
+/// fecha efectiva de la terminacion anulada sigue integra en el VinculacionTerminada que el stream
+/// ya conserva -- anular no borra el historial, solo dice "ese hecho ya no aplica".
+/// Reemplaza al comando "CorregirFechaTerminacionVinculacion" que el desglose original planeaba
+/// (decision de refinamiento 2026-08-11): corregir una fecha de terminacion es anular + terminar
+/// de nuevo, dos intenciones que componen (ver ColaboradorAggregateRoot.AnularTerminacion).
+/// No necesita ConfigurarSerializacion (sin campos que mapear) ni marca de bus
+/// (IPrivateEvent/IPublicEvent): event-sourcing puro, sin consumidores (issue #354 "Consumidores:
+/// ninguno").
+/// </remarks>
+public sealed record TerminacionAnulada;

--- a/src/Bitakora.ControlAsistencia.Colaboradores/AnularTerminacionFunction/AnularTerminacion.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/AnularTerminacionFunction/AnularTerminacion.cs
@@ -1,0 +1,18 @@
+namespace Bitakora.ControlAsistencia.Colaboradores.AnularTerminacionFunction;
+
+// Issue #354: comando para anular la terminacion registrada de la ULTIMA vinculacion de un
+// colaborador -- sexto comando del ciclo de vida de ColaboradorAggregateRoot (desglose #348-#357)
+// y el mas simple de la cadena: una sola regla, cero fechas en el payload. Resuelve dos casos
+// reales con el mismo hecho: el arrepentimiento del preaviso (Maria anuncio su salida al 30 y el
+// 27 decide quedarse) y la fecha de terminacion errada (se compone con TerminarVinculacion, ver
+// ColaboradorAggregateRoot.AnularTerminacion).
+// Trigger: HTTP POST, Route: Colaboradores/Terminaciones/Anulaciones (la anulacion como
+// sub-recurso de las terminaciones, #349; la identificacion viaja en el body porque su
+// representacion "CC:79543210" contiene ":", hostil como segmento de URL).
+// Payload primitivo -- igual que los demas comandos del ciclo de vida (MEF-ADR-0039 decision 6,
+// payload por rol): NUNCA reusa un tipo de Colaboradores.DomainEvents como campo. El handler
+// construye TipoIdentificacion/Identificacion a partir de estos primitivos (parseo tipado unico en
+// el borde, MEF-ADR-0037 seccion 2).
+// SIN fecha ni motivo: anular no lleva payload propio -- el hecho es el evento mismo
+// (TerminacionAnulada, sin campos).
+public record AnularTerminacion(string TipoIdentificacion, string NumeroIdentificacion);

--- a/src/Bitakora.ControlAsistencia.Colaboradores/AnularTerminacionFunction/CommandHandler/AnularTerminacionCommandHandler.Mensajes.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/AnularTerminacionFunction/CommandHandler/AnularTerminacionCommandHandler.Mensajes.cs
@@ -1,0 +1,21 @@
+using System.Resources;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.AnularTerminacionFunction.CommandHandler;
+
+// MEF-ADR-0009: mensajes del handler en .resx separado.
+// internal: accesible desde tests via InternalsVisibleTo en el .csproj.
+public partial class AnularTerminacionCommandHandler
+{
+    private static readonly ResourceManager ResourceManager = new(
+        "Bitakora.ControlAsistencia.Colaboradores.AnularTerminacionFunction.CommandHandler.AnularTerminacionCommandHandlerMensajes",
+        typeof(AnularTerminacionCommandHandler).Assembly);
+
+    internal static class Mensajes
+    {
+        public static string ColaboradorNoEncontrado =>
+            ResourceManager.GetString(nameof(ColaboradorNoEncontrado))!;
+
+        public static string VinculacionAbierta =>
+            ResourceManager.GetString(nameof(VinculacionAbierta))!;
+    }
+}

--- a/src/Bitakora.ControlAsistencia.Colaboradores/AnularTerminacionFunction/CommandHandler/AnularTerminacionCommandHandler.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/AnularTerminacionFunction/CommandHandler/AnularTerminacionCommandHandler.cs
@@ -1,0 +1,30 @@
+using Cosmos.EventSourcing.Abstractions.Commands;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.AnularTerminacionFunction.CommandHandler;
+
+// Issue #354: handler del comando AnularTerminacion.
+// Flujo esperado (precedente TerminarVinculacionCommandHandler #349, MEF-ADR-0004 capa 2 --
+// CA-ADR-0030):
+//   1. Normalizar y parsear TipoIdentificacion -> TipoIdentificacion.Desde(...) (borde HTTP:
+//      normalizar trim+MAYUSCULAS ANTES de Desde, mismo criterio que los handlers hermanos).
+//   2. Identificacion.Crear(tipo, command.NumeroIdentificacion) -- normaliza el numero.
+//   3. ComputarStreamId(identificacion) -> GetAggregateRootAsync<ColaboradorAggregateRoot> -- si
+//      es null, throw KeyNotFoundException(Mensajes.ColaboradorNoEncontrado) (-> 404).
+//   4. colaborador.AnularTerminacion() -- el aggregate declina con resultado (nunca lanza, nunca
+//      emite evento de fallo persistido):
+//        - ResultadoAnulacionTerminacion.VinculacionAbierta -> throw
+//          InvalidOperationException(Mensajes.VinculacionAbierta) (-> 409).
+//        - ResultadoAnulacionTerminacion.Exitosa -> el aggregate ya agrego TerminacionAnulada a
+//          _uncommittedEvents; WhenAsync/el middleware persiste via SaveChanges.
+// Sin publicacion a bus (event-sourcing puro, issue #354 "Consumidores: ninguno").
+// STUB (fase roja, issue #354): el cuerpo completo queda para el implementer.
+public partial class AnularTerminacionCommandHandler : ICommandHandlerAsync<AnularTerminacion>
+{
+    private readonly IEventStore _eventStore;
+
+    public AnularTerminacionCommandHandler(IEventStore eventStore) =>
+        _eventStore = eventStore;
+
+    public Task HandleAsync(AnularTerminacion command, CancellationToken ct = default) =>
+        throw new NotImplementedException();
+}

--- a/src/Bitakora.ControlAsistencia.Colaboradores/AnularTerminacionFunction/CommandHandler/AnularTerminacionCommandHandler.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/AnularTerminacionFunction/CommandHandler/AnularTerminacionCommandHandler.cs
@@ -1,3 +1,5 @@
+using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+using Bitakora.ControlAsistencia.Colaboradores.Entities;
 using Cosmos.EventSourcing.Abstractions.Commands;
 
 namespace Bitakora.ControlAsistencia.Colaboradores.AnularTerminacionFunction.CommandHandler;
@@ -25,6 +27,20 @@ public partial class AnularTerminacionCommandHandler : ICommandHandlerAsync<Anul
     public AnularTerminacionCommandHandler(IEventStore eventStore) =>
         _eventStore = eventStore;
 
-    public Task HandleAsync(AnularTerminacion command, CancellationToken ct = default) =>
-        throw new NotImplementedException();
+    public async Task HandleAsync(AnularTerminacion command, CancellationToken ct = default)
+    {
+        // Parseo tipado unico del borde (MEF-ADR-0037 seccion 2), mismo criterio que
+        // TerminarVinculacionCommandHandler.
+        var tipo = TipoIdentificacion.Desde(command.TipoIdentificacion.Trim().ToUpperInvariant());
+        var identificacion = Identificacion.Crear(tipo, command.NumeroIdentificacion);
+
+        var streamId = ColaboradorAggregateRoot.ComputarStreamId(identificacion);
+        var colaborador = await _eventStore.GetAggregateRootAsync<ColaboradorAggregateRoot>(streamId, ct);
+        if (colaborador is null)
+            throw new KeyNotFoundException(Mensajes.ColaboradorNoEncontrado);
+
+        var resultado = colaborador.AnularTerminacion();
+        if (resultado == ResultadoAnulacionTerminacion.VinculacionAbierta)
+            throw new InvalidOperationException(Mensajes.VinculacionAbierta);
+    }
 }

--- a/src/Bitakora.ControlAsistencia.Colaboradores/AnularTerminacionFunction/CommandHandler/AnularTerminacionCommandHandler.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/AnularTerminacionFunction/CommandHandler/AnularTerminacionCommandHandler.cs
@@ -4,22 +4,12 @@ using Cosmos.EventSourcing.Abstractions.Commands;
 
 namespace Bitakora.ControlAsistencia.Colaboradores.AnularTerminacionFunction.CommandHandler;
 
-// Issue #354: handler del comando AnularTerminacion.
-// Flujo esperado (precedente TerminarVinculacionCommandHandler #349, MEF-ADR-0004 capa 2 --
-// CA-ADR-0030):
-//   1. Normalizar y parsear TipoIdentificacion -> TipoIdentificacion.Desde(...) (borde HTTP:
-//      normalizar trim+MAYUSCULAS ANTES de Desde, mismo criterio que los handlers hermanos).
-//   2. Identificacion.Crear(tipo, command.NumeroIdentificacion) -- normaliza el numero.
-//   3. ComputarStreamId(identificacion) -> GetAggregateRootAsync<ColaboradorAggregateRoot> -- si
-//      es null, throw KeyNotFoundException(Mensajes.ColaboradorNoEncontrado) (-> 404).
-//   4. colaborador.AnularTerminacion() -- el aggregate declina con resultado (nunca lanza, nunca
-//      emite evento de fallo persistido):
-//        - ResultadoAnulacionTerminacion.VinculacionAbierta -> throw
-//          InvalidOperationException(Mensajes.VinculacionAbierta) (-> 409).
-//        - ResultadoAnulacionTerminacion.Exitosa -> el aggregate ya agrego TerminacionAnulada a
-//          _uncommittedEvents; WhenAsync/el middleware persiste via SaveChanges.
-// Sin publicacion a bus (event-sourcing puro, issue #354 "Consumidores: ninguno").
-// STUB (fase roja, issue #354): el cuerpo completo queda para el implementer.
+// Issue #354: handler del comando AnularTerminacion. Usa el mecanismo "declinar con resultado"
+// (CA-ADR-0030) con una unica razon de rechazo -- la ultima vinculacion no tiene terminacion
+// registrada --, que este handler traduce a InvalidOperationException/409 con mensaje .resx. El 404
+// es precondicion de orquestacion (MEF-ADR-0004 capa 2), no regla del aggregate. En el camino de
+// exito el aggregate ya dejo TerminacionAnulada en _uncommittedEvents -- el middleware persiste via
+// SaveChanges. Sin publicacion a bus (event-sourcing puro, issue #354 "Consumidores: ninguno").
 public partial class AnularTerminacionCommandHandler : ICommandHandlerAsync<AnularTerminacion>
 {
     private readonly IEventStore _eventStore;

--- a/src/Bitakora.ControlAsistencia.Colaboradores/AnularTerminacionFunction/CommandHandler/AnularTerminacionCommandHandlerMensajes.resx
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/AnularTerminacionFunction/CommandHandler/AnularTerminacionCommandHandlerMensajes.resx
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" msdata:Ordinal="0" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter</value></resheader>
+  <data name="ColaboradorNoEncontrado" xml:space="preserve">
+    <value>No existe un colaborador registrado con esa identificacion</value>
+  </data>
+  <data name="VinculacionAbierta" xml:space="preserve">
+    <value>La vinculacion vigente del colaborador no tiene una terminacion registrada</value>
+  </data>
+</root>

--- a/src/Bitakora.ControlAsistencia.Colaboradores/AnularTerminacionFunction/CommandHandler/AnularTerminacionValidator.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/AnularTerminacionFunction/CommandHandler/AnularTerminacionValidator.cs
@@ -1,0 +1,15 @@
+using FluentValidation;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.AnularTerminacionFunction.CommandHandler;
+
+// Issue #354: validacion de forma del comando AnularTerminacion en el borde (MEF-ADR-0004 capa 1
+// -> 400 BadRequest). CA-6: TipoIdentificacion (requerido + en la lista cerrada) y
+// NumeroIdentificacion requeridos. Sin FechaEfectiva ni otro campo: el comando no lleva payload
+// propio.
+// Se descubre via el AddValidatorsFromAssemblyContaining que ComposicionServicios ya configura:
+// no requiere tocar el wiring de DI.
+// STUB (fase roja, issue #354): sin reglas todavia -- el implementer las agrega (precedente
+// TerminarVinculacionValidator, issue #349; RegistrarColaboradorValidator, issue #330).
+public class AnularTerminacionValidator : AbstractValidator<AnularTerminacion>
+{
+}

--- a/src/Bitakora.ControlAsistencia.Colaboradores/AnularTerminacionFunction/CommandHandler/AnularTerminacionValidator.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/AnularTerminacionFunction/CommandHandler/AnularTerminacionValidator.cs
@@ -1,15 +1,43 @@
+using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
 using FluentValidation;
 
 namespace Bitakora.ControlAsistencia.Colaboradores.AnularTerminacionFunction.CommandHandler;
 
 // Issue #354: validacion de forma del comando AnularTerminacion en el borde (MEF-ADR-0004 capa 1
-// -> 400 BadRequest). CA-6: TipoIdentificacion (requerido + en la lista cerrada) y
-// NumeroIdentificacion requeridos. Sin FechaEfectiva ni otro campo: el comando no lleva payload
-// propio.
+// -> 400 BadRequest). CA-6: TipoIdentificacion (requerido + en la lista cerrada -- normalizar
+// trim+MAYUSCULAS antes de TipoIdentificacion.Desde, mismo criterio de normalizacion de entrada
+// que TerminarVinculacionValidator) y NumeroIdentificacion requeridos. Sin FechaEfectiva ni otro
+// campo: el comando no lleva payload propio.
 // Se descubre via el AddValidatorsFromAssemblyContaining que ComposicionServicios ya configura:
 // no requiere tocar el wiring de DI.
-// STUB (fase roja, issue #354): sin reglas todavia -- el implementer las agrega (precedente
-// TerminarVinculacionValidator, issue #349; RegistrarColaboradorValidator, issue #330).
 public class AnularTerminacionValidator : AbstractValidator<AnularTerminacion>
 {
+    public AnularTerminacionValidator()
+    {
+        // Cascade(Stop) evita que Must evalue un valor vacio que NotEmpty ya rechazo -- mismo
+        // criterio que TerminarVinculacionValidator.
+        RuleFor(x => x.TipoIdentificacion)
+            .Cascade(CascadeMode.Stop)
+            .NotEmpty()
+            .Must(EsTipoIdentificacionReconocido)
+            .WithMessage("El tipo de identificacion no es uno de los reconocidos");
+
+        RuleFor(x => x.NumeroIdentificacion).NotEmpty();
+    }
+
+    // Consulta la lista cerrada (#348) sin propagar la excepcion de dominio al boundary de
+    // validacion -- un codigo fuera de la lista debe traducirse en un error de FluentValidation
+    // (400), no en una excepcion no controlada.
+    private static bool EsTipoIdentificacionReconocido(string tipo)
+    {
+        try
+        {
+            TipoIdentificacion.Desde(tipo.Trim().ToUpperInvariant());
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+    }
 }

--- a/src/Bitakora.ControlAsistencia.Colaboradores/AnularTerminacionFunction/FunctionEndpoint.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/AnularTerminacionFunction/FunctionEndpoint.cs
@@ -1,0 +1,46 @@
+using Bitakora.ControlAsistencia.Colaboradores.Infraestructura;
+using Cosmos.EventSourcing.Abstractions.Commands;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.AnularTerminacionFunction;
+
+// Issue #354: endpoint HTTP POST para anular la terminacion registrada de la ultima vinculacion de
+// un colaborador. MEF-ADR-0006: [Function("AnularTerminacion")]; carpeta CON sufijo "Function" --
+// mismo criterio que los demas comandos del ciclo de vida: el record del comando es homonimo del
+// feature folder.
+// Route = "Colaboradores/Terminaciones/Anulaciones": la anulacion como sub-recurso de las
+// terminaciones (#349) -- identificacion en el body porque su representacion ("CC:79543210")
+// contiene ":", hostil como segmento de URL.
+// CA-ADR-0030 / MEF-ADR-0004 (precedente TerminarVinculacionFunction.FunctionEndpoint): validar
+// request (400 via IRequestValidator) -> despachar comando -> InvalidOperationException -> 409
+// Conflict, KeyNotFoundException -> 404 NotFound; exito -> 202 Accepted.
+public class FunctionEndpoint(IRequestValidator requestValidator, ICommandRouter commandRouter)
+{
+    [Function("AnularTerminacion")]
+    public async Task<IActionResult> Run(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "Colaboradores/Terminaciones/Anulaciones")]
+        HttpRequest req,
+        CancellationToken ct)
+    {
+        var (comando, error) = await requestValidator.ValidarAsync<AnularTerminacion>(req, ct);
+        if (error is not null)
+            return error;
+
+        try
+        {
+            await commandRouter.InvokeAsync(comando!, ct);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return new ConflictObjectResult(ex.Message);
+        }
+        catch (KeyNotFoundException ex)
+        {
+            return new NotFoundObjectResult(ex.Message);
+        }
+
+        return new AcceptedResult();
+    }
+}

--- a/src/Bitakora.ControlAsistencia.Colaboradores/Entities/ColaboradorAggregateRoot.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/Entities/ColaboradorAggregateRoot.cs
@@ -80,6 +80,12 @@ public partial class ColaboradorAggregateRoot : AggregateRoot
     // capa 4).
     public void Apply(VinculacionTerminada e) => _fechaTerminacionVinculacionVigente = e.FechaEfectiva;
 
+    // Issue #354: anula la terminacion registrada de la ULTIMA vinculacion -- la reabre sin tocar
+    // su codigo ni su fecha de inicio (ambos quedan intactos, Apply solo limpia la terminacion).
+    // Nunca lanza (MEF-ADR-0004 capa 4).
+    // STUB (fase roja, issue #354): el cuerpo completo queda para el implementer.
+    public void Apply(TerminacionAnulada e) => throw new NotImplementedException();
+
     // Issue #351: reemplaza el nombre de la persona. Nunca lanza (MEF-ADR-0004 capa 4).
     public void Apply(NombresCorregidos e) => _nombre = e.Nombre;
 
@@ -200,6 +206,22 @@ public partial class ColaboradorAggregateRoot : AggregateRoot
 
         return ResultadoCorreccionFechaInicioVinculacion.Exitosa;
     }
+
+    // Issue #354: mecanismo "declinar con resultado" (CA-ADR-0030) -- nunca lanza, nunca emite un
+    // evento de fallo persistido. Unica regla, evaluable solo con la historia del stream, sin
+    // reloj (decision de refinamiento 2026-08-11 -- el arrepentimiento del preaviso y la fecha de
+    // terminacion errada comparten esta misma solucion):
+    //   - VinculacionAbierta: _fechaTerminacionVinculacionVigente is null -- cubre tres casos que
+    //     el handler no distingue entre si (recien registrada, reingresada, o ya anulada antes,
+    //     CA-3/CA-4): tras un reingreso la terminacion de la vinculacion ANTERIOR queda congelada
+    //     (decision aprobada explicitamente) porque solo la ULTIMA vinculacion cuenta.
+    // Exito: appendea TerminacionAnulada a _uncommittedEvents y lo aplica -- reabre la vinculacion
+    // vigente con su codigo y fecha de inicio intactos (Apply no los toca).
+    // internal: mismo criterio de visibilidad que TerminarVinculacion/Reingresar/CorregirNombres/
+    // CorregirFechaInicio -- el unico llamador es el handler del mismo ensamblado (los tests lo
+    // alcanzan via InternalsVisibleTo).
+    // STUB (fase roja, issue #354): el cuerpo completo queda para el implementer.
+    internal ResultadoAnulacionTerminacion AnularTerminacion() => throw new NotImplementedException();
 
     // Factory interno: agrega los DOS eventos del commit a _uncommittedEvents y los aplica -- patron
     // RegistroDeMarcacionAggregateRoot.Iniciar, generalizado a dos eventos en el mismo commit.

--- a/src/Bitakora.ControlAsistencia.Colaboradores/Entities/ColaboradorAggregateRoot.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/Entities/ColaboradorAggregateRoot.cs
@@ -83,8 +83,7 @@ public partial class ColaboradorAggregateRoot : AggregateRoot
     // Issue #354: anula la terminacion registrada de la ULTIMA vinculacion -- la reabre sin tocar
     // su codigo ni su fecha de inicio (ambos quedan intactos, Apply solo limpia la terminacion).
     // Nunca lanza (MEF-ADR-0004 capa 4).
-    // STUB (fase roja, issue #354): el cuerpo completo queda para el implementer.
-    public void Apply(TerminacionAnulada e) => throw new NotImplementedException();
+    public void Apply(TerminacionAnulada e) => _fechaTerminacionVinculacionVigente = null;
 
     // Issue #351: reemplaza el nombre de la persona. Nunca lanza (MEF-ADR-0004 capa 4).
     public void Apply(NombresCorregidos e) => _nombre = e.Nombre;
@@ -220,8 +219,17 @@ public partial class ColaboradorAggregateRoot : AggregateRoot
     // internal: mismo criterio de visibilidad que TerminarVinculacion/Reingresar/CorregirNombres/
     // CorregirFechaInicio -- el unico llamador es el handler del mismo ensamblado (los tests lo
     // alcanzan via InternalsVisibleTo).
-    // STUB (fase roja, issue #354): el cuerpo completo queda para el implementer.
-    internal ResultadoAnulacionTerminacion AnularTerminacion() => throw new NotImplementedException();
+    internal ResultadoAnulacionTerminacion AnularTerminacion()
+    {
+        if (_fechaTerminacionVinculacionVigente is null)
+            return ResultadoAnulacionTerminacion.VinculacionAbierta;
+
+        var evento = new TerminacionAnulada();
+        _uncommittedEvents.Add(evento);
+        Apply(evento);
+
+        return ResultadoAnulacionTerminacion.Exitosa;
+    }
 
     // Factory interno: agrega los DOS eventos del commit a _uncommittedEvents y los aplica -- patron
     // RegistroDeMarcacionAggregateRoot.Iniciar, generalizado a dos eventos en el mismo commit.

--- a/src/Bitakora.ControlAsistencia.Colaboradores/Entities/ResultadoAnulacionTerminacion.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/Entities/ResultadoAnulacionTerminacion.cs
@@ -1,0 +1,21 @@
+namespace Bitakora.ControlAsistencia.Colaboradores.Entities;
+
+// Issue #354: resultado de ColaboradorAggregateRoot.AnularTerminacion. Gemelo de
+// ResultadoTerminacionVinculacion/ResultadoReingresoColaborador/ResultadoCorreccionFechaInicioVinculacion
+// (#349/#350/#352) -- mismo mecanismo "declinar con resultado" (CA-ADR-0030): el aggregate nunca
+// lanza y nunca emite un evento de fallo persistido -- responde el resultado de la operacion
+// (exito o razon del rechazo) y el handler traduce la razon a InvalidOperationException con
+// mensaje .resx en el borde (MEF-ADR-0004 capa 2).
+// Unica razon de rechazo (unica regla del comando, issue #354 -- el mas simple de la cadena): la
+// ULTIMA vinculacion no tiene terminacion registrada. Cubre tres casos que el handler no necesita
+// distinguir entre si (recien registrada, reingresada, o ya anulada antes -- CA-3/CA-4): tras un
+// reingreso la terminacion de la vinculacion ANTERIOR queda congelada (decision aprobada
+// explicitamente), porque solo la ULTIMA vinculacion cuenta para esta regla.
+// internal: mismo criterio de visibilidad que los resultados hermanos -- vive en el mismo
+// ensamblado que el handler que lo consume (Entities/ y CommandHandler/ en el mismo proyecto
+// Function App), publicos son solo Apply(...) y ComputarStreamId.
+internal enum ResultadoAnulacionTerminacion
+{
+    Exitosa,
+    VinculacionAbierta
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/AnularTerminacionFunction/AnularTerminacionSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/AnularTerminacionFunction/AnularTerminacionSmokeTests.cs
@@ -52,11 +52,6 @@ public class AnularTerminacionSmokeTests(ApiFixture api, PostgresFixture postgre
     private const string TipoIdentificacionCc = "CC";
     private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
 
-    // CA-3: la ausencia de evento es sincrona (sin proyeccion downstream) -- un timeout corto
-    // alcanza para probar que un rechazo no dejo escritura, sin alargar la suite esperando los 30s
-    // estandar sin ganar senal (mismo precedente que CorregirNombresSmokeTests.TimeoutAusencia).
-    private static readonly TimeSpan TimeoutAusencia = TimeSpan.FromSeconds(3);
-
     // Numero unico por test -- evita colisiones entre ejecuciones repetidas del smoke test: la
     // identidad del stream es Identificacion.ToString() ("CC:<numero>"), no un Guid nuevo por
     // llamada, asi que reusar un numero fijo haria que el arrange (RegistrarColaborador) choque con
@@ -299,10 +294,16 @@ public class AnularTerminacionSmokeTests(ApiFixture api, PostgresFixture postgre
         var streamId = ComputarStreamId(numeroIdentificacion);
 
         var existe = await postgres.ExisteEventoAsync(
-            SchemaColaboradores, streamId, TipoEventoTerminacionAnulada, TimeoutAusencia);
+            SchemaColaboradores, streamId, TipoEventoTerminacionAnulada, Timeout);
 
         existe.Should().BeTrue(
-            $"deberia existir exactamente el terminacion_anulada de la primera anulacion en el stream {streamId}");
+            $"el terminacion_anulada de la primera anulacion deberia estar en el stream {streamId}");
+
+        var anulaciones = await postgres.ContarEventosAsync(
+            SchemaColaboradores, streamId, TipoEventoTerminacionAnulada);
+
+        anulaciones.Should().Be(1,
+            "la segunda anulacion se rechazo con 409: no debe haber escrito un segundo terminacion_anulada");
     }
 
     // CA-4 (decision #3 del issue, aprobada explicitamente): tras un reingreso, la terminacion de la

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/AnularTerminacionFunction/AnularTerminacionSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/AnularTerminacionFunction/AnularTerminacionSmokeTests.cs
@@ -1,0 +1,372 @@
+// Issue #354: smoke tests del endpoint POST Colaboradores/Terminaciones/Anulaciones (anular la
+// terminacion registrada de la ULTIMA vinculacion de un colaborador). Sexto comando del ciclo de
+// vida de ColaboradorAggregateRoot (desglose #348-#357) y el mas simple de la cadena: una sola
+// regla, cero fechas en el payload. Molde: TerminarVinculacionSmokeTests/ReingresarColaboradorSmokeTests
+// (#349/#350) -- mismo comando event-sourcing puro sin consumidores downstream (CA-ADR-0030): sin
+// ServiceBusFixture, la unica verificacion black-box de los efectos del handler es leer mt_events
+// via PostgresFixture.
+//
+// Arrange: AnularTerminacion exige un ColaboradorAggregateRoot existente -- el arrange de cada test
+// registra el colaborador y, cuando aplica, termina su vinculacion o lo reingresa via los mismos
+// comandos que los originan (#330, #349, #350), nunca sembrando datos por fuera del API.
+//
+// Evento sin payload (TerminacionAnulada, tipo persistido "terminacion_anulada"): no hay campo de
+// contenido que comparar por valor -- cada smoke test usa una identificacion nueva, asi que su
+// stream contiene un solo evento de ese tipo y basta con ExisteEventoAsync sin filtro de contenido
+// (mismo precedente que CorregirNombresSmokeTests.ElStreamRecibioElNombreAsync).
+//
+// CA-1 (ruta de exito): 202 + el stream recibe terminacion_anulada. Que la vinculacion reabra con su
+// codigo y fecha de inicio ORIGINALES intactos se verifica black-box via composicion (CA-2): sin un
+// endpoint de consulta, la unica ventana observable a "quedo abierta otra vez" es que
+// TerminarVinculacion (que exige una vinculacion abierta) vuelva a tener exito.
+// CA-2: composicion de la correccion -- anular la terminacion errada y volver a terminar con la
+// fecha correcta -> 202 + una SEGUNDA VinculacionTerminada persistida con la fecha corregida (las
+// reglas de #349 se re-aplican; el flujo completo "corregir fecha de terminacion" funciona en dos
+// comandos).
+// CA-3 (rutas de rechazo, "vinculacion abierta"): nunca fue terminada, o ya fue anulada antes (dos
+// anulaciones seguidas -- no hay idempotencia silenciosa porque no hay valor que comparar, decision
+// #4 del issue) -> 409, sin evento nuevo en el stream.
+// CA-4: tras un reingreso, la terminacion de la vinculacion ANTERIOR queda CONGELADA -- la ULTIMA
+// vinculacion (la del reingreso) es la que cuenta y esta abierta -> 409.
+// CA-5: colaborador inexistente -> 404.
+// CA-6: request invalida -> 400, sin tocar el event store.
+using System.Globalization;
+using System.Net;
+using System.Net.Http.Json;
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.SmokeTests.Fixtures;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.SmokeTests.AnularTerminacionFunction;
+
+public class AnularTerminacionSmokeTests(ApiFixture api, PostgresFixture postgres)
+{
+    private readonly HttpClient _client = api.Client;
+
+    private const string RutaRegistrar = "/api/Colaboradores";
+    private const string RutaTerminaciones = "/api/Colaboradores/Terminaciones";
+    private const string RutaReingresos = "/api/Colaboradores/Reingresos";
+    private const string RutaAnulaciones = "/api/Colaboradores/Terminaciones/Anulaciones";
+    private const string SchemaColaboradores = "colaboradores";
+    private const string TipoEventoTerminacionAnulada = "terminacion_anulada";
+    private const string TipoEventoVinculacionTerminada = "vinculacion_terminada";
+    private const string TipoIdentificacionCc = "CC";
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
+
+    // CA-3: la ausencia de evento es sincrona (sin proyeccion downstream) -- un timeout corto
+    // alcanza para probar que un rechazo no dejo escritura, sin alargar la suite esperando los 30s
+    // estandar sin ganar senal (mismo precedente que CorregirNombresSmokeTests.TimeoutAusencia).
+    private static readonly TimeSpan TimeoutAusencia = TimeSpan.FromSeconds(3);
+
+    // Numero unico por test -- evita colisiones entre ejecuciones repetidas del smoke test: la
+    // identidad del stream es Identificacion.ToString() ("CC:<numero>"), no un Guid nuevo por
+    // llamada, asi que reusar un numero fijo haria que el arrange (RegistrarColaborador) choque con
+    // 409 en la segunda corrida.
+    private static string NuevoNumeroIdentificacion() => Guid.CreateVersion7().ToString("N").ToUpperInvariant();
+
+    private static string NuevoCodigoColaborador() => $"[TEST]-{Guid.CreateVersion7()}";
+
+    private static string ComputarStreamId(string numeroIdentificacion) =>
+        $"{TipoIdentificacionCc}:{numeroIdentificacion}";
+
+    private static string FormatearFecha(DateOnly fecha) =>
+        fecha.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+
+    private static object PayloadRegistro(string numeroIdentificacion, DateOnly fechaInicio) => new
+    {
+        tipoIdentificacion = TipoIdentificacionCc,
+        numeroIdentificacion,
+        primerNombre = "[TEST]",
+        segundoNombre = (string?)null,
+        primerApellido = "Smoke",
+        segundoApellido = (string?)null,
+        codigoColaborador = NuevoCodigoColaborador(),
+        fechaInicio
+    };
+
+    private static object PayloadTerminacion(string numeroIdentificacion, DateOnly fechaEfectiva) => new
+    {
+        tipoIdentificacion = TipoIdentificacionCc,
+        numeroIdentificacion,
+        fechaEfectiva
+    };
+
+    private static object PayloadReingreso(
+        string numeroIdentificacion, string codigoColaborador, DateOnly fechaInicio) => new
+        {
+            tipoIdentificacion = TipoIdentificacionCc,
+            numeroIdentificacion,
+            codigoColaborador,
+            fechaInicio
+        };
+
+    private static object PayloadAnulacion(
+        string numeroIdentificacion, string tipoIdentificacion = TipoIdentificacionCc) => new
+        {
+            tipoIdentificacion,
+            numeroIdentificacion
+        };
+
+    // Arrange comun: registra un colaborador con una vinculacion abierta -- via el comando que la
+    // origina (#330), nunca sembrando el event store por fuera del API.
+    private async Task RegistrarColaboradorAsync(
+        string numeroIdentificacion, DateOnly fechaInicio, CancellationToken ct)
+    {
+        var response = await _client.PostAsJsonAsync(
+            RutaRegistrar, PayloadRegistro(numeroIdentificacion, fechaInicio), ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted,
+            "el arrange de este smoke test depende de que RegistrarColaborador funcione");
+    }
+
+    // Arrange comun: cierra la vinculacion vigente -- via el comando que la origina (#349), nunca
+    // sembrando el event store por fuera del API.
+    private async Task TerminarVinculacionAsync(
+        string numeroIdentificacion, DateOnly fechaEfectiva, CancellationToken ct)
+    {
+        var response = await _client.PostAsJsonAsync(
+            RutaTerminaciones, PayloadTerminacion(numeroIdentificacion, fechaEfectiva), ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted,
+            "el arrange de este smoke test depende de que TerminarVinculacion funcione");
+    }
+
+    // Arrange comun (CA-4): reingresa al colaborador tras una terminacion -- via el comando que lo
+    // origina (#350), nunca sembrando el event store por fuera del API.
+    private async Task ReingresarColaboradorAsync(
+        string numeroIdentificacion, DateOnly fechaInicio, CancellationToken ct)
+    {
+        var response = await _client.PostAsJsonAsync(
+            RutaReingresos,
+            PayloadReingreso(numeroIdentificacion, NuevoCodigoColaborador(), fechaInicio),
+            ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted,
+            "el arrange de este smoke test depende de que ReingresarColaborador funcione");
+    }
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task DebeEstarDisponible_CuandoSeConsultaHealthCheck()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var response = await _client.GetAsync("/api/health", ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    // CA-1: camino feliz -- la ultima vinculacion tiene terminacion registrada + POST valido -> 202
+    // y el stream recibe terminacion_anulada. Sin Service Bus (event-sourcing puro): mt_events es
+    // la unica ventana black-box a lo que quedo grabado. El evento no tiene payload -- no hay
+    // contenido que comparar por valor, solo su existencia en el stream.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task AnularTerminacion_Retorna202YPersisteTerminacionAnulada_CuandoUltimaVinculacionTieneTerminacionRegistrada()
+    {
+        Assert.SkipWhen(!postgres.IsConfigured, postgres.SkipReason ?? "Postgres no disponible.");
+
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion();
+
+        await RegistrarColaboradorAsync(numeroIdentificacion, new DateOnly(2026, 1, 15), ct);
+        await TerminarVinculacionAsync(numeroIdentificacion, new DateOnly(2026, 6, 1), ct);
+
+        var response = await _client.PostAsJsonAsync(
+            RutaAnulaciones, PayloadAnulacion(numeroIdentificacion), ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+
+        var streamId = ComputarStreamId(numeroIdentificacion);
+
+        var existe = await postgres.ExisteEventoAsync(
+            SchemaColaboradores, streamId, TipoEventoTerminacionAnulada, Timeout);
+
+        existe.Should().BeTrue(
+            $"el evento {TipoEventoTerminacionAnulada} deberia existir en el stream {streamId}");
+    }
+
+    // CA-1: la anulacion tambien procede sobre un preaviso cuya fecha aun no llego -- sin reloj, el
+    // dato estaba mal y el sistema registra cuando se entero, sin importar si la fecha del preaviso
+    // ya paso o no.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task AnularTerminacion_Retorna202YPersisteTerminacionAnulada_CuandoTerminacionEsUnPreavisoFuturo()
+    {
+        Assert.SkipWhen(!postgres.IsConfigured, postgres.SkipReason ?? "Postgres no disponible.");
+
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion();
+        // Preaviso muy en el futuro -- el punto de esta CA es que la anulacion no consulta el reloj
+        // del servidor en ninguna direccion.
+        var fechaEfectivaPreaviso = new DateOnly(2030, 12, 31);
+
+        await RegistrarColaboradorAsync(numeroIdentificacion, new DateOnly(2026, 1, 1), ct);
+        await TerminarVinculacionAsync(numeroIdentificacion, fechaEfectivaPreaviso, ct);
+
+        var response = await _client.PostAsJsonAsync(
+            RutaAnulaciones, PayloadAnulacion(numeroIdentificacion), ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+
+        var existe = await postgres.ExisteEventoAsync(
+            SchemaColaboradores, ComputarStreamId(numeroIdentificacion), TipoEventoTerminacionAnulada, Timeout);
+
+        existe.Should().BeTrue(
+            "un preaviso cuya fecha no ha llegado deberia poder anularse igual que una terminacion pasada");
+    }
+
+    // CA-2: composicion de la correccion de una fecha de terminacion errada -- anular la terminacion
+    // errada y volver a terminar con la fecha correcta -> 202 y una SEGUNDA VinculacionTerminada
+    // persistida con la fecha corregida. La reapertura de la vinculacion (que TerminarVinculacion
+    // exige) es la unica ventana black-box observable a que la anulacion tuvo el efecto esperado --
+    // sin un endpoint de consulta, no hay otra forma de verificarlo desde afuera.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task AnularTerminacion_ComponeConTerminarVinculacion_ParaCorregirLaFechaDeTerminacion()
+    {
+        Assert.SkipWhen(!postgres.IsConfigured, postgres.SkipReason ?? "Postgres no disponible.");
+
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion();
+        var fechaEfectivaErrada = new DateOnly(2026, 6, 1);
+        var fechaEfectivaCorregida = new DateOnly(2026, 6, 5);
+
+        await RegistrarColaboradorAsync(numeroIdentificacion, new DateOnly(2026, 1, 15), ct);
+        await TerminarVinculacionAsync(numeroIdentificacion, fechaEfectivaErrada, ct);
+
+        var anulacion = await _client.PostAsJsonAsync(
+            RutaAnulaciones, PayloadAnulacion(numeroIdentificacion), ct);
+        anulacion.StatusCode.Should().Be(HttpStatusCode.Accepted,
+            "el arrange de este smoke test depende de que AnularTerminacion funcione");
+
+        var response = await _client.PostAsJsonAsync(
+            RutaTerminaciones, PayloadTerminacion(numeroIdentificacion, fechaEfectivaCorregida), ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted,
+            "tras anular, la vinculacion deberia quedar abierta y aceptar una nueva terminacion");
+
+        var streamId = ComputarStreamId(numeroIdentificacion);
+
+        var existe = await postgres.ExisteEventoAsync(
+            SchemaColaboradores, streamId, TipoEventoVinculacionTerminada, Timeout,
+            campoJson: "FechaEfectiva", valorJson: FormatearFecha(fechaEfectivaCorregida));
+
+        existe.Should().BeTrue(
+            $"el stream {streamId} deberia recibir una segunda vinculacion_terminada con la FechaEfectiva corregida ({FormatearFecha(fechaEfectivaCorregida)})");
+    }
+
+    // CA-3: la vinculacion vigente nunca fue terminada -> 409. No requiere Postgres: el status code
+    // ya prueba que el aggregate declino con resultado y el handler lo tradujo (CA-ADR-0030).
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task AnularTerminacion_Retorna409_CuandoVinculacionNuncaFueTerminada()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion();
+
+        await RegistrarColaboradorAsync(numeroIdentificacion, new DateOnly(2026, 2, 1), ct);
+
+        var response = await _client.PostAsJsonAsync(
+            RutaAnulaciones, PayloadAnulacion(numeroIdentificacion), ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    // CA-3 (decision #4 del issue): anular dos veces -- la segunda anulacion encuentra la
+    // vinculacion ya abierta (no hay idempotencia silenciosa porque no hay valor que comparar) ->
+    // 409, sin escribir un segundo terminacion_anulada.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task AnularTerminacion_Retorna409_CuandoLaTerminacionYaFueAnuladaAntes()
+    {
+        Assert.SkipWhen(!postgres.IsConfigured, postgres.SkipReason ?? "Postgres no disponible.");
+
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion();
+
+        await RegistrarColaboradorAsync(numeroIdentificacion, new DateOnly(2026, 3, 1), ct);
+        await TerminarVinculacionAsync(numeroIdentificacion, new DateOnly(2026, 7, 1), ct);
+
+        var primeraAnulacion = await _client.PostAsJsonAsync(
+            RutaAnulaciones, PayloadAnulacion(numeroIdentificacion), ct);
+        primeraAnulacion.StatusCode.Should().Be(HttpStatusCode.Accepted,
+            "el arrange de este smoke test depende de que la primera anulacion funcione");
+
+        var segundaAnulacion = await _client.PostAsJsonAsync(
+            RutaAnulaciones, PayloadAnulacion(numeroIdentificacion), ct);
+
+        segundaAnulacion.StatusCode.Should().Be(HttpStatusCode.Conflict);
+
+        var streamId = ComputarStreamId(numeroIdentificacion);
+
+        var existe = await postgres.ExisteEventoAsync(
+            SchemaColaboradores, streamId, TipoEventoTerminacionAnulada, TimeoutAusencia);
+
+        existe.Should().BeTrue(
+            $"deberia existir exactamente el terminacion_anulada de la primera anulacion en el stream {streamId}");
+    }
+
+    // CA-4 (decision #3 del issue, aprobada explicitamente): tras un reingreso, la terminacion de la
+    // vinculacion ANTERIOR queda CONGELADA -- la ULTIMA vinculacion (la del reingreso) es la que
+    // cuenta y esta abierta -> 409. Anularla reabriria una vinculacion teniendo otra abierta, lo que
+    // la invariante de no-solape prohibe.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task AnularTerminacion_Retorna409_CuandoLaUltimaVinculacionNacioDeUnReingresoSinTerminar()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion();
+        var fechaEfectivaTerminacionAnterior = new DateOnly(2026, 3, 1);
+        var fechaInicioReingreso = new DateOnly(2026, 4, 1);
+
+        await RegistrarColaboradorAsync(numeroIdentificacion, new DateOnly(2026, 1, 1), ct);
+        await TerminarVinculacionAsync(numeroIdentificacion, fechaEfectivaTerminacionAnterior, ct);
+        await ReingresarColaboradorAsync(numeroIdentificacion, fechaInicioReingreso, ct);
+
+        var response = await _client.PostAsJsonAsync(
+            RutaAnulaciones, PayloadAnulacion(numeroIdentificacion), ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    // CA-5: colaborador inexistente -> 404, sin escribir nada al event store (no hay stream para
+    // consultar: la ausencia de escritura la garantiza el propio 404 -- el handler lanza antes de
+    // llegar al aggregate).
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task AnularTerminacion_Retorna404_CuandoColaboradorNoExiste()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion(); // nunca registrado
+
+        var response = await _client.PostAsJsonAsync(
+            RutaAnulaciones, PayloadAnulacion(numeroIdentificacion), ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    // CA-6: NumeroIdentificacion vacio -> 400.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task AnularTerminacion_Retorna400_CuandoNumeroIdentificacionEsVacio()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var payload = PayloadAnulacion(numeroIdentificacion: "");
+
+        var response = await _client.PostAsJsonAsync(RutaAnulaciones, payload, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    // CA-6: TipoIdentificacion fuera de la lista cerrada (PILA: CC, CE, TI, PA, PT) -> 400.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task AnularTerminacion_Retorna400_CuandoTipoIdentificacionNoEsReconocido()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var payload = PayloadAnulacion(NuevoNumeroIdentificacion(), tipoIdentificacion: "XX");
+
+        var response = await _client.PostAsJsonAsync(RutaAnulaciones, payload, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/Fixtures/PostgresFixture.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/Fixtures/PostgresFixture.cs
@@ -64,6 +64,19 @@ public class PostgresFixture : IAsyncLifetime
     }
 
     /// <summary>
+    /// Cuenta los eventos del tipo indicado ya presentes en el stream, sin esperar.
+    /// </summary>
+    /// <remarks>
+    /// Issue #354: <see cref="ExisteEventoAsync"/> solo responde "hay al menos uno", asi que no
+    /// distingue "quedo el evento de la primera request" de "la segunda request escribio otro".
+    /// Un test que afirme que un rechazo NO agrego un evento necesita el conteo exacto. Sin
+    /// polling a proposito: se usa despues de una respuesta sincrona de rechazo (409), cuando el
+    /// escenario ya espero con <see cref="ExisteEventoAsync"/> a que apareciera el evento legitimo.
+    /// </remarks>
+    public async Task<int> ContarEventosAsync(string schema, string streamId, string tipoEvento) =>
+        (await ObtenerEventosInternoAsync(schema, streamId, tipoEvento)).Count;
+
+    /// <summary>
     /// Obtiene el primer evento del tipo indicado en el stream, sin filtrar por contenido.
     /// </summary>
     /// <remarks>

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/AnularTerminacionFunction/AnularTerminacionCommandHandlerMensajesTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/AnularTerminacionFunction/AnularTerminacionCommandHandlerMensajesTests.cs
@@ -1,0 +1,23 @@
+// Issue #354: guardrail de resolucion del .resx del handler (MEF-ADR-0009), gemelo del que
+// TerminarVinculacionCommandHandlerMensajesTests.cs aplica.
+//
+// Por que existe: AnularTerminacionCommandHandler.Mensajes devuelve ResourceManager.GetString(...)!
+// -- el "!" es supresion del compilador, no garantia de runtime. Si la CLAVE desaparece del .resx
+// (rename, merge que la pierde) GetString retorna null en silencio y los tests del handler pasan
+// en FALSO: sus aserciones son WithMessage($"*{Mensajes.X}*"), que con X == null se vuelve "**" y
+// matchea cualquier excepcion.
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.AnularTerminacionFunction.CommandHandler;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Tests.AnularTerminacionFunction;
+
+public class AnularTerminacionCommandHandlerMensajesTests
+{
+    [Fact]
+    public void Mensajes_ResuelvenTextoNoVacio_CuandoPertenecenAAnularTerminacionCommandHandler()
+    {
+        AnularTerminacionCommandHandler.Mensajes.ColaboradorNoEncontrado.Should().NotBeNullOrWhiteSpace();
+        AnularTerminacionCommandHandler.Mensajes.VinculacionAbierta.Should().NotBeNullOrWhiteSpace();
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/AnularTerminacionFunction/AnularTerminacionCommandHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/AnularTerminacionFunction/AnularTerminacionCommandHandlerTests.cs
@@ -29,6 +29,7 @@ public class AnularTerminacionCommandHandlerTests : CommandHandlerAsyncTest<Anul
     private const string StreamIdEsperado = "CC:79543210";
 
     private const string CodigoVinculacionVigente = "COL-001";
+    private const string CodigoVinculacionReingreso = "COL-002";
     private static readonly DateOnly FechaInicioVinculacionVigente = new(2026, 1, 15);
     private static readonly DateOnly FechaEfectivaTerminacion = new(2026, 6, 1);
 
@@ -134,6 +135,59 @@ public class AnularTerminacionCommandHandlerTests : CommandHandlerAsyncTest<Anul
             StreamIdEsperado, c => c.FechaTerminacionVinculacionVigente, null);
     }
 
+    // CA-1 + CA-4 (cara de exito de la misma regla): la ULTIMA vinculacion nacio de un reingreso y
+    // SI tiene terminacion registrada -> se anula esa, no la anterior. Unico estado del stream
+    // donde conviven las dos terminaciones (la congelada de la vinculacion anterior, #350/#352, y
+    // la de la vigente), asi que es el que demuestra que Apply(TerminacionAnulada) reabre solo la
+    // ULTIMA y deja intacto su codigo y su fecha de inicio (los del reingreso, no los originales).
+    [Fact]
+    public async Task AnularTerminacion_EmiteTerminacionAnulada_CuandoLaUltimaVinculacionNacioDeUnReingresoYaTerminado()
+    {
+        var fechaTerminacionAnterior = new DateOnly(2026, 3, 1);
+        var fechaInicioReingreso = new DateOnly(2026, 4, 1);
+        var fechaTerminacionReingreso = new DateOnly(2026, 9, 30);
+        Given(StreamIdEsperado,
+            ColaboradorRegistradoValido(),
+            VinculacionIniciadaVigente(),
+            new VinculacionTerminada(fechaTerminacionAnterior),
+            new VinculacionIniciada(CodigoVinculacionReingreso, fechaInicioReingreso),
+            new VinculacionTerminada(fechaTerminacionReingreso));
+
+        await WhenAsync(ComandoValido());
+
+        Then(StreamIdEsperado, new TerminacionAnulada());
+        And<ColaboradorAggregateRoot, DateOnly?>(
+            StreamIdEsperado, c => c.FechaTerminacionVinculacionVigente, null);
+        And<ColaboradorAggregateRoot, string>(
+            StreamIdEsperado, c => c.CodigoVinculacionVigente, CodigoVinculacionReingreso);
+        And<ColaboradorAggregateRoot, DateOnly>(
+            StreamIdEsperado, c => c.FechaInicioVinculacionVigente, fechaInicioReingreso);
+    }
+
+    // MEF-ADR-0004 capa 4 (ADR aplicable declarado en el issue): rehidratar un stream con orden
+    // anomalo -- una TerminacionAnulada sin VinculacionTerminada previa -- no lanza. Si Apply
+    // lanzara, el aggregate quedaria permanentemente roto y ningun evento posterior podria
+    // repararlo; aqui simplemente vuelve a dejar la vinculacion abierta, y el comando se rechaza
+    // por la unica regla, como cualquier otra vinculacion abierta.
+    [Fact]
+    public async Task AnularTerminacion_LanzaInvalidOperationException_CuandoElStreamTraeUnaAnulacionSinTerminacionPrevia()
+    {
+        Given(StreamIdEsperado,
+            ColaboradorRegistradoValido(),
+            VinculacionIniciadaVigente(),
+            new TerminacionAnulada());
+
+        var act = async () => await WhenAsync(ComandoValido());
+
+        await act.Should().ThrowExactlyAsync<InvalidOperationException>()
+            .WithMessage($"*{AnularTerminacionCommandHandler.Mensajes.VinculacionAbierta}*");
+        Then(StreamIdEsperado);
+        And<ColaboradorAggregateRoot, string>(
+            StreamIdEsperado, c => c.CodigoVinculacionVigente, CodigoVinculacionVigente);
+        And<ColaboradorAggregateRoot, DateOnly>(
+            StreamIdEsperado, c => c.FechaInicioVinculacionVigente, FechaInicioVinculacionVigente);
+    }
+
     // CA-3: la ultima vinculacion nunca ha sido terminada (recien registrada) -> 409, ningun evento
     // nuevo en el stream, el estado conserva la vinculacion abierta.
     [Fact]
@@ -180,7 +234,7 @@ public class AnularTerminacionCommandHandlerTests : CommandHandlerAsyncTest<Anul
             ColaboradorRegistradoValido(),
             VinculacionIniciadaVigente(),
             new VinculacionTerminada(fechaTerminacionAnterior),
-            new VinculacionIniciada("COL-002", fechaInicioReingreso));
+            new VinculacionIniciada(CodigoVinculacionReingreso, fechaInicioReingreso));
 
         var act = async () => await WhenAsync(ComandoValido());
 
@@ -190,7 +244,7 @@ public class AnularTerminacionCommandHandlerTests : CommandHandlerAsyncTest<Anul
         And<ColaboradorAggregateRoot, DateOnly?>(
             StreamIdEsperado, c => c.FechaTerminacionVinculacionVigente, null);
         And<ColaboradorAggregateRoot, string>(
-            StreamIdEsperado, c => c.CodigoVinculacionVigente, "COL-002");
+            StreamIdEsperado, c => c.CodigoVinculacionVigente, CodigoVinculacionReingreso);
     }
 
     // CA-5: colaborador inexistente -> 404 (KeyNotFoundException), sin escribir nada al event

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/AnularTerminacionFunction/AnularTerminacionCommandHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/AnularTerminacionFunction/AnularTerminacionCommandHandlerTests.cs
@@ -1,0 +1,209 @@
+// Issue #354: anular la terminacion de una vinculacion -- sexto comando del ciclo de vida de
+// ColaboradorAggregateRoot (desglose #348-#357) y el mas simple de la cadena: una sola regla, cero
+// fechas en el payload. CA-ADR-0030: el aggregate declina con resultado (nunca lanza, nunca emite
+// evento de fallo); el handler traduce la razon a InvalidOperationException (409) o
+// KeyNotFoundException (404). Resuelve el arrepentimiento del preaviso (Maria anuncio su salida al
+// 30 y el 27 decide quedarse) y compone con TerminarVinculacion (#349) la correccion de una fecha
+// de terminacion errada -- ver ComposicionAnularYTerminarVinculacionTests para el segundo tramo de
+// esa composicion (CA-2).
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.AnularTerminacionFunction;
+using Bitakora.ControlAsistencia.Colaboradores.AnularTerminacionFunction.CommandHandler;
+using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+using Bitakora.ControlAsistencia.Colaboradores.Entities;
+using Cosmos.EventSourcing.Abstractions.Commands;
+using Cosmos.EventSourcing.Testing.Utilities;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Tests.AnularTerminacionFunction;
+
+// El aggregate usa un stream ID compuesto (Identificacion.ToString(), "CC:79543210"), no el
+// GuidAggregateId del harness -- overloads explicitos de Given/Then/And (regla 18 del
+// test-writer, mismo criterio que el resto de la cadena #349-#352).
+public class AnularTerminacionCommandHandlerTests : CommandHandlerAsyncTest<AnularTerminacion>
+{
+    private const string NumeroValido = "79543210";
+
+    // Oraculo independiente de la clave de stream (MEF-ADR-0002 + MEF-ADR-0037): literal, no
+    // derivado de ColaboradorAggregateRoot.ComputarStreamId.
+    private const string StreamIdEsperado = "CC:79543210";
+
+    private const string CodigoVinculacionVigente = "COL-001";
+    private static readonly DateOnly FechaInicioVinculacionVigente = new(2026, 1, 15);
+    private static readonly DateOnly FechaEfectivaTerminacion = new(2026, 6, 1);
+
+    protected override ICommandHandlerAsync<AnularTerminacion> Handler =>
+        new AnularTerminacionCommandHandler(EventStore);
+
+    private static AnularTerminacion ComandoValido() => new(
+        TipoIdentificacion: "CC",
+        NumeroIdentificacion: NumeroValido);
+
+    private static Identificacion IdentificacionValida() =>
+        Identificacion.Crear(TipoIdentificacion.CC, NumeroValido);
+
+    private static NombreColaborador NombreValido() =>
+        NombreColaborador.Crear("Luis", "Augusto", "Barreto", null);
+
+    private static ColaboradorRegistrado ColaboradorRegistradoValido() =>
+        new(IdentificacionValida(), NombreValido());
+
+    private static VinculacionIniciada VinculacionIniciadaVigente() =>
+        new(CodigoVinculacionVigente, FechaInicioVinculacionVigente);
+
+    // Precondicion: colaborador registrado con una vinculacion abierta (sin terminacion) -- base
+    // de CA-3.
+    private void DadoUnColaboradorConVinculacionAbierta() =>
+        Given(StreamIdEsperado, ColaboradorRegistradoValido(), VinculacionIniciadaVigente());
+
+    // Precondicion: colaborador con la vinculacion vigente ya terminada en la fecha dada -- base de
+    // CA-1 (incluye el caso de un preaviso con fecha futura, que bloquea igual sin distincion de
+    // estado).
+    private void DadoUnColaboradorConTerminacionRegistrada(DateOnly fechaEfectiva) =>
+        Given(StreamIdEsperado,
+            ColaboradorRegistradoValido(),
+            VinculacionIniciadaVigente(),
+            new VinculacionTerminada(fechaEfectiva));
+
+    // Precondicion (CA-3, decision #4 del issue): la terminacion ya fue anulada antes -- una
+    // segunda anulacion encuentra la vinculacion abierta, sin distincion respecto de "nunca
+    // terminada".
+    private void DadoUnColaboradorConTerminacionYaAnulada(DateOnly fechaEfectivaOriginal) =>
+        Given(StreamIdEsperado,
+            ColaboradorRegistradoValido(),
+            VinculacionIniciadaVigente(),
+            new VinculacionTerminada(fechaEfectivaOriginal),
+            new TerminacionAnulada());
+
+    // CA-1: la ultima vinculacion tiene terminacion registrada + POST valido -> el stream recibe
+    // TerminacionAnulada; el aggregate rehidratado refleja la vinculacion abierta con su codigo y
+    // fecha de inicio ORIGINALES intactos. (El registro en
+    // IdentidadEventosColaboradores.TiposPersistidos lo cubren AliasEventosColaboradoresTests/
+    // ComposicionServiciosTests, no este handler.)
+    [Fact]
+    public async Task AnularTerminacion_EmiteTerminacionAnulada_CuandoLaUltimaVinculacionTieneTerminacionRegistrada()
+    {
+        DadoUnColaboradorConTerminacionRegistrada(FechaEfectivaTerminacion);
+
+        await WhenAsync(ComandoValido());
+
+        Then(StreamIdEsperado, new TerminacionAnulada());
+        And<ColaboradorAggregateRoot, DateOnly?>(
+            StreamIdEsperado, c => c.FechaTerminacionVinculacionVigente, null);
+        And<ColaboradorAggregateRoot, string>(
+            StreamIdEsperado, c => c.CodigoVinculacionVigente, CodigoVinculacionVigente);
+        And<ColaboradorAggregateRoot, DateOnly>(
+            StreamIdEsperado, c => c.FechaInicioVinculacionVigente, FechaInicioVinculacionVigente);
+    }
+
+    // CA-1 (el arrepentimiento del preaviso, decision #2 del issue): un preaviso con fecha futura
+    // ya registrado se anula igual que uno vencido -- "tiene terminacion registrada" se evalua sin
+    // reloj, sin importar si la fecha efectiva ya paso.
+    [Fact]
+    public async Task AnularTerminacion_EmiteTerminacionAnulada_CuandoLaTerminacionEsUnPreavisoConFechaFutura()
+    {
+        var fechaPreavisoFutura = new DateOnly(2030, 1, 1);
+        DadoUnColaboradorConTerminacionRegistrada(fechaPreavisoFutura);
+
+        await WhenAsync(ComandoValido());
+
+        Then(StreamIdEsperado, new TerminacionAnulada());
+        And<ColaboradorAggregateRoot, DateOnly?>(
+            StreamIdEsperado, c => c.FechaTerminacionVinculacionVigente, null);
+    }
+
+    // CA-1 (borde de identidad, MEF-ADR-0037): "cc" en minusculas + numero con espacios sobre un
+    // colaborador ya registrado -> la anulacion alcanza el MISMO stream ("CC:79543210") y tiene
+    // exito. La normalizacion del numero la garantiza Identificacion.Crear (#348); la del codigo de
+    // tipo ("cc" -> "CC") es responsabilidad del handler en el borde, porque TipoIdentificacion.Desde
+    // es case-sensitive por diseno (#348).
+    [Fact]
+    public async Task AnularTerminacion_EmiteTerminacionAnulada_CuandoTipoYNumeroLleganSinNormalizar()
+    {
+        DadoUnColaboradorConTerminacionRegistrada(FechaEfectivaTerminacion);
+        var comandoSinNormalizar = ComandoValido() with
+        {
+            TipoIdentificacion = "cc",
+            NumeroIdentificacion = "  79543210  "
+        };
+
+        await WhenAsync(comandoSinNormalizar);
+
+        Then(StreamIdEsperado, new TerminacionAnulada());
+        And<ColaboradorAggregateRoot, DateOnly?>(
+            StreamIdEsperado, c => c.FechaTerminacionVinculacionVigente, null);
+    }
+
+    // CA-3: la ultima vinculacion nunca ha sido terminada (recien registrada) -> 409, ningun evento
+    // nuevo en el stream, el estado conserva la vinculacion abierta.
+    [Fact]
+    public async Task AnularTerminacion_LanzaInvalidOperationException_CuandoLaVinculacionNuncaHaSidoTerminada()
+    {
+        DadoUnColaboradorConVinculacionAbierta();
+
+        var act = async () => await WhenAsync(ComandoValido());
+
+        await act.Should().ThrowExactlyAsync<InvalidOperationException>()
+            .WithMessage($"*{AnularTerminacionCommandHandler.Mensajes.VinculacionAbierta}*");
+        Then(StreamIdEsperado);
+        And<ColaboradorAggregateRoot, DateOnly?>(
+            StreamIdEsperado, c => c.FechaTerminacionVinculacionVigente, null);
+    }
+
+    // CA-3 (decision #4 del issue, idempotencia por rechazo): anular dos veces -> la segunda
+    // encuentra la vinculacion abierta (por la primera anulacion) -> 409 igual, sin distincion
+    // respecto de "nunca terminada".
+    [Fact]
+    public async Task AnularTerminacion_LanzaInvalidOperationException_CuandoLaTerminacionYaFueAnuladaAntes()
+    {
+        DadoUnColaboradorConTerminacionYaAnulada(FechaEfectivaTerminacion);
+
+        var act = async () => await WhenAsync(ComandoValido());
+
+        await act.Should().ThrowExactlyAsync<InvalidOperationException>()
+            .WithMessage($"*{AnularTerminacionCommandHandler.Mensajes.VinculacionAbierta}*");
+        Then(StreamIdEsperado);
+        And<ColaboradorAggregateRoot, DateOnly?>(
+            StreamIdEsperado, c => c.FechaTerminacionVinculacionVigente, null);
+    }
+
+    // CA-4 (decision #3 del issue, aprobada explicitamente): tras un reingreso, la terminacion de
+    // la vinculacion ANTERIOR queda CONGELADA -- la ULTIMA vinculacion (la del reingreso) es la que
+    // cuenta, y esta abierta -> 409. Anularla reabriria una vinculacion teniendo otra abierta, lo
+    // que la invariante de no-solape prohibe.
+    [Fact]
+    public async Task AnularTerminacion_LanzaInvalidOperationException_CuandoLaUltimaVinculacionNacioDeUnReingresoSinTerminar()
+    {
+        var fechaTerminacionAnterior = new DateOnly(2026, 3, 1);
+        var fechaInicioReingreso = new DateOnly(2026, 4, 1);
+        Given(StreamIdEsperado,
+            ColaboradorRegistradoValido(),
+            VinculacionIniciadaVigente(),
+            new VinculacionTerminada(fechaTerminacionAnterior),
+            new VinculacionIniciada("COL-002", fechaInicioReingreso));
+
+        var act = async () => await WhenAsync(ComandoValido());
+
+        await act.Should().ThrowExactlyAsync<InvalidOperationException>()
+            .WithMessage($"*{AnularTerminacionCommandHandler.Mensajes.VinculacionAbierta}*");
+        Then(StreamIdEsperado);
+        And<ColaboradorAggregateRoot, DateOnly?>(
+            StreamIdEsperado, c => c.FechaTerminacionVinculacionVigente, null);
+        And<ColaboradorAggregateRoot, string>(
+            StreamIdEsperado, c => c.CodigoVinculacionVigente, "COL-002");
+    }
+
+    // CA-5: colaborador inexistente -> 404 (KeyNotFoundException), sin escribir nada al event
+    // store. Sin Given: el stream no existe. Then sin eventos esperados demuestra "sin escribir
+    // nada al event store" (mismo precedente que TerminarVinculacionCommandHandlerTests CA-5 /
+    // ReingresarColaboradorCommandHandlerTests CA-5).
+    [Fact]
+    public async Task AnularTerminacion_LanzaKeyNotFoundException_CuandoColaboradorNoExiste()
+    {
+        var act = async () => await WhenAsync(ComandoValido());
+
+        await act.Should().ThrowExactlyAsync<KeyNotFoundException>()
+            .WithMessage($"*{AnularTerminacionCommandHandler.Mensajes.ColaboradorNoEncontrado}*");
+        Then(StreamIdEsperado);
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/AnularTerminacionFunction/AnularTerminacionValidatorTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/AnularTerminacionFunction/AnularTerminacionValidatorTests.cs
@@ -1,0 +1,75 @@
+// Issue #354: validacion de forma del comando AnularTerminacion en el borde (CA-6).
+// Patron de referencia: TerminarVinculacionValidatorTests (ValidateAsync + verificacion de
+// PropertyName en resultado.Errors).
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.AnularTerminacionFunction;
+using Bitakora.ControlAsistencia.Colaboradores.AnularTerminacionFunction.CommandHandler;
+using FluentValidation.Results;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Tests.AnularTerminacionFunction;
+
+public class AnularTerminacionValidatorTests
+{
+    private readonly AnularTerminacionValidator _validator = new();
+
+    private static AnularTerminacion ComandoValido() => new(
+        TipoIdentificacion: "CC",
+        NumeroIdentificacion: "79543210");
+
+    private Task<ValidationResult> Validar(AnularTerminacion comando) =>
+        _validator.ValidateAsync(comando, TestContext.Current.CancellationToken);
+
+    // Camino feliz -- todos los campos correctos
+    [Fact]
+    public async Task Validar_Aprueba_CuandoTodosLosCamposSonCorrectos()
+    {
+        var resultado = await Validar(ComandoValido());
+
+        resultado.IsValid.Should().BeTrue();
+    }
+
+    // CA-6: TipoIdentificacion vacio produce 400
+    [Fact]
+    public async Task Validar_RechazaTipoIdentificacion_CuandoEstaVacio()
+    {
+        var resultado = await Validar(ComandoValido() with { TipoIdentificacion = "" });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e =>
+            e.PropertyName == nameof(AnularTerminacion.TipoIdentificacion));
+    }
+
+    // CA-6: TipoIdentificacion fuera de la lista cerrada (PILA: CC/CE/TI/PA/PT) produce 400, no 500
+    [Fact]
+    public async Task Validar_RechazaTipoIdentificacion_CuandoNoEstaEnLaListaCerrada()
+    {
+        var resultado = await Validar(ComandoValido() with { TipoIdentificacion = "XX" });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e =>
+            e.PropertyName == nameof(AnularTerminacion.TipoIdentificacion));
+    }
+
+    // TipoIdentificacion en minusculas ("cc") DEBE seguir siendo valido -- la normalizacion de
+    // entrada (trim+MAYUSCULAS antes de TipoIdentificacion.Desde) es responsabilidad del borde, no
+    // un rechazo (mismo criterio que los demas validators del dominio).
+    [Fact]
+    public async Task Validar_Aprueba_CuandoTipoIdentificacionLlegaEnMinusculas()
+    {
+        var resultado = await Validar(ComandoValido() with { TipoIdentificacion = "cc" });
+
+        resultado.IsValid.Should().BeTrue();
+    }
+
+    // CA-6: NumeroIdentificacion vacio produce 400
+    [Fact]
+    public async Task Validar_RechazaNumeroIdentificacion_CuandoEstaVacio()
+    {
+        var resultado = await Validar(ComandoValido() with { NumeroIdentificacion = "" });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e =>
+            e.PropertyName == nameof(AnularTerminacion.NumeroIdentificacion));
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/AnularTerminacionFunction/ComposicionAnularYTerminarVinculacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/AnularTerminacionFunction/ComposicionAnularYTerminarVinculacionTests.cs
@@ -24,7 +24,6 @@
 // del issue #354): es un archivo nuevo, en la carpeta del comando que introduce el escenario de
 // composicion, que prueba exactamente la claim de negocio de CA-2 sin tocar un archivo existente.
 
-using AwesomeAssertions;
 using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
 using Bitakora.ControlAsistencia.Colaboradores.Entities;
 using Bitakora.ControlAsistencia.Colaboradores.TerminarVinculacionFunction;

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/AnularTerminacionFunction/ComposicionAnularYTerminarVinculacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/AnularTerminacionFunction/ComposicionAnularYTerminarVinculacionTests.cs
@@ -1,0 +1,79 @@
+// Issue #354, CA-2: composicion de la correccion de una fecha de terminacion errada. El comando
+// "CorregirFechaTerminacionVinculacion" que el desglose original planeaba desaparecio (decision de
+// refinamiento 2026-08-11): corregir es anular + terminar de nuevo, dos intenciones que componen.
+//
+// Este archivo prueba el segundo tramo de esa composicion -- que TerminarVinculacion (#349) vuelve
+// a tener exito con la fecha correcta una vez que la terminacion errada quedo anulada -- SIN
+// invocar dos handlers en vivo sobre el mismo TestStore. Verificado contra la fuente del harness
+// (TestStore.cs, Cosmos.EventSourcing.Testing.Utilities): GetAggregateRootAsync -- la via que
+// CUALQUIER handler de produccion usa para rehidratar, incluido AnularTerminacionCommandHandler y
+// TerminarVinculacionCommandHandler -- lee UNICAMENTE _previousEvents, nunca _newEvents. Encadenar
+// WhenAsync(AnularTerminacion) seguido de un HandleAsync manual de TerminarVinculacionCommandHandler
+// sobre el mismo EventStore no haria visible al segundo handler el TerminacionAnulada que el
+// primero acaba de commitear (SaveChanges lo mueve a _newEvents, no a _previousEvents) -- el
+// segundo handler veria la vinculacion todavia terminada y el test fallaria con un falso 409 que no
+// refleja ningun defecto de AnularTerminacion ni de TerminarVinculacion.
+//
+// El patron idiomatico y tecnicamente correcto -- ya usado en TerminarVinculacionCommandHandlerTests
+// para probar la composicion con el reingreso de #350 (Given incluye la VinculacionIniciada que
+// ReingresarColaborador habria commiteado en una request anterior) -- es construir con Given() la
+// historia YA persistida, incluyendo aqui el TerminacionAnulada que AnularTerminacion habria
+// commiteado, e invocar con WhenAsync solo el comando bajo prueba (TerminarVinculacion).
+//
+// Este archivo NO modifica TerminarVinculacionCommandHandlerTests.cs (fuera de "Impacto/Modifica"
+// del issue #354): es un archivo nuevo, en la carpeta del comando que introduce el escenario de
+// composicion, que prueba exactamente la claim de negocio de CA-2 sin tocar un archivo existente.
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+using Bitakora.ControlAsistencia.Colaboradores.Entities;
+using Bitakora.ControlAsistencia.Colaboradores.TerminarVinculacionFunction;
+using Bitakora.ControlAsistencia.Colaboradores.TerminarVinculacionFunction.CommandHandler;
+using Cosmos.EventSourcing.Abstractions.Commands;
+using Cosmos.EventSourcing.Testing.Utilities;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Tests.AnularTerminacionFunction;
+
+// El aggregate usa un stream ID compuesto (Identificacion.ToString(), "CC:79543210"), no el
+// GuidAggregateId del harness -- overloads explicitos de Given/Then/And (regla 18 del
+// test-writer, mismo criterio que el resto de la cadena #349-#352).
+public class ComposicionAnularYTerminarVinculacionTests : CommandHandlerAsyncTest<TerminarVinculacion>
+{
+    private const string NumeroValido = "79543210";
+    private const string StreamIdEsperado = "CC:79543210";
+    private const string CodigoVinculacionVigente = "COL-001";
+    private static readonly DateOnly FechaInicioVinculacionVigente = new(2026, 1, 15);
+    private static readonly DateOnly FechaEfectivaErrada = new(2026, 6, 1);
+    private static readonly DateOnly FechaEfectivaCorregida = new(2026, 6, 5);
+
+    protected override ICommandHandlerAsync<TerminarVinculacion> Handler =>
+        new TerminarVinculacionCommandHandler(EventStore);
+
+    private static Identificacion IdentificacionValida() =>
+        Identificacion.Crear(TipoIdentificacion.CC, NumeroValido);
+
+    private static NombreColaborador NombreValido() =>
+        NombreColaborador.Crear("Luis", "Augusto", "Barreto", null);
+
+    // CA-2: la historia YA refleja el resultado de un AnularTerminacion previo (una request HTTP
+    // anterior, ya persistida) sobre la terminacion errada. TerminarVinculacion con la fecha
+    // correcta re-aplica sus propias reglas (#349) sin necesitar ninguna regla nueva -- la
+    // composicion completa "corregir la fecha de terminacion" funciona en dos comandos.
+    [Fact]
+    public async Task TerminarVinculacion_EmiteVinculacionTerminadaConLaFechaCorregida_CuandoLaTerminacionErradaFueAnuladaAntes()
+    {
+        Given(StreamIdEsperado,
+            new ColaboradorRegistrado(IdentificacionValida(), NombreValido()),
+            new VinculacionIniciada(CodigoVinculacionVigente, FechaInicioVinculacionVigente),
+            new VinculacionTerminada(FechaEfectivaErrada),
+            new TerminacionAnulada());
+
+        await WhenAsync(new TerminarVinculacion("CC", NumeroValido, FechaEfectivaCorregida));
+
+        Then(StreamIdEsperado, new VinculacionTerminada(FechaEfectivaCorregida));
+        And<ColaboradorAggregateRoot, DateOnly?>(
+            StreamIdEsperado, c => c.FechaTerminacionVinculacionVigente, FechaEfectivaCorregida);
+        And<ColaboradorAggregateRoot, string>(
+            StreamIdEsperado, c => c.CodigoVinculacionVigente, CodigoVinculacionVigente);
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/AnularTerminacionFunction/Eventos/TerminacionAnuladaSerializacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/AnularTerminacionFunction/Eventos/TerminacionAnuladaSerializacionTests.cs
@@ -1,0 +1,35 @@
+// Issue #354. Requerido por regla 16: todo evento persistido en Marten debe sobrevivir
+// Serialize -> Deserialize con las opciones REALES de Marten del dominio (regla 6d).
+
+using System.Text.Json;
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Tests.AnularTerminacionFunction.Eventos;
+
+/// <summary>
+/// Verifica que TerminacionAnulada (sin payload -- el hecho es el evento mismo) sobrevive un
+/// roundtrip de serializacion STJ con las opciones reales de Marten del dominio. El harness tolera
+/// records sin propiedades (CommandHandlerTestBase ignora "No members were found for comparison."
+/// en Then/And), pero el roundtrip de serializacion no pasa por ese camino: aqui se verifica
+/// directamente que Serialize -> Deserialize reconstruye una instancia no nula, sin necesitar
+/// ConfigurarSerializacion (no hay ningun campo que mapear).
+/// </summary>
+public class TerminacionAnuladaSerializacionTests
+{
+    private static JsonSerializerOptions CrearOpcionesMarten() =>
+        ConfiguracionSerializacionColaboradores.CrearOpcionesMarten();
+
+    // CA-1: TerminacionAnulada sobrevive el roundtrip completo aunque no tenga ningun campo.
+    [Fact]
+    public void RoundTrip_ReconstruyeEvento_SinPayload()
+    {
+        var evento = new TerminacionAnulada();
+        var opciones = CrearOpcionesMarten();
+
+        var json = JsonSerializer.Serialize(evento, opciones);
+        var deserializado = JsonSerializer.Deserialize<TerminacionAnulada>(json, opciones);
+
+        deserializado.Should().NotBeNull();
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/AnularTerminacionFunction/FunctionEndpointTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/AnularTerminacionFunction/FunctionEndpointTests.cs
@@ -1,0 +1,140 @@
+// Issue #354: tests del endpoint HTTP POST Colaboradores/Terminaciones/Anulaciones (anular
+// terminacion). CA-ADR-0030 / MEF-ADR-0004: InvalidOperationException -> 409, KeyNotFoundException
+// -> 404, exito -> 202. Precedente: TerminarVinculacionFunction.FunctionEndpoint.
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.AnularTerminacionFunction;
+using Bitakora.ControlAsistencia.Colaboradores.Infraestructura;
+using Cosmos.EventSourcing.Abstractions.Commands;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Tests.AnularTerminacionFunction;
+
+public class FunctionEndpointTests
+{
+    private static AnularTerminacion ComandoValido() => new(
+        TipoIdentificacion: "CC",
+        NumeroIdentificacion: "79543210");
+
+    private static HttpRequest FakeHttpRequest()
+    {
+        var context = new DefaultHttpContext();
+        return context.Request;
+    }
+
+    // CA-1: POST exitoso retorna 202 Accepted
+    [Fact]
+    public async Task AnularTerminacion_Retorna202_CuandoComandoEsValido()
+    {
+        var validator = new FakeAnularTerminacionRequestValidator(ComandoValido());
+        var router = new FakeAnularTerminacionCommandRouter();
+        var function = new FunctionEndpoint(validator, router);
+
+        var result = await function.Run(FakeHttpRequest(), CancellationToken.None);
+
+        result.Should().BeOfType<AcceptedResult>();
+    }
+
+    // CA-3/CA-4: violacion de la unica regla (vinculacion abierta) retorna 409 Conflict.
+    [Fact]
+    public async Task AnularTerminacion_Retorna409_CuandoLaVinculacionEstaAbierta()
+    {
+        var validator = new FakeAnularTerminacionRequestValidator(ComandoValido());
+        var router = new FakeAnularTerminacionCommandRouter(
+            lanzar: new InvalidOperationException(
+                "La vinculacion vigente del colaborador no tiene una terminacion registrada"));
+        var function = new FunctionEndpoint(validator, router);
+
+        var result = await function.Run(FakeHttpRequest(), CancellationToken.None);
+
+        result.Should().BeOfType<ConflictObjectResult>();
+    }
+
+    // CA-5: colaborador inexistente retorna 404 Not Found
+    [Fact]
+    public async Task AnularTerminacion_Retorna404_CuandoColaboradorNoExiste()
+    {
+        var validator = new FakeAnularTerminacionRequestValidator(ComandoValido());
+        var router = new FakeAnularTerminacionCommandRouter(
+            lanzar: new KeyNotFoundException("No existe un colaborador registrado con esa identificacion"));
+        var function = new FunctionEndpoint(validator, router);
+
+        var result = await function.Run(FakeHttpRequest(), CancellationToken.None);
+
+        result.Should().BeOfType<NotFoundObjectResult>();
+    }
+
+    // CA-6: request invalida (sin identificacion, tipo fuera de la lista cerrada) retorna 400 Bad
+    // Request
+    [Fact]
+    public async Task AnularTerminacion_Retorna400_CuandoRequestEsInvalido()
+    {
+        var errorDeValidacion = new BadRequestObjectResult("El body es invalido o esta malformado");
+        var validator = new FakeAnularTerminacionRequestValidator(error: errorDeValidacion);
+        var router = new FakeAnularTerminacionCommandRouter();
+        var function = new FunctionEndpoint(validator, router);
+
+        var result = await function.Run(FakeHttpRequest(), CancellationToken.None);
+
+        result.Should().BeOfType<BadRequestObjectResult>();
+    }
+}
+
+// ---- Fakes manuales - NO NSubstitute ----
+
+/// <summary>
+/// Fake configurable de IRequestValidator. Retorna un comando pre-configurado o un error segun lo
+/// que se le pase en el constructor.
+/// </summary>
+internal class FakeAnularTerminacionRequestValidator : IRequestValidator
+{
+    private readonly AnularTerminacion? _comando;
+    private readonly IActionResult? _error;
+
+    public FakeAnularTerminacionRequestValidator(
+        AnularTerminacion? comando = null,
+        IActionResult? error = null)
+    {
+        _comando = comando;
+        _error = error;
+    }
+
+    public Task<(T? Comando, IActionResult? Error)> ValidarAsync<T>(
+        HttpRequest req, CancellationToken ct)
+    {
+        if (_error is not null)
+            return Task.FromResult<(T?, IActionResult?)>((default, _error));
+
+        if (_comando is T resultado)
+            return Task.FromResult<(T?, IActionResult?)>((resultado, null));
+
+        return Task.FromResult<(T?, IActionResult?)>((default, null));
+    }
+}
+
+/// <summary>
+/// Fake configurable de ICommandRouter. Puede completar exitosamente o lanzar la excepcion
+/// configurada (InvalidOperationException -> 409, KeyNotFoundException -> 404).
+/// </summary>
+internal class FakeAnularTerminacionCommandRouter : ICommandRouter
+{
+    private readonly Exception? _excepcion;
+
+    public FakeAnularTerminacionCommandRouter(Exception? lanzar = null) =>
+        _excepcion = lanzar;
+
+    public Task InvokeAsync<TCommand>(TCommand command, CancellationToken ct = default)
+        where TCommand : class
+    {
+        if (_excepcion is not null)
+            throw _excepcion;
+
+        return Task.CompletedTask;
+    }
+
+    public Task<TResult> InvokeAsync<TCommand, TResult>(
+        TCommand command, CancellationToken ct = default)
+        where TCommand : class
+        => throw new NotImplementedException();
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/Infraestructura/AliasEventosColaboradoresTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/Infraestructura/AliasEventosColaboradoresTests.cs
@@ -87,9 +87,8 @@ public class AliasEventosColaboradoresTests
 
     // Issue #354 (gemela de las cinco pruebas anteriores): congela el alias de TerminacionAnulada,
     // sexto evento persistido de ColaboradorAggregateRoot (anular la terminacion de la ultima
-    // vinculacion). Rojo esperado (fase roja, issue #354): IdentidadEventosColaboradores.TiposPersistidos
-    // sigue sin TerminacionAnulada hasta que el implementer lo registre -- el implementer lo agrega
-    // ahi (no aqui, MEF-ADR-0002).
+    // vinculacion). El alias es la identidad del evento en mt_events (CA-ADR-0029 decision #6): un
+    // rename futuro de la clase lo cambiaria en silencio, y este literal es quien lo delata.
     [Fact]
     public void TerminacionAnulada_TieneAliasTerminacionAnulada()
     {

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/Infraestructura/AliasEventosColaboradoresTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/Infraestructura/AliasEventosColaboradoresTests.cs
@@ -84,4 +84,17 @@ public class AliasEventosColaboradoresTests
 
         AliasDe<FechaInicioVinculacionCorregida>(options).Should().Be("fecha_inicio_vinculacion_corregida");
     }
+
+    // Issue #354 (gemela de las cinco pruebas anteriores): congela el alias de TerminacionAnulada,
+    // sexto evento persistido de ColaboradorAggregateRoot (anular la terminacion de la ultima
+    // vinculacion). Rojo esperado (fase roja, issue #354): IdentidadEventosColaboradores.TiposPersistidos
+    // sigue sin TerminacionAnulada hasta que el implementer lo registre -- el implementer lo agrega
+    // ahi (no aqui, MEF-ADR-0002).
+    [Fact]
+    public void TerminacionAnulada_TieneAliasTerminacionAnulada()
+    {
+        var options = CrearOpcionesConEventosDeColaboradoresRegistrados();
+
+        AliasDe<TerminacionAnulada>(options).Should().Be("terminacion_anulada");
+    }
 }

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/Infraestructura/ComposicionServiciosTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/Infraestructura/ComposicionServiciosTests.cs
@@ -224,7 +224,6 @@ public class ComposicionServiciosTests
     // FechaInicioVinculacionCorregida.
     // Issue #354: agrega TerminacionAnulada (sexto evento persistido, anular la terminacion de la
     // ultima vinculacion) a la lista esperada.
-    // Rojo esperado (fase roja, issue #354): TiposPersistidos todavia no incluye TerminacionAnulada.
     [Fact]
     public async Task AgregarServiciosColaboradores_RegistraLosTiposDeEventoPersistidos_CuandoElContenedorEstaCompuesto()
     {
@@ -256,7 +255,6 @@ public class ComposicionServiciosTests
     // Rojo esperado (fase roja, issue #352): FechaInicioVinculacionCorregida no aparece en
     // AllKnownEventTypes().
     // Issue #354: agrega TerminacionAnulada -> "terminacion_anulada" al diccionario esperado.
-    // Rojo esperado (fase roja, issue #354): TerminacionAnulada no aparece en AllKnownEventTypes().
     [Fact]
     public async Task AgregarServiciosColaboradores_DerivaElAliasDeEventoDelNombreDeClase_CuandoElContenedorEstaCompuesto()
     {

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/Infraestructura/ComposicionServiciosTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/Infraestructura/ComposicionServiciosTests.cs
@@ -222,6 +222,9 @@ public class ComposicionServiciosTests
     // fecha de inicio de la ultima vinculacion) a la lista esperada.
     // Rojo esperado (fase roja, issue #352): TiposPersistidos todavia no incluye
     // FechaInicioVinculacionCorregida.
+    // Issue #354: agrega TerminacionAnulada (sexto evento persistido, anular la terminacion de la
+    // ultima vinculacion) a la lista esperada.
+    // Rojo esperado (fase roja, issue #354): TiposPersistidos todavia no incluye TerminacionAnulada.
     [Fact]
     public async Task AgregarServiciosColaboradores_RegistraLosTiposDeEventoPersistidos_CuandoElContenedorEstaCompuesto()
     {
@@ -236,7 +239,8 @@ public class ComposicionServiciosTests
                 typeof(VinculacionIniciada),
                 typeof(VinculacionTerminada),
                 typeof(NombresCorregidos),
-                typeof(FechaInicioVinculacionCorregida)
+                typeof(FechaInicioVinculacionCorregida),
+                typeof(TerminacionAnulada)
             ]);
     }
 
@@ -251,6 +255,8 @@ public class ComposicionServiciosTests
     // al diccionario esperado.
     // Rojo esperado (fase roja, issue #352): FechaInicioVinculacionCorregida no aparece en
     // AllKnownEventTypes().
+    // Issue #354: agrega TerminacionAnulada -> "terminacion_anulada" al diccionario esperado.
+    // Rojo esperado (fase roja, issue #354): TerminacionAnulada no aparece en AllKnownEventTypes().
     [Fact]
     public async Task AgregarServiciosColaboradores_DerivaElAliasDeEventoDelNombreDeClase_CuandoElContenedorEstaCompuesto()
     {
@@ -265,7 +271,8 @@ public class ComposicionServiciosTests
             [typeof(VinculacionIniciada)] = "vinculacion_iniciada",
             [typeof(VinculacionTerminada)] = "vinculacion_terminada",
             [typeof(NombresCorregidos)] = "nombres_corregidos",
-            [typeof(FechaInicioVinculacionCorregida)] = "fecha_inicio_vinculacion_corregida"
+            [typeof(FechaInicioVinculacionCorregida)] = "fecha_inicio_vinculacion_corregida",
+            [typeof(TerminacionAnulada)] = "terminacion_anulada"
         });
     }
 


### PR DESCRIPTION
## Resumen

Pipeline TDD completado:
- Fase roja: tests escritos con stubs
- Fase verde: implementación completa
- Smoke tests: escritos para endpoints detectados
- Fase refactor: revisión de calidad

## Decisiones del pipeline

<details>
<summary>Test Writer (fase roja) — 16m 15s</summary>

## ES Test Writer - Decisiones (issue #354)

### Tests creados

- `AnularTerminacionFunction/AnularTerminacionCommandHandlerTests.cs`: 7 tests
  - `AnularTerminacion_EmiteTerminacionAnulada_CuandoLaUltimaVinculacionTieneTerminacionRegistrada` - CA-1 (camino feliz)
  - `AnularTerminacion_EmiteTerminacionAnulada_CuandoLaTerminacionEsUnPreavisoConFechaFutura` - CA-1 (arrepentimiento del preaviso, decision #2)
  - `AnularTerminacion_EmiteTerminacionAnulada_CuandoTipoYNumeroLleganSinNormalizar` - CA-1 (borde de identidad, MEF-ADR-0037)
  - `AnularTerminacion_LanzaInvalidOperationException_CuandoLaVinculacionNuncaHaSidoTerminada` - CA-3
  - `AnularTerminacion_LanzaInvalidOperationException_CuandoLaTerminacionYaFueAnuladaAntes` - CA-3 (decision #4, doble anulacion)
  - `AnularTerminacion_LanzaInvalidOperationException_CuandoLaUltimaVinculacionNacioDeUnReingresoSinTerminar` - CA-4 (decision #3, terminacion anterior congelada)
  - `AnularTerminacion_LanzaKeyNotFoundException_CuandoColaboradorNoExiste` - CA-5

- `AnularTerminacionFunction/ComposicionAnularYTerminarVinculacionTests.cs`: 1 test
  - `TerminarVinculacion_EmiteVinculacionTerminadaConLaFechaCorregida_CuandoLaTerminacionErradaFueAnuladaAntes` - CA-2 (composicion completa)

- `AnularTerminacionFunction/AnularTerminacionValidatorTests.cs`: 5 tests - CA-6 (forma del comando) + camino feliz + normalizacion de tipo en minusculas

- `AnularTerminacionFunction/AnularTerminacionCommandHandlerMensajesTests.cs`: 1 test - guardrail de resolucion del .resx

- `AnularTerminacionFunction/FunctionEndpointTests.cs`: 4 tests - 202/409/404/400

- `AnularTerminacionFunction/Eventos/TerminacionAnuladaSerializacionTests.cs`: 1 test - roundtrip de un evento sin payload (regla 16/6d)

- `Infraestructura/AliasEventosColaboradoresTests.cs` (modificado): +1 test - alias `terminacion_anulada`

- `Infraestructura/ComposicionServiciosTests.cs` (modificado): +1 tipo en cada uno de los dos guardrails existentes (`AgregarServiciosColaboradores_RegistraLosTiposDeEventoPersistidos...` y `..._DerivaElAliasDeEventoDelNombreDeClase...`) - patron idiomatico ya usado por #349/#350/#351/#352, no crea archivos nuevos.

Total: 19 tests nuevos + 2 aserciones agregadas a guardrails existentes.

### Estructura elegida

- Una clase por command handler (`AnularTerminacionCommandHandlerTests`), consistente con el resto de la cadena #349-#352 (un aggregate, pero cada comando tiene su propio archivo de test porque no comparten Given() de la misma forma que #349-#352 justificarian nested classes).
- El test de composicion (CA-2) vive en un archivo SEPARADO (`ComposicionAnularYTerminarVinculacionTests.cs`), dentro de la carpeta de tests `AnularTerminacionFunction/` (el comando que introduce el escenario), no en `TerminarVinculacionFunction/` (evita modificar un archivo de test existente que el issue no lista en "Impacto/Modifica").

### Stubs creados

- `ColaboradorAggregateRoot.Apply(TerminacionAnulada)` - stub, `throw new NotImplementedException()`
- `ColaboradorAggregateRoot.AnularTerminacion()` - stub `internal`, `throw new NotImplementedException()`, mismo mecanismo "declinar con resultado" (CA-ADR-0030) que `TerminarVinculacion`/`Reingresar`/`CorregirFechaInicio`
- `ResultadoAnulacionTerminacion` (enum `internal`): `Exitosa`, `VinculacionAbierta` - unica razon de rechazo (unica regla del comando)
- `TerminacionAnulada` (record `sealed`, sin campos) - el hecho es el evento mismo
- `AnularTerminacion` (record, `TipoIdentificacion` + `NumeroIdentificacion`)
- `AnularTerminacionCommandHandler` - stub, `HandleAsync` lanza `NotImplementedException`
- `AnularTerminacionCommandHandler.Mensajes` (+ .resx) - `ColaboradorNoEncontrado`, `VinculacionAbierta`
- `AnularTerminacionValidator` - stub vacio (sin reglas), mismo patron que `TerminarVinculacionValidator`/`CorregirFechaInicioVinculacionValidator` en su fase roja
- `FunctionEndpoint` - **completo, no stub**: boilerplate identico (400/409/404/202) replicado de los 4 endpoints hermanos ya implementados en el repo (`TerminarVinculacionFunction`, `ReingresarColaboradorFunction`, `CorregirNombresFunction`, `CorregirFechaInicioVinculacionFunction`); no encierra logica de negocio del issue, es pura traduccion de excepciones a status code. Confirmado como convencion establecida del repo revisando los 4 commits `test(issue-XXX)` previos: en los cuatro, `FunctionEndpoint.cs` se escribe completo en la fase roja.

### Decisiones de diseno

- **Enum de rechazo con una sola razon** (`VinculacionAbierta`): la unica regla del comando cubre tres casos de negocio distintos (recien registrada, reingresada, ya anulada antes) sin que el handler necesite distinguirlos -- documentado en los comentarios del aggregate y en los 3 tests que ejercitan cada caso con el mismo mensaje esperado.
- **CA-2 sin encadenar dos handlers en vivo**: verificado contra la fuente real del harness (`TestStore.cs`, `Cosmos.BuildingBlocks/Cosmos.EventSourcing.Testing.Utilities`) que `GetAggregateRootAsync` -- la via que CUALQUIER handler de produccion usa para rehidratar -- lee UNICAMENTE `_previousEvents`, nunca `_newEvents`. Si el test hubiera invocado `WhenAsync(AnularTerminacion)` seguido de un `HandleAsync` manual de `TerminarVinculacionCommandHandler` sobre el mismo `EventStore`, el segundo handler no habria visto el `TerminacionAnulada` recien commiteado (queda en `_newEvents` tras `SaveChanges`, no se mueve a `_previousEvents`) y el test habria fallado con un falso 409 que no refleja ningun defecto real. Se opto por el patron idiomatico YA USADO en `TerminarVinculacionCommandHandlerTests` para probar la composicion con el reingreso de #350: construir con `Given()` la historia ya persistida (incluyendo el evento que el "otro" comando habria commiteado) e invocar con `WhenAsync` solo el comando bajo prueba.
- **Ruta HTTP**: `Colaboradores/Terminaciones/Anulaciones` (POST), tal como la propuso el planner -- sub-recurso de las terminaciones, identificacion en el body por la misma razon que el resto de la cadena (`:` en la representacion de `Identificacion`).

### Cobertura de criterios

| Criterio de aceptacion | Test(s) |
|---|---|
| CA-1 (terminacion registrada -> exito, incluye preaviso) | `AnularTerminacion_EmiteTerminacionAnulada_CuandoLaUltimaVinculacionTieneTerminacionRegistrada`, `..._CuandoLaTerminacionEsUnPreavisoConFechaFutura`, `..._CuandoTipoYNumeroLleganSinNormalizar` |
| CA-2 (composicion anular + terminar) | `ComposicionAnularYTerminarVinculacionTests.TerminarVinculacion_EmiteVinculacionTerminadaConLaFechaCorregida_CuandoLaTerminacionErradaFueAnuladaAntes` |
| CA-3 (vinculacion abierta -> 409) | `AnularTerminacion_LanzaInvalidOperationException_CuandoLaVinculacionNuncaHaSidoTerminada`, `..._CuandoLaTerminacionYaFueAnuladaAntes` |
| CA-4 (tras reingreso, terminacion anterior congelada) | `AnularTerminacion_LanzaInvalidOperationException_CuandoLaUltimaVinculacionNacioDeUnReingresoSinTerminar` |
| CA-5 (colaborador inexistente -> 404) | `AnularTerminacion_LanzaKeyNotFoundException_CuandoColaboradorNoExiste`, `FunctionEndpointTests.AnularTerminacion_Retorna404_CuandoColaboradorNoExiste` |
| CA-6 (request invalida -> 400) | `AnularTerminacionValidatorTests.*`, `FunctionEndpointTests.AnularTerminacion_Retorna400_CuandoRequestEsInvalido` |
| Alta en `TiposPersistidos` / alias `terminacion_anulada` | `AliasEventosColaboradoresTests.TerminacionAnulada_TieneAliasTerminacionAnulada`, `ComposicionServiciosTests.AgregarServiciosColaboradores_RegistraLosTiposDeEventoPersistidos...`, `..._DerivaElAliasDeEventoDelNombreDeClase...` |
| Roundtrip de serializacion (regla 16) | `TerminacionAnuladaSerializacionTests.RoundTrip_ReconstruyeEvento_SinPayload` |

### Desviaciones del plan del planner

| Sugerencia del issue | Desviacion aplicada | Razon tecnica | Consecuencia |
|---|---|---|---|
| "Crea: .../AnularTerminacion/AnularTerminacion.cs, FunctionEndpoint.cs, CommandHandler/AnularTerminacionCommandHandler.cs..." (carpeta sin sufijo) | Carpeta `AnularTerminacionFunction/` (CON sufijo) | MEF-ADR-0006: los directorios HTTP **de comando** llevan sufijo "Function" para evitar colision entre el namespace y el record del comando homonimo -- mismo criterio aplicado sin excepcion en los 4 comandos previos de esta cadena (`TerminarVinculacionFunction`, `ReingresarColaboradorFunction`, `CorregirNombresFunction`, `CorregirFechaInicioVinculacionFunction`). El texto del issue fue una simplificacion de notacion del planner, no una propuesta deliberada de romper la convencion. | Ningun CA afectado; solo cambia la ruta de archivo, coherente con el resto del dominio. |
| "Tests con el DSL: ... el CA-2 encadena dos comandos" (literal) | CA-2 se prueba con `Given()` reconstruyendo la historia persistida (incluye `TerminacionAnulada`) + un solo `WhenAsync(TerminarVinculacion)`, sin invocar dos handlers en vivo sobre el mismo `TestStore` | Verificado contra la fuente del harness (`TestStore.GetAggregateRootAsync` solo lee `_previousEvents`, nunca `_newEvents` -- confirmado leyendo `Cosmos.BuildingBlocks/Cosmos.EventSourcing.Testing.Utilities/TestStore.cs` y su propio test `TestStoreTests.cs`). Encadenar dos handlers reales en el mismo `EventStore` haria que el segundo handler no viera el evento recien commiteado por el primero, produciendo un 409 falso que no refleja ningun defecto de produccion -- exactamente el patron de test enganoso que la regla 20 (oraculo independiente) prohibe. | El CA-2 queda cubierto con la misma tecnica ya usada en `TerminarVinculacionCommandHandlerTests` para la composicion con el reingreso de #350 (Given incluye el evento del "otro" comando). Documentado extensamente en los comentarios del archivo de test para que el reviewer y el implementer entiendan por que no hay una llamada literal a dos `WhenAsync`. |

Ninguna otra desviacion: la interfaz publica propuesta (`AnularTerminacion(): <resultado>`, `Apply(TerminacionAnulada)` publico) se aplico tal cual, con el nombre concreto de enum `ResultadoAnulacionTerminacion` (no prescrito por el issue, decision tecnica consistente con el naming de los resultados hermanos).

</details>

<details>
<summary>Implementer (fase verde) — 5m 27s</summary>

## ES Implementer - Decisiones

### Enfoque de implementacion
El test-writer dejo el andamiaje completo (comando, endpoint, validator vacio, handler y
`Apply`/metodo del aggregate como stubs `NotImplementedException`, `.resx` con las dos claves de
mensaje ya escritas, `TerminacionAnulada` sin payload, `ResultadoAnulacionTerminacion` con sus dos
valores). El trabajo se redujo a completar cuatro stubs siguiendo al pie de la letra el molde ya
validado por la cadena #349 (`TerminarVinculacionCommandHandler`/`Validator`) y #350
(`ReingresarColaborador`), sin inventar mecanismos nuevos:

1. `ColaboradorAggregateRoot.Apply(TerminacionAnulada e)` -> limpia
   `_fechaTerminacionVinculacionVigente` a `null` (reabre la vinculacion sin tocar codigo ni fecha
   de inicio). Nunca lanza (MEF-ADR-0004 capa 4).
2. `ColaboradorAggregateRoot.AnularTerminacion()` -> unica regla: si
   `_fechaTerminacionVinculacionVigente is null` declina con
   `ResultadoAnulacionTerminacion.VinculacionAbierta` (CA-ADR-0030, "declinar con resultado", nunca
   lanza ni emite evento de fallo); si no, appendea `TerminacionAnulada` y lo aplica, retorna
   `Exitosa`.
3. `AnularTerminacionCommandHandler.HandleAsync` -> mismo flujo de cuatro pasos que
   `TerminarVinculacionCommandHandler`: parseo tipado unico (`TipoIdentificacion.Desde` sobre
   trim+mayusculas, `Identificacion.Crear`) -> `ComputarStreamId` -> `GetAggregateRootAsync` (null
   -> `KeyNotFoundException` 404) -> `AnularTerminacion()` (resultado `VinculacionAbierta` ->
   `InvalidOperationException` 409; `Exitosa` -> nada mas, el middleware persiste).
4. `AnularTerminacionValidator` -> mismas dos reglas que `TerminarVinculacionValidator` menos la
   de `FechaEfectiva` (este comando no lleva fecha): `TipoIdentificacion` requerido + en la lista
   cerrada (`Cascade(Stop)` + `Must(EsTipoIdentificacionReconocido)`), `NumeroIdentificacion`
   requerido.
5. Alta de `TerminacionAnulada` en `IdentidadEventosColaboradores.TiposPersistidos` (CA-ADR-0029 /
   MEF-ADR-0039 decision 5) -- lo cubre `AliasEventosColaboradoresTests`/`ComposicionServiciosTests`.

`FunctionEndpoint.cs`, `AnularTerminacion.cs` (comando), la clase `.Mensajes.cs` y el `.resx` ya
llegaron completos del test-writer, sin necesidad de tocarlos.

### Decisiones de diseno
- Ninguna decision de diseno nueva: el issue y el planner ya fijaron la unica regla
  (`VinculacionAbierta` cubre los tres casos "nunca terminada / reingresada sin terminar / ya
  anulada antes" sin que el handler los distinga) y el test-writer ya materializo esa forma en
  `ResultadoAnulacionTerminacion` (dos valores) y en el `.resx` (dos claves). Implementar consistio
  en rellenar los cuerpos con la logica que la firma y los comentarios ya describian.

### ADRs consultados
- CA-ADR-0030 (fallos sincronos para comandos HTTP sin consumidores downstream): mecanismo
  "declinar con resultado" aplicado tal cual en `AnularTerminacion()`.
- MEF-ADR-0012 (Tell-don't-Ask, estilo de modelado de objetos de dominio): el handler consulta
  unicamente el resultado que el aggregate responde, nunca su estado interno; `Apply` solo asigna
  estado, sin logica condicional.
- MEF-ADR-0037 (identidad del stream, parseo tipado unico): `ComputarStreamId` como unico punto de
  conversion, ya existente en el aggregate; el handler no reconstruye la clave por su cuenta.
- CA-ADR-0029 / MEF-ADR-0039 (composicion de ensamblados por rol de evento): `TerminacionAnulada`
  vive en `Colaboradores.DomainEvents`, sin marker de bus, dado de alta en `TiposPersistidos`.
- MEF-ADR-0006 (naming de funciones Azure): `[Function("AnularTerminacion")]` ya correcto en el
  endpoint entregado por el test-writer -- no requirio cambios.
- MEF-ADR-0009 (mensajes .resx por handler): las dos claves (`ColaboradorNoEncontrado`,
  `VinculacionAbierta`) ya existian en el `.resx`; el handler las consume via
  `Mensajes.ColaboradorNoEncontrado`/`Mensajes.VinculacionAbierta`.
- CA-ADR-0027 (tenancy conjoined): sin superficie afectada por este comando (no toca resolucion de
  tenant).
- MEF-ADR-0002 / MEF-ADR-0016 (DSL y naming de tests): no aplico directamente (trabajo de
  test-writer), verificado que los tests entregados siguen el patron `<Sujeto>_<Resultado>_Cuando<Condicion>`.
- MEF-ADR-0005 (evento en pasado): `TerminacionAnulada` ya cumple el naming.
- MEF-ADR-0004 (capa 4, `Apply` nunca lanza): verificado -- `Apply(TerminacionAnulada)` es una
  asignacion pura, sin condicionales ni excepciones, tolerante a cualquier orden de eventos previo
  en el stream.

### Desviaciones de ADRs
Ninguna desviacion -- todos los ADRs aplicados al pie de la letra.

### Desviaciones del plan del planner
Ninguna desviacion -- la interfaz publica propuesta por el planner (metodo del aggregate, `Apply`,
evento sin campos, validator, handler, ruta del endpoint) coincidio exactamente con lo que el
test-writer ya habia materializado como stub, y se implemento sin ajustes.

### Precedentes consultados
- `TerminarVinculacionCommandHandler`/`TerminarVinculacionValidator` (issue #349): molde del flujo
  de cuatro pasos del handler y de las reglas de validacion de identificacion. Alineado con
  CA-ADR-0030 y MEF-ADR-0037 -- replicado sin cambios de fondo.
- `ReingresarColaboradorCommandHandler`/`ColaboradorAggregateRoot.Reingresar` (issue #350): confirma
  el mismo mecanismo "declinar con resultado" para un metodo con una sola regla de rechazo.
  Alineado con CA-ADR-0030.
- `ColaboradorAggregateRoot.CorregirNombres` (issue #351): precedente de "declinar en silencio",
  descartado para este caso porque el issue exige que el handler distinga la razon de rechazo via
  `KeyNotFoundException`/`InvalidOperationException` -- no aplica aqui, ya que
  `AnularTerminacion()` solo tiene una razon de rechazo y el handler ya la traduce con
  `InvalidOperationException` (patron correcto, no "declinar en silencio").
- Ningun precedente detectado que violara un ADR aplicable a este issue.

### Infraestructura modificada
Ninguna. El comando es event-sourcing puro sin consumidores (issue #354, "Consumidores: ninguno")
-- no publica a ningun bus, no requiere topics ni subscriptions nuevas en
`infra/environments/dev/main.tf`.

### Complejidad encontrada
Ninguna. El test-writer dejo el trabajo acotado a cuatro cuerpos de metodo siguiendo un molde ya
usado tres veces en la misma cadena (#349/#350/#352); todos los tests (237 en
`Bitakora.ControlAsistencia.Colaboradores.Tests`) pasaron en el primer intento tras completar los
stubs, sin iteracion adicional.

### Resultado
- Tests pasando (dominio Colaboradores): 237/237
- Tests pasando (suite completa del repo): 1094 correctos, 32 omitidos (smoke tests que requieren
  Postgres/ServiceBus local, sin relacion con este issue), 0 errores

</details>
<details>
<summary>Smoke Test Writer — 4m 11s</summary>

_(El agente no generó resumen)_

</details>
<details>
<summary>Reviewer (fase refactor) — 13m 31s</summary>

## ES Reviewer - Revision

### Evaluacion general
- Calidad: **buena**
- Cambios realizados: **si** (commit `86d418e` — 2 tests nuevos, 1 aserción de smoke corregida, limpieza de cruft)

Suite tras el refactor: **1098 correctos, 36 omitidos, 4 en rojo** — los 4 rojos son smoke tests
contra dev del endpoint que **todavia no esta desplegado** (ver "Estado de la suite" abajo). Los
tests unitarios del dominio pasan 239/239 (237 heredados + 2 agregados en esta fase).

---

### Estado de la suite: los 4 smoke tests rojos NO son un defecto del codigo

`dotnet test` termina en rojo, pero la causa esta verificada empiricamente y es de **orden de
despliegue**, no de implementacion:

```
POST https://func-asist-dev-colaboradores.azurewebsites.net/api/Colaboradores/Terminaciones/Anulaciones  -> 404
POST https://func-asist-dev-colaboradores.azurewebsites.net/api/Colaboradores/Terminaciones            -> 400
```

La ruta hermana de #349 responde `400` (validator vivo, dominio desplegado); la ruta nueva de #354
responde `404` porque el Function App de dev todavia corre el build anterior a este PR. Los 4 tests
que fallan son exactamente los que **no** dependen de Postgres y por eso no se saltan:

| Test | Espera | Recibe | Causa |
|---|---|---|---|
| `AnularTerminacion_Retorna409_CuandoVinculacionNuncaFueTerminada` | 409 | 404 | ruta no desplegada |
| `AnularTerminacion_Retorna409_CuandoLaUltimaVinculacionNacioDeUnReingresoSinTerminar` | 409 | 404 | ruta no desplegada |
| `AnularTerminacion_Retorna400_CuandoNumeroIdentificacionEsVacio` | 400 | 404 | ruta no desplegada |
| `AnularTerminacion_Retorna400_CuandoTipoIdentificacionNoEsReconocido` | 400 | 404 | ruta no desplegada |

No existe `blockage-report.md` ni hacia falta: no hay nada que resolver en codigo. Pasaran en el job
`smoke-tests` de `deploy-colaboradores.yml`, despues del deploy (MEF-ADR-0013).

**Advertencia para quien lea el resultado del job**: `AnularTerminacion_Retorna404_CuandoColaboradorNoExiste`
esta hoy en **verde falso** — recibe 404 por ruta inexistente, no por colaborador inexistente. Solo
sera senal real despues del despliegue. No se corrige (el test es correcto; lo que falta es el
deploy), pero queda registrado para que nadie lo lea como evidencia hoy.

---

### Cumplimiento de ADRs aplicables

| ADR | Cumplimiento | Observacion |
|---|---|---|
| **CA-ADR-0030**: fallos sincronos sin consumidores | ok | `AnularTerminacion()` declina con `ResultadoAnulacionTerminacion.VinculacionAbierta`, sin lanzar ni emitir evento de fallo; el handler traduce a `InvalidOperationException` (409) y `KeyNotFoundException` (404), ambos con mensaje `.resx`. Sin evento de fallo persistido — correcto: trigger HTTP, "Consumidores: ninguno". |
| **MEF-ADR-0012**: Tell-don't-Ask | ok | El handler decide unicamente por el valor de retorno del aggregate; nunca interroga `FechaTerminacionVinculacionVigente`. El diff **no agrega ninguna propiedad, getter ni clase estatica nueva** — los observables `internal` que consumen los tests son preexistentes (#330/#349). Checklist de 7 antipatrones recorrido: ninguno presente (detalle abajo). |
| **MEF-ADR-0037**: identidad de stream | ok | `ComputarStreamId` sigue siendo el punto unico de conversion (delega en `Identificacion.ToString()`, sin formato explicito); el handler no concatena la clave. Parseo tipado unico en el borde (`TipoIdentificacion.Desde` + `Identificacion.Crear`). Sin GET, sin segmento de ruta que parsear. |
| **CA-ADR-0029 / MEF-ADR-0039**: ensamblados por rol | ok | `TerminacionAnulada` vive en `Colaboradores.DomainEvents` (se persiste), sin marker de bus, sin payload; alta en `IdentidadEventosColaboradores.TiposPersistidos`, artefacto que registran los dos lados. Cero `.csproj` tocados. Sin tipo homonimo en `PublicEvents`/`PrivateEvents` (verificado por grep). |
| **MEF-ADR-0006**: naming de funciones Azure | ok | `[Function("AnularTerminacion")]` (literal = nombre del comando); `Route = "Colaboradores/Terminaciones/Anulaciones"`, coherente con la familia de sub-recursos ya desplegada (`/Terminaciones`, `/Reingresos`, `/Nombres`, `/FechasInicio`). |
| **MEF-ADR-0009**: mensajes `.resx` | ok | `AnularTerminacionCommandHandler.Mensajes` con `.resx` propio del handler; el guardrail `AnularTerminacionCommandHandlerMensajesTests` protege el `!` de `GetString` (la falla que volveria vacuas las aserciones `WithMessage`). |
| **CA-ADR-0027**: tenancy | ok (n/a activo) | El comando no toca resolucion de tenant; el `ITenantResolver` fijo del contenedor no se modifica. |
| **MEF-ADR-0002 / MEF-ADR-0016**: DSL y naming de tests | ok | Solo `[Fact]`; DSL Given/WhenAsync/Then/And con overloads de stream id compuesto; nombres `<Sujeto>_<LoQuePasa>_Cuando<Condicion>` con sujeto = nombre del comando. Oraculo de stream id literal (`"CC:79543210"`), no derivado de `ComputarStreamId`. |
| **MEF-ADR-0005**: evento en pasado | ok | `TerminacionAnulada` — participio, hecho consumado. |
| **MEF-ADR-0004**: capas de error | ok | Capa 1: validator -> 400. Capa 2: handler -> 404/409. Capa 3: sin evento de fallo (justificado por CA-ADR-0030). Capa 4: `Apply(TerminacionAnulada)` es una asignacion pura. **El issue declaraba explicitamente "capa 4: Apply nunca lanza, incluso ante orden anomalo" y no habia test que lo ejerciera — agregado en esta fase.** |

El issue **si** traia seccion `## ADRs aplicables` completa. No hay nada que escalar al planner.

#### Antipatrones de MEF-ADR-0012 (recorrido explicito)

| # | Antipatron | Veredicto |
|---|---|---|
| 1 | Propiedad publica nueva en VO/aggregate con unico consumidor externo | no aplica — el diff no agrega ninguna |
| 2 | Clase estatica operando sobre datos crudos de un VO | no aplica |
| 3 | Getter expuesto solo para que los tests afirmen estado | no aplica — los `internal` que usa `And<>()` son de #330/#349, no de este diff |
| 4 | `InternalsVisibleTo` desde un ensamblado de eventos | no aplica — `Colaboradores.DomainEvents` sin cambios de visibilidad |
| 5 | `[JsonConstructor]` en ctor privado | no aplica — `TerminacionAnulada` no tiene campos |
| 6 | `record` con `IReadOnlyList<T>` como propiedad de igualdad | no aplica |
| 7 | Evento con marker de bus cargando modelo rico | no aplica — el evento **no** lleva marker (`IPrivateEvent`/`IPublicEvent`); por eso tampoco corresponde el guardrail de round-trip con serializador por defecto |

### Desviaciones de ADRs

**Ninguna desviacion — todos los ADRs aplicables se cumplen.**

- Declaradas por el implementer: ninguna (su resumen dice "todos los ADRs aplicados al pie de la letra"). Verificado contra el diff: correcto.
- Detectadas por el reviewer y no declaradas: ninguna.

Unica diferencia respecto del plan del planner, benigna y ya normativa en el repo: la carpeta es
`AnularTerminacionFunction/` y no `AnularTerminacion/` como sugeria "Impacto esperado en archivos".
Es la convencion del pipeline para HTTP triggers (`{Comando}Function/`) y la que siguen los cinco
comandos hermanos ya mergeados. El issue autoriza expresamente ese ajuste ("Archivos anticipados por
el planner"). No se cuenta como desviacion de ADR.

### Precedentes consultados por el implementer

| Precedente | ADR aplicable | Veredicto |
|---|---|---|
| `TerminarVinculacionCommandHandler`/`Validator` (#349) | CA-ADR-0030, MEF-ADR-0037 | alineado — mismo flujo de cuatro pasos, mismo parseo tipado unico |
| `ColaboradorAggregateRoot.Reingresar` (#350) | CA-ADR-0030 | alineado — "declinar con resultado" con una sola razon de rechazo |
| `ColaboradorAggregateRoot.CorregirNombres` (#351) | CA-ADR-0030 | alineado — evaluado y **descartado** con razon correcta (aqui el borde si debe distinguir la razon) |
| `CorregirFechaInicioVinculacionCommandHandler` (#352) | MEF-ADR-0009, CA-ADR-0030 | alineado — ademas es el precedente de estilo de comentario que se aplico en el refactor |

Ningun precedente citado viola un ADR. **Observacion de higiene, no bug**: `TerminarVinculacionCommandHandler`
(#349, ya en `main`) conserva el marcador `// STUB (fase roja, issue #349)` sobre codigo ya
implementado — el mismo cruft que #352 limpio y que aqui se limpio para #354. Queda fuera del
alcance de este PR (archivo no tocado por el diff); candidato a barrido en un issue de tooling.

### Convenciones del pipeline (no ADRs)

| Convencion | Estado | Observacion |
|---|---|---|
| Cada test con `Then()` + `And<>()` | ok | Todos los tests del DSL cumplen, salvo `AnularTerminacion_LanzaKeyNotFoundException_CuandoColaboradorNoExiste`: sin stream no hay aggregate que rehidratar y `And<>()` no puede ejecutarse. Excepcion legitima y con precedente identico en `TerminarVinculacion`/`ReingresarColaborador` CA-5. |
| Overloads correctos para stream IDs compuestos | ok | `Given(streamId, ...)`, `Then(streamId, ...)`, `And<T,P>(streamId, ...)` en todos los tests — el aggregate usa `Identificacion.ToString()`, no GUID |
| Fakes manuales (no NSubstitute) | ok | `FakeAnularTerminacionRequestValidator` / `FakeAnularTerminacionCommandRouter`, clases concretas |
| Feature folders (produccion y tests) | ok | `AnularTerminacionFunction/` + `CommandHandler/` en produccion; espejo exacto en tests, un archivo por responsabilidad (handler, validator, endpoint, mensajes, serializacion, composicion) |
| Smoke tests: SkipWhen, secrets, cobertura | ok | `Assert.SkipWhen` (xUnit v3) en los 4 que tocan Postgres; `appsettings.json` con connection strings vacios; identificacion unica por test (sin filtro posicional); **cobertura completa de efectos secundarios**: el handler solo persiste (sin `PublishAsync`), y la persistencia se verifica contra `mt_events`. Sin suscripcion `smoke-tests` que exigir: el comando no publica a ningun topic |
| Proyecciones read-side | n/a | El diff no toca `ReadModels`/`Projections` ni ninguna Function GET |
| Antipatrones de habilitacion (MEF-ADR-0039) | ok | Cero `.csproj` en el diff -> (a),(b),(c),(e) n/a. (d) verificado: no existe tipo homonimo `TerminacionAnulada` en `PublicEvents`/`PrivateEvents` |
| Compatibilidad Marten write-side/read-side | ok | Gate **disparado** (el diff toca `IdentidadEventosColaboradores.cs`). Detalle abajo |
| Identidad de stream (MEF-ADR-0037) | ok | Gate disparado (`GetAggregateRootAsync`/`ComputarStreamId`). Sin `ToString("N"/"B"/...)` sobre ninguna clave de stream, sin concatenacion fuera de `ComputarStreamId`, sin GET |
| Control de volumen de telemetria (MEF-ADR-0038) | n/a | El diff no toca `ComposicionServicios*`, `ConfiguracionObservabilidad*` ni el callback de Wolverine |
| Tests via ToString/comportamiento | ok | La reapertura de la vinculacion se verifica por comportamiento: en unitarios via el estado rehidratado del DSL, en smoke via composicion (que `TerminarVinculacion` vuelva a aceptar) — no se abrio ningun getter para el test |
| Sin numeros magicos | ok | Fechas y codigos con nombre; `"COL-002"` (repetido dos veces tras el test nuevo) se extrajo a `CodigoVinculacionReingreso` |
| Condiciones en positivo | ok | `if (_fechaTerminacionVinculacionVigente is null) return VinculacionAbierta;` es guard clause de precondicion, no bifurcacion `if/else` invertible |

#### Detalle del gate de compatibilidad Marten (issue #447)

Gate disparado por `IdentidadEventosColaboradores.cs`. **Sin decompilar**: ningun `.csproj` cambia
en el diff, asi que la version de `Cosmos.EventSourcing.CritterStack` — y con ella la linea base que
el paquete fija del lado write — es exactamente la ya verificada en PRs previos.

- **Par 1 (eventos), fila "Tipos de evento registrados"**: es el unico atributo que este diff mueve, y
  **no puede divergir por construccion**: write-side (`ComposicionServicios.AgregarServiciosColaboradores`)
  y worker (`ConfiguracionMartenProjectionsColaboradores`, linea 81) invocan ambos
  `opts.Events.AddEventTypes(IdentidadEventosColaboradores.TiposPersistidos)` sobre la **misma**
  lista. El alta de `TerminacionAnulada` llega a los dos lados en el mismo commit.
- Resto de la columna "debe coincidir" (`DatabaseSchemaName`, `StreamIdentity`, `EventNamingStyle`,
  `TenancyStyle`, `MetadataConfig`, serializador): sin cambios en el diff; el worker las declara
  explicitamente replicando el write-side, con la justificacion escrita en el propio archivo.
- **Par 2 (read models)**: n/a — Colaboradores todavia no materializa ninguna vista.

**Observacion (no hallazgo)**: el guardrail read-side `ConfigurarColaboradores_RegistraLosTiposDeEventoPersistidos`
(Projections.Tests) sigue congelando solo los dos eventos de #330. No se actualizo en #349/#351/#352
ni aqui. No es divergencia de configuracion (fuente unica) ni falla el test (`AssertEventosPersistidosRegistrados`
usa `Contain`, semantica de subconjunto), pero su literal ya no retrata el contrato completo.
Actualizarlo con los seis tipos tocaria un archivo ajeno a este diff y arrastraria la deuda de tres
issues anteriores: mejor candidato para el issue que estrene la primera proyeccion de Colaboradores.

### Elegancia del codigo

El codigo de produccion llego **ya elegante**: el aggregate suma 4 lineas de logica (una guarda, tres
de emision) y un `Apply` de una linea; el handler es un `if` sobre el resultado, no un `switch` de
un solo caso; el evento sin payload es un `sealed record` sin cuerpo. Nada que compactar, ningun
algoritmo que mejorar (el metodo es O(1) sobre estado ya rehidratado), ninguna guarda negativa que
permutar.

Lo que si tenia rebaba, y se corrigio:

- **Verbosidad**: el comentario del `CommandHandler` narraba el metodo paso a paso (16 lineas para
  15 de codigo) y conservaba el marcador `// STUB (fase roja, issue #354): el cuerpo completo queda
  para el implementer` sobre codigo ya implementado. Compactado al "por que" (mismo criterio y misma
  forma que #352).
- **Limpieza**: `using AwesomeAssertions` innecesario en `ComposicionAnularYTerminarVinculacionTests`
  (IDE0005 reportado por `dotnet format`); constante `TimeoutAusencia` que quedo sin uso al corregir
  el smoke; afirmaciones "Rojo esperado (fase roja, issue #354)" en los guardrails de alias y
  composicion, falsas desde el momento en que el pipeline paso a verde.
- **Numero magico**: `"COL-002"` repetido; extraido a `CodigoVinculacionReingreso`.

Build sin warnings del compilador en el dominio; `dotnet format --verify-no-changes` limpio para
todos los archivos de Colaboradores (los 4 `NU1902` restantes son del paquete OpenTelemetry en
Programacion, preexistentes y ajenos a este issue).

### Criticas y hallazgos

1. **[mayor — corregido] Aserción de smoke que afirma mas de lo que verifica.** El test de doble
   anulacion cerraba con `existe.Should().BeTrue("deberia existir **exactamente** el
   terminacion_anulada de la primera anulacion")`, pero `ExisteEventoAsync` solo responde "hay al
   menos uno": si la segunda anulacion hubiera escrito un evento (el bug que CA-3 quiere prevenir),
   el test seguiria en verde. Era la mitad no verificable de CA-3 ("ningun evento nuevo en el
   stream"). **Corregido**: `PostgresFixture.ContarEventosAsync` (reusa la consulta ya probada de
   `ObtenerEventosInternoAsync`, sin SQL nuevo) + aserción de conteo exacto `== 1`.

2. **[menor — corregido] CA declarado sin test.** El issue lista MEF-ADR-0004 capa 4 con la
   precision *"`Apply` nunca lanza, incluso ante orden anomalo de eventos"*, y ningun test ejercia
   un stream anomalo. **Corregido**: test que rehidrata `ColaboradorRegistrado + VinculacionIniciada +
   TerminacionAnulada` (anulacion sin terminacion previa) y verifica que no rompe y que el comando
   se rechaza por la unica regla.

3. **[menor — corregido] Estado no cubierto en la cara de exito.** CA-4 solo probaba el reingreso
   **sin terminar** (rechazo). Faltaba el reingreso **ya terminado**: el unico estado del stream
   donde conviven `_fechaTerminacionVinculacionAnterior` (congelada) y
   `_fechaTerminacionVinculacionVigente`, y por tanto el unico que demuestra que
   `Apply(TerminacionAnulada)` reabre **solo la ultima** y con el codigo/fecha del reingreso, no los
   originales. **Corregido** con un test.

4. **[cosmetico — corregido] Cruft de fase roja** en el handler y en los guardrails (ver
   "Elegancia").

5. **[cosmetico — no corregido, fuera de alcance] Boilerplate de fakes duplicado 6 veces.**
   `Fake{Comando}RequestValidator` y `Fake{Comando}CommandRouter` son identicos salvo el tipo
   generico, en los 6 `FunctionEndpointTests.cs` del dominio. Supera el umbral de la Rule of Three,
   pero MEF-ADR-0018 ("Autoridad de extraccion") reserva la iniciativa al implementer y extraerlo
   tocaria 5 archivos ajenos a este diff. Se reporta como candidato a issue de tooling propio, no se
   fuerza aqui.

6. **[observacion, no hallazgo] `Guid.CreateVersion7().ToString("N")` en el smoke test.** Evaluado
   contra el gate de MEF-ADR-0037 punto 1: **no aplica**. Ese GUID genera un *numero de
   identificacion* de prueba (dato de dominio), no una clave de stream; la clave se arma despues
   como `"CC:<numero>"` a partir del mismo string, sin segunda via de conversion. Patron preexistente
   en toda la cadena #349-#352.

### Refactorings aplicados

| Cambio | Justificacion |
|---|---|
| Comentario del `CommandHandler` compactado (16 -> 6 lineas), sin `// STUB` | El cruft de fase roja describia un stub que ya no existe; el "que" lo dice el codigo. Mismo criterio aplicado en el refactor de #352 |
| `CodigoVinculacionReingreso` extraido | `"COL-002"` pasaba a repetirse con el test nuevo |
| `PostgresFixture.ContarEventosAsync` agregado | Habilita verificar "no se escribio un segundo evento", claim que ningun helper existente soportaba |
| `TimeoutAusencia` eliminado | Quedo sin uso al pasar a conteo exacto; ademas su nombre ya no describia el uso (se usaba para afirmar presencia) |
| `using AwesomeAssertions` eliminado de `ComposicionAnularYTerminarVinculacionTests` | IDE0005: el test asevera solo con el DSL |
| Lineas "Rojo esperado (fase roja, issue #354)" eliminadas | Afirmaciones falsas una vez en verde. Las de #330/#349/#351/#352 quedan (archivos/lineas fuera del diff) |

No se cambio ninguna firma publica ni la API del dominio.

### Cobertura de criterios de aceptacion

| Criterio | Estado | Test(s) |
|---|---|---|
| CA-1: terminacion registrada + POST valido -> 202, `TerminacionAnulada` en el stream, vinculacion abierta con codigo y fecha originales, tipo en `TiposPersistidos` | cubierto | `AnularTerminacion_EmiteTerminacionAnulada_CuandoLaUltimaVinculacionTieneTerminacionRegistrada`, `..._CuandoLaTerminacionEsUnPreavisoConFechaFutura`, `..._CuandoTipoYNumeroLleganSinNormalizar`, **`..._CuandoLaUltimaVinculacionNacioDeUnReingresoYaTerminado` (agregado)**; `FunctionEndpointTests.AnularTerminacion_Retorna202_...`; alta del tipo: `AliasEventosColaboradoresTests.TerminacionAnulada_TieneAliasTerminacionAnulada` + `ComposicionServiciosTests.AgregarServiciosColaboradores_RegistraLosTiposDeEventoPersistidos_...` y `..._DerivaElAliasDeEventoDelNombreDeClase_...`; smoke `AnularTerminacion_Retorna202YPersisteTerminacionAnulada_*` |
| CA-2: composicion anular + `TerminarVinculacion` -> 202 + nueva `VinculacionTerminada` con la fecha correcta | cubierto | `ComposicionAnularYTerminarVinculacionTests.TerminarVinculacion_EmiteVinculacionTerminadaConLaFechaCorregida_CuandoLaTerminacionErradaFueAnuladaAntes`; smoke `AnularTerminacion_ComponeConTerminarVinculacion_ParaCorregirLaFechaDeTerminacion` |
| CA-3: vinculacion abierta (recien registrada / reingresada / ya anulada) -> 409 con `.resx`, sin evento nuevo | cubierto | `AnularTerminacion_LanzaInvalidOperationException_CuandoLaVinculacionNuncaHaSidoTerminada`, `..._CuandoLaTerminacionYaFueAnuladaAntes`, **`..._CuandoElStreamTraeUnaAnulacionSinTerminacionPrevia` (agregado)**; `FunctionEndpointTests.AnularTerminacion_Retorna409_...`; smoke `AnularTerminacion_Retorna409_CuandoVinculacionNuncaFueTerminada` y `..._CuandoLaTerminacionYaFueAnuladaAntes` (ahora con **conteo exacto** del stream) |
| CA-4: tras un reingreso, terminacion anterior congelada -> 409 | cubierto | `AnularTerminacion_LanzaInvalidOperationException_CuandoLaUltimaVinculacionNacioDeUnReingresoSinTerminar`; su cara de exito en el test agregado del reingreso ya terminado; smoke `AnularTerminacion_Retorna409_CuandoLaUltimaVinculacionNacioDeUnReingresoSinTerminar` |
| CA-5: colaborador inexistente -> 404 con `.resx`, sin escribir nada | cubierto | `AnularTerminacion_LanzaKeyNotFoundException_CuandoColaboradorNoExiste` (con `Then` vacio = sin escritura); `FunctionEndpointTests.AnularTerminacion_Retorna404_...`; smoke `AnularTerminacion_Retorna404_CuandoColaboradorNoExiste` (verde falso hasta el deploy, ver arriba) |
| CA-6: request invalida -> 400 sin tocar el event store | cubierto | `AnularTerminacionValidatorTests` (5 casos: vacio, fuera de lista, minusculas validas, numero vacio, camino feliz); `FunctionEndpointTests.AnularTerminacion_Retorna400_...`; smoke `..._Retorna400_CuandoNumeroIdentificacionEsVacio` y `..._CuandoTipoIdentificacionNoEsReconocido` |

Guardrail adicional verificado: `AnularTerminacionCommandHandlerMensajesTests` (las claves del
`.resx` resuelven; sin el, un `GetString` nulo volveria vacuas todas las aserciones `WithMessage`).
`TerminacionAnuladaSerializacionTests` cubre el round-trip contra las opciones reales de Marten pese
a que el evento no tenga campos.

### Tests agregados

1. `AnularTerminacion_EmiteTerminacionAnulada_CuandoLaUltimaVinculacionNacioDeUnReingresoYaTerminado`
   — CA-1/CA-4 en su cara de exito: unico estado con las dos terminaciones conviviendo; prueba que
   se reabre la ULTIMA vinculacion conservando el codigo y la fecha de inicio **del reingreso**.
2. `AnularTerminacion_LanzaInvalidOperationException_CuandoElStreamTraeUnaAnulacionSinTerminacionPrevia`
   — MEF-ADR-0004 capa 4: rehidratacion tolerante ante orden anomalo, exigencia declarada en el
   issue que no tenia test.

Tests de contrato (igualdad / serializacion, seccion 4b): **no aplican** — el diff no introduce
ningun tipo con `IEquatable<T>` ni con `ConfigurarSerializacion`, y `TerminacionAnulada` no lleva
marker de bus, asi que tampoco corresponde el guardrail de round-trip con serializador por defecto.

</details>

## Commits

86d418e refactor(hu-354): cubre la anulacion sobre reingreso y el orden anomalo, y hace exacto el smoke de doble anulacion
7fc021b Agrega smoke tests para AnularTerminacion (issue #354)
8b9d88b feat(issue-354): implementacion de anular la terminacion de una vinculacion (fase verde)
52225c2 test(issue-354): tests para anular la terminacion de una vinculacion (fase roja)

Closes #354