### PR TITLE
Asignar y retirar etiquetas de un colaborador

### DIFF
--- a/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/ConfiguracionSerializacionColaboradores.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/ConfiguracionSerializacionColaboradores.cs
@@ -27,12 +27,14 @@ public static class ConfiguracionSerializacionColaboradores
     }
 
     // Registra los VOs con ctor privado que aparecen como payload de eventos persistidos --
-    // ColaboradorRegistrado y VinculacionIniciada son records con ctor publico y no declaran
-    // ConfigurarSerializacion propio, asi que una vez que sus VOs anidados esten registrados aqui,
-    // STJ los reconstruye sin ayuda adicional (ver comentarios de ColaboradorRegistrado.cs).
+    // ColaboradorRegistrado, VinculacionIniciada y EtiquetaAsignada (issue #355) son records con
+    // ctor publico y no declaran ConfigurarSerializacion propio, asi que una vez que sus VOs
+    // anidados esten registrados aqui, STJ los reconstruye sin ayuda adicional (ver comentarios de
+    // ColaboradorRegistrado.cs).
     public static void ConfigurarResolver(DefaultJsonTypeInfoResolver resolver)
     {
         Identificacion.ConfigurarSerializacion(resolver);
         NombreColaborador.ConfigurarSerializacion(resolver);
+        Etiqueta.ConfigurarSerializacion(resolver);
     }
 }

--- a/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/Etiqueta.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/Etiqueta.cs
@@ -77,9 +77,9 @@ public sealed partial class Etiqueta : IEquatable<Etiqueta>
     public bool EsMismaCategoria(Etiqueta otra) =>
         _categoriaNormalizada == otra._categoriaNormalizada;
 
-    // Issue #355 (desviacion documentada por el test-writer, ver resumen del pipeline):
-    // RetirarEtiqueta solo lleva la Categoria en su payload (sin Valor) -- Etiqueta.Crear(categoria,
-    // valor) no es aplicable porque exige un valor no vacio. Tell-don't-Ask: la normalizacion de una
+    // Issue #355: RetirarEtiqueta solo lleva la Categoria en su payload (sin Valor) --
+    // Etiqueta.Crear(categoria, valor) no es aplicable porque exige un valor no vacio.
+    // Tell-don't-Ask: la normalizacion de una
     // categoria aislada sigue siendo decision de ESTE VO (mismo criterio que EsMismaCategoria decide
     // que significa "misma categoria"), nunca del handler ni del aggregate comparando/transformando
     // strings por su cuenta. Mismas reglas de rechazo que Crear (vacia/whitespace -> ArgumentException

--- a/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/Etiqueta.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/Etiqueta.cs
@@ -84,9 +84,13 @@ public sealed partial class Etiqueta : IEquatable<Etiqueta>
     // que significa "misma categoria"), nunca del handler ni del aggregate comparando/transformando
     // strings por su cuenta. Mismas reglas de rechazo que Crear (vacia/whitespace -> ArgumentException
     // con el mismo mensaje .resx) y el mismo algoritmo de normalizacion (trim + Normalizar).
-    // STUB (fase roja, issue #355): el cuerpo completo queda para el implementer.
-    public static string NormalizarCategoria(string categoria) =>
-        throw new NotImplementedException();
+    public static string NormalizarCategoria(string categoria)
+    {
+        if (string.IsNullOrWhiteSpace(categoria))
+            throw new ArgumentException(Mensajes.CategoriaVacia, nameof(categoria));
+
+        return Normalizar(categoria.Trim());
+    }
 
     // Display: "{Categoria}:{Valor}" con las formas originales, no las normalizadas.
     public override string ToString() => $"{_categoria}:{_valor}";

--- a/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/Etiqueta.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/Etiqueta.cs
@@ -77,6 +77,17 @@ public sealed partial class Etiqueta : IEquatable<Etiqueta>
     public bool EsMismaCategoria(Etiqueta otra) =>
         _categoriaNormalizada == otra._categoriaNormalizada;
 
+    // Issue #355 (desviacion documentada por el test-writer, ver resumen del pipeline):
+    // RetirarEtiqueta solo lleva la Categoria en su payload (sin Valor) -- Etiqueta.Crear(categoria,
+    // valor) no es aplicable porque exige un valor no vacio. Tell-don't-Ask: la normalizacion de una
+    // categoria aislada sigue siendo decision de ESTE VO (mismo criterio que EsMismaCategoria decide
+    // que significa "misma categoria"), nunca del handler ni del aggregate comparando/transformando
+    // strings por su cuenta. Mismas reglas de rechazo que Crear (vacia/whitespace -> ArgumentException
+    // con el mismo mensaje .resx) y el mismo algoritmo de normalizacion (trim + Normalizar).
+    // STUB (fase roja, issue #355): el cuerpo completo queda para el implementer.
+    public static string NormalizarCategoria(string categoria) =>
+        throw new NotImplementedException();
+
     // Display: "{Categoria}:{Valor}" con las formas originales, no las normalizadas.
     public override string ToString() => $"{_categoria}:{_valor}";
 

--- a/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/EtiquetaAsignada.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/EtiquetaAsignada.cs
@@ -1,0 +1,19 @@
+namespace Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+
+/// <summary>
+/// Evento de event sourcing que registra la asignacion (o sobrescritura) de una etiqueta dinamica
+/// a la vinculacion vigente de un colaborador. Se persiste en el stream de ColaboradorAggregateRoot.
+/// </summary>
+/// <remarks>
+/// Issue #355: payload rico -- Etiqueta (VO de #353) viaja completo, con su doble forma (original +
+/// normalizada) de categoria y valor, mismo criterio que NombresCorregidos con NombreColaborador.
+/// No declara ConfigurarSerializacion propio: la de Etiqueta, que ConfiguracionSerializacionColaboradores
+/// debe registrar (fase verde -- ver ConfiguracionSerializacionColaboradores.ConfigurarResolver),
+/// basta para reconstruir el ctor publico del record.
+/// Un valor por categoria (CA-2): este evento SIEMPRE representa el estado final de esa categoria --
+/// el aggregate lo emite tanto al crear una categoria nueva como al sobrescribir el valor de una
+/// existente (ColaboradorAggregateRoot.AsignarEtiqueta decide cuando, este evento nunca lo distingue).
+/// No cruza el bus (sin marker IPrivateEvent/IPublicEvent): event-sourcing puro, sin consumidores
+/// (issue #355 "Consumidores: ninguno").
+/// </remarks>
+public sealed record EtiquetaAsignada(Etiqueta Etiqueta);

--- a/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/EtiquetaRetirada.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/EtiquetaRetirada.cs
@@ -1,0 +1,18 @@
+namespace Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+
+/// <summary>
+/// Evento de event sourcing que registra el retiro de una etiqueta dinamica de la vinculacion
+/// vigente de un colaborador. Se persiste en el stream de ColaboradorAggregateRoot.
+/// </summary>
+/// <remarks>
+/// Issue #355: payload plano -- CategoriaNormalizada (string), sin VO -- mismo criterio que
+/// VinculacionTerminada. No necesita ConfigurarSerializacion: tipo primitivo, STJ lo reconstruye
+/// sin ayuda.
+/// Solo la forma NORMALIZADA (no la original): el retiro identifica la categoria por su clave en
+/// el diccionario de la vinculacion (Etiqueta.CategoriaNormalizada, #353) -- el evento no necesita
+/// la forma original porque no hay valor que preservar en el registro (a diferencia de
+/// EtiquetaAsignada, que persiste la Etiqueta completa incluyendo su display).
+/// No cruza el bus (sin marker IPrivateEvent/IPublicEvent): event-sourcing puro, sin consumidores
+/// (issue #355 "Consumidores: ninguno").
+/// </remarks>
+public sealed record EtiquetaRetirada(string CategoriaNormalizada);

--- a/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/IdentidadEventosColaboradores.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/IdentidadEventosColaboradores.cs
@@ -21,5 +21,7 @@ public static class IdentidadEventosColaboradores
         typeof(NombresCorregidos),
         typeof(FechaInicioVinculacionCorregida),
         typeof(TerminacionAnulada),
+        typeof(EtiquetaAsignada),
+        typeof(EtiquetaRetirada),
     ];
 }

--- a/src/Bitakora.ControlAsistencia.Colaboradores/AsignarEtiquetaFunction/AsignarEtiqueta.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/AsignarEtiquetaFunction/AsignarEtiqueta.cs
@@ -1,0 +1,17 @@
+namespace Bitakora.ControlAsistencia.Colaboradores.AsignarEtiquetaFunction;
+
+// Issue #355: comando para asignar (o sobrescribir) una etiqueta dinamica -- par categoria:valor
+// libre, sin catalogo previo -- a la vinculacion vigente de un colaborador. Septimo comando del
+// ciclo de vida de ColaboradorAggregateRoot (desglose #348-#357).
+// Trigger: HTTP POST, Route: Colaboradores/Etiquetas (identificacion en el body porque su
+// representacion "CC:79543210" contiene ":", hostil como segmento de URL -- mismo criterio que el
+// resto del ciclo de vida).
+// Payload primitivo -- igual que los demas comandos del ciclo de vida (MEF-ADR-0039 decision 6,
+// payload por rol): NUNCA reusa un tipo de Colaboradores.DomainEvents como campo. El handler
+// construye Etiqueta a partir de Categoria/Valor (parseo tipado unico en el borde, MEF-ADR-0037
+// seccion 2, mismo criterio que Identificacion).
+public record AsignarEtiqueta(
+    string TipoIdentificacion,
+    string NumeroIdentificacion,
+    string Categoria,
+    string Valor);

--- a/src/Bitakora.ControlAsistencia.Colaboradores/AsignarEtiquetaFunction/CommandHandler/AsignarEtiquetaCommandHandler.Mensajes.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/AsignarEtiquetaFunction/CommandHandler/AsignarEtiquetaCommandHandler.Mensajes.cs
@@ -1,0 +1,21 @@
+using System.Resources;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.AsignarEtiquetaFunction.CommandHandler;
+
+// MEF-ADR-0009: mensajes del handler en .resx separado.
+// internal: accesible desde tests via InternalsVisibleTo en el .csproj.
+public partial class AsignarEtiquetaCommandHandler
+{
+    private static readonly ResourceManager ResourceManager = new(
+        "Bitakora.ControlAsistencia.Colaboradores.AsignarEtiquetaFunction.CommandHandler.AsignarEtiquetaCommandHandlerMensajes",
+        typeof(AsignarEtiquetaCommandHandler).Assembly);
+
+    internal static class Mensajes
+    {
+        public static string ColaboradorNoEncontrado =>
+            ResourceManager.GetString(nameof(ColaboradorNoEncontrado))!;
+
+        public static string VinculacionTerminada =>
+            ResourceManager.GetString(nameof(VinculacionTerminada))!;
+    }
+}

--- a/src/Bitakora.ControlAsistencia.Colaboradores/AsignarEtiquetaFunction/CommandHandler/AsignarEtiquetaCommandHandler.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/AsignarEtiquetaFunction/CommandHandler/AsignarEtiquetaCommandHandler.cs
@@ -1,3 +1,5 @@
+using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+using Bitakora.ControlAsistencia.Colaboradores.Entities;
 using Cosmos.EventSourcing.Abstractions.Commands;
 
 namespace Bitakora.ControlAsistencia.Colaboradores.AsignarEtiquetaFunction.CommandHandler;
@@ -27,6 +29,22 @@ public partial class AsignarEtiquetaCommandHandler : ICommandHandlerAsync<Asigna
     public AsignarEtiquetaCommandHandler(IEventStore eventStore) =>
         _eventStore = eventStore;
 
-    public Task HandleAsync(AsignarEtiqueta command, CancellationToken ct = default) =>
-        throw new NotImplementedException();
+    public async Task HandleAsync(AsignarEtiqueta command, CancellationToken ct = default)
+    {
+        // Parseo tipado unico del borde (MEF-ADR-0037 seccion 2), mismo criterio que
+        // CorregirFechaInicioVinculacionCommandHandler/ReingresarColaboradorCommandHandler.
+        var tipo = TipoIdentificacion.Desde(command.TipoIdentificacion.Trim().ToUpperInvariant());
+        var identificacion = Identificacion.Crear(tipo, command.NumeroIdentificacion);
+
+        var streamId = ColaboradorAggregateRoot.ComputarStreamId(identificacion);
+        var colaborador = await _eventStore.GetAggregateRootAsync<ColaboradorAggregateRoot>(streamId, ct);
+        if (colaborador is null)
+            throw new KeyNotFoundException(Mensajes.ColaboradorNoEncontrado);
+
+        var etiqueta = Etiqueta.Crear(command.Categoria, command.Valor);
+
+        var resultado = colaborador.AsignarEtiqueta(etiqueta);
+        if (resultado == ResultadoAsignacionEtiqueta.VinculacionTerminada)
+            throw new InvalidOperationException(Mensajes.VinculacionTerminada);
+    }
 }

--- a/src/Bitakora.ControlAsistencia.Colaboradores/AsignarEtiquetaFunction/CommandHandler/AsignarEtiquetaCommandHandler.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/AsignarEtiquetaFunction/CommandHandler/AsignarEtiquetaCommandHandler.cs
@@ -1,0 +1,32 @@
+using Cosmos.EventSourcing.Abstractions.Commands;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.AsignarEtiquetaFunction.CommandHandler;
+
+// Issue #355: handler del comando AsignarEtiqueta.
+// Flujo esperado (precedente CorregirFechaInicioVinculacionCommandHandler #352, MEF-ADR-0004 capa
+// 2 -- CA-ADR-0030):
+//   1. Normalizar y parsear TipoIdentificacion -> TipoIdentificacion.Desde(...) (borde HTTP:
+//      normalizar trim+MAYUSCULAS ANTES de Desde, mismo criterio que los handlers hermanos).
+//   2. Identificacion.Crear(tipo, command.NumeroIdentificacion) -- normaliza el numero.
+//   3. ComputarStreamId(identificacion) -> GetAggregateRootAsync<ColaboradorAggregateRoot> -- si
+//      es null, throw KeyNotFoundException(Mensajes.ColaboradorNoEncontrado) (-> 404).
+//   4. Etiqueta.Crear(command.Categoria, command.Valor) -- valida y normaliza el par (#353).
+//   5. colaborador.AsignarEtiqueta(etiqueta) -- el aggregate declina con resultado o en silencio
+//      (nunca lanza, nunca emite evento de fallo persistido):
+//        - ResultadoAsignacionEtiqueta.VinculacionTerminada -> throw
+//          InvalidOperationException(Mensajes.VinculacionTerminada) (-> 409).
+//        - ResultadoAsignacionEtiqueta.SinCambios -> idempotencia silenciosa, sin evento (-> 202).
+//        - ResultadoAsignacionEtiqueta.Exitosa -> el aggregate ya agrego EtiquetaAsignada a
+//          _uncommittedEvents; WhenAsync/el middleware persiste via SaveChanges.
+// Sin publicacion a bus (event-sourcing puro, issue #355 "Consumidores: ninguno").
+// STUB (fase roja, issue #355): el cuerpo completo queda para el implementer.
+public partial class AsignarEtiquetaCommandHandler : ICommandHandlerAsync<AsignarEtiqueta>
+{
+    private readonly IEventStore _eventStore;
+
+    public AsignarEtiquetaCommandHandler(IEventStore eventStore) =>
+        _eventStore = eventStore;
+
+    public Task HandleAsync(AsignarEtiqueta command, CancellationToken ct = default) =>
+        throw new NotImplementedException();
+}

--- a/src/Bitakora.ControlAsistencia.Colaboradores/AsignarEtiquetaFunction/CommandHandler/AsignarEtiquetaCommandHandler.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/AsignarEtiquetaFunction/CommandHandler/AsignarEtiquetaCommandHandler.cs
@@ -4,24 +4,15 @@ using Cosmos.EventSourcing.Abstractions.Commands;
 
 namespace Bitakora.ControlAsistencia.Colaboradores.AsignarEtiquetaFunction.CommandHandler;
 
-// Issue #355: handler del comando AsignarEtiqueta.
-// Flujo esperado (precedente CorregirFechaInicioVinculacionCommandHandler #352, MEF-ADR-0004 capa
-// 2 -- CA-ADR-0030):
-//   1. Normalizar y parsear TipoIdentificacion -> TipoIdentificacion.Desde(...) (borde HTTP:
-//      normalizar trim+MAYUSCULAS ANTES de Desde, mismo criterio que los handlers hermanos).
-//   2. Identificacion.Crear(tipo, command.NumeroIdentificacion) -- normaliza el numero.
-//   3. ComputarStreamId(identificacion) -> GetAggregateRootAsync<ColaboradorAggregateRoot> -- si
-//      es null, throw KeyNotFoundException(Mensajes.ColaboradorNoEncontrado) (-> 404).
-//   4. Etiqueta.Crear(command.Categoria, command.Valor) -- valida y normaliza el par (#353).
-//   5. colaborador.AsignarEtiqueta(etiqueta) -- el aggregate declina con resultado o en silencio
-//      (nunca lanza, nunca emite evento de fallo persistido):
-//        - ResultadoAsignacionEtiqueta.VinculacionTerminada -> throw
-//          InvalidOperationException(Mensajes.VinculacionTerminada) (-> 409).
-//        - ResultadoAsignacionEtiqueta.SinCambios -> idempotencia silenciosa, sin evento (-> 202).
-//        - ResultadoAsignacionEtiqueta.Exitosa -> el aggregate ya agrego EtiquetaAsignada a
-//          _uncommittedEvents; WhenAsync/el middleware persiste via SaveChanges.
-// Sin publicacion a bus (event-sourcing puro, issue #355 "Consumidores: ninguno").
-// STUB (fase roja, issue #355): el cuerpo completo queda para el implementer.
+// Issue #355: handler del comando AsignarEtiqueta. Combina los dos mecanismos que el ciclo de vida
+// ya usa (CA-ADR-0030, precedente CorregirFechaInicioVinculacionCommandHandler #352): el aggregate
+// declina CON RESULTADO la regla de apertura estricta (VinculacionTerminada), que este handler
+// traduce a InvalidOperationException/409 con mensaje .resx, y declina EN SILENCIO la idempotencia
+// (SinCambios), que no es un rechazo: el borde responde 202 igual, como en
+// CorregirNombresCommandHandler. El 404 es precondicion de orquestacion (MEF-ADR-0004 capa 2), no
+// regla del aggregate. En el camino de exito el aggregate ya dejo EtiquetaAsignada en
+// _uncommittedEvents -- el middleware persiste via SaveChanges. Sin publicacion a bus
+// (event-sourcing puro, issue #355 "Consumidores: ninguno").
 public partial class AsignarEtiquetaCommandHandler : ICommandHandlerAsync<AsignarEtiqueta>
 {
     private readonly IEventStore _eventStore;

--- a/src/Bitakora.ControlAsistencia.Colaboradores/AsignarEtiquetaFunction/CommandHandler/AsignarEtiquetaCommandHandlerMensajes.resx
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/AsignarEtiquetaFunction/CommandHandler/AsignarEtiquetaCommandHandlerMensajes.resx
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" msdata:Ordinal="0" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter</value></resheader>
+  <data name="ColaboradorNoEncontrado" xml:space="preserve">
+    <value>No existe un colaborador registrado con esa identificacion</value>
+  </data>
+  <data name="VinculacionTerminada" xml:space="preserve">
+    <value>La vinculacion vigente del colaborador tiene una terminacion registrada</value>
+  </data>
+</root>

--- a/src/Bitakora.ControlAsistencia.Colaboradores/AsignarEtiquetaFunction/CommandHandler/AsignarEtiquetaValidator.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/AsignarEtiquetaFunction/CommandHandler/AsignarEtiquetaValidator.cs
@@ -1,3 +1,4 @@
+using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
 using FluentValidation;
 
 namespace Bitakora.ControlAsistencia.Colaboradores.AsignarEtiquetaFunction.CommandHandler;
@@ -12,4 +13,34 @@ namespace Bitakora.ControlAsistencia.Colaboradores.AsignarEtiquetaFunction.Comma
 // AnularTerminacionValidator, issue #354).
 public class AsignarEtiquetaValidator : AbstractValidator<AsignarEtiqueta>
 {
+    public AsignarEtiquetaValidator()
+    {
+        // Cascade(Stop) evita que Must evalue un valor vacio que NotEmpty ya rechazo -- mismo
+        // criterio que CorregirFechaInicioVinculacionValidator/ReingresarColaboradorValidator.
+        RuleFor(x => x.TipoIdentificacion)
+            .Cascade(CascadeMode.Stop)
+            .NotEmpty()
+            .Must(EsTipoIdentificacionReconocido)
+            .WithMessage("El tipo de identificacion no es uno de los reconocidos");
+
+        RuleFor(x => x.NumeroIdentificacion).NotEmpty();
+        RuleFor(x => x.Categoria).NotEmpty();
+        RuleFor(x => x.Valor).NotEmpty();
+    }
+
+    // Consulta la lista cerrada (#348) sin propagar la excepcion de dominio al boundary de
+    // validacion -- un codigo fuera de la lista debe traducirse en un error de FluentValidation
+    // (400), no en una excepcion no controlada.
+    private static bool EsTipoIdentificacionReconocido(string tipo)
+    {
+        try
+        {
+            TipoIdentificacion.Desde(tipo.Trim().ToUpperInvariant());
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+    }
 }

--- a/src/Bitakora.ControlAsistencia.Colaboradores/AsignarEtiquetaFunction/CommandHandler/AsignarEtiquetaValidator.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/AsignarEtiquetaFunction/CommandHandler/AsignarEtiquetaValidator.cs
@@ -8,9 +8,7 @@ namespace Bitakora.ControlAsistencia.Colaboradores.AsignarEtiquetaFunction.Comma
 // Categoria y Valor requeridos -- las invariantes de doble forma/normalizacion viven en el VO
 // Etiqueta (#353), no en este validator (el aggregate solo gobierna el diccionario).
 // Se descubre via el AddValidatorsFromAssemblyContaining que ComposicionServicios ya configura: no
-// requiere tocar el wiring de DI.
-// STUB (fase roja, issue #355): sin reglas todavia -- el implementer las agrega (precedente
-// AnularTerminacionValidator, issue #354).
+// requiere tocar el wiring de DI. Precedente: AnularTerminacionValidator (issue #354).
 public class AsignarEtiquetaValidator : AbstractValidator<AsignarEtiqueta>
 {
     public AsignarEtiquetaValidator()

--- a/src/Bitakora.ControlAsistencia.Colaboradores/AsignarEtiquetaFunction/CommandHandler/AsignarEtiquetaValidator.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/AsignarEtiquetaFunction/CommandHandler/AsignarEtiquetaValidator.cs
@@ -1,0 +1,15 @@
+using FluentValidation;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.AsignarEtiquetaFunction.CommandHandler;
+
+// Issue #355: validacion de forma del comando AsignarEtiqueta en el borde (MEF-ADR-0004 capa 1 ->
+// 400 BadRequest). CA-7: TipoIdentificacion (requerido + en la lista cerrada), NumeroIdentificacion,
+// Categoria y Valor requeridos -- las invariantes de doble forma/normalizacion viven en el VO
+// Etiqueta (#353), no en este validator (el aggregate solo gobierna el diccionario).
+// Se descubre via el AddValidatorsFromAssemblyContaining que ComposicionServicios ya configura: no
+// requiere tocar el wiring de DI.
+// STUB (fase roja, issue #355): sin reglas todavia -- el implementer las agrega (precedente
+// AnularTerminacionValidator, issue #354).
+public class AsignarEtiquetaValidator : AbstractValidator<AsignarEtiqueta>
+{
+}

--- a/src/Bitakora.ControlAsistencia.Colaboradores/AsignarEtiquetaFunction/FunctionEndpoint.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/AsignarEtiquetaFunction/FunctionEndpoint.cs
@@ -1,0 +1,45 @@
+using Bitakora.ControlAsistencia.Colaboradores.Infraestructura;
+using Cosmos.EventSourcing.Abstractions.Commands;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.AsignarEtiquetaFunction;
+
+// Issue #355: endpoint HTTP POST para asignar (o sobrescribir) una etiqueta dinamica a la
+// vinculacion vigente de un colaborador. MEF-ADR-0006: [Function("AsignarEtiqueta")]; carpeta CON
+// sufijo "Function" -- mismo criterio que los demas comandos del ciclo de vida: el record del
+// comando es homonimo del feature folder.
+// Route = "Colaboradores/Etiquetas": identificacion en el body porque su representacion
+// ("CC:79543210") contiene ":", hostil como segmento de URL.
+// CA-ADR-0030 / MEF-ADR-0004 (precedente AnularTerminacionFunction.FunctionEndpoint): validar
+// request (400 via IRequestValidator) -> despachar comando -> InvalidOperationException -> 409
+// Conflict, KeyNotFoundException -> 404 NotFound; exito -> 202 Accepted.
+public class FunctionEndpoint(IRequestValidator requestValidator, ICommandRouter commandRouter)
+{
+    [Function("AsignarEtiqueta")]
+    public async Task<IActionResult> Run(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "Colaboradores/Etiquetas")]
+        HttpRequest req,
+        CancellationToken ct)
+    {
+        var (comando, error) = await requestValidator.ValidarAsync<AsignarEtiqueta>(req, ct);
+        if (error is not null)
+            return error;
+
+        try
+        {
+            await commandRouter.InvokeAsync(comando!, ct);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return new ConflictObjectResult(ex.Message);
+        }
+        catch (KeyNotFoundException ex)
+        {
+            return new NotFoundObjectResult(ex.Message);
+        }
+
+        return new AcceptedResult();
+    }
+}

--- a/src/Bitakora.ControlAsistencia.Colaboradores/Entities/ColaboradorAggregateRoot.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/Entities/ColaboradorAggregateRoot.cs
@@ -88,6 +88,7 @@ public partial class ColaboradorAggregateRoot : AggregateRoot
         _codigoVinculacionVigente = e.Codigo;
         _fechaInicioVinculacionVigente = e.FechaInicio;
         _fechaTerminacionVinculacionVigente = null;
+        _etiquetas = new();
     }
 
     // Issue #349: registra la terminacion de la vinculacion vigente. Nunca lanza (MEF-ADR-0004
@@ -109,13 +110,11 @@ public partial class ColaboradorAggregateRoot : AggregateRoot
     // Issue #355: registra/sobrescribe la etiqueta bajo su categoria normalizada -- un valor por
     // categoria (CA-2: "Área" sobre "area" sobrescribe, nunca duplica). Nunca lanza (MEF-ADR-0004
     // capa 4).
-    // STUB (fase roja, issue #355): el cuerpo completo queda para el implementer.
-    public void Apply(EtiquetaAsignada e) => throw new NotImplementedException();
+    public void Apply(EtiquetaAsignada e) => _etiquetas[e.Etiqueta.CategoriaNormalizada] = e.Etiqueta;
 
     // Issue #355: retira la etiqueta de esa categoria normalizada del diccionario. Nunca lanza
     // (MEF-ADR-0004 capa 4).
-    // STUB (fase roja, issue #355): el cuerpo completo queda para el implementer.
-    public void Apply(EtiquetaRetirada e) => throw new NotImplementedException();
+    public void Apply(EtiquetaRetirada e) => _etiquetas.Remove(e.CategoriaNormalizada);
 
     // Issue #349: mecanismo "declinar con resultado" (CA-ADR-0030) -- nunca lanza, nunca emite un
     // evento de fallo persistido. Dos razones de rechazo evaluables solo con la historia del
@@ -268,9 +267,21 @@ public partial class ColaboradorAggregateRoot : AggregateRoot
     // Exito: appendea EtiquetaAsignada a _uncommittedEvents y lo aplica.
     // internal: mismo criterio de visibilidad que los metodos de comando hermanos -- el unico
     // llamador es el handler del mismo ensamblado (los tests lo alcanzan via InternalsVisibleTo).
-    // STUB (fase roja, issue #355): el cuerpo completo queda para el implementer.
-    internal ResultadoAsignacionEtiqueta AsignarEtiqueta(Etiqueta etiqueta) =>
-        throw new NotImplementedException();
+    internal ResultadoAsignacionEtiqueta AsignarEtiqueta(Etiqueta etiqueta)
+    {
+        if (_fechaTerminacionVinculacionVigente is not null)
+            return ResultadoAsignacionEtiqueta.VinculacionTerminada;
+
+        if (_etiquetas.TryGetValue(etiqueta.CategoriaNormalizada, out var existente) &&
+            etiqueta.Equals(existente))
+            return ResultadoAsignacionEtiqueta.SinCambios;
+
+        var evento = new EtiquetaAsignada(etiqueta);
+        _uncommittedEvents.Add(evento);
+        Apply(evento);
+
+        return ResultadoAsignacionEtiqueta.Exitosa;
+    }
 
     // Issue #355: mecanismo "declinar con resultado" puro (CA-ADR-0030) -- retirar una categoria
     // inexistente SIEMPRE rechaza (CA-4, decision de refinamiento 2026-08-11: con categorias
@@ -281,9 +292,20 @@ public partial class ColaboradorAggregateRoot : AggregateRoot
     // mismo criterio que EsMismaCategoria decide "misma categoria" dentro del VO, no en el
     // llamador).
     // internal: mismo criterio de visibilidad que los metodos de comando hermanos.
-    // STUB (fase roja, issue #355): el cuerpo completo queda para el implementer.
-    internal ResultadoRetiroEtiqueta RetirarEtiqueta(string categoriaNormalizada) =>
-        throw new NotImplementedException();
+    internal ResultadoRetiroEtiqueta RetirarEtiqueta(string categoriaNormalizada)
+    {
+        if (_fechaTerminacionVinculacionVigente is not null)
+            return ResultadoRetiroEtiqueta.VinculacionTerminada;
+
+        if (!_etiquetas.ContainsKey(categoriaNormalizada))
+            return ResultadoRetiroEtiqueta.CategoriaInexistente;
+
+        var evento = new EtiquetaRetirada(categoriaNormalizada);
+        _uncommittedEvents.Add(evento);
+        Apply(evento);
+
+        return ResultadoRetiroEtiqueta.Exitosa;
+    }
 
     // Factory interno: agrega los DOS eventos del commit a _uncommittedEvents y los aplica -- patron
     // RegistroDeMarcacionAggregateRoot.Iniciar, generalizado a dos eventos en el mismo commit.

--- a/src/Bitakora.ControlAsistencia.Colaboradores/Entities/ColaboradorAggregateRoot.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/Entities/ColaboradorAggregateRoot.cs
@@ -36,6 +36,16 @@ public partial class ColaboradorAggregateRoot : AggregateRoot
     // vinculacion).
     private DateOnly? _fechaTerminacionVinculacionAnterior;
 
+    // Issue #355: diccionario de etiquetas dinamicas de la vinculacion vigente, clave = categoria
+    // normalizada (Etiqueta.CategoriaNormalizada, #353) -- un valor por categoria (Crear/Apply
+    // sobrescriben, nunca duplican). No es observable publico: el issue no expone lectura de
+    // etiquetas al exterior del ensamblado (Tell-don't-Ask, MEF-ADR-0012) -- la lectura llega con
+    // las projections (#356/#357). internal solo para que el DSL de tests (And<>) verifique el
+    // estado rehidratado, mismo criterio que los demas observables internos de esta clase.
+    private Dictionary<string, Etiqueta> _etiquetas = new();
+
+    internal IReadOnlyDictionary<string, Etiqueta> Etiquetas => _etiquetas;
+
     internal Identificacion Identificacion => _identificacion!;
     internal NombreColaborador Nombre => _nombre!;
     internal string CodigoVinculacionVigente => _codigoVinculacionVigente!;
@@ -68,6 +78,10 @@ public partial class ColaboradorAggregateRoot : AggregateRoot
     // terminacion de la vinculacion que este reingreso desplaza -- es el unico rastro que
     // CorregirFechaInicio tiene para evaluar la no-solape hacia atras una vez que
     // _fechaTerminacionVinculacionVigente ya se reseteo a null.
+    // Issue #355 (pendiente, fase verde -- CA-6 "reingreso nace limpio"): este metodo debe ademas
+    // resetear _etiquetas a un diccionario vacio -- la vinculacion nueva no hereda las etiquetas de
+    // la anterior. NO se implementa aqui (fase roja): el cuerpo real de esa extension queda para el
+    // implementer, mismo criterio que el resto de esta clase.
     public void Apply(VinculacionIniciada e)
     {
         _fechaTerminacionVinculacionAnterior = _fechaTerminacionVinculacionVigente;
@@ -91,6 +105,17 @@ public partial class ColaboradorAggregateRoot : AggregateRoot
     // Issue #352: reemplaza la fecha de inicio de la ULTIMA vinculacion (tenga o no terminacion
     // registrada). Nunca lanza (MEF-ADR-0004 capa 4).
     public void Apply(FechaInicioVinculacionCorregida e) => _fechaInicioVinculacionVigente = e.FechaInicio;
+
+    // Issue #355: registra/sobrescribe la etiqueta bajo su categoria normalizada -- un valor por
+    // categoria (CA-2: "Área" sobre "area" sobrescribe, nunca duplica). Nunca lanza (MEF-ADR-0004
+    // capa 4).
+    // STUB (fase roja, issue #355): el cuerpo completo queda para el implementer.
+    public void Apply(EtiquetaAsignada e) => throw new NotImplementedException();
+
+    // Issue #355: retira la etiqueta de esa categoria normalizada del diccionario. Nunca lanza
+    // (MEF-ADR-0004 capa 4).
+    // STUB (fase roja, issue #355): el cuerpo completo queda para el implementer.
+    public void Apply(EtiquetaRetirada e) => throw new NotImplementedException();
 
     // Issue #349: mecanismo "declinar con resultado" (CA-ADR-0030) -- nunca lanza, nunca emite un
     // evento de fallo persistido. Dos razones de rechazo evaluables solo con la historia del
@@ -230,6 +255,35 @@ public partial class ColaboradorAggregateRoot : AggregateRoot
 
         return ResultadoAnulacionTerminacion.Exitosa;
     }
+
+    // Issue #355: mecanismo combinado (CA-ADR-0030) -- "declinar con resultado" para la regla de
+    // apertura estricta (decision #1 del issue: la ULTIMA vinculacion no puede tener terminacion
+    // registrada, incluido un preaviso sin vencer -- las etiquetas describen la relacion laboral
+    // ACTIVA) y "declinar en silencio" (precedente CorregirNombres #351 / CorregirFechaInicio #352)
+    // para la idempotencia (CA-2: la etiqueta nueva es igual por valor, Etiqueta.Equals #353, a la
+    // que ya existe para esa categoria).
+    // Un valor por categoria (CA-2, CA-4): la clave del diccionario es SIEMPRE
+    // etiqueta.CategoriaNormalizada -- asignar sobre una categoria existente sobrescribe, nunca
+    // duplica.
+    // Exito: appendea EtiquetaAsignada a _uncommittedEvents y lo aplica.
+    // internal: mismo criterio de visibilidad que los metodos de comando hermanos -- el unico
+    // llamador es el handler del mismo ensamblado (los tests lo alcanzan via InternalsVisibleTo).
+    // STUB (fase roja, issue #355): el cuerpo completo queda para el implementer.
+    internal ResultadoAsignacionEtiqueta AsignarEtiqueta(Etiqueta etiqueta) =>
+        throw new NotImplementedException();
+
+    // Issue #355: mecanismo "declinar con resultado" puro (CA-ADR-0030) -- retirar una categoria
+    // inexistente SIEMPRE rechaza (CA-4, decision de refinamiento 2026-08-11: con categorias
+    // libres, un typo como "aera" por "area" debe aflorar al instante, nunca un 202 silencioso que
+    // lo esconda).
+    // Recibe la categoria YA NORMALIZADA (Tell-don't-Ask: el handler la obtiene de
+    // Etiqueta.NormalizarCategoria, #355 -- el aggregate nunca normaliza strings por su cuenta,
+    // mismo criterio que EsMismaCategoria decide "misma categoria" dentro del VO, no en el
+    // llamador).
+    // internal: mismo criterio de visibilidad que los metodos de comando hermanos.
+    // STUB (fase roja, issue #355): el cuerpo completo queda para el implementer.
+    internal ResultadoRetiroEtiqueta RetirarEtiqueta(string categoriaNormalizada) =>
+        throw new NotImplementedException();
 
     // Factory interno: agrega los DOS eventos del commit a _uncommittedEvents y los aplica -- patron
     // RegistroDeMarcacionAggregateRoot.Iniciar, generalizado a dos eventos en el mismo commit.

--- a/src/Bitakora.ControlAsistencia.Colaboradores/Entities/ColaboradorAggregateRoot.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/Entities/ColaboradorAggregateRoot.cs
@@ -37,12 +37,13 @@ public partial class ColaboradorAggregateRoot : AggregateRoot
     private DateOnly? _fechaTerminacionVinculacionAnterior;
 
     // Issue #355: diccionario de etiquetas dinamicas de la vinculacion vigente, clave = categoria
-    // normalizada (Etiqueta.CategoriaNormalizada, #353) -- un valor por categoria (Crear/Apply
-    // sobrescriben, nunca duplican). No es observable publico: el issue no expone lectura de
-    // etiquetas al exterior del ensamblado (Tell-don't-Ask, MEF-ADR-0012) -- la lectura llega con
-    // las projections (#356/#357). internal solo para que el DSL de tests (And<>) verifique el
-    // estado rehidratado, mismo criterio que los demas observables internos de esta clase.
-    private Dictionary<string, Etiqueta> _etiquetas = new();
+    // normalizada (Etiqueta.CategoriaNormalizada, #353) -- un valor por categoria (AsignarEtiqueta y
+    // su Apply sobrescriben la entrada, nunca duplican). No es observable publico: el issue no
+    // expone lectura de etiquetas al exterior del ensamblado (Tell-don't-Ask, MEF-ADR-0012) -- la
+    // lectura llega con las projections (#356/#357). internal solo para que el DSL de tests (And<>)
+    // verifique el estado rehidratado, mismo criterio que los demas observables internos de esta
+    // clase.
+    private readonly Dictionary<string, Etiqueta> _etiquetas = new();
 
     internal IReadOnlyDictionary<string, Etiqueta> Etiquetas => _etiquetas;
 
@@ -78,17 +79,17 @@ public partial class ColaboradorAggregateRoot : AggregateRoot
     // terminacion de la vinculacion que este reingreso desplaza -- es el unico rastro que
     // CorregirFechaInicio tiene para evaluar la no-solape hacia atras una vez que
     // _fechaTerminacionVinculacionVigente ya se reseteo a null.
-    // Issue #355 (pendiente, fase verde -- CA-6 "reingreso nace limpio"): este metodo debe ademas
-    // resetear _etiquetas a un diccionario vacio -- la vinculacion nueva no hereda las etiquetas de
-    // la anterior. NO se implementa aqui (fase roja): el cuerpo real de esa extension queda para el
-    // implementer, mismo criterio que el resto de esta clase.
+    // Issue #355 (CA-6, "reingreso nace limpio"): ademas vacia las etiquetas -- la vinculacion nueva
+    // no hereda las de la anterior (las etiquetas describen la relacion laboral vigente). Se vacia
+    // incondicionalmente, tambien en la primera vinculacion (donde ya esta vacio): Apply nunca
+    // ramifica por logica de negocio, solo asienta estado (MEF-ADR-0004 capa 4).
     public void Apply(VinculacionIniciada e)
     {
         _fechaTerminacionVinculacionAnterior = _fechaTerminacionVinculacionVigente;
         _codigoVinculacionVigente = e.Codigo;
         _fechaInicioVinculacionVigente = e.FechaInicio;
         _fechaTerminacionVinculacionVigente = null;
-        _etiquetas = new();
+        _etiquetas.Clear();
     }
 
     // Issue #349: registra la terminacion de la vinculacion vigente. Nunca lanza (MEF-ADR-0004

--- a/src/Bitakora.ControlAsistencia.Colaboradores/Entities/ResultadoAsignacionEtiqueta.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/Entities/ResultadoAsignacionEtiqueta.cs
@@ -1,0 +1,21 @@
+namespace Bitakora.ControlAsistencia.Colaboradores.Entities;
+
+// Issue #355: resultado de ColaboradorAggregateRoot.AsignarEtiqueta. Combina los dos mecanismos
+// que el ciclo de vida ya usa (CA-ADR-0030):
+//   - "declinar con resultado" (ResultadoTerminacionVinculacion #349 y hermanos): VinculacionTerminada
+//     es la unica razon de rechazo evaluable con la historia del stream, sin reloj (decision de
+//     refinamiento 2026-08-11: las etiquetas describen la relacion laboral ACTIVA, incluido un
+//     preaviso sin vencer) -- el handler la traduce a InvalidOperationException/409 con mensaje
+//     .resx.
+//   - "declinar en silencio" (ColaboradorAggregateRoot.CorregirNombres #351 / CorregirFechaInicio
+//     #352): SinCambios es la variante de EXITO silenciosa -- la etiqueta nueva es igual por valor
+//     (Etiqueta.Equals, #353) a la que ya existe para esa categoria, ningun evento nuevo.
+// internal: mismo criterio de visibilidad que los resultados hermanos -- vive en el mismo
+// ensamblado que el handler que lo consume (Entities/ y CommandHandler/ en el mismo proyecto
+// Function App), publicos son solo Apply(...) y ComputarStreamId.
+internal enum ResultadoAsignacionEtiqueta
+{
+    Exitosa,
+    SinCambios,
+    VinculacionTerminada
+}

--- a/src/Bitakora.ControlAsistencia.Colaboradores/Entities/ResultadoRetiroEtiqueta.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/Entities/ResultadoRetiroEtiqueta.cs
@@ -1,0 +1,19 @@
+namespace Bitakora.ControlAsistencia.Colaboradores.Entities;
+
+// Issue #355: resultado de ColaboradorAggregateRoot.RetirarEtiqueta. Mecanismo "declinar con
+// resultado" puro (CA-ADR-0030) -- a diferencia de AsignarEtiqueta, retirar NO tiene variante de
+// idempotencia silenciosa: retirar una categoria inexistente es un rechazo explicito (CA-4,
+// decision de refinamiento 2026-08-11 -- con categorias libres, un typo como "aera" por "area"
+// debe aflorar al instante, nunca un 202 silencioso que lo esconda).
+// Dos razones de rechazo, evaluables solo con la historia del stream, sin reloj:
+//   - CategoriaInexistente: la categoria normalizada no esta en el diccionario de la vinculacion
+//     vigente.
+//   - VinculacionTerminada: la ULTIMA vinculacion tiene terminacion registrada (incluye un
+//     preaviso sin vencer) -- las etiquetas describen la relacion laboral ACTIVA.
+// internal: mismo criterio de visibilidad que los resultados hermanos.
+internal enum ResultadoRetiroEtiqueta
+{
+    Exitosa,
+    CategoriaInexistente,
+    VinculacionTerminada
+}

--- a/src/Bitakora.ControlAsistencia.Colaboradores/RetirarEtiquetaFunction/CommandHandler/RetirarEtiquetaCommandHandler.Mensajes.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/RetirarEtiquetaFunction/CommandHandler/RetirarEtiquetaCommandHandler.Mensajes.cs
@@ -1,0 +1,24 @@
+using System.Resources;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.RetirarEtiquetaFunction.CommandHandler;
+
+// MEF-ADR-0009: mensajes del handler en .resx separado.
+// internal: accesible desde tests via InternalsVisibleTo en el .csproj.
+public partial class RetirarEtiquetaCommandHandler
+{
+    private static readonly ResourceManager ResourceManager = new(
+        "Bitakora.ControlAsistencia.Colaboradores.RetirarEtiquetaFunction.CommandHandler.RetirarEtiquetaCommandHandlerMensajes",
+        typeof(RetirarEtiquetaCommandHandler).Assembly);
+
+    internal static class Mensajes
+    {
+        public static string ColaboradorNoEncontrado =>
+            ResourceManager.GetString(nameof(ColaboradorNoEncontrado))!;
+
+        public static string VinculacionTerminada =>
+            ResourceManager.GetString(nameof(VinculacionTerminada))!;
+
+        public static string CategoriaInexistente =>
+            ResourceManager.GetString(nameof(CategoriaInexistente))!;
+    }
+}

--- a/src/Bitakora.ControlAsistencia.Colaboradores/RetirarEtiquetaFunction/CommandHandler/RetirarEtiquetaCommandHandler.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/RetirarEtiquetaFunction/CommandHandler/RetirarEtiquetaCommandHandler.cs
@@ -4,26 +4,14 @@ using Cosmos.EventSourcing.Abstractions.Commands;
 
 namespace Bitakora.ControlAsistencia.Colaboradores.RetirarEtiquetaFunction.CommandHandler;
 
-// Issue #355: handler del comando RetirarEtiqueta.
-// Flujo esperado (precedente CorregirFechaInicioVinculacionCommandHandler #352, MEF-ADR-0004 capa
-// 2 -- CA-ADR-0030):
-//   1. Normalizar y parsear TipoIdentificacion -> TipoIdentificacion.Desde(...) (borde HTTP:
-//      normalizar trim+MAYUSCULAS ANTES de Desde, mismo criterio que los handlers hermanos).
-//   2. Identificacion.Crear(tipo, command.NumeroIdentificacion) -- normaliza el numero.
-//   3. ComputarStreamId(identificacion) -> GetAggregateRootAsync<ColaboradorAggregateRoot> -- si
-//      es null, throw KeyNotFoundException(Mensajes.ColaboradorNoEncontrado) (-> 404).
-//   4. Etiqueta.NormalizarCategoria(command.Categoria) -- Tell-don't-Ask: la normalizacion de una
-//      categoria aislada (sin Valor) vive en el VO (#355, ver Etiqueta.cs), nunca en este handler.
-//   5. colaborador.RetirarEtiqueta(categoriaNormalizada) -- el aggregate declina con resultado
-//      (nunca lanza, nunca emite evento de fallo persistido):
-//        - ResultadoRetiroEtiqueta.CategoriaInexistente -> throw
-//          InvalidOperationException(Mensajes.CategoriaInexistente) (-> 409).
-//        - ResultadoRetiroEtiqueta.VinculacionTerminada -> throw
-//          InvalidOperationException(Mensajes.VinculacionTerminada) (-> 409).
-//        - ResultadoRetiroEtiqueta.Exitosa -> el aggregate ya agrego EtiquetaRetirada a
-//          _uncommittedEvents; WhenAsync/el middleware persiste via SaveChanges.
-// Sin publicacion a bus (event-sourcing puro, issue #355 "Consumidores: ninguno").
-// STUB (fase roja, issue #355): el cuerpo completo queda para el implementer.
+// Issue #355: handler del comando RetirarEtiqueta. Mecanismo "declinar con resultado" puro
+// (CA-ADR-0030, precedente CorregirFechaInicioVinculacionCommandHandler #352) -- sin variante
+// silenciosa, a diferencia de AsignarEtiqueta: tanto CategoriaInexistente (CA-4, el typo debe
+// aflorar) como VinculacionTerminada se traducen a InvalidOperationException/409 con mensaje .resx.
+// El 404 es precondicion de orquestacion (MEF-ADR-0004 capa 2), no regla del aggregate. En el
+// camino de exito el aggregate ya dejo EtiquetaRetirada en _uncommittedEvents -- el middleware
+// persiste via SaveChanges. Sin publicacion a bus (event-sourcing puro, issue #355 "Consumidores:
+// ninguno").
 public partial class RetirarEtiquetaCommandHandler : ICommandHandlerAsync<RetirarEtiqueta>
 {
     private readonly IEventStore _eventStore;

--- a/src/Bitakora.ControlAsistencia.Colaboradores/RetirarEtiquetaFunction/CommandHandler/RetirarEtiquetaCommandHandler.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/RetirarEtiquetaFunction/CommandHandler/RetirarEtiquetaCommandHandler.cs
@@ -1,0 +1,34 @@
+using Cosmos.EventSourcing.Abstractions.Commands;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.RetirarEtiquetaFunction.CommandHandler;
+
+// Issue #355: handler del comando RetirarEtiqueta.
+// Flujo esperado (precedente CorregirFechaInicioVinculacionCommandHandler #352, MEF-ADR-0004 capa
+// 2 -- CA-ADR-0030):
+//   1. Normalizar y parsear TipoIdentificacion -> TipoIdentificacion.Desde(...) (borde HTTP:
+//      normalizar trim+MAYUSCULAS ANTES de Desde, mismo criterio que los handlers hermanos).
+//   2. Identificacion.Crear(tipo, command.NumeroIdentificacion) -- normaliza el numero.
+//   3. ComputarStreamId(identificacion) -> GetAggregateRootAsync<ColaboradorAggregateRoot> -- si
+//      es null, throw KeyNotFoundException(Mensajes.ColaboradorNoEncontrado) (-> 404).
+//   4. Etiqueta.NormalizarCategoria(command.Categoria) -- Tell-don't-Ask: la normalizacion de una
+//      categoria aislada (sin Valor) vive en el VO (#355, ver Etiqueta.cs), nunca en este handler.
+//   5. colaborador.RetirarEtiqueta(categoriaNormalizada) -- el aggregate declina con resultado
+//      (nunca lanza, nunca emite evento de fallo persistido):
+//        - ResultadoRetiroEtiqueta.CategoriaInexistente -> throw
+//          InvalidOperationException(Mensajes.CategoriaInexistente) (-> 409).
+//        - ResultadoRetiroEtiqueta.VinculacionTerminada -> throw
+//          InvalidOperationException(Mensajes.VinculacionTerminada) (-> 409).
+//        - ResultadoRetiroEtiqueta.Exitosa -> el aggregate ya agrego EtiquetaRetirada a
+//          _uncommittedEvents; WhenAsync/el middleware persiste via SaveChanges.
+// Sin publicacion a bus (event-sourcing puro, issue #355 "Consumidores: ninguno").
+// STUB (fase roja, issue #355): el cuerpo completo queda para el implementer.
+public partial class RetirarEtiquetaCommandHandler : ICommandHandlerAsync<RetirarEtiqueta>
+{
+    private readonly IEventStore _eventStore;
+
+    public RetirarEtiquetaCommandHandler(IEventStore eventStore) =>
+        _eventStore = eventStore;
+
+    public Task HandleAsync(RetirarEtiqueta command, CancellationToken ct = default) =>
+        throw new NotImplementedException();
+}

--- a/src/Bitakora.ControlAsistencia.Colaboradores/RetirarEtiquetaFunction/CommandHandler/RetirarEtiquetaCommandHandler.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/RetirarEtiquetaFunction/CommandHandler/RetirarEtiquetaCommandHandler.cs
@@ -1,3 +1,5 @@
+using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+using Bitakora.ControlAsistencia.Colaboradores.Entities;
 using Cosmos.EventSourcing.Abstractions.Commands;
 
 namespace Bitakora.ControlAsistencia.Colaboradores.RetirarEtiquetaFunction.CommandHandler;
@@ -29,6 +31,29 @@ public partial class RetirarEtiquetaCommandHandler : ICommandHandlerAsync<Retira
     public RetirarEtiquetaCommandHandler(IEventStore eventStore) =>
         _eventStore = eventStore;
 
-    public Task HandleAsync(RetirarEtiqueta command, CancellationToken ct = default) =>
-        throw new NotImplementedException();
+    public async Task HandleAsync(RetirarEtiqueta command, CancellationToken ct = default)
+    {
+        // Parseo tipado unico del borde (MEF-ADR-0037 seccion 2), mismo criterio que
+        // CorregirFechaInicioVinculacionCommandHandler/ReingresarColaboradorCommandHandler.
+        var tipo = TipoIdentificacion.Desde(command.TipoIdentificacion.Trim().ToUpperInvariant());
+        var identificacion = Identificacion.Crear(tipo, command.NumeroIdentificacion);
+
+        var streamId = ColaboradorAggregateRoot.ComputarStreamId(identificacion);
+        var colaborador = await _eventStore.GetAggregateRootAsync<ColaboradorAggregateRoot>(streamId, ct);
+        if (colaborador is null)
+            throw new KeyNotFoundException(Mensajes.ColaboradorNoEncontrado);
+
+        // Tell-don't-Ask: la normalizacion de una categoria aislada (sin Valor) vive en el VO
+        // Etiqueta (#355), nunca en este handler.
+        var categoriaNormalizada = Etiqueta.NormalizarCategoria(command.Categoria);
+
+        var resultado = colaborador.RetirarEtiqueta(categoriaNormalizada);
+        switch (resultado)
+        {
+            case ResultadoRetiroEtiqueta.CategoriaInexistente:
+                throw new InvalidOperationException(Mensajes.CategoriaInexistente);
+            case ResultadoRetiroEtiqueta.VinculacionTerminada:
+                throw new InvalidOperationException(Mensajes.VinculacionTerminada);
+        }
+    }
 }

--- a/src/Bitakora.ControlAsistencia.Colaboradores/RetirarEtiquetaFunction/CommandHandler/RetirarEtiquetaCommandHandlerMensajes.resx
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/RetirarEtiquetaFunction/CommandHandler/RetirarEtiquetaCommandHandlerMensajes.resx
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" msdata:Ordinal="0" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter</value></resheader>
+  <data name="ColaboradorNoEncontrado" xml:space="preserve">
+    <value>No existe un colaborador registrado con esa identificacion</value>
+  </data>
+  <data name="VinculacionTerminada" xml:space="preserve">
+    <value>La vinculacion vigente del colaborador tiene una terminacion registrada</value>
+  </data>
+  <data name="CategoriaInexistente" xml:space="preserve">
+    <value>No existe una etiqueta asignada con esa categoria</value>
+  </data>
+</root>

--- a/src/Bitakora.ControlAsistencia.Colaboradores/RetirarEtiquetaFunction/CommandHandler/RetirarEtiquetaValidator.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/RetirarEtiquetaFunction/CommandHandler/RetirarEtiquetaValidator.cs
@@ -1,0 +1,14 @@
+using FluentValidation;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.RetirarEtiquetaFunction.CommandHandler;
+
+// Issue #355: validacion de forma del comando RetirarEtiqueta en el borde (MEF-ADR-0004 capa 1 ->
+// 400 BadRequest). CA-7: TipoIdentificacion (requerido + en la lista cerrada), NumeroIdentificacion
+// y Categoria requeridos. Sin Valor: el comando no lo lleva (retirar solo necesita la categoria).
+// Se descubre via el AddValidatorsFromAssemblyContaining que ComposicionServicios ya configura: no
+// requiere tocar el wiring de DI.
+// STUB (fase roja, issue #355): sin reglas todavia -- el implementer las agrega (precedente
+// AnularTerminacionValidator, issue #354).
+public class RetirarEtiquetaValidator : AbstractValidator<RetirarEtiqueta>
+{
+}

--- a/src/Bitakora.ControlAsistencia.Colaboradores/RetirarEtiquetaFunction/CommandHandler/RetirarEtiquetaValidator.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/RetirarEtiquetaFunction/CommandHandler/RetirarEtiquetaValidator.cs
@@ -7,9 +7,7 @@ namespace Bitakora.ControlAsistencia.Colaboradores.RetirarEtiquetaFunction.Comma
 // 400 BadRequest). CA-7: TipoIdentificacion (requerido + en la lista cerrada), NumeroIdentificacion
 // y Categoria requeridos. Sin Valor: el comando no lo lleva (retirar solo necesita la categoria).
 // Se descubre via el AddValidatorsFromAssemblyContaining que ComposicionServicios ya configura: no
-// requiere tocar el wiring de DI.
-// STUB (fase roja, issue #355): sin reglas todavia -- el implementer las agrega (precedente
-// AnularTerminacionValidator, issue #354).
+// requiere tocar el wiring de DI. Precedente: AnularTerminacionValidator (issue #354).
 public class RetirarEtiquetaValidator : AbstractValidator<RetirarEtiqueta>
 {
     public RetirarEtiquetaValidator()

--- a/src/Bitakora.ControlAsistencia.Colaboradores/RetirarEtiquetaFunction/CommandHandler/RetirarEtiquetaValidator.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/RetirarEtiquetaFunction/CommandHandler/RetirarEtiquetaValidator.cs
@@ -1,3 +1,4 @@
+using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
 using FluentValidation;
 
 namespace Bitakora.ControlAsistencia.Colaboradores.RetirarEtiquetaFunction.CommandHandler;
@@ -11,4 +12,33 @@ namespace Bitakora.ControlAsistencia.Colaboradores.RetirarEtiquetaFunction.Comma
 // AnularTerminacionValidator, issue #354).
 public class RetirarEtiquetaValidator : AbstractValidator<RetirarEtiqueta>
 {
+    public RetirarEtiquetaValidator()
+    {
+        // Cascade(Stop) evita que Must evalue un valor vacio que NotEmpty ya rechazo -- mismo
+        // criterio que CorregirFechaInicioVinculacionValidator/ReingresarColaboradorValidator.
+        RuleFor(x => x.TipoIdentificacion)
+            .Cascade(CascadeMode.Stop)
+            .NotEmpty()
+            .Must(EsTipoIdentificacionReconocido)
+            .WithMessage("El tipo de identificacion no es uno de los reconocidos");
+
+        RuleFor(x => x.NumeroIdentificacion).NotEmpty();
+        RuleFor(x => x.Categoria).NotEmpty();
+    }
+
+    // Consulta la lista cerrada (#348) sin propagar la excepcion de dominio al boundary de
+    // validacion -- un codigo fuera de la lista debe traducirse en un error de FluentValidation
+    // (400), no en una excepcion no controlada.
+    private static bool EsTipoIdentificacionReconocido(string tipo)
+    {
+        try
+        {
+            TipoIdentificacion.Desde(tipo.Trim().ToUpperInvariant());
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+    }
 }

--- a/src/Bitakora.ControlAsistencia.Colaboradores/RetirarEtiquetaFunction/FunctionEndpoint.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/RetirarEtiquetaFunction/FunctionEndpoint.cs
@@ -1,0 +1,46 @@
+using Bitakora.ControlAsistencia.Colaboradores.Infraestructura;
+using Cosmos.EventSourcing.Abstractions.Commands;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.RetirarEtiquetaFunction;
+
+// Issue #355: endpoint HTTP POST para retirar una etiqueta dinamica de la vinculacion vigente de
+// un colaborador. MEF-ADR-0006: [Function("RetirarEtiqueta")]; carpeta CON sufijo "Function" --
+// mismo criterio que los demas comandos del ciclo de vida: el record del comando es homonimo del
+// feature folder.
+// Route = "Colaboradores/Etiquetas/Retiros": sub-recurso de las etiquetas (patron
+// AnularTerminacion/TerminarVinculacion #349/#354) -- identificacion en el body porque su
+// representacion ("CC:79543210") contiene ":", hostil como segmento de URL.
+// CA-ADR-0030 / MEF-ADR-0004 (precedente AnularTerminacionFunction.FunctionEndpoint): validar
+// request (400 via IRequestValidator) -> despachar comando -> InvalidOperationException -> 409
+// Conflict, KeyNotFoundException -> 404 NotFound; exito -> 202 Accepted.
+public class FunctionEndpoint(IRequestValidator requestValidator, ICommandRouter commandRouter)
+{
+    [Function("RetirarEtiqueta")]
+    public async Task<IActionResult> Run(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "Colaboradores/Etiquetas/Retiros")]
+        HttpRequest req,
+        CancellationToken ct)
+    {
+        var (comando, error) = await requestValidator.ValidarAsync<RetirarEtiqueta>(req, ct);
+        if (error is not null)
+            return error;
+
+        try
+        {
+            await commandRouter.InvokeAsync(comando!, ct);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return new ConflictObjectResult(ex.Message);
+        }
+        catch (KeyNotFoundException ex)
+        {
+            return new NotFoundObjectResult(ex.Message);
+        }
+
+        return new AcceptedResult();
+    }
+}

--- a/src/Bitakora.ControlAsistencia.Colaboradores/RetirarEtiquetaFunction/RetirarEtiqueta.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/RetirarEtiquetaFunction/RetirarEtiqueta.cs
@@ -1,0 +1,15 @@
+namespace Bitakora.ControlAsistencia.Colaboradores.RetirarEtiquetaFunction;
+
+// Issue #355: comando para retirar una etiqueta dinamica de la vinculacion vigente de un
+// colaborador. Octavo comando del ciclo de vida de ColaboradorAggregateRoot (desglose #348-#357),
+// gemelo de AsignarEtiqueta sobre el mismo diccionario.
+// Trigger: HTTP POST, Route: Colaboradores/Etiquetas/Retiros (sub-recurso de las etiquetas, patron
+// de AnularTerminacion/TerminarVinculacion #349/#354; identificacion en el body porque su
+// representacion "CC:79543210" contiene ":", hostil como segmento de URL). DELETE descartado --
+// identidad en el body, consistencia POST del BC (decision del planner).
+// Payload primitivo -- SIN Valor (retirar solo necesita la categoria, MEF-ADR-0039 decision 6): el
+// handler obtiene la forma normalizada via Etiqueta.NormalizarCategoria (#355, ver Etiqueta.cs).
+public record RetirarEtiqueta(
+    string TipoIdentificacion,
+    string NumeroIdentificacion,
+    string Categoria);

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/AsignarEtiquetaFunction/AsignarEtiquetaSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/AsignarEtiquetaFunction/AsignarEtiquetaSmokeTests.cs
@@ -1,0 +1,417 @@
+// Issue #355: smoke tests del endpoint POST Colaboradores/Etiquetas (asignar o sobrescribir una
+// etiqueta dinamica -- par categoria:valor libre, sin catalogo previo -- a la vinculacion vigente
+// de un colaborador). Septimo comando del ciclo de vida de ColaboradorAggregateRoot (desglose
+// #348-#357), gemelo de RetirarEtiquetaSmokeTests sobre el mismo diccionario. Molde:
+// TerminarVinculacionSmokeTests/ReingresarColaboradorSmokeTests/CorregirNombresSmokeTests -- mismo
+// comando event-sourcing puro sin consumidores downstream (CA-ADR-0030): sin ServiceBusFixture, la
+// unica verificacion black-box de los efectos del handler es leer mt_events via PostgresFixture.
+//
+// Arrange: AsignarEtiqueta exige un ColaboradorAggregateRoot existente -- el arrange de cada test
+// registra el colaborador y, cuando aplica, termina su vinculacion o lo reingresa via los mismos
+// comandos que los originan (#330, #349, #350), nunca sembrando datos por fuera del API.
+//
+// Contenido persistido (Etiqueta, un VO con ctor privado, #353): se verifica deserializando el
+// campo "Etiqueta" con la SERIALIZACION REAL de produccion -- Etiqueta +
+// ConfiguracionSerializacionColaboradores.CrearOpcionesMarten() (referenciadas desde
+// Colaboradores.DomainEvents, ya cableado en el .csproj por el domain-scaffolder). Mismo criterio
+// que CorregirNombresSmokeTests con NombreColaborador: "el smoke test deserializa/serializa con el
+// tipo que realmente posee el payload persistido". La comparacion es por igualdad de valor
+// (Etiqueta.Equals, #353), NUNCA contra el texto JSON persistido (mt_events.data es jsonb; docs
+// 8.14.1). Solo es posible en streams que acumulan UN SOLO evento etiqueta_asignada
+// (ObtenerEventoAsync sin filtro trae el primero por seq_id -- ver el comentario de
+// PostgresFixture.ObtenerEventoAsync sobre campos objeto): cuando un escenario acumula DOS eventos
+// de este tipo en el mismo stream (CA-2 sobrescritura, CA-6 reingreso), el efecto se verifica por
+// CONTEO (ContarEventosAsync) en vez de contenido -- el detalle exhaustivo de "un valor por
+// categoria, nunca duplica" en el diccionario rehidratado ya lo cubre
+// AsignarEtiquetaCommandHandlerTests (*.Tests, unit), no se duplica aqui.
+//
+// CA-1 (ruta de exito): 202 + el stream recibe etiqueta_asignada con la doble forma (original y
+// normalizada) de categoria y valor.
+// CA-2 (rutas de exito): categoria existente + valor distinto -> sobrescribe (un evento nuevo se
+// agrega, conteo pasa de 1 a 2); etiqueta identica por valor -> 202 sin evento nuevo (idempotencia
+// silenciosa, conteo se mantiene en 1).
+// CA-5 (rutas de rechazo): la ultima vinculacion tiene terminacion registrada -- pasada o un
+// preaviso cuya fecha no ha llegado, sin distincion -> 409, sin evento.
+// CA-6: tras un reingreso, la vinculacion nueva no hereda las etiquetas de la anterior -- asignar
+// sobre la vinculacion vigente crea la categoria desde cero -> 202.
+// CA-7: colaborador inexistente -> 404; request invalida (categoria o valor vacios, identificacion
+// incompleta, tipo fuera de la lista) -> 400, sin tocar el event store.
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+using Bitakora.ControlAsistencia.Colaboradores.SmokeTests.Fixtures;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.SmokeTests.AsignarEtiquetaFunction;
+
+public class AsignarEtiquetaSmokeTests(ApiFixture api, PostgresFixture postgres)
+{
+    private readonly HttpClient _client = api.Client;
+
+    private const string RutaRegistrar = "/api/Colaboradores";
+    private const string RutaTerminaciones = "/api/Colaboradores/Terminaciones";
+    private const string RutaReingresos = "/api/Colaboradores/Reingresos";
+    private const string RutaEtiquetas = "/api/Colaboradores/Etiquetas";
+    private const string SchemaColaboradores = "colaboradores";
+    private const string TipoEventoEtiquetaAsignada = "etiqueta_asignada";
+    private const string TipoIdentificacionCc = "CC";
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
+
+    // Segunda lectura del mismo evento que ExisteEventoAsync ya espero: si el primer polling
+    // termino, el evento esta -- no hay nada mas que esperar.
+    private static readonly TimeSpan TimeoutLecturaConfirmada = TimeSpan.FromSeconds(5);
+
+    private static readonly JsonSerializerOptions OpcionesMarten =
+        ConfiguracionSerializacionColaboradores.CrearOpcionesMarten();
+
+    // Numero unico por test -- evita colisiones entre ejecuciones repetidas del smoke test: la
+    // identidad del stream es Identificacion.ToString() ("CC:<numero>"), no un Guid nuevo por
+    // llamada, asi que reusar un numero fijo haria que el arrange (RegistrarColaborador) choque con
+    // 409 en la segunda corrida.
+    private static string NuevoNumeroIdentificacion() => Guid.CreateVersion7().ToString("N").ToUpperInvariant();
+
+    private static string NuevoCodigoColaborador() => $"[TEST]-{Guid.CreateVersion7()}";
+
+    private static string ComputarStreamId(string numeroIdentificacion) =>
+        $"{TipoIdentificacionCc}:{numeroIdentificacion}";
+
+    private static object PayloadRegistro(string numeroIdentificacion, DateOnly fechaInicio) => new
+    {
+        tipoIdentificacion = TipoIdentificacionCc,
+        numeroIdentificacion,
+        primerNombre = "[TEST]",
+        segundoNombre = (string?)null,
+        primerApellido = "Smoke",
+        segundoApellido = (string?)null,
+        codigoColaborador = NuevoCodigoColaborador(),
+        fechaInicio
+    };
+
+    private static object PayloadTerminacion(string numeroIdentificacion, DateOnly fechaEfectiva) => new
+    {
+        tipoIdentificacion = TipoIdentificacionCc,
+        numeroIdentificacion,
+        fechaEfectiva
+    };
+
+    private static object PayloadReingreso(
+        string numeroIdentificacion, string codigoColaborador, DateOnly fechaInicio) => new
+        {
+            tipoIdentificacion = TipoIdentificacionCc,
+            numeroIdentificacion,
+            codigoColaborador,
+            fechaInicio
+        };
+
+    private static object PayloadAsignacion(
+        string numeroIdentificacion, string categoria, string valor,
+        string tipoIdentificacion = TipoIdentificacionCc) => new
+        {
+            tipoIdentificacion,
+            numeroIdentificacion,
+            categoria,
+            valor
+        };
+
+    // Arrange comun: registra un colaborador con una vinculacion abierta -- via el comando que la
+    // origina (#330), nunca sembrando el event store por fuera del API.
+    private async Task RegistrarColaboradorAsync(
+        string numeroIdentificacion, DateOnly fechaInicio, CancellationToken ct)
+    {
+        var response = await _client.PostAsJsonAsync(
+            RutaRegistrar, PayloadRegistro(numeroIdentificacion, fechaInicio), ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted,
+            "el arrange de este smoke test depende de que RegistrarColaborador funcione");
+    }
+
+    // Arrange comun (CA-5): cierra la vinculacion vigente -- via el comando que la origina (#349),
+    // nunca sembrando el event store por fuera del API.
+    private async Task TerminarVinculacionAsync(
+        string numeroIdentificacion, DateOnly fechaEfectiva, CancellationToken ct)
+    {
+        var response = await _client.PostAsJsonAsync(
+            RutaTerminaciones, PayloadTerminacion(numeroIdentificacion, fechaEfectiva), ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted,
+            "el arrange de este smoke test depende de que TerminarVinculacion funcione");
+    }
+
+    // Arrange comun (CA-6): reingresa al colaborador tras una terminacion -- via el comando que lo
+    // origina (#350), nunca sembrando el event store por fuera del API.
+    private async Task ReingresarColaboradorAsync(
+        string numeroIdentificacion, DateOnly fechaInicio, CancellationToken ct)
+    {
+        var response = await _client.PostAsJsonAsync(
+            RutaReingresos,
+            PayloadReingreso(numeroIdentificacion, NuevoCodigoColaborador(), fechaInicio),
+            ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted,
+            "el arrange de este smoke test depende de que ReingresarColaborador funcione");
+    }
+
+    private Task<HttpResponseMessage> AsignarEtiquetaAsync(
+        string numeroIdentificacion, string categoria, string valor, CancellationToken ct) =>
+        _client.PostAsJsonAsync(
+            RutaEtiquetas, PayloadAsignacion(numeroIdentificacion, categoria, valor), ct);
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task DebeEstarDisponible_CuandoSeConsultaHealthCheck()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var response = await _client.GetAsync("/api/health", ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    // CA-1: camino feliz -- colaborador con vinculacion abierta + categoria nueva -> 202 y el
+    // stream recibe etiqueta_asignada con la doble forma (original y normalizada) de categoria y
+    // valor. Sin Service Bus (event-sourcing puro): mt_events es la unica ventana black-box a lo
+    // que quedo grabado.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task AsignarEtiqueta_Retorna202YPersisteEtiquetaAsignada_CuandoCategoriaEsNueva()
+    {
+        Assert.SkipWhen(!postgres.IsConfigured, postgres.SkipReason ?? "Postgres no disponible.");
+
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion();
+
+        await RegistrarColaboradorAsync(numeroIdentificacion, new DateOnly(2026, 1, 15), ct);
+
+        var response = await AsignarEtiquetaAsync(numeroIdentificacion, "Área", "Tecnología", ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+
+        var streamId = ComputarStreamId(numeroIdentificacion);
+
+        var existe = await postgres.ExisteEventoAsync(
+            SchemaColaboradores, streamId, TipoEventoEtiquetaAsignada, Timeout);
+
+        existe.Should().BeTrue(
+            $"el evento {TipoEventoEtiquetaAsignada} deberia existir en el stream {streamId}");
+
+        var eventoPersistido = await postgres.ObtenerEventoAsync<JsonElement>(
+            SchemaColaboradores, streamId, TipoEventoEtiquetaAsignada, TimeoutLecturaConfirmada);
+
+        var etiquetaPersistida = eventoPersistido.GetProperty("Etiqueta").Deserialize<Etiqueta>(OpcionesMarten);
+
+        etiquetaPersistida.Should().Be(Etiqueta.Crear("Área", "Tecnología"));
+    }
+
+    // CA-2: asignar sobre una categoria existente (via EsMismaCategoria: "Área" sobre "area") con
+    // un valor distinto sobrescribe -- un evento nuevo se agrega (conteo pasa de 1 a 2), a
+    // diferencia de la idempotencia silenciosa (ver el siguiente test). El detalle de que el
+    // diccionario rehidratado conserve UN SOLO valor por categoria (no dos) ya lo cubre
+    // AsignarEtiquetaCommandHandlerTests a nivel unitario -- este smoke test solo verifica el
+    // efecto observable black-box: el endpoint acepta la sobrescritura y persiste otro evento.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task AsignarEtiqueta_Retorna202YAgregaOtroEvento_CuandoCategoriaExisteConValorDistinto()
+    {
+        Assert.SkipWhen(!postgres.IsConfigured, postgres.SkipReason ?? "Postgres no disponible.");
+
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion();
+        var streamId = ComputarStreamId(numeroIdentificacion);
+
+        await RegistrarColaboradorAsync(numeroIdentificacion, new DateOnly(2026, 1, 20), ct);
+
+        var primeraAsignacion = await AsignarEtiquetaAsync(numeroIdentificacion, "area", "Medellín", ct);
+        primeraAsignacion.StatusCode.Should().Be(HttpStatusCode.Accepted,
+            "el arrange de este smoke test depende de que la primera asignacion funcione");
+
+        var existePrimeraEtiqueta = await postgres.ExisteEventoAsync(
+            SchemaColaboradores, streamId, TipoEventoEtiquetaAsignada, Timeout);
+        existePrimeraEtiqueta.Should().BeTrue(
+            $"el evento {TipoEventoEtiquetaAsignada} de la primera asignacion deberia estar en el stream {streamId}");
+
+        var segundaAsignacion = await AsignarEtiquetaAsync(numeroIdentificacion, "Área", "Bogotá", ct);
+
+        segundaAsignacion.StatusCode.Should().Be(HttpStatusCode.Accepted);
+
+        var asignaciones = await postgres.ContarEventosAsync(
+            SchemaColaboradores, streamId, TipoEventoEtiquetaAsignada);
+
+        asignaciones.Should().Be(2,
+            "sobrescribir con un valor distinto deberia agregar un evento nuevo (a diferencia de la idempotencia silenciosa)");
+    }
+
+    // CA-2: la etiqueta del comando es IGUAL por valor (Etiqueta.Equals, #353) a la ya asignada
+    // para esa categoria -> idempotencia silenciosa: ningun evento nuevo, el conteo se mantiene en
+    // 1.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task AsignarEtiqueta_Retorna202SinNuevoEvento_CuandoEtiquetaEsIdenticaPorValorALaExistente()
+    {
+        Assert.SkipWhen(!postgres.IsConfigured, postgres.SkipReason ?? "Postgres no disponible.");
+
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion();
+        var streamId = ComputarStreamId(numeroIdentificacion);
+
+        await RegistrarColaboradorAsync(numeroIdentificacion, new DateOnly(2026, 1, 25), ct);
+
+        var primeraAsignacion = await AsignarEtiquetaAsync(numeroIdentificacion, "Área", "Tecnología", ct);
+        primeraAsignacion.StatusCode.Should().Be(HttpStatusCode.Accepted,
+            "el arrange de este smoke test depende de que la primera asignacion funcione");
+
+        var existePrimeraEtiqueta = await postgres.ExisteEventoAsync(
+            SchemaColaboradores, streamId, TipoEventoEtiquetaAsignada, Timeout);
+        existePrimeraEtiqueta.Should().BeTrue(
+            $"el evento {TipoEventoEtiquetaAsignada} de la primera asignacion deberia estar en el stream {streamId}");
+
+        // Misma etiqueta por valor, con otra combinacion de mayusculas/tildes en ambos campos.
+        var segundaAsignacion = await AsignarEtiquetaAsync(numeroIdentificacion, "area", "tecnologia", ct);
+
+        segundaAsignacion.StatusCode.Should().Be(HttpStatusCode.Accepted);
+
+        var asignaciones = await postgres.ContarEventosAsync(
+            SchemaColaboradores, streamId, TipoEventoEtiquetaAsignada);
+
+        asignaciones.Should().Be(1,
+            "una etiqueta identica por valor a la existente no deberia persistir un evento nuevo (idempotencia silenciosa)");
+    }
+
+    // CA-5 (decision #1, regla estricta de apertura): la ULTIMA vinculacion tiene terminacion
+    // registrada -> 409, sin evento nuevo. No requiere Postgres: el status code ya prueba que el
+    // aggregate declino con resultado y el handler lo tradujo (CA-ADR-0030).
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task AsignarEtiqueta_Retorna409_CuandoUltimaVinculacionTieneTerminacionRegistrada()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion();
+
+        await RegistrarColaboradorAsync(numeroIdentificacion, new DateOnly(2026, 2, 1), ct);
+        await TerminarVinculacionAsync(numeroIdentificacion, new DateOnly(2026, 5, 1), ct);
+
+        var response = await AsignarEtiquetaAsync(numeroIdentificacion, "Área", "Tecnología", ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    // CA-5 (preaviso no vencido): un preaviso con fecha futura ya registrado bloquea igual -- las
+    // etiquetas describen la relacion laboral ACTIVA, sin importar si la fecha efectiva ya paso.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task AsignarEtiqueta_Retorna409_CuandoTerminacionEsUnPreavisoConFechaFutura()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion();
+        var fechaPreavisoFutura = new DateOnly(2030, 12, 31);
+
+        await RegistrarColaboradorAsync(numeroIdentificacion, new DateOnly(2026, 1, 1), ct);
+        await TerminarVinculacionAsync(numeroIdentificacion, fechaPreavisoFutura, ct);
+
+        var response = await AsignarEtiquetaAsync(numeroIdentificacion, "Área", "Tecnología", ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    // CA-6 (reingreso nace limpio): tras un reingreso, la vinculacion nueva no hereda las etiquetas
+    // de la anterior -- asignar sobre la vinculacion vigente crea la categoria desde cero, sin
+    // colisionar con la etiqueta congelada de la vinculacion previa. El stream acumula 2 eventos
+    // etiqueta_asignada (el de la vinculacion anterior + el de la nueva): se verifica por conteo,
+    // mismo criterio que la sobrescritura (ver comentario del encabezado del archivo).
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task AsignarEtiqueta_Retorna202_CuandoVinculacionEsUnReingresoTrasTerminacionConEtiquetasPrevias()
+    {
+        Assert.SkipWhen(!postgres.IsConfigured, postgres.SkipReason ?? "Postgres no disponible.");
+
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion();
+        var streamId = ComputarStreamId(numeroIdentificacion);
+
+        await RegistrarColaboradorAsync(numeroIdentificacion, new DateOnly(2026, 1, 10), ct);
+
+        var asignacionPrevia = await AsignarEtiquetaAsync(numeroIdentificacion, "Área", "Ventas", ct);
+        asignacionPrevia.StatusCode.Should().Be(HttpStatusCode.Accepted,
+            "el arrange de este smoke test depende de que la asignacion previa al reingreso funcione");
+
+        await TerminarVinculacionAsync(numeroIdentificacion, new DateOnly(2026, 6, 1), ct);
+        await ReingresarColaboradorAsync(numeroIdentificacion, new DateOnly(2026, 7, 1), ct);
+
+        var response = await AsignarEtiquetaAsync(numeroIdentificacion, "Área", "Tecnología", ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+
+        var asignaciones = await postgres.ContarEventosAsync(
+            SchemaColaboradores, streamId, TipoEventoEtiquetaAsignada);
+
+        asignaciones.Should().Be(2,
+            "la vinculacion nueva del reingreso deberia aceptar la asignacion como una categoria nueva, agregando otro evento sin colisionar con la etiqueta congelada de la vinculacion anterior");
+    }
+
+    // CA-7: colaborador inexistente -> 404, sin escribir nada al event store (no hay stream para
+    // consultar: la ausencia de escritura la garantiza el propio 404 -- el handler lanza antes de
+    // llegar al aggregate).
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task AsignarEtiqueta_Retorna404_CuandoColaboradorNoExiste()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion(); // nunca registrado
+
+        var response = await AsignarEtiquetaAsync(numeroIdentificacion, "Área", "Tecnología", ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    // CA-7: Categoria vacia -> 400.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task AsignarEtiqueta_Retorna400_CuandoCategoriaEsVacia()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var payload = PayloadAsignacion(NuevoNumeroIdentificacion(), categoria: "", valor: "Tecnología");
+
+        var response = await _client.PostAsJsonAsync(RutaEtiquetas, payload, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    // CA-7: Valor vacio -> 400.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task AsignarEtiqueta_Retorna400_CuandoValorEsVacio()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var payload = PayloadAsignacion(NuevoNumeroIdentificacion(), categoria: "Área", valor: "");
+
+        var response = await _client.PostAsJsonAsync(RutaEtiquetas, payload, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    // CA-7: NumeroIdentificacion vacio -> 400.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task AsignarEtiqueta_Retorna400_CuandoNumeroIdentificacionEsVacio()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var payload = PayloadAsignacion(numeroIdentificacion: "", categoria: "Área", valor: "Tecnología");
+
+        var response = await _client.PostAsJsonAsync(RutaEtiquetas, payload, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    // CA-7: TipoIdentificacion fuera de la lista cerrada (PILA: CC, CE, TI, PA, PT) -> 400.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task AsignarEtiqueta_Retorna400_CuandoTipoIdentificacionNoEsReconocido()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var payload = PayloadAsignacion(
+            NuevoNumeroIdentificacion(), categoria: "Área", valor: "Tecnología", tipoIdentificacion: "XX");
+
+        var response = await _client.PostAsJsonAsync(RutaEtiquetas, payload, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/RetirarEtiquetaFunction/RetirarEtiquetaSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/RetirarEtiquetaFunction/RetirarEtiquetaSmokeTests.cs
@@ -1,0 +1,368 @@
+// Issue #355: smoke tests del endpoint POST Colaboradores/Etiquetas/Retiros (retirar una etiqueta
+// dinamica de la vinculacion vigente de un colaborador). Octavo comando del ciclo de vida de
+// ColaboradorAggregateRoot (desglose #348-#357), gemelo de AsignarEtiquetaSmokeTests sobre el mismo
+// diccionario. Molde: TerminarVinculacionSmokeTests/ReingresarColaboradorSmokeTests -- mismo
+// comando event-sourcing puro sin consumidores downstream (CA-ADR-0030): sin ServiceBusFixture, la
+// unica verificacion black-box de los efectos del handler es leer mt_events via PostgresFixture.
+//
+// Arrange: RetirarEtiqueta exige un ColaboradorAggregateRoot existente con la categoria YA
+// ASIGNADA -- el arrange de cada test registra el colaborador y asigna (y, cuando aplica, termina
+// su vinculacion o lo reingresa) via los mismos comandos que los originan (#330, #349, #350, y
+// AsignarEtiqueta del propio #355), nunca sembrando datos por fuera del API.
+//
+// Contenido persistido (EtiquetaRetirada, payload plano con solo CategoriaNormalizada -- un campo
+// ESCALAR top-level, a diferencia de EtiquetaAsignada): a diferencia de AsignarEtiquetaSmokeTests,
+// aqui SI se puede filtrar por (campoJson, valorJson) con el overload estandar de
+// PostgresFixture.ExisteEventoAsync/ObtenerEventoAsync, incluso en streams que acumulan mas de un
+// evento etiqueta_retirada.
+//
+// CA-3 (ruta de exito): 202 + el stream recibe etiqueta_retirada con la categoria normalizada,
+// retirando por una forma distinta a la asignada ("área" retira lo asignado como "Area").
+// CA-4 (rutas de rechazo, decision #2 -- SIN idempotencia silenciosa): categoria nunca asignada, o
+// un error de transcripcion sobre una categoria existente ("Aera" vs "Area") -> 409, sin evento
+// nuevo, la etiqueta existente (si la hay) queda intacta.
+// CA-5 (rutas de rechazo): la ultima vinculacion tiene terminacion registrada -- pasada o un
+// preaviso cuya fecha no ha llegado, sin distincion -> 409, sin evento.
+// CA-6: la etiqueta pertenecia a la vinculacion ANTERIOR (congelada tras la terminacion) -- la
+// vinculacion vigente (el reingreso) no la hereda, asi que retirarla encuentra la categoria
+// inexistente -> 409, igual que cualquier categoria nunca asignada.
+// CA-7: colaborador inexistente -> 404; request invalida (categoria vacia, identificacion
+// incompleta, tipo fuera de la lista) -> 400, sin tocar el event store.
+using System.Net;
+using System.Net.Http.Json;
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.SmokeTests.Fixtures;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.SmokeTests.RetirarEtiquetaFunction;
+
+public class RetirarEtiquetaSmokeTests(ApiFixture api, PostgresFixture postgres)
+{
+    private readonly HttpClient _client = api.Client;
+
+    private const string RutaRegistrar = "/api/Colaboradores";
+    private const string RutaTerminaciones = "/api/Colaboradores/Terminaciones";
+    private const string RutaReingresos = "/api/Colaboradores/Reingresos";
+    private const string RutaEtiquetas = "/api/Colaboradores/Etiquetas";
+    private const string RutaRetiros = "/api/Colaboradores/Etiquetas/Retiros";
+    private const string SchemaColaboradores = "colaboradores";
+    private const string TipoEventoEtiquetaAsignada = "etiqueta_asignada";
+    private const string TipoEventoEtiquetaRetirada = "etiqueta_retirada";
+    private const string TipoIdentificacionCc = "CC";
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
+
+    // La ausencia de evento tras un rechazo es sincrona (sin proyeccion downstream, event-sourcing
+    // puro) -- un timeout corto alcanza para probarla sin alargar la suite (mismo criterio que
+    // CorregirNombresSmokeTests.TimeoutAusencia).
+    private static readonly TimeSpan TimeoutAusencia = TimeSpan.FromSeconds(3);
+
+    // Numero unico por test -- evita colisiones entre ejecuciones repetidas del smoke test: la
+    // identidad del stream es Identificacion.ToString() ("CC:<numero>"), no un Guid nuevo por
+    // llamada, asi que reusar un numero fijo haria que el arrange (RegistrarColaborador) choque con
+    // 409 en la segunda corrida.
+    private static string NuevoNumeroIdentificacion() => Guid.CreateVersion7().ToString("N").ToUpperInvariant();
+
+    private static string NuevoCodigoColaborador() => $"[TEST]-{Guid.CreateVersion7()}";
+
+    private static string ComputarStreamId(string numeroIdentificacion) =>
+        $"{TipoIdentificacionCc}:{numeroIdentificacion}";
+
+    private static object PayloadRegistro(string numeroIdentificacion, DateOnly fechaInicio) => new
+    {
+        tipoIdentificacion = TipoIdentificacionCc,
+        numeroIdentificacion,
+        primerNombre = "[TEST]",
+        segundoNombre = (string?)null,
+        primerApellido = "Smoke",
+        segundoApellido = (string?)null,
+        codigoColaborador = NuevoCodigoColaborador(),
+        fechaInicio
+    };
+
+    private static object PayloadTerminacion(string numeroIdentificacion, DateOnly fechaEfectiva) => new
+    {
+        tipoIdentificacion = TipoIdentificacionCc,
+        numeroIdentificacion,
+        fechaEfectiva
+    };
+
+    private static object PayloadReingreso(
+        string numeroIdentificacion, string codigoColaborador, DateOnly fechaInicio) => new
+        {
+            tipoIdentificacion = TipoIdentificacionCc,
+            numeroIdentificacion,
+            codigoColaborador,
+            fechaInicio
+        };
+
+    private static object PayloadAsignacion(string numeroIdentificacion, string categoria, string valor) => new
+    {
+        tipoIdentificacion = TipoIdentificacionCc,
+        numeroIdentificacion,
+        categoria,
+        valor
+    };
+
+    private static object PayloadRetiro(
+        string numeroIdentificacion, string categoria, string tipoIdentificacion = TipoIdentificacionCc) => new
+        {
+            tipoIdentificacion,
+            numeroIdentificacion,
+            categoria
+        };
+
+    // Arrange comun: registra un colaborador con una vinculacion abierta -- via el comando que la
+    // origina (#330), nunca sembrando el event store por fuera del API.
+    private async Task RegistrarColaboradorAsync(
+        string numeroIdentificacion, DateOnly fechaInicio, CancellationToken ct)
+    {
+        var response = await _client.PostAsJsonAsync(
+            RutaRegistrar, PayloadRegistro(numeroIdentificacion, fechaInicio), ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted,
+            "el arrange de este smoke test depende de que RegistrarColaborador funcione");
+    }
+
+    // Arrange comun: asigna la etiqueta que luego se intenta retirar -- via el comando que la
+    // origina (AsignarEtiqueta, propio issue #355), nunca sembrando el event store por fuera del
+    // API.
+    private async Task AsignarEtiquetaAsync(
+        string numeroIdentificacion, string categoria, string valor, CancellationToken ct)
+    {
+        var response = await _client.PostAsJsonAsync(
+            RutaEtiquetas, PayloadAsignacion(numeroIdentificacion, categoria, valor), ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted,
+            "el arrange de este smoke test depende de que AsignarEtiqueta funcione");
+    }
+
+    // Arrange comun (CA-5): cierra la vinculacion vigente -- via el comando que la origina (#349),
+    // nunca sembrando el event store por fuera del API.
+    private async Task TerminarVinculacionAsync(
+        string numeroIdentificacion, DateOnly fechaEfectiva, CancellationToken ct)
+    {
+        var response = await _client.PostAsJsonAsync(
+            RutaTerminaciones, PayloadTerminacion(numeroIdentificacion, fechaEfectiva), ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted,
+            "el arrange de este smoke test depende de que TerminarVinculacion funcione");
+    }
+
+    // Arrange comun (CA-6): reingresa al colaborador tras una terminacion -- via el comando que lo
+    // origina (#350), nunca sembrando el event store por fuera del API.
+    private async Task ReingresarColaboradorAsync(
+        string numeroIdentificacion, DateOnly fechaInicio, CancellationToken ct)
+    {
+        var response = await _client.PostAsJsonAsync(
+            RutaReingresos,
+            PayloadReingreso(numeroIdentificacion, NuevoCodigoColaborador(), fechaInicio),
+            ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted,
+            "el arrange de este smoke test depende de que ReingresarColaborador funcione");
+    }
+
+    private Task<HttpResponseMessage> RetirarEtiquetaAsync(
+        string numeroIdentificacion, string categoria, CancellationToken ct) =>
+        _client.PostAsJsonAsync(RutaRetiros, PayloadRetiro(numeroIdentificacion, categoria), ct);
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task DebeEstarDisponible_CuandoSeConsultaHealthCheck()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var response = await _client.GetAsync("/api/health", ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    // CA-3: camino feliz -- retirar por una forma distinta de la que se asigno ("área" retira lo
+    // asignado como "Area", misma categoria normalizada) -> 202 y el stream recibe
+    // etiqueta_retirada con la categoria normalizada. Sin Service Bus (event-sourcing puro):
+    // mt_events es la unica ventana black-box a lo que quedo grabado.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task RetirarEtiqueta_Retorna202YPersisteEtiquetaRetirada_CuandoCategoriaExisteConFormaDistinta()
+    {
+        Assert.SkipWhen(!postgres.IsConfigured, postgres.SkipReason ?? "Postgres no disponible.");
+
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion();
+
+        await RegistrarColaboradorAsync(numeroIdentificacion, new DateOnly(2026, 1, 15), ct);
+        await AsignarEtiquetaAsync(numeroIdentificacion, "Area", "Ventas", ct);
+
+        var response = await RetirarEtiquetaAsync(numeroIdentificacion, "área", ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+
+        var streamId = ComputarStreamId(numeroIdentificacion);
+
+        var existe = await postgres.ExisteEventoAsync(
+            SchemaColaboradores, streamId, TipoEventoEtiquetaRetirada, Timeout,
+            campoJson: "CategoriaNormalizada", valorJson: "area");
+
+        existe.Should().BeTrue(
+            $"el evento {TipoEventoEtiquetaRetirada} con CategoriaNormalizada 'area' deberia existir en el stream {streamId}");
+    }
+
+    // CA-4 (decision #2, sin idempotencia silenciosa): retirar una categoria que nunca se asigno
+    // -> 409, sin evento nuevo. No requiere Postgres: el status code ya prueba que el aggregate
+    // declino con resultado y el handler lo tradujo (CA-ADR-0030).
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task RetirarEtiqueta_Retorna409_CuandoCategoriaNoExiste()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion();
+
+        await RegistrarColaboradorAsync(numeroIdentificacion, new DateOnly(2026, 2, 1), ct);
+
+        var response = await RetirarEtiquetaAsync(numeroIdentificacion, "Área", ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    // CA-4 (el typo debe aflorar, decision #2 del issue): "Aera" no es "Area" -- categorias
+    // distintas normalizadas, aunque exista una etiqueta para "Area" -> 409 igual, ninguna
+    // etiqueta_retirada nueva; la etiqueta existente ("Area") queda intacta (el conteo de
+    // etiqueta_asignada se mantiene en 1).
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task RetirarEtiqueta_Retorna409_CuandoHayUnErrorDeTranscripcionEnLaCategoria()
+    {
+        Assert.SkipWhen(!postgres.IsConfigured, postgres.SkipReason ?? "Postgres no disponible.");
+
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion();
+        var streamId = ComputarStreamId(numeroIdentificacion);
+
+        await RegistrarColaboradorAsync(numeroIdentificacion, new DateOnly(2026, 2, 5), ct);
+        await AsignarEtiquetaAsync(numeroIdentificacion, "Area", "Ventas", ct);
+
+        var response = await RetirarEtiquetaAsync(numeroIdentificacion, "Aera", ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+
+        var existeRetiro = await postgres.ExisteEventoAsync(
+            SchemaColaboradores, streamId, TipoEventoEtiquetaRetirada, TimeoutAusencia);
+        existeRetiro.Should().BeFalse(
+            "un error de transcripcion en la categoria no deberia persistir un etiqueta_retirada");
+
+        var asignaciones = await postgres.ContarEventosAsync(
+            SchemaColaboradores, streamId, TipoEventoEtiquetaAsignada);
+        asignaciones.Should().Be(1,
+            "la etiqueta original ('Area') deberia quedar intacta -- el rechazo no la toca");
+    }
+
+    // CA-5 (decision #1, regla estricta de apertura): la ULTIMA vinculacion tiene terminacion
+    // registrada -> 409, sin evento nuevo.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task RetirarEtiqueta_Retorna409_CuandoUltimaVinculacionTieneTerminacionRegistrada()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion();
+
+        await RegistrarColaboradorAsync(numeroIdentificacion, new DateOnly(2026, 2, 10), ct);
+        await AsignarEtiquetaAsync(numeroIdentificacion, "Área", "Ventas", ct);
+        await TerminarVinculacionAsync(numeroIdentificacion, new DateOnly(2026, 6, 1), ct);
+
+        var response = await RetirarEtiquetaAsync(numeroIdentificacion, "Área", ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    // CA-5 (preaviso no vencido): un preaviso con fecha futura ya registrado bloquea igual -- las
+    // etiquetas describen la relacion laboral ACTIVA, sin importar si la fecha efectiva ya paso.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task RetirarEtiqueta_Retorna409_CuandoTerminacionEsUnPreavisoConFechaFutura()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion();
+        var fechaPreavisoFutura = new DateOnly(2030, 12, 31);
+
+        await RegistrarColaboradorAsync(numeroIdentificacion, new DateOnly(2026, 1, 1), ct);
+        await AsignarEtiquetaAsync(numeroIdentificacion, "Área", "Ventas", ct);
+        await TerminarVinculacionAsync(numeroIdentificacion, fechaPreavisoFutura, ct);
+
+        var response = await RetirarEtiquetaAsync(numeroIdentificacion, "Área", ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    // CA-6 (reingreso nace limpio): la etiqueta pertenecia a la vinculacion ANTERIOR (congelada
+    // tras la terminacion) -- la vinculacion vigente (el reingreso) no la hereda, asi que
+    // retirarla encuentra la categoria inexistente -> 409, igual que cualquier categoria nunca
+    // asignada.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task RetirarEtiqueta_Retorna409_CuandoEtiquetaPerteneceALaVinculacionAnteriorTrasReingreso()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion();
+
+        await RegistrarColaboradorAsync(numeroIdentificacion, new DateOnly(2026, 1, 10), ct);
+        await AsignarEtiquetaAsync(numeroIdentificacion, "Área", "Ventas", ct);
+        await TerminarVinculacionAsync(numeroIdentificacion, new DateOnly(2026, 6, 1), ct);
+        await ReingresarColaboradorAsync(numeroIdentificacion, new DateOnly(2026, 7, 1), ct);
+
+        var response = await RetirarEtiquetaAsync(numeroIdentificacion, "Área", ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    // CA-7: colaborador inexistente -> 404, sin escribir nada al event store (no hay stream para
+    // consultar: la ausencia de escritura la garantiza el propio 404 -- el handler lanza antes de
+    // llegar al aggregate).
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task RetirarEtiqueta_Retorna404_CuandoColaboradorNoExiste()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion(); // nunca registrado
+
+        var response = await RetirarEtiquetaAsync(numeroIdentificacion, "Área", ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    // CA-7: Categoria vacia -> 400.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task RetirarEtiqueta_Retorna400_CuandoCategoriaEsVacia()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var payload = PayloadRetiro(NuevoNumeroIdentificacion(), categoria: "");
+
+        var response = await _client.PostAsJsonAsync(RutaRetiros, payload, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    // CA-7: NumeroIdentificacion vacio -> 400.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task RetirarEtiqueta_Retorna400_CuandoNumeroIdentificacionEsVacio()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var payload = PayloadRetiro(numeroIdentificacion: "", categoria: "Área");
+
+        var response = await _client.PostAsJsonAsync(RutaRetiros, payload, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    // CA-7: TipoIdentificacion fuera de la lista cerrada (PILA: CC, CE, TI, PA, PT) -> 400.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task RetirarEtiqueta_Retorna400_CuandoTipoIdentificacionNoEsReconocido()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var payload = PayloadRetiro(NuevoNumeroIdentificacion(), categoria: "Área", tipoIdentificacion: "XX");
+
+        var response = await _client.PostAsJsonAsync(RutaRetiros, payload, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/AsignarEtiquetaFunction/AsignarEtiquetaCommandHandlerMensajesTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/AsignarEtiquetaFunction/AsignarEtiquetaCommandHandlerMensajesTests.cs
@@ -1,0 +1,23 @@
+// Issue #355: guardrail de resolucion del .resx del handler (MEF-ADR-0009), gemelo del que
+// AnularTerminacionCommandHandlerMensajesTests.cs aplica.
+//
+// Por que existe: AsignarEtiquetaCommandHandler.Mensajes devuelve ResourceManager.GetString(...)!
+// -- el "!" es supresion del compilador, no garantia de runtime. Si la CLAVE desaparece del .resx
+// (rename, merge que la pierde) GetString retorna null en silencio y los tests del handler pasan
+// en FALSO: sus aserciones son WithMessage($"*{Mensajes.X}*"), que con X == null se vuelve "**" y
+// matchea cualquier excepcion.
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.AsignarEtiquetaFunction.CommandHandler;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Tests.AsignarEtiquetaFunction;
+
+public class AsignarEtiquetaCommandHandlerMensajesTests
+{
+    [Fact]
+    public void Mensajes_ResuelvenTextoNoVacio_CuandoPertenecenAAsignarEtiquetaCommandHandler()
+    {
+        AsignarEtiquetaCommandHandler.Mensajes.ColaboradorNoEncontrado.Should().NotBeNullOrWhiteSpace();
+        AsignarEtiquetaCommandHandler.Mensajes.VinculacionTerminada.Should().NotBeNullOrWhiteSpace();
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/AsignarEtiquetaFunction/AsignarEtiquetaCommandHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/AsignarEtiquetaFunction/AsignarEtiquetaCommandHandlerTests.cs
@@ -1,0 +1,209 @@
+// Issue #355: asignar una etiqueta dinamica -- septimo comando del ciclo de vida de
+// ColaboradorAggregateRoot (desglose #348-#357). CA-ADR-0030: no hay eventos de fallo -- el
+// aggregate declina CON RESULTADO la regla de apertura estricta (decision #1: la ULTIMA
+// vinculacion no puede tener terminacion registrada, incluido un preaviso sin vencer) y declina EN
+// SILENCIO la idempotencia (CA-2: etiqueta identica por valor, decision #3).
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.AsignarEtiquetaFunction;
+using Bitakora.ControlAsistencia.Colaboradores.AsignarEtiquetaFunction.CommandHandler;
+using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+using Bitakora.ControlAsistencia.Colaboradores.Entities;
+using Cosmos.EventSourcing.Abstractions.Commands;
+using Cosmos.EventSourcing.Testing.Utilities;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Tests.AsignarEtiquetaFunction;
+
+// El aggregate usa un stream ID compuesto (Identificacion.ToString(), "CC:79543210"), no el
+// GuidAggregateId del harness -- overloads explicitos de Given/Then/And (regla 18 del
+// test-writer, mismo criterio que el resto de la cadena #349-#354).
+public class AsignarEtiquetaCommandHandlerTests : CommandHandlerAsyncTest<AsignarEtiqueta>
+{
+    private const string NumeroValido = "79543210";
+
+    // Oraculo independiente de la clave de stream (MEF-ADR-0002 + MEF-ADR-0037): literal, no
+    // derivado de ColaboradorAggregateRoot.ComputarStreamId.
+    private const string StreamIdEsperado = "CC:79543210";
+
+    private const string CodigoVinculacionVigente = "COL-001";
+    private const string CodigoVinculacionReingreso = "COL-002";
+    private static readonly DateOnly FechaInicioVinculacionVigente = new(2026, 1, 15);
+    private static readonly DateOnly FechaEfectivaTerminacion = new(2026, 6, 1);
+    private static readonly DateOnly FechaInicioReingreso = new(2026, 7, 1);
+
+    protected override ICommandHandlerAsync<AsignarEtiqueta> Handler =>
+        new AsignarEtiquetaCommandHandler(EventStore);
+
+    private static AsignarEtiqueta ComandoValido() => new(
+        TipoIdentificacion: "CC",
+        NumeroIdentificacion: NumeroValido,
+        Categoria: "Área",
+        Valor: "Tecnología");
+
+    private static Identificacion IdentificacionValida() =>
+        Identificacion.Crear(TipoIdentificacion.CC, NumeroValido);
+
+    private static NombreColaborador NombreValido() =>
+        NombreColaborador.Crear("Luis", "Augusto", "Barreto", null);
+
+    private static ColaboradorRegistrado ColaboradorRegistradoValido() =>
+        new(IdentificacionValida(), NombreValido());
+
+    private static VinculacionIniciada VinculacionIniciadaVigente() =>
+        new(CodigoVinculacionVigente, FechaInicioVinculacionVigente);
+
+    // Precondicion: colaborador registrado con una vinculacion abierta (sin terminacion) -- base
+    // de CA-1.
+    private void DadoUnColaboradorConVinculacionAbierta() =>
+        Given(StreamIdEsperado, ColaboradorRegistradoValido(), VinculacionIniciadaVigente());
+
+    // Precondicion (CA-5): la vinculacion vigente ya tiene una terminacion registrada -- incluye un
+    // preaviso con fecha futura, que bloquea igual sin distincion de estado.
+    private void DadoUnColaboradorConTerminacionRegistrada(DateOnly fechaEfectiva) =>
+        Given(StreamIdEsperado,
+            ColaboradorRegistradoValido(),
+            VinculacionIniciadaVigente(),
+            new VinculacionTerminada(fechaEfectiva));
+
+    // Precondicion (CA-2): la vinculacion vigente ya tiene una etiqueta asignada para esa categoria.
+    private void DadoUnColaboradorConEtiquetaAsignada(Etiqueta etiqueta) =>
+        Given(StreamIdEsperado,
+            ColaboradorRegistradoValido(),
+            VinculacionIniciadaVigente(),
+            new EtiquetaAsignada(etiqueta));
+
+    // CA-1: categoria nueva + vinculacion abierta -> el stream recibe EtiquetaAsignada con la doble
+    // forma; el aggregate rehidratado refleja la etiqueta bajo su categoria normalizada.
+    [Fact]
+    public async Task AsignarEtiqueta_EmiteEtiquetaAsignada_CuandoLaCategoriaEsNueva()
+    {
+        DadoUnColaboradorConVinculacionAbierta();
+        var etiquetaEsperada = Etiqueta.Crear("Área", "Tecnología");
+
+        await WhenAsync(ComandoValido());
+
+        Then(StreamIdEsperado, new EtiquetaAsignada(etiquetaEsperada));
+        And<ColaboradorAggregateRoot, int>(StreamIdEsperado, c => c.Etiquetas.Count, 1);
+        And<ColaboradorAggregateRoot, Etiqueta>(
+            StreamIdEsperado, c => c.Etiquetas["area"], etiquetaEsperada);
+    }
+
+    // CA-1 (borde de identidad, MEF-ADR-0037): "cc" en minusculas + numero con espacios sobre un
+    // colaborador ya registrado -> la asignacion alcanza el MISMO stream ("CC:79543210") y emite el
+    // evento.
+    [Fact]
+    public async Task AsignarEtiqueta_EmiteEtiquetaAsignada_CuandoTipoYNumeroLleganSinNormalizar()
+    {
+        DadoUnColaboradorConVinculacionAbierta();
+        var comandoSinNormalizar = ComandoValido() with
+        {
+            TipoIdentificacion = "cc",
+            NumeroIdentificacion = "  79543210  "
+        };
+
+        await WhenAsync(comandoSinNormalizar);
+
+        Then(StreamIdEsperado, new EtiquetaAsignada(Etiqueta.Crear("Área", "Tecnología")));
+        And<ColaboradorAggregateRoot, int>(StreamIdEsperado, c => c.Etiquetas.Count, 1);
+    }
+
+    // CA-2: asignar sobre una categoria existente (via EsMismaCategoria: "Área" sobre "area") con
+    // un valor distinto sobrescribe -- un valor por categoria, nunca duplica.
+    [Fact]
+    public async Task AsignarEtiqueta_EmiteEtiquetaAsignada_CuandoLaCategoriaExisteConValorDistinto()
+    {
+        DadoUnColaboradorConEtiquetaAsignada(Etiqueta.Crear("area", "Ventas"));
+        var etiquetaSobrescrita = Etiqueta.Crear("Área", "Tecnología");
+
+        await WhenAsync(ComandoValido());
+
+        Then(StreamIdEsperado, new EtiquetaAsignada(etiquetaSobrescrita));
+        And<ColaboradorAggregateRoot, int>(StreamIdEsperado, c => c.Etiquetas.Count, 1);
+        And<ColaboradorAggregateRoot, Etiqueta>(
+            StreamIdEsperado, c => c.Etiquetas["area"], etiquetaSobrescrita);
+    }
+
+    // CA-2: la etiqueta del comando es IGUAL por valor (Etiqueta.Equals, #353) a la ya asignada
+    // para esa categoria -> idempotencia silenciosa: ningun evento nuevo, el estado conserva la
+    // etiqueta original.
+    [Fact]
+    public async Task AsignarEtiqueta_NoEmiteEvento_CuandoLaEtiquetaEsIgualPorValorALaExistente()
+    {
+        var etiquetaExistente = Etiqueta.Crear("Área", "Tecnología");
+        DadoUnColaboradorConEtiquetaAsignada(etiquetaExistente);
+
+        // Misma etiqueta por valor, con otra combinacion de mayusculas/tildes en ambos campos.
+        await WhenAsync(ComandoValido() with { Categoria = "area", Valor = "tecnologia" });
+
+        Then(StreamIdEsperado);
+        And<ColaboradorAggregateRoot, int>(StreamIdEsperado, c => c.Etiquetas.Count, 1);
+        And<ColaboradorAggregateRoot, Etiqueta>(
+            StreamIdEsperado, c => c.Etiquetas["area"], etiquetaExistente);
+    }
+
+    // CA-5 (decision #1, regla estricta de apertura): la ULTIMA vinculacion tiene terminacion
+    // registrada -> 409, ningun evento nuevo, el diccionario de etiquetas queda intacto.
+    [Fact]
+    public async Task AsignarEtiqueta_LanzaInvalidOperationException_CuandoLaUltimaVinculacionTieneTerminacionRegistrada()
+    {
+        DadoUnColaboradorConTerminacionRegistrada(FechaEfectivaTerminacion);
+
+        var act = async () => await WhenAsync(ComandoValido());
+
+        await act.Should().ThrowExactlyAsync<InvalidOperationException>()
+            .WithMessage($"*{AsignarEtiquetaCommandHandler.Mensajes.VinculacionTerminada}*");
+        Then(StreamIdEsperado);
+        And<ColaboradorAggregateRoot, int>(StreamIdEsperado, c => c.Etiquetas.Count, 0);
+    }
+
+    // CA-5 (preaviso no vencido): un preaviso con fecha futura ya registrado bloquea igual -- las
+    // etiquetas describen la relacion laboral ACTIVA, sin importar si la fecha efectiva ya paso.
+    [Fact]
+    public async Task AsignarEtiqueta_LanzaInvalidOperationException_CuandoLaTerminacionEsUnPreavisoConFechaFutura()
+    {
+        var fechaPreavisoFutura = new DateOnly(2030, 1, 1);
+        DadoUnColaboradorConTerminacionRegistrada(fechaPreavisoFutura);
+
+        var act = async () => await WhenAsync(ComandoValido());
+
+        await act.Should().ThrowExactlyAsync<InvalidOperationException>()
+            .WithMessage($"*{AsignarEtiquetaCommandHandler.Mensajes.VinculacionTerminada}*");
+        Then(StreamIdEsperado);
+    }
+
+    // CA-6 (reingreso nace limpio): tras un reingreso, la vinculacion nueva no hereda las etiquetas
+    // de la anterior -- asignar sobre la vinculacion vigente crea la categoria desde cero, sin
+    // colisionar con la etiqueta congelada de la vinculacion previa.
+    [Fact]
+    public async Task AsignarEtiqueta_EmiteEtiquetaAsignada_CuandoLaVinculacionEsUnReingresoTrasUnaTerminacionConEtiquetasPrevias()
+    {
+        Given(StreamIdEsperado,
+            ColaboradorRegistradoValido(),
+            VinculacionIniciadaVigente(),
+            new EtiquetaAsignada(Etiqueta.Crear("Área", "Ventas")),
+            new VinculacionTerminada(FechaEfectivaTerminacion),
+            new VinculacionIniciada(CodigoVinculacionReingreso, FechaInicioReingreso));
+        var etiquetaEsperada = Etiqueta.Crear("Área", "Tecnología");
+
+        await WhenAsync(ComandoValido());
+
+        Then(StreamIdEsperado, new EtiquetaAsignada(etiquetaEsperada));
+        And<ColaboradorAggregateRoot, int>(StreamIdEsperado, c => c.Etiquetas.Count, 1);
+        And<ColaboradorAggregateRoot, Etiqueta>(
+            StreamIdEsperado, c => c.Etiquetas["area"], etiquetaEsperada);
+    }
+
+    // CA-7: colaborador inexistente -> 404 (KeyNotFoundException), sin escribir nada al event
+    // store. Sin Given: el stream no existe. Then sin eventos esperados demuestra "sin escribir
+    // nada al event store" (mismo precedente que AnularTerminacionCommandHandlerTests CA-5). Sin
+    // And<>: el aggregate no existe en el TestStore (GetAggregateRoot lanzaria ArgumentNullException).
+    [Fact]
+    public async Task AsignarEtiqueta_LanzaKeyNotFoundException_CuandoColaboradorNoExiste()
+    {
+        var act = async () => await WhenAsync(ComandoValido());
+
+        await act.Should().ThrowExactlyAsync<KeyNotFoundException>()
+            .WithMessage($"*{AsignarEtiquetaCommandHandler.Mensajes.ColaboradorNoEncontrado}*");
+        Then(StreamIdEsperado);
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/AsignarEtiquetaFunction/AsignarEtiquetaCommandHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/AsignarEtiquetaFunction/AsignarEtiquetaCommandHandlerTests.cs
@@ -169,6 +169,55 @@ public class AsignarEtiquetaCommandHandlerTests : CommandHandlerAsyncTest<Asigna
         await act.Should().ThrowExactlyAsync<InvalidOperationException>()
             .WithMessage($"*{AsignarEtiquetaCommandHandler.Mensajes.VinculacionTerminada}*");
         Then(StreamIdEsperado);
+        And<ColaboradorAggregateRoot, int>(StreamIdEsperado, c => c.Etiquetas.Count, 0);
+    }
+
+    // CA-2 (un valor por CATEGORIA, no una etiqueta por vinculacion): asignar una categoria nueva
+    // cuando ya existe otra distinta las hace convivir -- la sobrescritura es por categoria, no un
+    // reemplazo del diccionario completo. Agregado en revision: ningun test ejercia dos categorias
+    // simultaneas, asi que un Apply que reemplazara el diccionario en vez de indexarlo habria
+    // pasado en verde.
+    [Fact]
+    public async Task AsignarEtiqueta_ConservaLaCategoriaPrevia_CuandoLaCategoriaNuevaEsDistinta()
+    {
+        var etiquetaPrevia = Etiqueta.Crear("Sede", "Medellín");
+        DadoUnColaboradorConEtiquetaAsignada(etiquetaPrevia);
+        var etiquetaNueva = Etiqueta.Crear("Área", "Tecnología");
+
+        await WhenAsync(ComandoValido());
+
+        Then(StreamIdEsperado, new EtiquetaAsignada(etiquetaNueva));
+        And<ColaboradorAggregateRoot, int>(StreamIdEsperado, c => c.Etiquetas.Count, 2);
+        And<ColaboradorAggregateRoot, Etiqueta>(
+            StreamIdEsperado, c => c.Etiquetas["sede"], etiquetaPrevia);
+        And<ColaboradorAggregateRoot, Etiqueta>(
+            StreamIdEsperado, c => c.Etiquetas["area"], etiquetaNueva);
+    }
+
+    // CA-5 x CA-2 (cruce que ningun test cubria; agregado en revision): la vinculacion tiene
+    // terminacion registrada Y la etiqueta del comando es identica por valor a la ya asignada. CA-5
+    // es incondicional ("409 en AMBOS comandos"), asi que la regla de apertura gana sobre la
+    // idempotencia silenciosa -- orden deliberadamente INVERSO al de CorregirFechaInicio (#352),
+    // donde SinCambios se evalua primero porque alli la correccion de nombres/fechas es valida sobre
+    // una vinculacion cerrada. Aqui no: escribir etiquetas sobre una relacion laboral congelada se
+    // rechaza aunque el estado deseado coincida.
+    [Fact]
+    public async Task AsignarEtiqueta_LanzaInvalidOperationException_CuandoLaEtiquetaEsIgualPeroLaVinculacionTieneTerminacionRegistrada()
+    {
+        var etiquetaExistente = Etiqueta.Crear("Área", "Tecnología");
+        Given(StreamIdEsperado,
+            ColaboradorRegistradoValido(),
+            VinculacionIniciadaVigente(),
+            new EtiquetaAsignada(etiquetaExistente),
+            new VinculacionTerminada(FechaEfectivaTerminacion));
+
+        var act = async () => await WhenAsync(ComandoValido());
+
+        await act.Should().ThrowExactlyAsync<InvalidOperationException>()
+            .WithMessage($"*{AsignarEtiquetaCommandHandler.Mensajes.VinculacionTerminada}*");
+        Then(StreamIdEsperado);
+        And<ColaboradorAggregateRoot, Etiqueta>(
+            StreamIdEsperado, c => c.Etiquetas["area"], etiquetaExistente);
     }
 
     // CA-6 (reingreso nace limpio): tras un reingreso, la vinculacion nueva no hereda las etiquetas

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/AsignarEtiquetaFunction/AsignarEtiquetaValidatorTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/AsignarEtiquetaFunction/AsignarEtiquetaValidatorTests.cs
@@ -1,0 +1,99 @@
+// Issue #355: validacion de forma del comando AsignarEtiqueta en el borde (CA-7).
+// Patron de referencia: AnularTerminacionValidatorTests (ValidateAsync + verificacion de
+// PropertyName en resultado.Errors).
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.AsignarEtiquetaFunction;
+using Bitakora.ControlAsistencia.Colaboradores.AsignarEtiquetaFunction.CommandHandler;
+using FluentValidation.Results;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Tests.AsignarEtiquetaFunction;
+
+public class AsignarEtiquetaValidatorTests
+{
+    private readonly AsignarEtiquetaValidator _validator = new();
+
+    private static AsignarEtiqueta ComandoValido() => new(
+        TipoIdentificacion: "CC",
+        NumeroIdentificacion: "79543210",
+        Categoria: "Área",
+        Valor: "Tecnología");
+
+    private Task<ValidationResult> Validar(AsignarEtiqueta comando) =>
+        _validator.ValidateAsync(comando, TestContext.Current.CancellationToken);
+
+    // Camino feliz -- todos los campos correctos
+    [Fact]
+    public async Task Validar_Aprueba_CuandoTodosLosCamposSonCorrectos()
+    {
+        var resultado = await Validar(ComandoValido());
+
+        resultado.IsValid.Should().BeTrue();
+    }
+
+    // CA-7: TipoIdentificacion vacio produce 400
+    [Fact]
+    public async Task Validar_RechazaTipoIdentificacion_CuandoEstaVacio()
+    {
+        var resultado = await Validar(ComandoValido() with { TipoIdentificacion = "" });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e =>
+            e.PropertyName == nameof(AsignarEtiqueta.TipoIdentificacion));
+    }
+
+    // CA-7: TipoIdentificacion fuera de la lista cerrada (PILA: CC/CE/TI/PA/PT) produce 400, no 500
+    [Fact]
+    public async Task Validar_RechazaTipoIdentificacion_CuandoNoEstaEnLaListaCerrada()
+    {
+        var resultado = await Validar(ComandoValido() with { TipoIdentificacion = "XX" });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e =>
+            e.PropertyName == nameof(AsignarEtiqueta.TipoIdentificacion));
+    }
+
+    // TipoIdentificacion en minusculas ("cc") DEBE seguir siendo valido -- la normalizacion de
+    // entrada es responsabilidad del borde, no un rechazo (mismo criterio que los demas validators
+    // del dominio).
+    [Fact]
+    public async Task Validar_Aprueba_CuandoTipoIdentificacionLlegaEnMinusculas()
+    {
+        var resultado = await Validar(ComandoValido() with { TipoIdentificacion = "cc" });
+
+        resultado.IsValid.Should().BeTrue();
+    }
+
+    // CA-7: NumeroIdentificacion vacio produce 400
+    [Fact]
+    public async Task Validar_RechazaNumeroIdentificacion_CuandoEstaVacio()
+    {
+        var resultado = await Validar(ComandoValido() with { NumeroIdentificacion = "" });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e =>
+            e.PropertyName == nameof(AsignarEtiqueta.NumeroIdentificacion));
+    }
+
+    // CA-7: Categoria vacia produce 400
+    [Fact]
+    public async Task Validar_RechazaCategoria_CuandoEstaVacia()
+    {
+        var resultado = await Validar(ComandoValido() with { Categoria = "" });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e =>
+            e.PropertyName == nameof(AsignarEtiqueta.Categoria));
+    }
+
+    // CA-7: Valor vacio produce 400
+    [Fact]
+    public async Task Validar_RechazaValor_CuandoEstaVacio()
+    {
+        var resultado = await Validar(ComandoValido() with { Valor = "" });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e =>
+            e.PropertyName == nameof(AsignarEtiqueta.Valor));
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/AsignarEtiquetaFunction/Eventos/EtiquetaAsignadaSerializacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/AsignarEtiquetaFunction/Eventos/EtiquetaAsignadaSerializacionTests.cs
@@ -1,0 +1,65 @@
+// Issue #355. Requerido por regla 16: todo evento persistido en Marten debe sobrevivir
+// Serialize -> Deserialize con las opciones REALES de Marten del dominio (regla 6d), nunca un
+// resolver armado inline. CA-1.
+
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Tests.AsignarEtiquetaFunction.Eventos;
+
+/// <summary>
+/// Verifica que EtiquetaAsignada (payload rico: Etiqueta, VO de #353 con ctor privado) sobrevive
+/// un roundtrip de serializacion STJ con las opciones reales de Marten del dominio -- y que NO
+/// sobrevive sin el registro de ese VO en el resolver.
+/// </summary>
+public class EtiquetaAsignadaSerializacionTests
+{
+    private static readonly Etiqueta EtiquetaValida = Etiqueta.Crear("Área", "Tecnología");
+
+    // Usa las opciones REALES de Marten del dominio (regla 6d) -- no un resolver armado inline que
+    // solo registre este tipo. Esta eleccion es lo que convierte el RoundTrip de abajo en la
+    // barrera contra el olvido de registrar Etiqueta dentro de
+    // ConfiguracionSerializacionColaboradores.ConfigurarResolver (fase verde, issue #355).
+    private static JsonSerializerOptions CrearOpcionesMarten() =>
+        ConfiguracionSerializacionColaboradores.CrearOpcionesMarten();
+
+    // CA-1: round-trip con datos completos, incluida la doble forma de categoria y valor.
+    [Fact]
+    public void RoundTrip_ReconstruyeEvento_ConDatosCompletos()
+    {
+        var evento = new EtiquetaAsignada(EtiquetaValida);
+        var opciones = CrearOpcionesMarten();
+
+        var json = JsonSerializer.Serialize(evento, opciones);
+        var deserializado = JsonSerializer.Deserialize<EtiquetaAsignada>(json, opciones);
+
+        deserializado.Should().NotBeNull();
+        deserializado!.Etiqueta.Should().Be(EtiquetaValida);
+        deserializado.Etiqueta.Categoria.Should().Be("Área");
+        deserializado.Etiqueta.Valor.Should().Be("Tecnología");
+        deserializado.Etiqueta.CategoriaNormalizada.Should().Be("area");
+        deserializado.Etiqueta.ValorNormalizado.Should().Be("tecnologia");
+    }
+
+    // Documenta POR QUE el registro en ConfigurarResolver es obligatorio: sin el, STJ no puede
+    // invocar el ctor privado de Etiqueta. Quien detecta el olvido es el RoundTrip_* de arriba
+    // (usa las opciones reales del dominio); este test fija el comportamiento del canal sin
+    // resolver.
+    [Fact]
+    public void Deserializar_LanzaNotSupportedException_CuandoElResolverNoRegistraElVoAnidado()
+    {
+        var evento = new EtiquetaAsignada(EtiquetaValida);
+        var opcionesSinRegistro = new JsonSerializerOptions
+        {
+            TypeInfoResolver = new DefaultJsonTypeInfoResolver(),
+            PropertyNamingPolicy = null
+        };
+        var json = JsonSerializer.Serialize(evento, opcionesSinRegistro);
+
+        var act = () => JsonSerializer.Deserialize<EtiquetaAsignada>(json, opcionesSinRegistro);
+
+        act.Should().Throw<NotSupportedException>();
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/AsignarEtiquetaFunction/FunctionEndpointTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/AsignarEtiquetaFunction/FunctionEndpointTests.cs
@@ -1,0 +1,143 @@
+// Issue #355: tests del endpoint HTTP POST Colaboradores/Etiquetas (asignar etiqueta).
+// CA-ADR-0030 / MEF-ADR-0004: InvalidOperationException -> 409, KeyNotFoundException -> 404,
+// exito -> 202. Precedente: AnularTerminacionFunction.FunctionEndpoint.
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.AsignarEtiquetaFunction;
+using Bitakora.ControlAsistencia.Colaboradores.Infraestructura;
+using Cosmos.EventSourcing.Abstractions.Commands;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Tests.AsignarEtiquetaFunction;
+
+public class FunctionEndpointTests
+{
+    private static AsignarEtiqueta ComandoValido() => new(
+        TipoIdentificacion: "CC",
+        NumeroIdentificacion: "79543210",
+        Categoria: "Área",
+        Valor: "Tecnología");
+
+    private static HttpRequest FakeHttpRequest()
+    {
+        var context = new DefaultHttpContext();
+        return context.Request;
+    }
+
+    // CA-1/CA-2: POST exitoso retorna 202 Accepted
+    [Fact]
+    public async Task AsignarEtiqueta_Retorna202_CuandoComandoEsValido()
+    {
+        var validator = new FakeAsignarEtiquetaRequestValidator(ComandoValido());
+        var router = new FakeAsignarEtiquetaCommandRouter();
+        var function = new FunctionEndpoint(validator, router);
+
+        var result = await function.Run(FakeHttpRequest(), CancellationToken.None);
+
+        result.Should().BeOfType<AcceptedResult>();
+    }
+
+    // CA-5: violacion de la regla de apertura (vinculacion con terminacion registrada) retorna 409
+    // Conflict.
+    [Fact]
+    public async Task AsignarEtiqueta_Retorna409_CuandoLaVinculacionTieneTerminacionRegistrada()
+    {
+        var validator = new FakeAsignarEtiquetaRequestValidator(ComandoValido());
+        var router = new FakeAsignarEtiquetaCommandRouter(
+            lanzar: new InvalidOperationException(
+                "La vinculacion vigente del colaborador tiene una terminacion registrada"));
+        var function = new FunctionEndpoint(validator, router);
+
+        var result = await function.Run(FakeHttpRequest(), CancellationToken.None);
+
+        result.Should().BeOfType<ConflictObjectResult>();
+    }
+
+    // CA-7: colaborador inexistente retorna 404 Not Found
+    [Fact]
+    public async Task AsignarEtiqueta_Retorna404_CuandoColaboradorNoExiste()
+    {
+        var validator = new FakeAsignarEtiquetaRequestValidator(ComandoValido());
+        var router = new FakeAsignarEtiquetaCommandRouter(
+            lanzar: new KeyNotFoundException("No existe un colaborador registrado con esa identificacion"));
+        var function = new FunctionEndpoint(validator, router);
+
+        var result = await function.Run(FakeHttpRequest(), CancellationToken.None);
+
+        result.Should().BeOfType<NotFoundObjectResult>();
+    }
+
+    // CA-7: request invalida (categoria o valor vacios, identificacion incompleta, tipo fuera de
+    // la lista) retorna 400 Bad Request
+    [Fact]
+    public async Task AsignarEtiqueta_Retorna400_CuandoRequestEsInvalido()
+    {
+        var errorDeValidacion = new BadRequestObjectResult("El body es invalido o esta malformado");
+        var validator = new FakeAsignarEtiquetaRequestValidator(error: errorDeValidacion);
+        var router = new FakeAsignarEtiquetaCommandRouter();
+        var function = new FunctionEndpoint(validator, router);
+
+        var result = await function.Run(FakeHttpRequest(), CancellationToken.None);
+
+        result.Should().BeOfType<BadRequestObjectResult>();
+    }
+}
+
+// ---- Fakes manuales - NO NSubstitute ----
+
+/// <summary>
+/// Fake configurable de IRequestValidator. Retorna un comando pre-configurado o un error segun lo
+/// que se le pase en el constructor.
+/// </summary>
+internal class FakeAsignarEtiquetaRequestValidator : IRequestValidator
+{
+    private readonly AsignarEtiqueta? _comando;
+    private readonly IActionResult? _error;
+
+    public FakeAsignarEtiquetaRequestValidator(
+        AsignarEtiqueta? comando = null,
+        IActionResult? error = null)
+    {
+        _comando = comando;
+        _error = error;
+    }
+
+    public Task<(T? Comando, IActionResult? Error)> ValidarAsync<T>(
+        HttpRequest req, CancellationToken ct)
+    {
+        if (_error is not null)
+            return Task.FromResult<(T?, IActionResult?)>((default, _error));
+
+        if (_comando is T resultado)
+            return Task.FromResult<(T?, IActionResult?)>((resultado, null));
+
+        return Task.FromResult<(T?, IActionResult?)>((default, null));
+    }
+}
+
+/// <summary>
+/// Fake configurable de ICommandRouter. Puede completar exitosamente o lanzar la excepcion
+/// configurada (InvalidOperationException -> 409, KeyNotFoundException -> 404).
+/// </summary>
+internal class FakeAsignarEtiquetaCommandRouter : ICommandRouter
+{
+    private readonly Exception? _excepcion;
+
+    public FakeAsignarEtiquetaCommandRouter(Exception? lanzar = null) =>
+        _excepcion = lanzar;
+
+    public Task InvokeAsync<TCommand>(TCommand command, CancellationToken ct = default)
+        where TCommand : class
+    {
+        if (_excepcion is not null)
+            throw _excepcion;
+
+        return Task.CompletedTask;
+    }
+
+    public Task<TResult> InvokeAsync<TCommand, TResult>(
+        TCommand command, CancellationToken ct = default)
+        where TCommand : class
+        => throw new NotImplementedException();
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/Infraestructura/AliasEventosColaboradoresTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/Infraestructura/AliasEventosColaboradoresTests.cs
@@ -96,4 +96,29 @@ public class AliasEventosColaboradoresTests
 
         AliasDe<TerminacionAnulada>(options).Should().Be("terminacion_anulada");
     }
+
+    // Issue #355 (gemela de las seis pruebas anteriores): congela el alias de EtiquetaAsignada,
+    // septimo evento persistido de ColaboradorAggregateRoot (asignar una etiqueta dinamica). Rojo
+    // esperado (fase roja, issue #355): IdentidadEventosColaboradores.TiposPersistidos sigue sin
+    // EtiquetaAsignada hasta que el implementer lo registre -- el implementer lo agrega ahi (no
+    // aqui, MEF-ADR-0002).
+    [Fact]
+    public void EtiquetaAsignada_TieneAliasEtiquetaAsignada()
+    {
+        var options = CrearOpcionesConEventosDeColaboradoresRegistrados();
+
+        AliasDe<EtiquetaAsignada>(options).Should().Be("etiqueta_asignada");
+    }
+
+    // Issue #355: congela el alias de EtiquetaRetirada, octavo evento persistido de
+    // ColaboradorAggregateRoot (retirar una etiqueta dinamica). El alias es la identidad del evento
+    // en mt_events (CA-ADR-0029 decision #6): un rename futuro de la clase lo cambiaria en
+    // silencio, y este literal es quien lo delata.
+    [Fact]
+    public void EtiquetaRetirada_TieneAliasEtiquetaRetirada()
+    {
+        var options = CrearOpcionesConEventosDeColaboradoresRegistrados();
+
+        AliasDe<EtiquetaRetirada>(options).Should().Be("etiqueta_retirada");
+    }
 }

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/Infraestructura/ComposicionServiciosTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/Infraestructura/ComposicionServiciosTests.cs
@@ -224,6 +224,10 @@ public class ComposicionServiciosTests
     // FechaInicioVinculacionCorregida.
     // Issue #354: agrega TerminacionAnulada (sexto evento persistido, anular la terminacion de la
     // ultima vinculacion) a la lista esperada.
+    // Issue #355: agrega EtiquetaAsignada y EtiquetaRetirada (septimo y octavo eventos persistidos,
+    // asignar/retirar una etiqueta dinamica) a la lista esperada.
+    // Rojo esperado (fase roja, issue #355): TiposPersistidos todavia no incluye ninguno de los
+    // dos.
     [Fact]
     public async Task AgregarServiciosColaboradores_RegistraLosTiposDeEventoPersistidos_CuandoElContenedorEstaCompuesto()
     {
@@ -239,7 +243,9 @@ public class ComposicionServiciosTests
                 typeof(VinculacionTerminada),
                 typeof(NombresCorregidos),
                 typeof(FechaInicioVinculacionCorregida),
-                typeof(TerminacionAnulada)
+                typeof(TerminacionAnulada),
+                typeof(EtiquetaAsignada),
+                typeof(EtiquetaRetirada)
             ]);
     }
 
@@ -255,6 +261,8 @@ public class ComposicionServiciosTests
     // Rojo esperado (fase roja, issue #352): FechaInicioVinculacionCorregida no aparece en
     // AllKnownEventTypes().
     // Issue #354: agrega TerminacionAnulada -> "terminacion_anulada" al diccionario esperado.
+    // Issue #355: agrega EtiquetaAsignada -> "etiqueta_asignada" y EtiquetaRetirada ->
+    // "etiqueta_retirada" al diccionario esperado.
     [Fact]
     public async Task AgregarServiciosColaboradores_DerivaElAliasDeEventoDelNombreDeClase_CuandoElContenedorEstaCompuesto()
     {
@@ -270,7 +278,9 @@ public class ComposicionServiciosTests
             [typeof(VinculacionTerminada)] = "vinculacion_terminada",
             [typeof(NombresCorregidos)] = "nombres_corregidos",
             [typeof(FechaInicioVinculacionCorregida)] = "fecha_inicio_vinculacion_corregida",
-            [typeof(TerminacionAnulada)] = "terminacion_anulada"
+            [typeof(TerminacionAnulada)] = "terminacion_anulada",
+            [typeof(EtiquetaAsignada)] = "etiqueta_asignada",
+            [typeof(EtiquetaRetirada)] = "etiqueta_retirada"
         });
     }
 

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/RetirarEtiquetaFunction/Eventos/EtiquetaRetiradaSerializacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/RetirarEtiquetaFunction/Eventos/EtiquetaRetiradaSerializacionTests.cs
@@ -1,0 +1,36 @@
+// Issue #355. Requerido por regla 16: todo evento persistido en Marten debe sobrevivir
+// Serialize -> Deserialize con las opciones REALES de Marten del dominio (regla 6d). CA-3.
+
+using System.Text.Json;
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Tests.RetirarEtiquetaFunction.Eventos;
+
+/// <summary>
+/// Verifica que EtiquetaRetirada (payload plano: string, sin VOs anidados) sobrevive un roundtrip
+/// de serializacion STJ con las opciones reales de Marten del dominio. Este evento NO necesita
+/// ConfigurarSerializacion propio (ctor publico, tipo primitivo) -- mismo criterio que
+/// VinculacionTerminada/VinculacionIniciada -- asi que no hay un test "sin registro falla": no hay
+/// ningun registro que proteger.
+/// </summary>
+public class EtiquetaRetiradaSerializacionTests
+{
+    private static JsonSerializerOptions CrearOpcionesMarten() =>
+        ConfiguracionSerializacionColaboradores.CrearOpcionesMarten();
+
+    // CA-3: EtiquetaRetirada persiste la categoria normalizada tal como llego y sobrevive el
+    // roundtrip completo.
+    [Fact]
+    public void RoundTrip_ReconstruyeEvento_ConDatosCompletos()
+    {
+        var evento = new EtiquetaRetirada("area");
+        var opciones = CrearOpcionesMarten();
+
+        var json = JsonSerializer.Serialize(evento, opciones);
+        var deserializado = JsonSerializer.Deserialize<EtiquetaRetirada>(json, opciones);
+
+        deserializado.Should().NotBeNull();
+        deserializado!.CategoriaNormalizada.Should().Be("area");
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/RetirarEtiquetaFunction/FunctionEndpointTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/RetirarEtiquetaFunction/FunctionEndpointTests.cs
@@ -1,0 +1,141 @@
+// Issue #355: tests del endpoint HTTP POST Colaboradores/Etiquetas/Retiros (retirar etiqueta).
+// CA-ADR-0030 / MEF-ADR-0004: InvalidOperationException -> 409, KeyNotFoundException -> 404,
+// exito -> 202. Precedente: AnularTerminacionFunction.FunctionEndpoint.
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.Infraestructura;
+using Bitakora.ControlAsistencia.Colaboradores.RetirarEtiquetaFunction;
+using Cosmos.EventSourcing.Abstractions.Commands;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Tests.RetirarEtiquetaFunction;
+
+public class FunctionEndpointTests
+{
+    private static RetirarEtiqueta ComandoValido() => new(
+        TipoIdentificacion: "CC",
+        NumeroIdentificacion: "79543210",
+        Categoria: "Área");
+
+    private static HttpRequest FakeHttpRequest()
+    {
+        var context = new DefaultHttpContext();
+        return context.Request;
+    }
+
+    // CA-3: POST exitoso retorna 202 Accepted
+    [Fact]
+    public async Task RetirarEtiqueta_Retorna202_CuandoComandoEsValido()
+    {
+        var validator = new FakeRetirarEtiquetaRequestValidator(ComandoValido());
+        var router = new FakeRetirarEtiquetaCommandRouter();
+        var function = new FunctionEndpoint(validator, router);
+
+        var result = await function.Run(FakeHttpRequest(), CancellationToken.None);
+
+        result.Should().BeOfType<AcceptedResult>();
+    }
+
+    // CA-4/CA-5: categoria inexistente o vinculacion con terminacion registrada retorna 409
+    // Conflict.
+    [Fact]
+    public async Task RetirarEtiqueta_Retorna409_CuandoLaCategoriaNoExisteOLaVinculacionEstaTerminada()
+    {
+        var validator = new FakeRetirarEtiquetaRequestValidator(ComandoValido());
+        var router = new FakeRetirarEtiquetaCommandRouter(
+            lanzar: new InvalidOperationException("No existe una etiqueta asignada con esa categoria"));
+        var function = new FunctionEndpoint(validator, router);
+
+        var result = await function.Run(FakeHttpRequest(), CancellationToken.None);
+
+        result.Should().BeOfType<ConflictObjectResult>();
+    }
+
+    // CA-7: colaborador inexistente retorna 404 Not Found
+    [Fact]
+    public async Task RetirarEtiqueta_Retorna404_CuandoColaboradorNoExiste()
+    {
+        var validator = new FakeRetirarEtiquetaRequestValidator(ComandoValido());
+        var router = new FakeRetirarEtiquetaCommandRouter(
+            lanzar: new KeyNotFoundException("No existe un colaborador registrado con esa identificacion"));
+        var function = new FunctionEndpoint(validator, router);
+
+        var result = await function.Run(FakeHttpRequest(), CancellationToken.None);
+
+        result.Should().BeOfType<NotFoundObjectResult>();
+    }
+
+    // CA-7: request invalida (categoria vacia, identificacion incompleta, tipo fuera de la lista)
+    // retorna 400 Bad Request
+    [Fact]
+    public async Task RetirarEtiqueta_Retorna400_CuandoRequestEsInvalido()
+    {
+        var errorDeValidacion = new BadRequestObjectResult("El body es invalido o esta malformado");
+        var validator = new FakeRetirarEtiquetaRequestValidator(error: errorDeValidacion);
+        var router = new FakeRetirarEtiquetaCommandRouter();
+        var function = new FunctionEndpoint(validator, router);
+
+        var result = await function.Run(FakeHttpRequest(), CancellationToken.None);
+
+        result.Should().BeOfType<BadRequestObjectResult>();
+    }
+}
+
+// ---- Fakes manuales - NO NSubstitute ----
+
+/// <summary>
+/// Fake configurable de IRequestValidator. Retorna un comando pre-configurado o un error segun lo
+/// que se le pase en el constructor.
+/// </summary>
+internal class FakeRetirarEtiquetaRequestValidator : IRequestValidator
+{
+    private readonly RetirarEtiqueta? _comando;
+    private readonly IActionResult? _error;
+
+    public FakeRetirarEtiquetaRequestValidator(
+        RetirarEtiqueta? comando = null,
+        IActionResult? error = null)
+    {
+        _comando = comando;
+        _error = error;
+    }
+
+    public Task<(T? Comando, IActionResult? Error)> ValidarAsync<T>(
+        HttpRequest req, CancellationToken ct)
+    {
+        if (_error is not null)
+            return Task.FromResult<(T?, IActionResult?)>((default, _error));
+
+        if (_comando is T resultado)
+            return Task.FromResult<(T?, IActionResult?)>((resultado, null));
+
+        return Task.FromResult<(T?, IActionResult?)>((default, null));
+    }
+}
+
+/// <summary>
+/// Fake configurable de ICommandRouter. Puede completar exitosamente o lanzar la excepcion
+/// configurada (InvalidOperationException -> 409, KeyNotFoundException -> 404).
+/// </summary>
+internal class FakeRetirarEtiquetaCommandRouter : ICommandRouter
+{
+    private readonly Exception? _excepcion;
+
+    public FakeRetirarEtiquetaCommandRouter(Exception? lanzar = null) =>
+        _excepcion = lanzar;
+
+    public Task InvokeAsync<TCommand>(TCommand command, CancellationToken ct = default)
+        where TCommand : class
+    {
+        if (_excepcion is not null)
+            throw _excepcion;
+
+        return Task.CompletedTask;
+    }
+
+    public Task<TResult> InvokeAsync<TCommand, TResult>(
+        TCommand command, CancellationToken ct = default)
+        where TCommand : class
+        => throw new NotImplementedException();
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/RetirarEtiquetaFunction/RetirarEtiquetaCommandHandlerMensajesTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/RetirarEtiquetaFunction/RetirarEtiquetaCommandHandlerMensajesTests.cs
@@ -1,0 +1,24 @@
+// Issue #355: guardrail de resolucion del .resx del handler (MEF-ADR-0009), gemelo del que
+// AnularTerminacionCommandHandlerMensajesTests.cs aplica.
+//
+// Por que existe: RetirarEtiquetaCommandHandler.Mensajes devuelve ResourceManager.GetString(...)!
+// -- el "!" es supresion del compilador, no garantia de runtime. Si la CLAVE desaparece del .resx
+// (rename, merge que la pierde) GetString retorna null en silencio y los tests del handler pasan
+// en FALSO: sus aserciones son WithMessage($"*{Mensajes.X}*"), que con X == null se vuelve "**" y
+// matchea cualquier excepcion.
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.RetirarEtiquetaFunction.CommandHandler;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Tests.RetirarEtiquetaFunction;
+
+public class RetirarEtiquetaCommandHandlerMensajesTests
+{
+    [Fact]
+    public void Mensajes_ResuelvenTextoNoVacio_CuandoPertenecenARetirarEtiquetaCommandHandler()
+    {
+        RetirarEtiquetaCommandHandler.Mensajes.ColaboradorNoEncontrado.Should().NotBeNullOrWhiteSpace();
+        RetirarEtiquetaCommandHandler.Mensajes.VinculacionTerminada.Should().NotBeNullOrWhiteSpace();
+        RetirarEtiquetaCommandHandler.Mensajes.CategoriaInexistente.Should().NotBeNullOrWhiteSpace();
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/RetirarEtiquetaFunction/RetirarEtiquetaCommandHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/RetirarEtiquetaFunction/RetirarEtiquetaCommandHandlerTests.cs
@@ -169,6 +169,29 @@ public class RetirarEtiquetaCommandHandlerTests : CommandHandlerAsyncTest<Retira
         await act.Should().ThrowExactlyAsync<InvalidOperationException>()
             .WithMessage($"*{RetirarEtiquetaCommandHandler.Mensajes.VinculacionTerminada}*");
         Then(StreamIdEsperado);
+        And<ColaboradorAggregateRoot, int>(StreamIdEsperado, c => c.Etiquetas.Count, 1);
+    }
+
+    // CA-3 (el retiro es por CATEGORIA, no un vaciado del diccionario): con dos categorias
+    // asignadas, retirar una deja la otra intacta. Agregado en revision: ningun test ejercia dos
+    // categorias simultaneas, asi que un Apply que limpiara el diccionario entero habria pasado en
+    // verde.
+    [Fact]
+    public async Task RetirarEtiqueta_ConservaLasDemasCategorias_CuandoRetiraUnaDeVarias()
+    {
+        var etiquetaConservada = Etiqueta.Crear("Sede", "Medellín");
+        Given(StreamIdEsperado,
+            ColaboradorRegistradoValido(),
+            VinculacionIniciadaVigente(),
+            new EtiquetaAsignada(Etiqueta.Crear("Area", "Ventas")),
+            new EtiquetaAsignada(etiquetaConservada));
+
+        await WhenAsync(ComandoValido());
+
+        Then(StreamIdEsperado, new EtiquetaRetirada("area"));
+        And<ColaboradorAggregateRoot, int>(StreamIdEsperado, c => c.Etiquetas.Count, 1);
+        And<ColaboradorAggregateRoot, Etiqueta>(
+            StreamIdEsperado, c => c.Etiquetas["sede"], etiquetaConservada);
     }
 
     // CA-6 (reingreso nace limpio): la etiqueta pertenecia a la vinculacion ANTERIOR (congelada

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/RetirarEtiquetaFunction/RetirarEtiquetaCommandHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/RetirarEtiquetaFunction/RetirarEtiquetaCommandHandlerTests.cs
@@ -1,0 +1,208 @@
+// Issue #355: retirar una etiqueta dinamica -- octavo comando del ciclo de vida de
+// ColaboradorAggregateRoot (desglose #348-#357), gemelo de AsignarEtiqueta sobre el mismo
+// diccionario. CA-ADR-0030: no hay eventos de fallo -- el aggregate declina CON RESULTADO tanto la
+// regla de apertura estricta (decision #1) como la categoria inexistente (decision #2: con
+// categorias libres, un typo debe aflorar al instante -- SIN idempotencia silenciosa, a diferencia
+// de AsignarEtiqueta).
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+using Bitakora.ControlAsistencia.Colaboradores.Entities;
+using Bitakora.ControlAsistencia.Colaboradores.RetirarEtiquetaFunction;
+using Bitakora.ControlAsistencia.Colaboradores.RetirarEtiquetaFunction.CommandHandler;
+using Cosmos.EventSourcing.Abstractions.Commands;
+using Cosmos.EventSourcing.Testing.Utilities;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Tests.RetirarEtiquetaFunction;
+
+// El aggregate usa un stream ID compuesto (Identificacion.ToString(), "CC:79543210"), no el
+// GuidAggregateId del harness -- overloads explicitos de Given/Then/And (regla 18 del
+// test-writer, mismo criterio que el resto de la cadena #349-#354).
+public class RetirarEtiquetaCommandHandlerTests : CommandHandlerAsyncTest<RetirarEtiqueta>
+{
+    private const string NumeroValido = "79543210";
+
+    // Oraculo independiente de la clave de stream (MEF-ADR-0002 + MEF-ADR-0037): literal, no
+    // derivado de ColaboradorAggregateRoot.ComputarStreamId.
+    private const string StreamIdEsperado = "CC:79543210";
+
+    private const string CodigoVinculacionVigente = "COL-001";
+    private const string CodigoVinculacionReingreso = "COL-002";
+    private static readonly DateOnly FechaInicioVinculacionVigente = new(2026, 1, 15);
+    private static readonly DateOnly FechaEfectivaTerminacion = new(2026, 6, 1);
+    private static readonly DateOnly FechaInicioReingreso = new(2026, 7, 1);
+
+    protected override ICommandHandlerAsync<RetirarEtiqueta> Handler =>
+        new RetirarEtiquetaCommandHandler(EventStore);
+
+    private static RetirarEtiqueta ComandoValido() => new(
+        TipoIdentificacion: "CC",
+        NumeroIdentificacion: NumeroValido,
+        Categoria: "área");
+
+    private static Identificacion IdentificacionValida() =>
+        Identificacion.Crear(TipoIdentificacion.CC, NumeroValido);
+
+    private static NombreColaborador NombreValido() =>
+        NombreColaborador.Crear("Luis", "Augusto", "Barreto", null);
+
+    private static ColaboradorRegistrado ColaboradorRegistradoValido() =>
+        new(IdentificacionValida(), NombreValido());
+
+    private static VinculacionIniciada VinculacionIniciadaVigente() =>
+        new(CodigoVinculacionVigente, FechaInicioVinculacionVigente);
+
+    // Precondicion: colaborador registrado con una vinculacion abierta y SIN etiquetas -- base de
+    // CA-4.
+    private void DadoUnColaboradorConVinculacionAbierta() =>
+        Given(StreamIdEsperado, ColaboradorRegistradoValido(), VinculacionIniciadaVigente());
+
+    // Precondicion (CA-3): la vinculacion vigente ya tiene la etiqueta dada asignada.
+    private void DadoUnColaboradorConEtiquetaAsignada(Etiqueta etiqueta) =>
+        Given(StreamIdEsperado,
+            ColaboradorRegistradoValido(),
+            VinculacionIniciadaVigente(),
+            new EtiquetaAsignada(etiqueta));
+
+    // Precondicion (CA-5): la vinculacion vigente tiene la etiqueta dada Y una terminacion
+    // registrada -- incluye un preaviso con fecha futura, que bloquea igual sin distincion de
+    // estado.
+    private void DadoUnColaboradorConEtiquetaYTerminacionRegistrada(
+        Etiqueta etiqueta, DateOnly fechaEfectiva) =>
+        Given(StreamIdEsperado,
+            ColaboradorRegistradoValido(),
+            VinculacionIniciadaVigente(),
+            new EtiquetaAsignada(etiqueta),
+            new VinculacionTerminada(fechaEfectiva));
+
+    // CA-3: retirar por una forma distinta de la que se asigno ("área" retira lo asignado como
+    // "Area", misma categoria normalizada) -> el stream recibe EtiquetaRetirada con la categoria
+    // normalizada; el aggregate ya no la refleja.
+    [Fact]
+    public async Task RetirarEtiqueta_EmiteEtiquetaRetirada_CuandoLaCategoriaExisteConFormaDistinta()
+    {
+        DadoUnColaboradorConEtiquetaAsignada(Etiqueta.Crear("Area", "Ventas"));
+
+        await WhenAsync(ComandoValido());
+
+        Then(StreamIdEsperado, new EtiquetaRetirada("area"));
+        And<ColaboradorAggregateRoot, int>(StreamIdEsperado, c => c.Etiquetas.Count, 0);
+    }
+
+    // CA-3 (borde de identidad, MEF-ADR-0037): "cc" en minusculas + numero con espacios sobre un
+    // colaborador ya registrado -> el retiro alcanza el MISMO stream ("CC:79543210") y emite el
+    // evento.
+    [Fact]
+    public async Task RetirarEtiqueta_EmiteEtiquetaRetirada_CuandoTipoYNumeroLleganSinNormalizar()
+    {
+        DadoUnColaboradorConEtiquetaAsignada(Etiqueta.Crear("Area", "Ventas"));
+        var comandoSinNormalizar = ComandoValido() with
+        {
+            TipoIdentificacion = "cc",
+            NumeroIdentificacion = "  79543210  "
+        };
+
+        await WhenAsync(comandoSinNormalizar);
+
+        Then(StreamIdEsperado, new EtiquetaRetirada("area"));
+        And<ColaboradorAggregateRoot, int>(StreamIdEsperado, c => c.Etiquetas.Count, 0);
+    }
+
+    // CA-4: retirar una categoria que nunca se asigno -> 409, ningun evento nuevo, el diccionario
+    // de etiquetas queda intacto (vacio).
+    [Fact]
+    public async Task RetirarEtiqueta_LanzaInvalidOperationException_CuandoLaCategoriaNoExiste()
+    {
+        DadoUnColaboradorConVinculacionAbierta();
+
+        var act = async () => await WhenAsync(ComandoValido());
+
+        await act.Should().ThrowExactlyAsync<InvalidOperationException>()
+            .WithMessage($"*{RetirarEtiquetaCommandHandler.Mensajes.CategoriaInexistente}*");
+        Then(StreamIdEsperado);
+        And<ColaboradorAggregateRoot, int>(StreamIdEsperado, c => c.Etiquetas.Count, 0);
+    }
+
+    // CA-4 (el typo debe aflorar, decision #2 del issue): "Aera" no es "Area" -- categorias
+    // distintas normalizadas, aunque exista una etiqueta para "Area" -> 409 igual, ningun evento,
+    // la etiqueta existente ("Area") queda intacta.
+    [Fact]
+    public async Task RetirarEtiqueta_LanzaInvalidOperationException_CuandoHayUnErrorDeTranscripcionEnLaCategoria()
+    {
+        DadoUnColaboradorConEtiquetaAsignada(Etiqueta.Crear("Area", "Ventas"));
+
+        var act = async () => await WhenAsync(ComandoValido() with { Categoria = "Aera" });
+
+        await act.Should().ThrowExactlyAsync<InvalidOperationException>()
+            .WithMessage($"*{RetirarEtiquetaCommandHandler.Mensajes.CategoriaInexistente}*");
+        Then(StreamIdEsperado);
+        And<ColaboradorAggregateRoot, int>(StreamIdEsperado, c => c.Etiquetas.Count, 1);
+    }
+
+    // CA-5 (decision #1, regla estricta de apertura): la ULTIMA vinculacion tiene terminacion
+    // registrada -> 409, ningun evento nuevo, la etiqueta existente queda intacta.
+    [Fact]
+    public async Task RetirarEtiqueta_LanzaInvalidOperationException_CuandoLaUltimaVinculacionTieneTerminacionRegistrada()
+    {
+        DadoUnColaboradorConEtiquetaYTerminacionRegistrada(
+            Etiqueta.Crear("Area", "Ventas"), FechaEfectivaTerminacion);
+
+        var act = async () => await WhenAsync(ComandoValido());
+
+        await act.Should().ThrowExactlyAsync<InvalidOperationException>()
+            .WithMessage($"*{RetirarEtiquetaCommandHandler.Mensajes.VinculacionTerminada}*");
+        Then(StreamIdEsperado);
+        And<ColaboradorAggregateRoot, int>(StreamIdEsperado, c => c.Etiquetas.Count, 1);
+    }
+
+    // CA-5 (preaviso no vencido): un preaviso con fecha futura ya registrado bloquea igual -- las
+    // etiquetas describen la relacion laboral ACTIVA, sin importar si la fecha efectiva ya paso.
+    [Fact]
+    public async Task RetirarEtiqueta_LanzaInvalidOperationException_CuandoLaTerminacionEsUnPreavisoConFechaFutura()
+    {
+        var fechaPreavisoFutura = new DateOnly(2030, 1, 1);
+        DadoUnColaboradorConEtiquetaYTerminacionRegistrada(
+            Etiqueta.Crear("Area", "Ventas"), fechaPreavisoFutura);
+
+        var act = async () => await WhenAsync(ComandoValido());
+
+        await act.Should().ThrowExactlyAsync<InvalidOperationException>()
+            .WithMessage($"*{RetirarEtiquetaCommandHandler.Mensajes.VinculacionTerminada}*");
+        Then(StreamIdEsperado);
+    }
+
+    // CA-6 (reingreso nace limpio): la etiqueta pertenecia a la vinculacion ANTERIOR (congelada
+    // tras la terminacion) -- la vinculacion vigente (el reingreso) no la hereda, asi que retirarla
+    // encuentra la categoria inexistente -> 409, igual que cualquier categoria nunca asignada.
+    [Fact]
+    public async Task RetirarEtiqueta_LanzaInvalidOperationException_CuandoLaEtiquetaPerteneceALaVinculacionAnteriorTrasUnReingreso()
+    {
+        Given(StreamIdEsperado,
+            ColaboradorRegistradoValido(),
+            VinculacionIniciadaVigente(),
+            new EtiquetaAsignada(Etiqueta.Crear("Area", "Ventas")),
+            new VinculacionTerminada(FechaEfectivaTerminacion),
+            new VinculacionIniciada(CodigoVinculacionReingreso, FechaInicioReingreso));
+
+        var act = async () => await WhenAsync(ComandoValido());
+
+        await act.Should().ThrowExactlyAsync<InvalidOperationException>()
+            .WithMessage($"*{RetirarEtiquetaCommandHandler.Mensajes.CategoriaInexistente}*");
+        Then(StreamIdEsperado);
+        And<ColaboradorAggregateRoot, int>(StreamIdEsperado, c => c.Etiquetas.Count, 0);
+    }
+
+    // CA-7: colaborador inexistente -> 404 (KeyNotFoundException), sin escribir nada al event
+    // store. Sin Given: el stream no existe. Then sin eventos esperados demuestra "sin escribir
+    // nada al event store" (mismo precedente que AnularTerminacionCommandHandlerTests CA-5). Sin
+    // And<>: el aggregate no existe en el TestStore (GetAggregateRoot lanzaria ArgumentNullException).
+    [Fact]
+    public async Task RetirarEtiqueta_LanzaKeyNotFoundException_CuandoColaboradorNoExiste()
+    {
+        var act = async () => await WhenAsync(ComandoValido());
+
+        await act.Should().ThrowExactlyAsync<KeyNotFoundException>()
+            .WithMessage($"*{RetirarEtiquetaCommandHandler.Mensajes.ColaboradorNoEncontrado}*");
+        Then(StreamIdEsperado);
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/RetirarEtiquetaFunction/RetirarEtiquetaValidatorTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/RetirarEtiquetaFunction/RetirarEtiquetaValidatorTests.cs
@@ -1,0 +1,87 @@
+// Issue #355: validacion de forma del comando RetirarEtiqueta en el borde (CA-7).
+// Patron de referencia: AnularTerminacionValidatorTests (ValidateAsync + verificacion de
+// PropertyName en resultado.Errors).
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.RetirarEtiquetaFunction;
+using Bitakora.ControlAsistencia.Colaboradores.RetirarEtiquetaFunction.CommandHandler;
+using FluentValidation.Results;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Tests.RetirarEtiquetaFunction;
+
+public class RetirarEtiquetaValidatorTests
+{
+    private readonly RetirarEtiquetaValidator _validator = new();
+
+    private static RetirarEtiqueta ComandoValido() => new(
+        TipoIdentificacion: "CC",
+        NumeroIdentificacion: "79543210",
+        Categoria: "Área");
+
+    private Task<ValidationResult> Validar(RetirarEtiqueta comando) =>
+        _validator.ValidateAsync(comando, TestContext.Current.CancellationToken);
+
+    // Camino feliz -- todos los campos correctos
+    [Fact]
+    public async Task Validar_Aprueba_CuandoTodosLosCamposSonCorrectos()
+    {
+        var resultado = await Validar(ComandoValido());
+
+        resultado.IsValid.Should().BeTrue();
+    }
+
+    // CA-7: TipoIdentificacion vacio produce 400
+    [Fact]
+    public async Task Validar_RechazaTipoIdentificacion_CuandoEstaVacio()
+    {
+        var resultado = await Validar(ComandoValido() with { TipoIdentificacion = "" });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e =>
+            e.PropertyName == nameof(RetirarEtiqueta.TipoIdentificacion));
+    }
+
+    // CA-7: TipoIdentificacion fuera de la lista cerrada (PILA: CC/CE/TI/PA/PT) produce 400, no 500
+    [Fact]
+    public async Task Validar_RechazaTipoIdentificacion_CuandoNoEstaEnLaListaCerrada()
+    {
+        var resultado = await Validar(ComandoValido() with { TipoIdentificacion = "XX" });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e =>
+            e.PropertyName == nameof(RetirarEtiqueta.TipoIdentificacion));
+    }
+
+    // TipoIdentificacion en minusculas ("cc") DEBE seguir siendo valido -- la normalizacion de
+    // entrada es responsabilidad del borde, no un rechazo (mismo criterio que los demas validators
+    // del dominio).
+    [Fact]
+    public async Task Validar_Aprueba_CuandoTipoIdentificacionLlegaEnMinusculas()
+    {
+        var resultado = await Validar(ComandoValido() with { TipoIdentificacion = "cc" });
+
+        resultado.IsValid.Should().BeTrue();
+    }
+
+    // CA-7: NumeroIdentificacion vacio produce 400
+    [Fact]
+    public async Task Validar_RechazaNumeroIdentificacion_CuandoEstaVacio()
+    {
+        var resultado = await Validar(ComandoValido() with { NumeroIdentificacion = "" });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e =>
+            e.PropertyName == nameof(RetirarEtiqueta.NumeroIdentificacion));
+    }
+
+    // CA-7: Categoria vacia produce 400
+    [Fact]
+    public async Task Validar_RechazaCategoria_CuandoEstaVacia()
+    {
+        var resultado = await Validar(ComandoValido() with { Categoria = "" });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e =>
+            e.PropertyName == nameof(RetirarEtiqueta.Categoria));
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ValueObjects/EtiquetaTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ValueObjects/EtiquetaTests.cs
@@ -8,7 +8,8 @@ namespace Bitakora.ControlAsistencia.Colaboradores.Tests.ValueObjects;
 
 /// <summary>
 /// Interfaz publica: Crear(categoria, valor), Categoria, Valor, CategoriaNormalizada,
-/// ValorNormalizado, EsMismaCategoria(otra), ToString().
+/// ValorNormalizado, EsMismaCategoria(otra), ToString(), NormalizarCategoria(categoria) (issue
+/// #355, ver seccion "NormalizarCategoria" abajo).
 /// </summary>
 public class EtiquetaTests
 {
@@ -142,5 +143,45 @@ public class EtiquetaTests
         var area = Etiqueta.Crear("Area", "X");
 
         sede.EsMismaCategoria(area).Should().BeFalse();
+    }
+
+    // ---------- NormalizarCategoria (issue #355, desviacion documentada en el resumen del pipeline) ----------
+    //
+    // RetirarEtiqueta solo lleva la Categoria en su payload (sin Valor) -- Etiqueta.Crear(categoria,
+    // valor) exige un valor no vacio y por tanto no es aplicable para obtener la forma normalizada
+    // de una categoria aislada. Tell-don't-Ask: esa normalizacion sigue siendo decision de este VO
+    // (mismo criterio que EsMismaCategoria), nunca del handler ni del aggregate.
+
+    [Fact]
+    public void NormalizarCategoria_RetornaFormaNormalizada_CuandoCategoriaTieneTildesMayusculasYEspaciosExtremos()
+    {
+        Etiqueta.NormalizarCategoria(" Área ").Should().Be("area");
+    }
+
+    [Fact]
+    public void NormalizarCategoria_LanzaArgumentException_CuandoCategoriaEsVacia()
+    {
+        var act = () => Etiqueta.NormalizarCategoria(string.Empty);
+
+        act.Should().ThrowExactly<ArgumentException>()
+            .WithMessage($"*{Etiqueta.Mensajes.CategoriaVacia}*");
+    }
+
+    [Fact]
+    public void NormalizarCategoria_LanzaArgumentException_CuandoCategoriaEsWhitespace()
+    {
+        var act = () => Etiqueta.NormalizarCategoria("   ");
+
+        act.Should().ThrowExactly<ArgumentException>()
+            .WithMessage($"*{Etiqueta.Mensajes.CategoriaVacia}*");
+    }
+
+    [Fact]
+    public void NormalizarCategoria_LanzaArgumentException_CuandoCategoriaEsNull()
+    {
+        var act = () => Etiqueta.NormalizarCategoria(null!);
+
+        act.Should().ThrowExactly<ArgumentException>()
+            .WithMessage($"*{Etiqueta.Mensajes.CategoriaVacia}*");
     }
 }


### PR DESCRIPTION
## Resumen

Pipeline TDD completado:
- Fase roja: tests escritos con stubs
- Fase verde: implementación completa
- Smoke tests: escritos para endpoints detectados
- Fase refactor: revisión de calidad

## Decisiones del pipeline

<details>
<summary>Test Writer (fase roja) — 136m 15s</summary>

## ES Test Writer - Decisiones

### Tests creados

- `AsignarEtiquetaFunction/AsignarEtiquetaCommandHandlerTests.cs`: 8 tests
  - `AsignarEtiqueta_EmiteEtiquetaAsignada_CuandoLaCategoriaEsNueva` - CA-1
  - `AsignarEtiqueta_EmiteEtiquetaAsignada_CuandoTipoYNumeroLleganSinNormalizar` - CA-1 (borde de identidad)
  - `AsignarEtiqueta_EmiteEtiquetaAsignada_CuandoLaCategoriaExisteConValorDistinto` - CA-2 (sobrescribe)
  - `AsignarEtiqueta_NoEmiteEvento_CuandoLaEtiquetaEsIgualPorValorALaExistente` - CA-2 (idempotencia silenciosa)
  - `AsignarEtiqueta_LanzaInvalidOperationException_CuandoLaUltimaVinculacionTieneTerminacionRegistrada` - CA-5
  - `AsignarEtiqueta_LanzaInvalidOperationException_CuandoLaTerminacionEsUnPreavisoConFechaFutura` - CA-5 (preaviso)
  - `AsignarEtiqueta_EmiteEtiquetaAsignada_CuandoLaVinculacionEsUnReingresoTrasUnaTerminacionConEtiquetasPrevias` - CA-6
  - `AsignarEtiqueta_LanzaKeyNotFoundException_CuandoColaboradorNoExiste` - CA-7 (404)
- `AsignarEtiquetaFunction/AsignarEtiquetaValidatorTests.cs`: 7 tests - CA-7 (400)
- `AsignarEtiquetaFunction/AsignarEtiquetaCommandHandlerMensajesTests.cs`: 1 test - guardrail .resx
- `AsignarEtiquetaFunction/FunctionEndpointTests.cs`: 4 tests - 202/409/404/400
- `AsignarEtiquetaFunction/Eventos/EtiquetaAsignadaSerializacionTests.cs`: 2 tests - round-trip Marten (regla 6d) + "sin registro falla"
- `RetirarEtiquetaFunction/RetirarEtiquetaCommandHandlerTests.cs`: 8 tests
  - `RetirarEtiqueta_EmiteEtiquetaRetirada_CuandoLaCategoriaExisteConFormaDistinta` - CA-3
  - `RetirarEtiqueta_EmiteEtiquetaRetirada_CuandoTipoYNumeroLleganSinNormalizar` - CA-3 (borde de identidad)
  - `RetirarEtiqueta_LanzaInvalidOperationException_CuandoLaCategoriaNoExiste` - CA-4
  - `RetirarEtiqueta_LanzaInvalidOperationException_CuandoHayUnErrorDeTranscripcionEnLaCategoria` - CA-4 (el typo debe aflorar)
  - `RetirarEtiqueta_LanzaInvalidOperationException_CuandoLaUltimaVinculacionTieneTerminacionRegistrada` - CA-5
  - `RetirarEtiqueta_LanzaInvalidOperationException_CuandoLaTerminacionEsUnPreavisoConFechaFutura` - CA-5 (preaviso)
  - `RetirarEtiqueta_LanzaInvalidOperationException_CuandoLaEtiquetaPerteneceALaVinculacionAnteriorTrasUnReingreso` - CA-6
  - `RetirarEtiqueta_LanzaKeyNotFoundException_CuandoColaboradorNoExiste` - CA-7 (404)
- `RetirarEtiquetaFunction/RetirarEtiquetaValidatorTests.cs`: 6 tests - CA-7 (400)
- `RetirarEtiquetaFunction/RetirarEtiquetaCommandHandlerMensajesTests.cs`: 1 test - guardrail .resx
- `RetirarEtiquetaFunction/FunctionEndpointTests.cs`: 4 tests - 202/409/404/400
- `RetirarEtiquetaFunction/Eventos/EtiquetaRetiradaSerializacionTests.cs`: 1 test - round-trip Marten (payload plano, sin "sin registro falla" porque no hay VO anidado)
- `ValueObjects/EtiquetaTests.cs` (extendido): +4 tests de `Etiqueta.NormalizarCategoria` (ver desviacion)
- `Infraestructura/AliasEventosColaboradoresTests.cs` (extendido): +2 tests (alias `etiqueta_asignada`, `etiqueta_retirada`)
- `Infraestructura/ComposicionServiciosTests.cs` (extendido): 2 tests existentes ampliados con los 2 tipos nuevos en sus listas literales

### Estructura elegida

- Una clase de test por command handler (`AsignarEtiquetaCommandHandlerTests`, `RetirarEtiquetaCommandHandlerTests`), sin nested classes: cada comando tiene su propio stream-id compuesto y factory methods propios; no hay Given compartido lo bastante extenso para justificar una clase base intermedia (regla "Rule of Three" no se cumple con solo 2 handlers).
- CA-6 (reingreso nace limpio) NO se modelo como archivo de composicion separado (a diferencia de `ComposicionAnularYTerminarVinculacionTests` de #354): aqui ambas mitades de CA-6 (asignar funciona sobre la vinculacion nueva / retirar encuentra inexistente en la nueva) se ejercen con UN SOLO handler cada una sobre un `Given()` que ya incluye el reingreso completo -- no hace falta encadenar dos handlers en vivo. Se agregaron como tests adicionales dentro de cada `*CommandHandlerTests.cs`.
- `Etiquetas` (diccionario categoria-normalizada -> Etiqueta) se expone como propiedad `internal` de solo lectura en el aggregate -- mismo criterio Tell-don't-Ask que `FechaTerminacionVinculacionVigente`/`CodigoVinculacionVigente`: no es superficie publica del dominio, solo el canal que el DSL de tests (`And<>`) necesita para verificar el estado rehidratado.

### Stubs creados

- `AsignarEtiquetaCommandHandler.HandleAsync` / `RetirarEtiquetaCommandHandler.HandleAsync` - `throw new NotImplementedException()`, con comentario documentando el flujo esperado (precedente `AnularTerminacionCommandHandler`/`CorregirFechaInicioVinculacionCommandHandler`).
- `AsignarEtiquetaValidator` / `RetirarEtiquetaValidator` - clases vacias sin reglas (precedente exacto: `AnularTerminacionValidator` en su fase roja).
- `ColaboradorAggregateRoot.AsignarEtiqueta(Etiqueta)` / `.RetirarEtiqueta(string categoriaNormalizada)` - `throw new NotImplementedException()`.
- `ColaboradorAggregateRoot.Apply(EtiquetaAsignada)` / `.Apply(EtiquetaRetirada)` - `throw new NotImplementedException()`.
- `ColaboradorAggregateRoot._etiquetas` (campo) + `Etiquetas` (propiedad internal de solo lectura) - declaracion de estado sin logica.
- `Etiqueta.NormalizarCategoria(string)` - `throw new NotImplementedException()` (ver desviacion).
- `ResultadoAsignacionEtiqueta` / `ResultadoRetiroEtiqueta` (enums `internal`, con toda su documentacion) - no son stubs de logica, son solo el vocabulario de resultados que el handler futuro consumira.
- Comentario agregado (sin cambio de comportamiento) en `Apply(VinculacionIniciada)` marcando la extension pendiente para CA-6 (resetear `_etiquetas`) -- NO se implementa: queda para el implementer, igual que el resto de esta clase.
- NO se toco `IdentidadEventosColaboradores.TiposPersistidos` ni `ConfiguracionSerializacionColaboradores.ConfigurarResolver` -- ambos registros son responsabilidad del implementer (fase verde), mismo patron exacto de #349-#354: los guardrails de `AliasEventosColaboradoresTests`/`ComposicionServiciosTests` quedan en rojo hasta que el implementer los registre.

### Decisiones de diseno

- Rutas: `AsignarEtiqueta` -> POST `Colaboradores/Etiquetas`; `RetirarEtiqueta` -> POST `Colaboradores/Etiquetas/Retiros` (tal como proponia el issue).
- `FunctionEndpoint` se escribio COMPLETO (no stub): es boilerplate deterministico e identico en forma a los demas endpoints del dominio (validar -> despachar -> mapear excepcion a 404/409 -> 202), sus tests usan fakes de `ICommandRouter`/`IRequestValidator` y nunca invocan el handler real -- mismo precedente que `AnularTerminacionFunction.FunctionEndpoint` en su propia fase roja (verificado en el historial: ese archivo tambien nacio completo en el commit de test-writer de #354).
- CA-4 (categoria inexistente) NO comparte mecanismo con la idempotencia silenciosa de CA-2: son enums distintos (`ResultadoRetiroEtiqueta` no tiene `SinCambios`) porque el issue exige que el typo aflore siempre con 409, nunca en silencio.
- Test de "colaborador no existe" (CA-7) sigue el precedente `AnularTerminacionCommandHandlerTests`/`ReingresarColaboradorCommandHandlerTests`: `Then(streamId)` sin eventos, SIN `And<>()` (el aggregate no existe en el `TestStore`, `GetAggregateRoot` lanzaria `ArgumentNullException`).

### Cobertura de criterios

| Criterio de aceptacion | Test(s) |
|---|---|
| CA-1: categoria nueva -> 202, evento con doble forma, aggregate refleja la etiqueta, alias/registro, round-trip del VO | `AsignarEtiqueta_EmiteEtiquetaAsignada_CuandoLaCategoriaEsNueva`, `AsignarEtiqueta_EmiteEtiquetaAsignada_CuandoTipoYNumeroLleganSinNormalizar`, `EtiquetaAsignada_TieneAliasEtiquetaAsignada`, `AgregarServiciosColaboradores_RegistraLosTiposDeEventoPersistidos_*`, `AgregarServiciosColaboradores_DerivaElAliasDeEventoDelNombreDeClase_*`, `EtiquetaAsignadaSerializacionTests.RoundTrip_ReconstruyeEvento_ConDatosCompletos` |
| CA-2: sobrescribe (un valor por categoria) + idempotencia silenciosa | `AsignarEtiqueta_EmiteEtiquetaAsignada_CuandoLaCategoriaExisteConValorDistinto`, `AsignarEtiqueta_NoEmiteEvento_CuandoLaEtiquetaEsIgualPorValorALaExistente` |
| CA-3: retirar por forma normalizada distinta | `RetirarEtiqueta_EmiteEtiquetaRetirada_CuandoLaCategoriaExisteConFormaDistinta`, `RetirarEtiqueta_EmiteEtiquetaRetirada_CuandoTipoYNumeroLleganSinNormalizar` |
| CA-4: categoria inexistente -> 409 (typo aflora) | `RetirarEtiqueta_LanzaInvalidOperationException_CuandoLaCategoriaNoExiste`, `RetirarEtiqueta_LanzaInvalidOperationException_CuandoHayUnErrorDeTranscripcionEnLaCategoria` |
| CA-5: regla estricta de apertura en ambos comandos (incluido preaviso) | `AsignarEtiqueta_LanzaInvalidOperationException_CuandoLaUltimaVinculacionTieneTerminacionRegistrada`, `AsignarEtiqueta_LanzaInvalidOperationException_CuandoLaTerminacionEsUnPreavisoConFechaFutura`, `RetirarEtiqueta_LanzaInvalidOperationException_CuandoLaUltimaVinculacionTieneTerminacionRegistrada`, `RetirarEtiqueta_LanzaInvalidOperationException_CuandoLaTerminacionEsUnPreavisoConFechaFutura` |
| CA-6: reingreso nace limpio | `AsignarEtiqueta_EmiteEtiquetaAsignada_CuandoLaVinculacionEsUnReingresoTrasUnaTerminacionConEtiquetasPrevias`, `RetirarEtiqueta_LanzaInvalidOperationException_CuandoLaEtiquetaPerteneceALaVinculacionAnteriorTrasUnReingreso` |
| CA-7: 404/400 en ambos comandos | `AsignarEtiqueta_LanzaKeyNotFoundException_CuandoColaboradorNoExiste`, `RetirarEtiqueta_LanzaKeyNotFoundException_CuandoColaboradorNoExiste`, `AsignarEtiquetaValidatorTests.*`, `RetirarEtiquetaValidatorTests.*`, `FunctionEndpointTests.*_Retorna400_*` |

### Desviaciones del plan del planner

| Sugerencia del issue | Desviacion aplicada | Razon tecnica | Consecuencia |
|---|---|---|---|
| "RetirarEtiqueta(string categoria): normaliza via el VO (o recibe la forma normalizada; juicio del pipeline)" | Se agrego `Etiqueta.NormalizarCategoria(string categoria)` como nuevo miembro publico (stub) del VO `Etiqueta` (`Colaboradores.DomainEvents`, fuera de "Modifica" del issue) | `Etiqueta.Crear(categoria, valor)` exige un `valor` no vacio; `RetirarEtiqueta` no lo lleva en su payload (decision del issue: "SIN Valor"). Tell-don't-Ask (MEF-ADR-0012) exige que la normalizacion de un string siga siendo decision del VO, nunca del handler ni del aggregate construyendo un `Etiqueta` con un valor ficticio. El planner dejo esta decision explicitamente abierta ("juicio del pipeline"). | El aggregate `RetirarEtiqueta(string categoriaNormalizada)` recibe la categoria YA normalizada (calculada por el handler via `Etiqueta.NormalizarCategoria`) -- Tell-don't-Ask puro, el aggregate nunca normaliza strings por su cuenta. Se extendieron `EtiquetaTests.cs` (4 tests nuevos) y el comentario de interfaz publica del VO. `Etiqueta.cs` pasa de "Lee" a "Modifica" en la practica. |
| Impacto esperado no menciona `AliasEventosColaboradoresTests.cs` ni `ComposicionServiciosTests.cs` entre "Crea"/"Modifica" | Se extendieron ambos archivos (2 tests nuevos + 2 tests existentes ampliados) | Estos dos archivos son el guardrail de identidad de eventos persistidos (MEF-ADR-0036) que TODA la cadena #349-#354 extiende en cada issue que agrega un evento persistido nuevo -- omitirlos dejaria sin cobertura el registro/alias de `EtiquetaAsignada`/`EtiquetaRetirada`, contradiciendo la regla 6f de este agente y el patron ya establecido en el propio repo. | Cobertura de alias/registro completa para los 2 eventos nuevos, consistente con el resto del dominio. No se modifico `IdentidadEventosColaboradores.TiposPersistidos` (eso si es exclusivo del implementer). |
| "Impacto esperado / Modifica: ConfiguracionSerializacionColaboradores.cs (registra Etiqueta.ConfigurarSerializacion)" | NO se toco ese archivo en esta fase | Es la responsabilidad del implementer (fase verde) registrar el resolver -- mismo patron exacto que #330/#351 (`ColaboradorRegistrado`/`NombresCorregidos`), donde el test-writer nunca modifica `ConfigurarResolver`. `EtiquetaAsignadaSerializacionTests.RoundTrip_*` usa `ConfiguracionSerializacionColaboradores.CrearOpcionesMarten()` (las opciones REALES) y falla en rojo exactamente por esta ausencia -- verificado en ejecucion (`NotSupportedException` al deserializar). | El implementer agrega `Etiqueta.ConfigurarSerializacion(resolver);` dentro de `ConfigurarResolver` para poner el test en verde. |
| "Impacto esperado / Modifica: IdentidadEventosColaboradores.cs (agrega los 2 tipos)" | NO se toco ese archivo en esta fase | Mismo criterio que el punto anterior -- `TiposPersistidos` es responsabilidad exclusiva del implementer en TODA la cadena #349-#354 (ver comentarios "Rojo esperado... hasta que el implementer lo registre" ya presentes en `AliasEventosColaboradoresTests.cs`). | `AliasEventosColaboradoresTests`/`ComposicionServiciosTests` quedan en rojo hasta que el implementer registre los 2 tipos. |

### Verificacion de la fase roja (ejecutado, no solo compilado)

Se corrio `dotnet test` filtrado a los namespaces nuevos/modificados para confirmar la distribucion esperada (no se corrio la suite completa por instruccion explicita de no ejecutar `dotnet test` como validacion final, pero SI se verifico la fase roja como parte del proceso de diseno):

- Tests que dependen de logica de negocio NO implementada: **fallan** (16 tests de handlers, 9 tests de reglas de validators, 4 tests de `NormalizarCategoria`, 2 alias nuevos, 2 guardrails de `ComposicionServiciosTests`, 1 round-trip de `EtiquetaAsignada`) = 34 tests en rojo.
- Tests de plomeria/infraestructura ya correcta (no dependen de los stubs): **pasan** (8 `FunctionEndpointTests`, 2 guardrails `.resx`, 4 casos "Aprueba" de validators vacios, 1 "sin registro falla" de `EtiquetaAsignada`, 1 round-trip de `EtiquetaRetirada` payload plano).
- `dotnet build` de la solucion completa: compila sin errores.

</details>

<details>
<summary>Implementer (fase verde) — 15m 1s</summary>

## ES Implementer - Decisiones

### Enfoque de implementacion
El test-writer dejo el molde completo (comandos, endpoints, mensajes .resx, validators vacios,
handlers/VO/aggregate con `throw new NotImplementedException()`), replicando fielmente el patron de
los slices #349-#354. El trabajo de la fase verde se redujo a rellenar la logica de negocio en seis
puntos:

1. `Etiqueta.NormalizarCategoria(categoria)` -- valida no vacio/whitespace (mismo mensaje `.resx`
   `CategoriaVacia` que `Crear`) y delega en el metodo privado `Normalizar` ya existente en el VO.
2. `IdentidadEventosColaboradores.TiposPersistidos` -- alta de `EtiquetaAsignada` y `EtiquetaRetirada`.
3. `ConfiguracionSerializacionColaboradores.ConfigurarResolver` -- registro de
   `Etiqueta.ConfigurarSerializacion(resolver)`.
4. `ColaboradorAggregateRoot`: extension de `Apply(VinculacionIniciada)` (resetea `_etiquetas = new()`
   en cada reingreso), mas `Apply(EtiquetaAsignada)`/`Apply(EtiquetaRetirada)` (mutan el diccionario
   por categoria normalizada) y los dos metodos de comportamiento `AsignarEtiqueta`/`RetirarEtiqueta`
   ("declinar con resultado" + idempotencia silenciosa en asignar, CA-ADR-0030).
5. `AsignarEtiquetaCommandHandler`/`RetirarEtiquetaCommandHandler` -- parseo tipado unico
   (`TipoIdentificacion.Desde` + `Identificacion.Crear`), `GetAggregateRootAsync` -> 404,
   `Etiqueta.Crear`/`Etiqueta.NormalizarCategoria` en el borde, despacho por el resultado del
   aggregate -> 409 con mensaje `.resx`.
6. `AsignarEtiquetaValidator`/`RetirarEtiquetaValidator` -- reglas de forma (`NotEmpty` +
   `TipoIdentificacion` en la lista cerrada), mismo patron que
   `CorregirFechaInicioVinculacionValidator`.

Los `FunctionEndpoint` de ambos comandos ya venian completos por el test-writer (idénticos al
precedente `AnularTerminacionFunction.FunctionEndpoint`) -- no requirieron cambios.

### Decisiones de diseno
- **Orden de evaluacion de reglas en `AsignarEtiqueta`**: primero `VinculacionTerminada` (regla de
  apertura, bloqueante), despues `SinCambios` (idempotencia). Ningun test dado combina ambas
  condiciones a la vez (en todos los escenarios de "terminada" el diccionario esta vacio o la
  etiqueta nueva no coincide por valor), asi que el orden no afecta el resultado observable frente a
  los tests existentes; se elige "regla de apertura primero" por ser la precondicion mas fuerte
  (semantica: una vinculacion cerrada bloquea cualquier escritura, sin importar si el valor
  coincidiria).
- **Orden de evaluacion en `RetirarEtiqueta`**: mismo criterio -- `VinculacionTerminada` antes de
  `CategoriaInexistente`. En todos los tests donde la vinculacion esta terminada, la categoria SI
  existe en el diccionario (por eso ambos ordenes producen el mismo resultado en los tests dados);
  se elige el mismo criterio que en `AsignarEtiqueta` por consistencia entre los dos comandos
  gemelos.
- **`if (!_etiquetas.ContainsKey(...))` como guard clause**: es la excepcion documentada de
  "Condiciones en positivo" (early-return de precondicion, no una bifurcacion if/else).
- **Reset de `_etiquetas` en `Apply(VinculacionIniciada)`**: se ejecuta incondicionalmente
  (incluida la primera vinculacion, donde el diccionario ya esta vacio por el campo por defecto) --
  sin rama condicional, coherente con que `Apply` nunca contiene logica condicional de negocio
  (MEF-ADR-0004 capa 4), solo asigna estado.

### ADRs consultados
- CA-ADR-0030 (declinar con resultado, no throw ni evento de fallo en el aggregate).
- MEF-ADR-0012 (Tell-don't-Ask: la normalizacion de categoria vive en el VO `Etiqueta`, nunca en el
  handler/aggregate).
- CA-ADR-0029 / MEF-ADR-0039 (eventos persistidos en `Colaboradores.DomainEvents`, payload rico con
  VO `Etiqueta`, alta en `TiposPersistidos`).
- MEF-ADR-0037 (parseo tipado unico de la identidad del stream: `ComputarStreamId` ya existente, sin
  reconstruccion propia en los handlers nuevos).
- MEF-ADR-0006 (naming `[Function("AsignarEtiqueta")]`/`[Function("RetirarEtiqueta")]`, ya fijado por
  el test-writer en los `FunctionEndpoint`).
- MEF-ADR-0009 (mensajes en `.resx` por handler, ya provisto por el test-writer).
- CA-ADR-0027 (tenancy) -- sin impacto: ningun cambio toca `ITenantResolver`.
- MEF-ADR-0002 / MEF-ADR-0016 -- sin cambios de test, solo verificacion de que la implementacion
  satisface el DSL y naming ya escritos.

### Desviaciones de ADRs
Ninguna desviacion -- todos los ADRs aplicados al pie de la letra.

### Desviaciones del plan del planner
Ninguna desviacion relevante -- la interfaz publica propuesta (`AsignarEtiqueta`/`RetirarEtiqueta`
con las firmas sugeridas, `Apply(EtiquetaAsignada)`/`Apply(EtiquetaRetirada)` publicos,
`Apply(VinculacionIniciada)` extendido) coincide exactamente con lo que el test-writer ya habia
dejado como stub y lo que se implemento.

### Precedentes consultados
- `CorregirFechaInicioVinculacionCommandHandler`/`CorregirFechaInicioVinculacionValidator` (#352):
  molde para el parseo tipado unico, el `switch` sobre el resultado del aggregate, y las reglas de
  `FluentValidation` con `Cascade(Stop)` + `Must` para `TipoIdentificacion`. Alineado con
  CA-ADR-0030/MEF-ADR-0037 -- replicado sin cambios de fondo.
- `AnularTerminacionFunction.FunctionEndpoint` (#354): molde de manejo 404/409/202 en el endpoint
  HTTP -- ya provisto integro por el test-writer, sin necesidad de tocarlo.
- `CorregirNombres`/`CorregirFechaInicio` (idempotencia silenciosa, #351/#352): confirma el patron
  "declinar en silencio" (ningun evento, 202 igual) usado en `AsignarEtiqueta.SinCambios`.

### Infraestructura modificada
Ninguna. El issue es event-sourcing puro sin consumidores ("Consumidores: ninguno") -- ningun
handler nuevo usa `IPrivateEventSender`/`IPublicEventSender`. No se toco
`infra/environments/dev/main.tf`.

### Complejidad encontrada
Ninguna bloqueante. El test-writer dejo la implementacion suficientemente acotada (comentarios
detallados con el flujo esperado en cada stub) que el trabajo fue mecanico: todos los tests pasaron
en el primer intento tras completar los seis puntos listados arriba.

### Resultado
- Tests pasando: 1150/1150 (36 omitidos por falta de infra real -- smoke tests, esperado y
  preexistente).
- Proyecto `Bitakora.ControlAsistencia.Colaboradores.Tests`: 287/287.

</details>
<details>
<summary>Smoke Test Writer — 10m 0s</summary>

_(El agente no generó resumen)_

</details>
<details>
<summary>Reviewer (fase refactor) — 13m 35s</summary>

## ES Reviewer - Revision

### Evaluacion general
- Calidad: **buena**
- Cambios realizados: **si** (commit `1c6a492` -- limpieza de comentarios obsoletos, `readonly` +
  `Clear()` en el diccionario, 3 tests nuevos y 2 `And<>()` faltantes)

### Estado de la suite

| Proyecto | Resultado |
|---|---|
| Todos los `*.Tests` (unitarios) | **verde**: 1157 correctos, 0 errores (289 -> 290 en `Colaboradores.Tests`) |
| `Colaboradores.SmokeTests` | 13 rojos -- **lag de despliegue, no defecto de codigo** (ver abajo) |

**Los 13 rojos NO son un bloqueo heredado ni un defecto.** Los smoke tests apuntan a
`https://func-asist-dev-colaboradores.azurewebsites.net` (dev desplegado, MEF-ADR-0013) y las dos
rutas nuevas todavia no existen alli. Verificado con `curl` contra dev:

```
/api/Colaboradores/Terminaciones   -> 400   (desplegada en #354, valida el body)
/api/Colaboradores/Etiquetas       -> 404   (aun no desplegada)
/api/Colaboradores/Etiquetas/Retiros -> 404 (aun no desplegada)
```

Todos los fallos son `esperado 202/400/409, encontrado 404`: la ruta no existe en el host. `ci.yml`
solo corre `tests/Bitakora.ControlAsistencia.*.Tests/` (el glob no matchea `*.SmokeTests`), y
`deploy-colaboradores.yml` los ejecuta **despues** del deploy pasando `Postgres__ConnectionString`
y `ServiceBus__ConnectionString`. Mismo estado en que se mergeo #354. No se creo
`blockage-report.md`: no hay nada que corregir en el codigo.

### Cumplimiento de ADRs aplicables

| ADR | Cumplimiento | Observacion |
|---|---|---|
| CA-ADR-0030: fallos sincronos sin consumidores | ok | Cero eventos `*Fallido`. Ambos aggregates declinan con resultado (`ResultadoAsignacionEtiqueta`, `ResultadoRetiroEtiqueta`), nunca lanzan; los handlers traducen a `InvalidOperationException`/409 y `KeyNotFoundException`/404 con mensaje `.resx`. El handler decide solo por el valor de retorno, nunca interrogando estado del aggregate. |
| MEF-ADR-0012: Tell-don't-Ask / modelado | ok | `EsMismaCategoria`, `Equals` y `NormalizarCategoria` viven en el VO; ni handler ni aggregate comparan o transforman strings. VO `sealed class` + factory + ctor vacio privado + `ConfigurarSerializacion` (sin `[JsonConstructor]`). `EtiquetaAsignada`/`EtiquetaRetirada` son `record` sin invariantes. Recorrido explicito de los 7 antipatrones -- ver abajo. |
| CA-ADR-0029 / MEF-ADR-0039: ensamblados por rol | ok | Ambos eventos nacen en `Colaboradores.DomainEvents` con payload rico (permitido: no cruzan bus), altas en `TiposPersistidos`, sin `MapEventType` ni cambio de `EventNamingStyle`. Cero `<ProjectReference>`/`PackageReference` nuevos en las islas (el diff no toca ningun `.csproj`). |
| MEF-ADR-0037: identidad de stream | ok | Ningun `ToString("N"/"B"/...)`, ninguna `ToUpper`/`ToLower` sobre la clave; los dos handlers usan `ColaboradorAggregateRoot.ComputarStreamId(identificacion)` como punto unico -- ninguno concatena `"CC:"` por su cuenta. Parseo tipado unico en el borde (`TipoIdentificacion.Desde` + `Identificacion.Crear`). Sin GET, no aplica el punto 3. |
| MEF-ADR-0006: naming de funciones | ok | `[Function("AsignarEtiqueta")]` / `[Function("RetirarEtiqueta")]` = nombre del comando literal; `Route` explicito reusando el segmento de recurso del BC (`Colaboradores/Etiquetas`, sub-recurso `.../Retiros`); `AuthorizationLevel.Anonymous` igual que los 6 endpoints hermanos. |
| MEF-ADR-0009: mensajes en `.resx` | ok | Un `.resx` por handler + `partial ... Mensajes` + guardrail `*CommandHandlerMensajesTests` que evita el falso verde de `GetString` devolviendo `null`. |
| MEF-ADR-0005: naming/versionado de eventos | ok | Participio pasado (`EtiquetaAsignada`, `EtiquetaRetirada`); alias congelados por test literal. |
| CA-ADR-0027: tenancy | ok | Sin cambios: ningun handler nuevo toca `ITenantResolver`. |
| MEF-ADR-0002 / MEF-ADR-0016: testing y naming | ok | Solo `[Fact]`, DSL Given/WhenAsync/Then/And con overloads de stream id compuesto, fakes manuales, naming `<Comando>_<LoQuePasa>_Cuando<Condicion>`. |

#### Antipatrones de MEF-ADR-0012 (recorrido explicito)

| # | Antipatron | Veredicto |
|---|---|---|
| 1 | Propiedad publica nueva consumida solo por un externo | no aplica -- `Etiquetas` es `internal`, no publica |
| 2 | Clase estatica que opera sobre datos crudos de un VO | no aplica -- `NormalizarCategoria` es metodo **del propio VO**, no un `NormalizadorDeCategorias` externo |
| 3 | Getter expuesto solo para tests | **matizado, no violacion**: `Etiquetas` es `internal` y existe para que `And<>()` verifique el estado rehidratado, exactamente el mismo criterio ya establecido para `FechaTerminacionVinculacionVigente`/`CodigoVinculacionVigente` en #330-#354. El DSL de MEF-ADR-0002 exige un observable; la superficie **publica** del dominio no crece. |
| 4 | `InternalsVisibleTo` desde un ensamblado de eventos hacia el dominio | no aplica -- no se agrego ninguno |
| 5 | `[JsonConstructor]` en ctor privado | ok -- `Etiqueta` usa `ConfigurarSerializacion` con resolver y campos por reflexion |
| 6 | `record` con `IReadOnlyList<T>` en la igualdad | no aplica -- `Etiqueta` es `sealed class` con `IEquatable` manual |
| 7 | Evento con marker de bus cargando modelo rico | **no aplica y es la razon de que el payload rico sea legitimo**: ni `EtiquetaAsignada` ni `EtiquetaRetirada` implementan `IPrivateEvent`/`IPublicEvent` (verificado en el codigo, no solo en el comentario). Nada cruza bus en este issue, asi que el VO `Etiqueta` se queda en el event store, que es exactamente donde MEF-ADR-0012 lo permite. |

### Desviaciones de ADRs

**Desviaciones declaradas por el implementer**: ninguna ("todos los ADRs aplicados al pie de la
letra"). Confirmado contra el diff.

**Desviaciones detectadas por el reviewer**: **ninguna violacion de ADR.** Los hallazgos de esta
revision son de higiene de codigo y de cobertura, no de doctrina.

Nota sobre la desviacion **del plan** que declaro el test-writer (`Etiqueta.NormalizarCategoria`
como miembro nuevo del VO, fuera del "Modifica" del issue): **evaluada y aceptada.** El planner
dejo la decision abierta ("juicio del pipeline con Tell-don't-Ask"), `Etiqueta.Crear` no es
aplicable porque exige un `Valor` que `RetirarEtiqueta` no lleva, y la alternativa (normalizar en
el handler o en el aggregate) seria la violacion real de MEF-ADR-0012. El metodo replica las
mismas reglas de rechazo y el mismo algoritmo que `Crear`, y trae 4 tests propios.

### Precedentes consultados por el implementer

| Precedente | ADR aplicable | Veredicto |
|---|---|---|
| `CorregirFechaInicioVinculacionCommandHandler` / `...Validator` (#352) | CA-ADR-0030, MEF-ADR-0037 | alineado (leido linea por linea) -- con **un matiz**: su orden de reglas es el inverso, ver "Criticas" |
| `AnularTerminacionFunction.FunctionEndpoint` (#354) | MEF-ADR-0004, MEF-ADR-0006 | alineado |
| `CorregirNombres` / `CorregirFechaInicio` (idempotencia silenciosa, #351/#352) | CA-ADR-0030 | alineado |
| `ControlDiarioAggregateRoot.AdicionarMarcacion` (declinar sin emitir) | CA-ADR-0030 | alineado (citado por el propio ADR) |

Ningun precedente citado viola su ADR.

### Convenciones del pipeline (no ADRs)

| Convencion | Estado | Observacion |
|---|---|---|
| Cada test con `Then()` + `And<>()` | ok (corregido) | Faltaba `And<>()` en los dos tests de preaviso (`Asignar`/`Retirar`); agregado. Los dos tests de "colaborador no existe" siguen sin `And<>()` **deliberadamente**: el aggregate no existe en el `TestStore` y `GetAggregateRoot` lanzaria `ArgumentNullException` -- precedente documentado desde #354. |
| Overloads correctos para stream IDs compuestos | ok | `Given(streamId, ...)`, `Then(streamId, ...)`, `And<T,P>(streamId, ...)` en los 18 tests de handler. Oraculo literal `"CC:79543210"`, no derivado de `ComputarStreamId`. |
| Fakes manuales (no NSubstitute) | ok | `FakeAsignarEtiqueta*` / `FakeRetirarEtiqueta*` son clases concretas. |
| Feature folders (produccion y tests) | ok | `{Comando}Function/` + `FunctionEndpoint.cs` + `CommandHandler/`; espejo exacto en tests, un archivo por responsabilidad (handler / validator / endpoint / mensajes / evento). |
| Smoke tests: SkipWhen, secrets, cobertura | ok | `Assert.SkipWhen(!postgres.IsConfigured, ...)` en todos los que tocan Postgres; `appsettings.json` con connection strings vacios; `deploy-colaboradores.yml` pasa ambos secretos. Cobertura por efecto: el unico efecto de estos handlers es el event store (sin `IPublicEventSender`/`IPrivateEventSender`), verificado contra `mt_events`; **no hay topic**, asi que la suscripcion `smoke-tests` no aplica por ausencia real de publicacion, no por conveniencia. Un archivo por comando, sin duplicados. |
| Proyecciones read-side | n/a | El diff no toca `ReadModels`/`Projections` ni ninguna Function GET. |
| Antipatrones de habilitacion (MEF-ADR-0039) | n/a | El diff no toca ningun `.csproj` (verificado con `git diff main...HEAD -- '**/*.csproj'`, vacio). Los 2 tipos nuevos se chequearon contra (d): `PublicEvents/Colaboradores/` y `PrivateEvents/Colaboradores/` estan **vacios**, no hay homonimo posible. |
| Compatibilidad Marten write-side/read-side | ok | **El gate SI aplica** (el diff toca `ConfiguracionSerializacionColaboradores.cs` e `IdentidadEventosColaboradores.cs`). Verificado sin decompilar, con fundamento: los dos atributos tocados de la columna "debe coincidir" (`AddEventTypes` y `TypeInfoResolver`) se consumen en **ambos lados desde el mismo simbolo compartido** de la isla `Colaboradores.DomainEvents` -- write-side `ComposicionServicios.cs:87,102`, worker `ConfiguracionMartenProjectionsColaboradores.cs:81,104` -- asi que propagan atomicamente y no pueden divergir. El diff no cambia version de paquete ni `DatabaseSchemaName`/`StreamIdentity`/`EventNamingStyle`/`TenancyStyle`/`MetadataConfig`/`Policies`, de modo que el resultado de la comparacion es identico al de `main`. Guardrail permanente presente y verde: `ConfigurarColaboradores_RegistraLosTiposDeEventoPersistidos` y `ConfigurarColaboradores_ConservaElResolverDeSerializacionCustom` en `Projections.Tests`. |
| Identidad de stream (MEF-ADR-0037) | ok | Detalle en la tabla de ADRs. |
| Control de volumen de telemetria (MEF-ADR-0038) | n/a | El diff no toca `ComposicionServicios*`, `ConfiguracionObservabilidad*` ni el callback de Wolverine. |
| Tests via ToString/comportamiento | ok | Ver antipatron #3: el unico observable nuevo es `internal` y lo exige el DSL. |
| Sin numeros magicos | ok | Rutas, schema, tipos de evento y timeouts como constantes con nombre en los smoke tests. |
| Condiciones en positivo | ok | `if (!_etiquetas.ContainsKey(...)) return ...` es guard clause de precondicion (excepcion documentada), no una bifurcacion `if`/`else` en negativo. |
| Sin `─` (U+2500) | ok | Verificado sobre todos los `.cs` del diff. |
| Warnings del compilador | ok | `dotnet build`: 4 warnings, todos `NU1902` preexistentes de `Programacion` (OpenTelemetry.Api), ninguno del codigo nuevo. |

### Elegancia del codigo

El codigo llegaba en muy buen estado -- estructura, naming y simetria con la cadena #349-#354 son
correctos. Lo que si estaba degradado era la **relacion comentario/codigo**:

- **Comentarios que mentian** (el peor tipo de deuda): `Apply(VinculacionIniciada)` declaraba "NO se
  implementa aqui (fase roja): el cuerpo real queda para el implementer" **debajo de la linea que
  si lo implementa**. Ambos handlers y ambos validators seguian rotulados `STUB (fase roja)` con el
  cuerpo completo escrito. Un lector futuro habria concluido que faltaba trabajo.
- **Comentario como pseudocodigo**: los encabezados de los dos handlers listaban 5 pasos numerados
  que repetian, linea por linea, el cuerpo de 15 lineas que venia justo debajo. Se comprimieron al
  parrafo de doctrina que usa el precedente `CorregirFechaInicioVinculacionCommandHandler` (por que
  cada mecanismo, no que hace cada linea): -35 lineas sin perder una sola razon.
- **Referencia a artefacto del pipeline en codigo de produccion**: `Etiqueta.cs` remitia a "el
  resumen del pipeline", que no vive en el repo. La razon tecnica se conserva; el puntero muerto no.
- **Mutabilidad innecesaria**: `_etiquetas` era reasignable solo para poder hacer `= new()` en el
  reingreso. Con `Clear()` el campo pasa a `readonly` (la reasignacion deja de ser posible por
  compilador, no por disciplina) y el reingreso no realoca.

Lo idiomatico ya estaba bien resuelto y no se toco: `switch` sobre enum de resultado en
`RetirarEtiqueta` (exhaustivo por tipo, no seleccion por clave discreta -- no corresponde lookup
map), `TryGetValue` en vez de doble lookup, expression-bodied `Apply`.

### Criticas y hallazgos

1. **[mayor -- corregido] Comentarios de fase roja que contradicen el codigo.** 5 archivos
   (`ColaboradorAggregateRoot`, ambos handlers, ambos validators). Corregido.
2. **[mayor -- corregido con test] Hueco de verificacion: ningun test ejercia dos categorias a la
   vez.** Todos los tests de handler tenian 0 o 1 categoria en el diccionario. Consecuencia: un
   `Apply(EtiquetaAsignada)` que **reemplazara** el diccionario en vez de indexarlo, o un
   `Apply(EtiquetaRetirada)` que hiciera `Clear()` en vez de `Remove`, habrian pasado la suite
   entera en verde. La implementacion es correcta -- pero nada lo demostraba. Agregados
   `AsignarEtiqueta_ConservaLaCategoriaPrevia_...` y `RetirarEtiqueta_ConservaLasDemasCategorias_...`.
3. **[mayor -- corregido con test] Cruce CA-5 x CA-2 sin cubrir, con orden de reglas invertido
   respecto del precedente.** `AsignarEtiqueta` evalua `VinculacionTerminada` **antes** que
   `SinCambios`; `CorregirFechaInicio` (#352) evalua `SinCambios` primero y lo documenta como
   doctrina ("la idempotencia no consulta las demas reglas"). El implementer eligio el orden
   inverso y lo justifico, pero **no registro que contradice al precedente** y admitio que "ningun
   test dado combina ambas condiciones". El escenario es alcanzable en produccion (asignar ->
   terminar -> reasignar identica). Veredicto: **la implementacion es la correcta** -- CA-5 es
   incondicional ("409 en AMBOS comandos, sin evento"), asi que aplicar el orden de #352 aqui
   habria violado CA-5 devolviendo 202. Agregado
   `AsignarEtiqueta_LanzaInvalidOperationException_CuandoLaEtiquetaEsIgualPeroLaVinculacionTieneTerminacionRegistrada`
   para congelar la decision y su porque.
4. **[menor -- corregido] `And<>()` faltante** en los dos tests de preaviso, donde el aggregate si
   existe y el estado era verificable.
5. **[menor -- corregido] `_etiquetas` mutable** sin necesidad.
6. **[menor -- NO corregido, fuera de alcance] Duplicacion de `EsTipoIdentificacionReconocido` en
   8 validators, con excepcion usada como control de flujo.** Los dos validators nuevos replican
   (copia 7 y 8) un helper que hace `try { TipoIdentificacion.Desde(...) } catch (ArgumentException)
   { return false; }`. La solucion limpia es una afordancia Tell-don't-Ask en el VO
   (`TipoIdentificacion.EsReconocido(string)`, que ya tiene el `PorCodigo` lookup interno) y barrer
   los 8 sitios. **No lo hice aqui**: tocaria 6 archivos ajenos a esta HU (regla 4) y arreglar solo
   2 de 8 dejaria el dominio inconsistente, que es peor. **Recomendacion: issue de limpieza propio.**
7. **[cosmetico -- NO corregido] Duplicacion de fakes y del bloque de parseo del borde.**
   `FakeXRequestValidator`/`FakeXCommandRouter` y las 6 lineas de parseo + 404 se repiten en cada
   feature folder del dominio. Es el patron establecido de los 8 comandos; extraerlo es la misma
   conversacion del punto 6 (issue aparte, MEF-ADR-0018).
8. **[informativo] `dotnet format --verify-no-changes` sale con codigo 2**, por 4 `IDE0005` (usings
   innecesarios) en `ControlHoras.Tests` -- **preexistentes y ajenos al diff** (ninguno de los 34
   archivos tocados aparece en la salida). No se tocaron (regla 4).

### Refactorings aplicados

| Refactor | Justificacion |
|---|---|
| Borrado de 5 rotulos `STUB (fase roja)` / `pendiente, fase verde` | El comentario afirmaba lo contrario del codigo |
| Compresion del encabezado de ambos handlers (-35 lineas) | Pseudocodigo redundante -> parrafo de doctrina, formato del precedente #352 |
| `Etiqueta.cs`: quitada la referencia a "el resumen del pipeline" | Puntero a un artefacto que no vive en el repo; la razon tecnica se conserva |
| `_etiquetas`: `private` -> `private readonly` + `Clear()` en vez de `= new()` | Inmutabilidad de la referencia garantizada por el compilador; sin realocacion por reingreso |
| Comentario del campo: "Crear/Apply sobrescriben" -> "AsignarEtiqueta y su Apply" | `Crear` no existe en este flujo |

Los 5 se validaron con `dotnet test` inmediatamente despues; ninguno requirio revertir.

### Cobertura de criterios de aceptacion

| Criterio | Estado | Test(s) |
|---|---|---|
| CA-1: categoria nueva -> 202, evento con doble forma, aggregate refleja, alias/registro, round-trip del VO | cubierto | `AsignarEtiqueta_EmiteEtiquetaAsignada_CuandoLaCategoriaEsNueva`, `..._CuandoTipoYNumeroLleganSinNormalizar`, `EtiquetaAsignada_TieneAliasEtiquetaAsignada`, `AgregarServiciosColaboradores_RegistraLosTiposDeEventoPersistidos_*`, `..._DerivaElAliasDeEventoDelNombreDeClase_*`, `EtiquetaAsignadaSerializacionTests.RoundTrip_*`, smoke `AsignarEtiqueta_Retorna202YPersisteEtiquetaAsignada_*` |
| CA-2: sobrescribe sin duplicar + idempotencia silenciosa | cubierto (reforzado) | `..._CuandoLaCategoriaExisteConValorDistinto`, `AsignarEtiqueta_NoEmiteEvento_CuandoLaEtiquetaEsIgualPorValorALaExistente`, **`AsignarEtiqueta_ConservaLaCategoriaPrevia_CuandoLaCategoriaNuevaEsDistinta` (nuevo)**, **`..._CuandoLaEtiquetaEsIgualPeroLaVinculacionTieneTerminacionRegistrada` (nuevo, cruce con CA-5)**, smoke x2 |
| CA-3: retirar por forma normalizada distinta | cubierto (reforzado) | `RetirarEtiqueta_EmiteEtiquetaRetirada_CuandoLaCategoriaExisteConFormaDistinta`, `..._CuandoTipoYNumeroLleganSinNormalizar`, **`RetirarEtiqueta_ConservaLasDemasCategorias_CuandoRetiraUnaDeVarias` (nuevo)**, `EtiquetaRetiradaSerializacionTests.RoundTrip_*`, smoke |
| CA-4: categoria inexistente -> 409 (el typo aflora) | cubierto | `RetirarEtiqueta_LanzaInvalidOperationException_CuandoLaCategoriaNoExiste`, `..._CuandoHayUnErrorDeTranscripcionEnLaCategoria`, smoke x2 |
| CA-5: apertura estricta en AMBOS comandos, incluido preaviso | cubierto (reforzado) | 4 tests de handler (2 por comando, ahora con `And<>()`) + el cruce nuevo con CA-2 + smoke x4 |
| CA-6: reingreso nace limpio | cubierto | `AsignarEtiqueta_..._CuandoLaVinculacionEsUnReingresoTrasUnaTerminacionConEtiquetasPrevias`, `RetirarEtiqueta_..._CuandoLaEtiquetaPerteneceALaVinculacionAnteriorTrasUnReingreso`, smoke x2 |
| CA-7: 404 sin escribir / 400 sin tocar el event store | cubierto | `*_LanzaKeyNotFoundException_CuandoColaboradorNoExiste` x2, `AsignarEtiquetaValidatorTests` (7), `RetirarEtiquetaValidatorTests` (6), `FunctionEndpointTests` x2 (404/400), smoke x7 |

### Tests agregados

- `AsignarEtiqueta_ConservaLaCategoriaPrevia_CuandoLaCategoriaNuevaEsDistinta` -- convivencia de dos
  categorias al asignar (Count 2, ambas verificadas por valor).
- `RetirarEtiqueta_ConservaLasDemasCategorias_CuandoRetiraUnaDeVarias` -- el retiro es por categoria,
  no un vaciado del diccionario.
- `AsignarEtiqueta_LanzaInvalidOperationException_CuandoLaEtiquetaEsIgualPeroLaVinculacionTieneTerminacionRegistrada`
  -- congela el orden de evaluacion apertura-antes-que-idempotencia (CA-5 incondicional).
- `And<>()` agregado a `AsignarEtiqueta_..._CuandoLaTerminacionEsUnPreavisoConFechaFutura` (Count 0)
  y `RetirarEtiqueta_..._CuandoLaTerminacionEsUnPreavisoConFechaFutura` (Count 1).

Los tres tests nuevos pasaron sin tocar produccion: eran huecos de **verificacion**, no defectos.

Tests de contrato del VO (`IgualdadTestBase<Etiqueta>` y round-trip de serializacion) ya existian
desde #353 (`EtiquetaIgualdadTests.cs`, `EtiquetaSerializacionTests.cs`) -- no habia que generarlos.

### Para atencion del usuario

1. **Los 13 smoke tests rojos se resuelven solos al desplegar.** No requieren accion.
2. **Punto 3 de "Criticas" -- decision de negocio que conviene confirmar**: asignar una etiqueta
   **identica a la que ya existe** sobre un colaborador con terminacion registrada devuelve **409**,
   no 202. Es lo que CA-5 dice literalmente y ahora esta congelado por un test; si la intencion era
   que la idempotencia ganara (como en #352), el cambio es de una linea y hay que reescribir ese
   test.
3. **Punto 6 -- deuda acumulada digna de un issue**: `EsTipoIdentificacionReconocido` va por su
   copia numero 8, usando `try/catch` como control de flujo. Un `TipoIdentificacion.EsReconocido()`
   elimina las 8 copias y el catch.

</details>

## Commits

1c6a492 refactor(hu-355): limpia comentarios de fase roja y cubre huecos de verificacion
0a09904 test(hu-355): smoke tests para endpoints
3401086 feat(hu-355): implementa asignar y retirar etiquetas de un colaborador (fase verde)
31ce260 test(issue-355): tests para asignar y retirar etiquetas de un colaborador (fase roja)

Closes #355