### PR TITLE
Mover la normalizacion del codigo de tipo de identificacion al VO TipoIdentificacion

### DIFF
--- a/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/TipoIdentificacion.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/TipoIdentificacion.cs
@@ -43,12 +43,16 @@ public sealed partial class TipoIdentificacion
     // El chequeo de null NO es defensivo redundante: este es el boundary de rehidratacion desde
     // JSON (Identificacion.ConfigurarSerializacion lo llama con el valor crudo del payload), asi
     // que un "tipo": null persistido debe fallar con el mensaje de dominio y no con el
-    // ArgumentNullException del diccionario, que no dice nada del contrato roto.
-    // La comparacion es exacta y sensible a mayusculas: lo persistido es siempre el codigo
-    // canonico ("CC"), y aceptar "cc" en silencio abriria dos representaciones para la misma
-    // identidad -- y con ellas dos claves de stream distintas.
+    // ArgumentNullException del diccionario, que no dice nada del contrato roto. El null-check se
+    // evalua ANTES de normalizar -- no se puede invocar Trim() sobre null.
+    // Issue #371: normaliza (trim + MAYUSCULAS invariante) antes del lookup -- el conocimiento de
+    // como normalizar la entrada pertenece al VO (Tell-don't-Ask, MEF-ADR-0012), no a los callers.
+    // El racional de #348 (aceptar "cc" abriria dos representaciones/claves de stream distintas) no
+    // se sostiene con el diseno actual: Desde() nunca almacena el input, siempre retorna la
+    // instancia canonica de la lista cerrada, y la clave de stream se compone desde esa instancia
+    // canonica -- nunca desde el input crudo.
     public static TipoIdentificacion Desde(string codigo) =>
-        codigo is not null && PorCodigo.TryGetValue(codigo, out var tipo)
+        codigo is not null && PorCodigo.TryGetValue(codigo.Trim().ToUpperInvariant(), out var tipo)
             ? tipo
             : throw new ArgumentException(Mensajes.CodigoNoReconocido, nameof(codigo));
 

--- a/src/Bitakora.ControlAsistencia.Colaboradores/AnularTerminacionFunction/CommandHandler/AnularTerminacionCommandHandler.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/AnularTerminacionFunction/CommandHandler/AnularTerminacionCommandHandler.cs
@@ -21,7 +21,7 @@ public partial class AnularTerminacionCommandHandler : ICommandHandlerAsync<Anul
     {
         // Parseo tipado unico del borde (MEF-ADR-0037 seccion 2), mismo criterio que
         // TerminarVinculacionCommandHandler.
-        var tipo = TipoIdentificacion.Desde(command.TipoIdentificacion.Trim().ToUpperInvariant());
+        var tipo = TipoIdentificacion.Desde(command.TipoIdentificacion);
         var identificacion = Identificacion.Crear(tipo, command.NumeroIdentificacion);
 
         var streamId = ColaboradorAggregateRoot.ComputarStreamId(identificacion);

--- a/src/Bitakora.ControlAsistencia.Colaboradores/AnularTerminacionFunction/CommandHandler/AnularTerminacionValidator.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/AnularTerminacionFunction/CommandHandler/AnularTerminacionValidator.cs
@@ -4,9 +4,9 @@ using FluentValidation;
 namespace Bitakora.ControlAsistencia.Colaboradores.AnularTerminacionFunction.CommandHandler;
 
 // Issue #354: validacion de forma del comando AnularTerminacion en el borde (MEF-ADR-0004 capa 1
-// -> 400 BadRequest). CA-6: TipoIdentificacion (requerido + en la lista cerrada -- normalizar
-// trim+MAYUSCULAS antes de TipoIdentificacion.Desde, mismo criterio de normalizacion de entrada
-// que TerminarVinculacionValidator) y NumeroIdentificacion requeridos. Sin FechaEfectiva ni otro
+// -> 400 BadRequest). CA-6: TipoIdentificacion (requerido + en la lista cerrada -- la normalizacion
+// trim+MAYUSCULAS vive dentro de TipoIdentificacion.Desde, issue #371, mismo criterio que
+// TerminarVinculacionValidator) y NumeroIdentificacion requeridos. Sin FechaEfectiva ni otro
 // campo: el comando no lleva payload propio.
 // Se descubre via el AddValidatorsFromAssemblyContaining que ComposicionServicios ya configura:
 // no requiere tocar el wiring de DI.

--- a/src/Bitakora.ControlAsistencia.Colaboradores/AnularTerminacionFunction/CommandHandler/AnularTerminacionValidator.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/AnularTerminacionFunction/CommandHandler/AnularTerminacionValidator.cs
@@ -32,7 +32,7 @@ public class AnularTerminacionValidator : AbstractValidator<AnularTerminacion>
     {
         try
         {
-            TipoIdentificacion.Desde(tipo.Trim().ToUpperInvariant());
+            TipoIdentificacion.Desde(tipo);
             return true;
         }
         catch (ArgumentException)

--- a/src/Bitakora.ControlAsistencia.Colaboradores/AsignarEtiquetaFunction/CommandHandler/AsignarEtiquetaCommandHandler.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/AsignarEtiquetaFunction/CommandHandler/AsignarEtiquetaCommandHandler.cs
@@ -24,7 +24,7 @@ public partial class AsignarEtiquetaCommandHandler : ICommandHandlerAsync<Asigna
     {
         // Parseo tipado unico del borde (MEF-ADR-0037 seccion 2), mismo criterio que
         // CorregirFechaInicioVinculacionCommandHandler/ReingresarColaboradorCommandHandler.
-        var tipo = TipoIdentificacion.Desde(command.TipoIdentificacion.Trim().ToUpperInvariant());
+        var tipo = TipoIdentificacion.Desde(command.TipoIdentificacion);
         var identificacion = Identificacion.Crear(tipo, command.NumeroIdentificacion);
 
         var streamId = ColaboradorAggregateRoot.ComputarStreamId(identificacion);

--- a/src/Bitakora.ControlAsistencia.Colaboradores/AsignarEtiquetaFunction/CommandHandler/AsignarEtiquetaValidator.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/AsignarEtiquetaFunction/CommandHandler/AsignarEtiquetaValidator.cs
@@ -33,7 +33,7 @@ public class AsignarEtiquetaValidator : AbstractValidator<AsignarEtiqueta>
     {
         try
         {
-            TipoIdentificacion.Desde(tipo.Trim().ToUpperInvariant());
+            TipoIdentificacion.Desde(tipo);
             return true;
         }
         catch (ArgumentException)

--- a/src/Bitakora.ControlAsistencia.Colaboradores/CorregirFechaInicioVinculacionFunction/CommandHandler/CorregirFechaInicioVinculacionCommandHandler.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/CorregirFechaInicioVinculacionFunction/CommandHandler/CorregirFechaInicioVinculacionCommandHandler.cs
@@ -24,7 +24,7 @@ public partial class CorregirFechaInicioVinculacionCommandHandler
     {
         // Parseo tipado unico del borde (MEF-ADR-0037 seccion 2), mismo criterio que
         // ReingresarColaboradorCommandHandler/TerminarVinculacionCommandHandler.
-        var tipo = TipoIdentificacion.Desde(command.TipoIdentificacion.Trim().ToUpperInvariant());
+        var tipo = TipoIdentificacion.Desde(command.TipoIdentificacion);
         var identificacion = Identificacion.Crear(tipo, command.NumeroIdentificacion);
 
         var streamId = ColaboradorAggregateRoot.ComputarStreamId(identificacion);

--- a/src/Bitakora.ControlAsistencia.Colaboradores/CorregirFechaInicioVinculacionFunction/CommandHandler/CorregirFechaInicioVinculacionValidator.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/CorregirFechaInicioVinculacionFunction/CommandHandler/CorregirFechaInicioVinculacionValidator.cs
@@ -36,7 +36,7 @@ public class CorregirFechaInicioVinculacionValidator : AbstractValidator<Corregi
     {
         try
         {
-            TipoIdentificacion.Desde(tipo.Trim().ToUpperInvariant());
+            TipoIdentificacion.Desde(tipo);
             return true;
         }
         catch (ArgumentException)

--- a/src/Bitakora.ControlAsistencia.Colaboradores/CorregirFechaInicioVinculacionFunction/CommandHandler/CorregirFechaInicioVinculacionValidator.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/CorregirFechaInicioVinculacionFunction/CommandHandler/CorregirFechaInicioVinculacionValidator.cs
@@ -5,8 +5,8 @@ namespace Bitakora.ControlAsistencia.Colaboradores.CorregirFechaInicioVinculacio
 
 // Issue #352: validacion de forma del comando CorregirFechaInicioVinculacion en el borde
 // (MEF-ADR-0004 capa 1 -> 400 BadRequest). CA-6: TipoIdentificacion (requerido + en la lista
-// cerrada -- normalizar trim+MAYUSCULAS antes de TipoIdentificacion.Desde, mismo criterio de
-// normalizacion de entrada que los demas validators del dominio), NumeroIdentificacion y
+// cerrada -- la normalizacion trim+MAYUSCULAS vive dentro de TipoIdentificacion.Desde, issue #371,
+// mismo criterio que los demas validators del dominio), NumeroIdentificacion y
 // FechaCorregida requeridos.
 // Se descubre via el AddValidatorsFromAssemblyContaining que ComposicionServicios ya configura: no
 // requiere tocar el wiring de DI.

--- a/src/Bitakora.ControlAsistencia.Colaboradores/CorregirNombresFunction/CommandHandler/CorregirNombresCommandHandler.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/CorregirNombresFunction/CommandHandler/CorregirNombresCommandHandler.cs
@@ -20,9 +20,9 @@ public partial class CorregirNombresCommandHandler : ICommandHandlerAsync<Correg
     public async Task HandleAsync(CorregirNombres command, CancellationToken ct = default)
     {
         // Parseo tipado unico del borde (MEF-ADR-0037 seccion 2), mismo criterio que los handlers
-        // hermanos: TipoIdentificacion.Desde es case-sensitive por diseno (#348), asi que el borde
-        // normaliza antes de consultar la lista cerrada.
-        var tipo = TipoIdentificacion.Desde(command.TipoIdentificacion.Trim().ToUpperInvariant());
+        // hermanos: TipoIdentificacion.Desde normaliza (trim + MAYUSCULAS invariante) internamente
+        // (issue #371), asi que el borde no repite esa normalizacion.
+        var tipo = TipoIdentificacion.Desde(command.TipoIdentificacion);
         var identificacion = Identificacion.Crear(tipo, command.NumeroIdentificacion);
         var nombre = NombreColaborador.Crear(
             command.PrimerNombre, command.SegundoNombre, command.PrimerApellido, command.SegundoApellido);

--- a/src/Bitakora.ControlAsistencia.Colaboradores/CorregirNombresFunction/CommandHandler/CorregirNombresValidator.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/CorregirNombresFunction/CommandHandler/CorregirNombresValidator.cs
@@ -4,9 +4,9 @@ using FluentValidation;
 namespace Bitakora.ControlAsistencia.Colaboradores.CorregirNombresFunction.CommandHandler;
 
 // Issue #351: validacion de forma del comando CorregirNombres en el borde (MEF-ADR-0004 capa 1 ->
-// 400 BadRequest). CA-5: TipoIdentificacion (requerido + en la lista cerrada -- normalizar
-// trim+MAYUSCULAS antes de TipoIdentificacion.Desde, mismo criterio de normalizacion de entrada
-// que TerminarVinculacionValidator/RegistrarColaboradorValidator), NumeroIdentificacion,
+// 400 BadRequest). CA-5: TipoIdentificacion (requerido + en la lista cerrada -- la normalizacion
+// trim+MAYUSCULAS vive dentro de TipoIdentificacion.Desde, issue #371, mismo criterio que
+// TerminarVinculacionValidator/RegistrarColaboradorValidator), NumeroIdentificacion,
 // PrimerNombre y PrimerApellido requeridos no vacios. SegundoNombre/SegundoApellido son opcionales
 // (NombreColaborador.Crear ya los normaliza).
 // Se descubre via el AddValidatorsFromAssemblyContaining que ComposicionServicios ya configura: no
@@ -35,7 +35,7 @@ public class CorregirNombresValidator : AbstractValidator<CorregirNombres>
     {
         try
         {
-            TipoIdentificacion.Desde(tipo.Trim().ToUpperInvariant());
+            TipoIdentificacion.Desde(tipo);
             return true;
         }
         catch (ArgumentException)

--- a/src/Bitakora.ControlAsistencia.Colaboradores/RegistrarColaboradorFunction/CommandHandler/RegistrarColaboradorCommandHandler.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/RegistrarColaboradorFunction/CommandHandler/RegistrarColaboradorCommandHandler.cs
@@ -18,11 +18,10 @@ public partial class RegistrarColaboradorCommandHandler : ICommandHandlerAsync<R
 
     public async Task HandleAsync(RegistrarColaborador command, CancellationToken ct = default)
     {
-        // Parseo tipado unico del borde (MEF-ADR-0037 seccion 2): normalizar trim+MAYUSCULAS ANTES
-        // de Desde -- TipoIdentificacion.Desde es case-sensitive por diseno (#348) para proteger la
-        // rehidratacion de lo ya persistido; normalizar la ENTRADA del usuario es responsabilidad de
-        // este borde, no del VO. El numero lo normaliza Identificacion.Crear.
-        var tipo = TipoIdentificacion.Desde(command.TipoIdentificacion.Trim().ToUpperInvariant());
+        // Parseo tipado unico del borde (MEF-ADR-0037 seccion 2): TipoIdentificacion.Desde ya
+        // normaliza trim+MAYUSCULAS internamente (issue #371), asi que el borde no repite esa
+        // normalizacion. El numero lo normaliza Identificacion.Crear.
+        var tipo = TipoIdentificacion.Desde(command.TipoIdentificacion);
         var identificacion = Identificacion.Crear(tipo, command.NumeroIdentificacion);
 
         var streamId = ColaboradorAggregateRoot.ComputarStreamId(identificacion);

--- a/src/Bitakora.ControlAsistencia.Colaboradores/RegistrarColaboradorFunction/CommandHandler/RegistrarColaboradorValidator.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/RegistrarColaboradorFunction/CommandHandler/RegistrarColaboradorValidator.cs
@@ -40,7 +40,7 @@ public class RegistrarColaboradorValidator : AbstractValidator<RegistrarColabora
     {
         try
         {
-            TipoIdentificacion.Desde(tipo.Trim().ToUpperInvariant());
+            TipoIdentificacion.Desde(tipo);
             return true;
         }
         catch (ArgumentException)

--- a/src/Bitakora.ControlAsistencia.Colaboradores/RegistrarColaboradorFunction/CommandHandler/RegistrarColaboradorValidator.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/RegistrarColaboradorFunction/CommandHandler/RegistrarColaboradorValidator.cs
@@ -14,8 +14,8 @@ public class RegistrarColaboradorValidator : AbstractValidator<RegistrarColabora
     public RegistrarColaboradorValidator()
     {
         // CA-3/CA-4: requerido y en la lista cerrada -- pero "cc" (minusculas) debe seguir siendo
-        // valido, la normalizacion trim+MAYUSCULAS ocurre ANTES de consultar la lista cerrada
-        // (mismo criterio de normalizacion de entrada que el handler, MEF-ADR-0037 seccion 2).
+        // valido: la normalizacion trim+MAYUSCULAS vive dentro de TipoIdentificacion.Desde
+        // (issue #371), no en este borde.
         // Cascade(Stop) evita que Must evalue un valor vacio que NotEmpty ya rechazo.
         RuleFor(x => x.TipoIdentificacion)
             .Cascade(CascadeMode.Stop)

--- a/src/Bitakora.ControlAsistencia.Colaboradores/ReingresarColaboradorFunction/CommandHandler/ReingresarColaboradorCommandHandler.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/ReingresarColaboradorFunction/CommandHandler/ReingresarColaboradorCommandHandler.cs
@@ -22,7 +22,7 @@ public partial class ReingresarColaboradorCommandHandler : ICommandHandlerAsync<
     {
         // Parseo tipado unico del borde (MEF-ADR-0037 seccion 2), mismo criterio que
         // TerminarVinculacionCommandHandler.
-        var tipo = TipoIdentificacion.Desde(command.TipoIdentificacion.Trim().ToUpperInvariant());
+        var tipo = TipoIdentificacion.Desde(command.TipoIdentificacion);
         var identificacion = Identificacion.Crear(tipo, command.NumeroIdentificacion);
 
         var streamId = ColaboradorAggregateRoot.ComputarStreamId(identificacion);

--- a/src/Bitakora.ControlAsistencia.Colaboradores/ReingresarColaboradorFunction/CommandHandler/ReingresarColaboradorValidator.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/ReingresarColaboradorFunction/CommandHandler/ReingresarColaboradorValidator.cs
@@ -4,9 +4,9 @@ using FluentValidation;
 namespace Bitakora.ControlAsistencia.Colaboradores.ReingresarColaboradorFunction.CommandHandler;
 
 // Issue #350: validacion de forma del comando ReingresarColaborador en el borde (MEF-ADR-0004
-// capa 1 -> 400 BadRequest). CA-6: TipoIdentificacion (requerido + en la lista cerrada --
-// normalizar trim+MAYUSCULAS antes de TipoIdentificacion.Desde, mismo criterio de normalizacion de
-// entrada que los demas validators del dominio), NumeroIdentificacion, CodigoColaborador y
+// capa 1 -> 400 BadRequest). CA-6: TipoIdentificacion (requerido + en la lista cerrada -- la
+// normalizacion trim+MAYUSCULAS vive dentro de TipoIdentificacion.Desde, issue #371, mismo criterio
+// que los demas validators del dominio), NumeroIdentificacion, CodigoColaborador y
 // FechaInicio requeridos.
 // Se descubre via el AddValidatorsFromAssemblyContaining que ComposicionServicios ya configura: no
 // requiere tocar el wiring de DI.

--- a/src/Bitakora.ControlAsistencia.Colaboradores/ReingresarColaboradorFunction/CommandHandler/ReingresarColaboradorValidator.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/ReingresarColaboradorFunction/CommandHandler/ReingresarColaboradorValidator.cs
@@ -38,7 +38,7 @@ public class ReingresarColaboradorValidator : AbstractValidator<ReingresarColabo
     {
         try
         {
-            TipoIdentificacion.Desde(tipo.Trim().ToUpperInvariant());
+            TipoIdentificacion.Desde(tipo);
             return true;
         }
         catch (ArgumentException)

--- a/src/Bitakora.ControlAsistencia.Colaboradores/RetirarEtiquetaFunction/CommandHandler/RetirarEtiquetaCommandHandler.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/RetirarEtiquetaFunction/CommandHandler/RetirarEtiquetaCommandHandler.cs
@@ -23,7 +23,7 @@ public partial class RetirarEtiquetaCommandHandler : ICommandHandlerAsync<Retira
     {
         // Parseo tipado unico del borde (MEF-ADR-0037 seccion 2), mismo criterio que
         // CorregirFechaInicioVinculacionCommandHandler/ReingresarColaboradorCommandHandler.
-        var tipo = TipoIdentificacion.Desde(command.TipoIdentificacion.Trim().ToUpperInvariant());
+        var tipo = TipoIdentificacion.Desde(command.TipoIdentificacion);
         var identificacion = Identificacion.Crear(tipo, command.NumeroIdentificacion);
 
         var streamId = ColaboradorAggregateRoot.ComputarStreamId(identificacion);

--- a/src/Bitakora.ControlAsistencia.Colaboradores/RetirarEtiquetaFunction/CommandHandler/RetirarEtiquetaValidator.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/RetirarEtiquetaFunction/CommandHandler/RetirarEtiquetaValidator.cs
@@ -31,7 +31,7 @@ public class RetirarEtiquetaValidator : AbstractValidator<RetirarEtiqueta>
     {
         try
         {
-            TipoIdentificacion.Desde(tipo.Trim().ToUpperInvariant());
+            TipoIdentificacion.Desde(tipo);
             return true;
         }
         catch (ArgumentException)

--- a/src/Bitakora.ControlAsistencia.Colaboradores/TerminarVinculacionFunction/CommandHandler/TerminarVinculacionCommandHandler.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/TerminarVinculacionFunction/CommandHandler/TerminarVinculacionCommandHandler.cs
@@ -33,7 +33,7 @@ public partial class TerminarVinculacionCommandHandler : ICommandHandlerAsync<Te
     {
         // Parseo tipado unico del borde (MEF-ADR-0037 seccion 2), mismo criterio que
         // RegistrarColaboradorCommandHandler.
-        var tipo = TipoIdentificacion.Desde(command.TipoIdentificacion.Trim().ToUpperInvariant());
+        var tipo = TipoIdentificacion.Desde(command.TipoIdentificacion);
         var identificacion = Identificacion.Crear(tipo, command.NumeroIdentificacion);
 
         var streamId = ColaboradorAggregateRoot.ComputarStreamId(identificacion);

--- a/src/Bitakora.ControlAsistencia.Colaboradores/TerminarVinculacionFunction/CommandHandler/TerminarVinculacionCommandHandler.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/TerminarVinculacionFunction/CommandHandler/TerminarVinculacionCommandHandler.cs
@@ -7,8 +7,8 @@ namespace Bitakora.ControlAsistencia.Colaboradores.TerminarVinculacionFunction.C
 // Issue #349: handler del comando TerminarVinculacion.
 // Flujo esperado (precedente SolicitarProgramacionTurnoCommandHandler, MEF-ADR-0004 capa 2 --
 // CA-ADR-0030):
-//   1. Normalizar y parsear TipoIdentificacion -> TipoIdentificacion.Desde(...) (borde HTTP:
-//      normalizar trim+MAYUSCULAS ANTES de Desde, mismo criterio que RegistrarColaboradorCommandHandler).
+//   1. Parsear TipoIdentificacion -> TipoIdentificacion.Desde(...), que normaliza trim+MAYUSCULAS
+//      internamente (issue #371, mismo criterio que RegistrarColaboradorCommandHandler).
 //   2. Identificacion.Crear(tipo, command.NumeroIdentificacion) -- normaliza el numero.
 //   3. ComputarStreamId(identificacion) -> GetAggregateRootAsync<ColaboradorAggregateRoot> -- si
 //      es null, throw KeyNotFoundException(Mensajes.ColaboradorNoEncontrado) (-> 404).

--- a/src/Bitakora.ControlAsistencia.Colaboradores/TerminarVinculacionFunction/CommandHandler/TerminarVinculacionValidator.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/TerminarVinculacionFunction/CommandHandler/TerminarVinculacionValidator.cs
@@ -4,9 +4,9 @@ using FluentValidation;
 namespace Bitakora.ControlAsistencia.Colaboradores.TerminarVinculacionFunction.CommandHandler;
 
 // Issue #349: validacion de forma del comando TerminarVinculacion en el borde (MEF-ADR-0004
-// capa 1 -> 400 BadRequest). CA-6: TipoIdentificacion (requerido + en la lista cerrada --
-// normalizar trim+MAYUSCULAS antes de TipoIdentificacion.Desde, mismo criterio de normalizacion
-// de entrada que RegistrarColaboradorValidator), NumeroIdentificacion y FechaEfectiva requeridos.
+// capa 1 -> 400 BadRequest). CA-6: TipoIdentificacion (requerido + en la lista cerrada -- la
+// normalizacion trim+MAYUSCULAS vive dentro de TipoIdentificacion.Desde, issue #371, mismo criterio
+// que RegistrarColaboradorValidator), NumeroIdentificacion y FechaEfectiva requeridos.
 // Se descubre via el AddValidatorsFromAssemblyContaining que ComposicionServicios ya configura:
 // no requiere tocar el wiring de DI.
 public class TerminarVinculacionValidator : AbstractValidator<TerminarVinculacion>

--- a/src/Bitakora.ControlAsistencia.Colaboradores/TerminarVinculacionFunction/CommandHandler/TerminarVinculacionValidator.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/TerminarVinculacionFunction/CommandHandler/TerminarVinculacionValidator.cs
@@ -35,7 +35,7 @@ public class TerminarVinculacionValidator : AbstractValidator<TerminarVinculacio
     {
         try
         {
-            TipoIdentificacion.Desde(tipo.Trim().ToUpperInvariant());
+            TipoIdentificacion.Desde(tipo);
             return true;
         }
         catch (ArgumentException)

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/RegistrarColaboradorFunction/RegistrarColaboradorSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/RegistrarColaboradorFunction/RegistrarColaboradorSmokeTests.cs
@@ -1,0 +1,279 @@
+// Issue #330: smoke tests del endpoint POST Colaboradores (registrar un colaborador bajo control
+// de asistencia -- primer comando del ciclo de vida de ColaboradorAggregateRoot, desglose
+// #348-#357). Molde: TerminarVinculacionSmokeTests/ReingresarColaboradorSmokeTests -- mismo comando
+// event-sourcing puro sin consumidores downstream (CA-ADR-0030): sin ServiceBusFixture, la unica
+// verificacion black-box de los efectos del handler es leer mt_events via PostgresFixture.
+//
+// Este archivo no existia antes del issue #371 (RegistrarColaboradorFunction no tenia smoke tests
+// dedicados; solo se usaba como arrange comun de los demas comandos del dominio). Se crea ahora
+// porque el issue #371 modifico su CommandHandler y Validator (movio la normalizacion de
+// TipoIdentificacion del borde al VO) y la cobertura black-box de ese endpoint quedaba en blanco.
+//
+// Issue #371 (foco de este archivo): TipoIdentificacion.Desde ya normaliza (trim + MAYUSCULAS
+// invariante) internamente -- el borde HTTP dejo de repetir esa normalizacion. El comportamiento
+// EXTERNO no cambia (ya normalizaba antes en el borde), pero el punto donde vive el conocimiento
+// si cambio, y eso es exactamente lo que las CA-1/CA-1-bis de abajo verifican end-to-end contra el
+// entorno real: un TipoIdentificacion con espacios y minusculas debe seguir colapsando a la MISMA
+// clave de stream canonica ("CC:<numero>"), nunca abrir una segunda clave ("cc:<numero>").
+//
+// CA-1 (ruta de exito): identificacion nueva -> 202 y el stream recibe, en un solo commit,
+// ColaboradorRegistrado + VinculacionIniciada (issue #330).
+// CA-1-bis (#371): mismo camino feliz, pero con TipoIdentificacion sin normalizar en el payload ->
+// 202 y el evento aparece en el stream CANONICO, no en uno alterno por casing.
+// CA-2 (duplicado exacto): misma Identificacion ya registrada -> 409, sin escribir un segundo
+// colaborador_registrado.
+// CA-2-bis (#371, corazon del refactor): el duplicado tambien se detecta cuando el segundo request
+// llega con TipoIdentificacion sin normalizar -- "CC" y " cc " deben colapsar a la MISMA clave de
+// stream, asi que el aggregate ya existe y el segundo registro se rechaza igual que con el mismo
+// casing exacto.
+// CA-3: request invalida (NumeroIdentificacion/CodigoColaborador vacios, FechaInicio vacia, tipo
+// fuera de la lista cerrada) -> 400, sin tocar el event store.
+using System.Net;
+using System.Net.Http.Json;
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.SmokeTests.Fixtures;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.SmokeTests.RegistrarColaboradorFunction;
+
+public class RegistrarColaboradorSmokeTests(ApiFixture api, PostgresFixture postgres)
+{
+    private readonly HttpClient _client = api.Client;
+
+    private const string RutaRegistrar = "/api/Colaboradores";
+    private const string SchemaColaboradores = "colaboradores";
+    private const string TipoEventoColaboradorRegistrado = "colaborador_registrado";
+    private const string TipoEventoVinculacionIniciada = "vinculacion_iniciada";
+    private const string TipoIdentificacionCc = "CC";
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
+
+    // Numero unico por test -- evita colisiones entre ejecuciones repetidas del smoke test: la
+    // identidad del stream es Identificacion.ToString() ("CC:<numero>"), no un Guid nuevo por
+    // llamada, asi que reusar un numero fijo haria que el segundo registro choque con 409 en la
+    // segunda corrida.
+    private static string NuevoNumeroIdentificacion() => Guid.CreateVersion7().ToString("N").ToUpperInvariant();
+
+    private static string NuevoCodigoColaborador() => $"[TEST]-{Guid.CreateVersion7()}";
+
+    // Siempre canonico ("CC:<numero>"): TipoIdentificacion.Desde nunca almacena el input crudo, solo
+    // retorna la instancia canonica de la lista cerrada (issue #371) -- por eso el streamId esperado
+    // no varia sin importar el casing con el que llego el TipoIdentificacion en el payload.
+    private static string ComputarStreamId(string numeroIdentificacion) =>
+        $"{TipoIdentificacionCc}:{numeroIdentificacion}";
+
+    private static object PayloadRegistro(
+        string numeroIdentificacion, DateOnly fechaInicio,
+        string tipoIdentificacion = TipoIdentificacionCc, string? codigoColaborador = null) => new
+        {
+            tipoIdentificacion,
+            numeroIdentificacion,
+            primerNombre = "[TEST]",
+            segundoNombre = (string?)null,
+            primerApellido = "Smoke",
+            segundoApellido = (string?)null,
+            codigoColaborador = codigoColaborador ?? NuevoCodigoColaborador(),
+            fechaInicio
+        };
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task DebeEstarDisponible_CuandoSeConsultaHealthCheck()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var response = await _client.GetAsync("/api/health", ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    // CA-1: camino feliz -- identificacion nueva -> 202 y el stream recibe, en un solo commit,
+    // ColaboradorRegistrado + VinculacionIniciada. Sin Service Bus (event-sourcing puro): mt_events
+    // es la unica ventana black-box a lo que quedo grabado.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task RegistrarColaborador_Retorna202YPersisteColaboradorRegistradoYVinculacionIniciada_CuandoIdentificacionNoExiste()
+    {
+        Assert.SkipWhen(!postgres.IsConfigured, postgres.SkipReason ?? "Postgres no disponible.");
+
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion();
+        var fechaInicio = new DateOnly(2026, 1, 15);
+
+        var response = await _client.PostAsJsonAsync(
+            RutaRegistrar, PayloadRegistro(numeroIdentificacion, fechaInicio), ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+
+        var streamId = ComputarStreamId(numeroIdentificacion);
+
+        var existeRegistrado = await postgres.ExisteEventoAsync(
+            SchemaColaboradores, streamId, TipoEventoColaboradorRegistrado, Timeout);
+
+        existeRegistrado.Should().BeTrue(
+            $"el evento {TipoEventoColaboradorRegistrado} deberia existir en el stream {streamId}");
+
+        var existeVinculacion = await postgres.ExisteEventoAsync(
+            SchemaColaboradores, streamId, TipoEventoVinculacionIniciada, Timeout);
+
+        existeVinculacion.Should().BeTrue(
+            $"el evento {TipoEventoVinculacionIniciada} deberia existir en el mismo commit que {TipoEventoColaboradorRegistrado}");
+    }
+
+    // CA-1-bis (issue #371): la normalizacion vive ahora en TipoIdentificacion.Desde -- un
+    // TipoIdentificacion con espacios y minusculas debe colapsar a la misma clave de stream
+    // canonica ("CC:<numero>"), nunca abrir una segunda clave ("cc:<numero>"). Verificacion
+    // end-to-end del refactor: el borde ya no normaliza, asi que si el VO dejara de hacerlo este
+    // test dejaria de encontrar el evento en el stream canonico.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task RegistrarColaborador_Retorna202YPersisteEnElStreamCanonico_CuandoTipoIdentificacionLlegaEnMinusculasConEspacios()
+    {
+        Assert.SkipWhen(!postgres.IsConfigured, postgres.SkipReason ?? "Postgres no disponible.");
+
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion();
+        var fechaInicio = new DateOnly(2026, 2, 1);
+
+        var response = await _client.PostAsJsonAsync(
+            RutaRegistrar,
+            PayloadRegistro(numeroIdentificacion, fechaInicio, tipoIdentificacion: " cc "),
+            ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+
+        var streamIdCanonico = ComputarStreamId(numeroIdentificacion);
+
+        var existe = await postgres.ExisteEventoAsync(
+            SchemaColaboradores, streamIdCanonico, TipoEventoColaboradorRegistrado, Timeout);
+
+        existe.Should().BeTrue(
+            $"' cc ' deberia normalizar a la instancia canonica CC y persistir en el stream {streamIdCanonico}, nunca en uno separado por casing");
+    }
+
+    // CA-2: duplicado exacto -- misma Identificacion ya registrada -> 409, sin escribir un segundo
+    // colaborador_registrado.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task RegistrarColaborador_Retorna409_CuandoIdentificacionYaExiste()
+    {
+        Assert.SkipWhen(!postgres.IsConfigured, postgres.SkipReason ?? "Postgres no disponible.");
+
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion();
+        var fechaInicio = new DateOnly(2026, 3, 1);
+
+        var primerRegistro = await _client.PostAsJsonAsync(
+            RutaRegistrar, PayloadRegistro(numeroIdentificacion, fechaInicio), ct);
+        primerRegistro.StatusCode.Should().Be(HttpStatusCode.Accepted,
+            "el arrange de este smoke test depende de que el primer registro funcione");
+
+        var streamId = ComputarStreamId(numeroIdentificacion);
+        await postgres.ExisteEventoAsync(
+            SchemaColaboradores, streamId, TipoEventoColaboradorRegistrado, Timeout);
+
+        var segundoRegistro = await _client.PostAsJsonAsync(
+            RutaRegistrar, PayloadRegistro(numeroIdentificacion, fechaInicio), ct);
+
+        segundoRegistro.StatusCode.Should().Be(HttpStatusCode.Conflict);
+
+        var registros = await postgres.ContarEventosAsync(
+            SchemaColaboradores, streamId, TipoEventoColaboradorRegistrado);
+
+        registros.Should().Be(1,
+            "el segundo registro se rechazo con 409: no debe haber escrito un segundo colaborador_registrado");
+    }
+
+    // CA-2-bis (issue #371, corazon del refactor): el duplicado tambien se detecta cuando el
+    // segundo request llega con TipoIdentificacion sin normalizar -- "CC" y " cc " colapsan a la
+    // MISMA clave de stream ("CC:<numero>") porque Desde normaliza antes del lookup, asi que el
+    // aggregate ya existe y el segundo registro se rechaza igual que con el mismo casing exacto.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task RegistrarColaborador_Retorna409YNoDuplicaEvento_CuandoSegundoRegistroLlegaConTipoIdentificacionSinNormalizar()
+    {
+        Assert.SkipWhen(!postgres.IsConfigured, postgres.SkipReason ?? "Postgres no disponible.");
+
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion();
+        var fechaInicio = new DateOnly(2026, 3, 10);
+
+        var primerRegistro = await _client.PostAsJsonAsync(
+            RutaRegistrar,
+            PayloadRegistro(numeroIdentificacion, fechaInicio, tipoIdentificacion: TipoIdentificacionCc),
+            ct);
+        primerRegistro.StatusCode.Should().Be(HttpStatusCode.Accepted,
+            "el arrange de este smoke test depende de que el primer registro (con 'CC') funcione");
+
+        var streamId = ComputarStreamId(numeroIdentificacion);
+        await postgres.ExisteEventoAsync(
+            SchemaColaboradores, streamId, TipoEventoColaboradorRegistrado, Timeout);
+
+        var segundoRegistro = await _client.PostAsJsonAsync(
+            RutaRegistrar,
+            PayloadRegistro(numeroIdentificacion, fechaInicio, tipoIdentificacion: " cc "),
+            ct);
+
+        segundoRegistro.StatusCode.Should().Be(HttpStatusCode.Conflict,
+            "'CC' y ' cc ' deberian colapsar a la misma Identificacion (TipoIdentificacion.Desde normaliza) y colisionar en el mismo stream");
+
+        var registros = await postgres.ContarEventosAsync(
+            SchemaColaboradores, streamId, TipoEventoColaboradorRegistrado);
+
+        registros.Should().Be(1,
+            "el segundo registro (con casing distinto) se rechazo con 409: no debe haber abierto un stream separado ni duplicado el evento");
+    }
+
+    // CA-3: NumeroIdentificacion vacio -> 400.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task RegistrarColaborador_Retorna400_CuandoNumeroIdentificacionEsVacio()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var payload = PayloadRegistro("", new DateOnly(2026, 1, 1));
+
+        var response = await _client.PostAsJsonAsync(RutaRegistrar, payload, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    // CA-3: CodigoColaborador vacio -> 400.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task RegistrarColaborador_Retorna400_CuandoCodigoColaboradorEsVacio()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var payload = PayloadRegistro(
+            NuevoNumeroIdentificacion(), new DateOnly(2026, 1, 1), codigoColaborador: "");
+
+        var response = await _client.PostAsJsonAsync(RutaRegistrar, payload, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    // CA-3: FechaInicio vacia (default de DateOnly, "no llego" segun la doctrina bitemporal del BC)
+    // -> 400.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task RegistrarColaborador_Retorna400_CuandoFechaInicioEsVacia()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var payload = PayloadRegistro(NuevoNumeroIdentificacion(), default(DateOnly));
+
+        var response = await _client.PostAsJsonAsync(RutaRegistrar, payload, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    // CA-3: TipoIdentificacion fuera de la lista cerrada (PILA: CC, CE, TI, PA, PT) -> 400, sin
+    // importar el casing -- Desde normaliza y LUEGO rechaza contra el diccionario cerrado (#371).
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task RegistrarColaborador_Retorna400_CuandoTipoIdentificacionNoEsReconocido()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var payload = PayloadRegistro(
+            NuevoNumeroIdentificacion(), new DateOnly(2026, 1, 1), tipoIdentificacion: "XX");
+
+        var response = await _client.PostAsJsonAsync(RutaRegistrar, payload, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/RegistrarColaboradorFunction/RegistrarColaboradorSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/RegistrarColaboradorFunction/RegistrarColaboradorSmokeTests.cs
@@ -166,8 +166,10 @@ public class RegistrarColaboradorSmokeTests(ApiFixture api, PostgresFixture post
             "el arrange de este smoke test depende de que el primer registro funcione");
 
         var streamId = ComputarStreamId(numeroIdentificacion);
-        await postgres.ExisteEventoAsync(
+        var existePrimerRegistro = await postgres.ExisteEventoAsync(
             SchemaColaboradores, streamId, TipoEventoColaboradorRegistrado, Timeout);
+        existePrimerRegistro.Should().BeTrue(
+            $"el evento {TipoEventoColaboradorRegistrado} del primer registro deberia estar en el stream {streamId} antes de reintentar");
 
         var segundoRegistro = await _client.PostAsJsonAsync(
             RutaRegistrar, PayloadRegistro(numeroIdentificacion, fechaInicio), ct);
@@ -203,8 +205,10 @@ public class RegistrarColaboradorSmokeTests(ApiFixture api, PostgresFixture post
             "el arrange de este smoke test depende de que el primer registro (con 'CC') funcione");
 
         var streamId = ComputarStreamId(numeroIdentificacion);
-        await postgres.ExisteEventoAsync(
+        var existePrimerRegistro = await postgres.ExisteEventoAsync(
             SchemaColaboradores, streamId, TipoEventoColaboradorRegistrado, Timeout);
+        existePrimerRegistro.Should().BeTrue(
+            $"el evento {TipoEventoColaboradorRegistrado} del primer registro (con 'CC') deberia estar en el stream {streamId} antes de reintentar con ' cc '");
 
         var segundoRegistro = await _client.PostAsJsonAsync(
             RutaRegistrar,

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/AnularTerminacionFunction/AnularTerminacionCommandHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/AnularTerminacionFunction/AnularTerminacionCommandHandlerTests.cs
@@ -116,8 +116,8 @@ public class AnularTerminacionCommandHandlerTests : CommandHandlerAsyncTest<Anul
     // CA-1 (borde de identidad, MEF-ADR-0037): "cc" en minusculas + numero con espacios sobre un
     // colaborador ya registrado -> la anulacion alcanza el MISMO stream ("CC:79543210") y tiene
     // exito. La normalizacion del numero la garantiza Identificacion.Crear (#348); la del codigo de
-    // tipo ("cc" -> "CC") es responsabilidad del handler en el borde, porque TipoIdentificacion.Desde
-    // es case-sensitive por diseno (#348).
+    // tipo ("cc" -> "CC") la garantiza TipoIdentificacion.Desde, que normaliza internamente (issue
+    // #371 -- supersede el racional de #348, ver TipoIdentificacionTests).
     [Fact]
     public async Task AnularTerminacion_EmiteTerminacionAnulada_CuandoTipoYNumeroLleganSinNormalizar()
     {

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/AnularTerminacionFunction/AnularTerminacionValidatorTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/AnularTerminacionFunction/AnularTerminacionValidatorTests.cs
@@ -51,9 +51,9 @@ public class AnularTerminacionValidatorTests
             e.PropertyName == nameof(AnularTerminacion.TipoIdentificacion));
     }
 
-    // TipoIdentificacion en minusculas ("cc") DEBE seguir siendo valido -- la normalizacion de
-    // entrada (trim+MAYUSCULAS antes de TipoIdentificacion.Desde) es responsabilidad del borde, no
-    // un rechazo (mismo criterio que los demas validators del dominio).
+    // TipoIdentificacion en minusculas ("cc") DEBE seguir siendo valido -- el validator no juzga
+    // formato del codigo de tipo; la normalizacion (trim+MAYUSCULAS) vive ahora dentro de
+    // TipoIdentificacion.Desde (issue #371, mismo criterio que los demas validators del dominio).
     [Fact]
     public async Task Validar_Aprueba_CuandoTipoIdentificacionLlegaEnMinusculas()
     {

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/AsignarEtiquetaFunction/AsignarEtiquetaValidatorTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/AsignarEtiquetaFunction/AsignarEtiquetaValidatorTests.cs
@@ -53,9 +53,9 @@ public class AsignarEtiquetaValidatorTests
             e.PropertyName == nameof(AsignarEtiqueta.TipoIdentificacion));
     }
 
-    // TipoIdentificacion en minusculas ("cc") DEBE seguir siendo valido -- la normalizacion de
-    // entrada es responsabilidad del borde, no un rechazo (mismo criterio que los demas validators
-    // del dominio).
+    // TipoIdentificacion en minusculas ("cc") DEBE seguir siendo valido -- el validator no juzga
+    // formato del codigo de tipo; la normalizacion (trim+MAYUSCULAS) vive dentro de
+    // TipoIdentificacion.Desde (issue #371, mismo criterio que los demas validators del dominio).
     [Fact]
     public async Task Validar_Aprueba_CuandoTipoIdentificacionLlegaEnMinusculas()
     {

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/CorregirFechaInicioVinculacionFunction/CorregirFechaInicioVinculacionCommandHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/CorregirFechaInicioVinculacionFunction/CorregirFechaInicioVinculacionCommandHandlerTests.cs
@@ -122,8 +122,8 @@ public class CorregirFechaInicioVinculacionCommandHandlerTests
     // CA-1 (borde de identidad, MEF-ADR-0037): "cc" en minusculas + numero con espacios sobre un
     // colaborador ya registrado -> la correccion alcanza el MISMO stream ("CC:79543210") y emite
     // el evento. La normalizacion del numero la garantiza Identificacion.Crear (#348); la del
-    // codigo de tipo ("cc" -> "CC") es responsabilidad del handler en el borde, porque
-    // TipoIdentificacion.Desde es case-sensitive por diseno (#348).
+    // codigo de tipo ("cc" -> "CC") la garantiza TipoIdentificacion.Desde, que normaliza
+    // internamente (issue #371 -- supersede el racional de #348, ver TipoIdentificacionTests).
     [Fact]
     public async Task CorregirFechaInicioVinculacion_EmiteFechaInicioVinculacionCorregida_CuandoTipoYNumeroLleganSinNormalizar()
     {

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/CorregirFechaInicioVinculacionFunction/CorregirFechaInicioVinculacionValidatorTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/CorregirFechaInicioVinculacionFunction/CorregirFechaInicioVinculacionValidatorTests.cs
@@ -52,9 +52,9 @@ public class CorregirFechaInicioVinculacionValidatorTests
             e.PropertyName == nameof(CorregirFechaInicioVinculacion.TipoIdentificacion));
     }
 
-    // TipoIdentificacion en minusculas ("cc") DEBE seguir siendo valido -- la normalizacion de
-    // entrada (trim+MAYUSCULAS antes de TipoIdentificacion.Desde) es responsabilidad del borde, no
-    // un rechazo (mismo criterio que los demas validators del dominio).
+    // TipoIdentificacion en minusculas ("cc") DEBE seguir siendo valido -- el validator no juzga
+    // formato del codigo de tipo; la normalizacion (trim+MAYUSCULAS) vive ahora dentro de
+    // TipoIdentificacion.Desde (issue #371, mismo criterio que los demas validators del dominio).
     [Fact]
     public async Task Validar_Aprueba_CuandoTipoIdentificacionLlegaEnMinusculas()
     {

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/CorregirNombresFunction/CorregirNombresCommandHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/CorregirNombresFunction/CorregirNombresCommandHandlerTests.cs
@@ -93,9 +93,10 @@ public class CorregirNombresCommandHandlerTests : CommandHandlerAsyncTest<Correg
     // CA-1 (borde de identidad, MEF-ADR-0037): "cc" en minusculas + numero con espacios sobre un
     // colaborador ya registrado -> la correccion alcanza el MISMO stream ("CC:79543210") y emite el
     // evento. La normalizacion del numero la garantiza Identificacion.Crear (#348); la del codigo
-    // de tipo ("cc" -> "CC") es responsabilidad del handler en el borde, porque
-    // TipoIdentificacion.Desde es case-sensitive por diseno (#348). Sin ella el handler computaria
-    // otra clave y responderia 404 sobre un colaborador que si existe.
+    // de tipo ("cc" -> "CC") la garantiza TipoIdentificacion.Desde, que normaliza internamente
+    // (issue #371 -- supersede el racional de #348, ver TipoIdentificacionTests). Sin esa
+    // normalizacion el handler computaria otra clave y responderia 404 sobre un colaborador que si
+    // existe.
     [Fact]
     public async Task CorregirNombres_EmiteNombresCorregidos_CuandoTipoYNumeroLleganSinNormalizar()
     {

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/CorregirNombresFunction/CorregirNombresValidatorTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/CorregirNombresFunction/CorregirNombresValidatorTests.cs
@@ -55,9 +55,10 @@ public class CorregirNombresValidatorTests
             e.PropertyName == nameof(CorregirNombres.TipoIdentificacion));
     }
 
-    // TipoIdentificacion en minusculas ("cc") DEBE seguir siendo valido -- la normalizacion de
-    // entrada (trim+MAYUSCULAS antes de TipoIdentificacion.Desde) es responsabilidad del borde,
-    // no un rechazo (mismo criterio que TerminarVinculacionValidator/RegistrarColaboradorValidator).
+    // TipoIdentificacion en minusculas ("cc") DEBE seguir siendo valido -- el validator no juzga
+    // formato del codigo de tipo; la normalizacion (trim+MAYUSCULAS) vive dentro de
+    // TipoIdentificacion.Desde (issue #371, mismo criterio que TerminarVinculacionValidator/
+    // RegistrarColaboradorValidator).
     [Fact]
     public async Task Validar_Aprueba_CuandoTipoIdentificacionLlegaEnMinusculas()
     {

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/RegistrarColaboradorFunction/RegistrarColaboradorCommandHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/RegistrarColaboradorFunction/RegistrarColaboradorCommandHandlerTests.cs
@@ -101,9 +101,10 @@ public class RegistrarColaboradorCommandHandlerTests : CommandHandlerAsyncTest<R
 
     // CA-4: "cc" (minusculas) + numero con espacios, tras haber registrado "CC" con el mismo numero
     // normalizado -> 409. La normalizacion del NUMERO ya la garantiza Identificacion.Crear (#348,
-    // trim+MAYUSCULAS); la normalizacion del CODIGO DE TIPO ("cc" -> "CC") es responsabilidad del
-    // handler en el borde (TipoIdentificacion.Desde es case-sensitive por diseno, #348).
-    // El Then sin eventos esperados es la asercion clave: si el borde no normalizara, el handler
+    // trim+MAYUSCULAS); la normalizacion del CODIGO DE TIPO ("cc" -> "CC") la garantiza
+    // TipoIdentificacion.Desde, que normaliza internamente (issue #371 -- supersede el racional de
+    // #348, ver TipoIdentificacionTests).
+    // El Then sin eventos esperados es la asercion clave: si Desde no normalizara, el handler
     // computaria otra clave, no encontraria el stream y nacerian dos personas -- un throw esperado
     // por si solo no distingue "no se registro nada" de "se registro en la clave equivocada".
     [Fact]

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/RegistrarColaboradorFunction/RegistrarColaboradorValidatorTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/RegistrarColaboradorFunction/RegistrarColaboradorValidatorTests.cs
@@ -57,9 +57,10 @@ public class RegistrarColaboradorValidatorTests
             e.PropertyName == nameof(RegistrarColaborador.TipoIdentificacion));
     }
 
-    // CA-4: TipoIdentificacion en minusculas ("cc") DEBE seguir siendo valido -- la normalizacion de
-    // entrada (trim+MAYUSCULAS antes de TipoIdentificacion.Desde) es responsabilidad del borde, no
-    // un rechazo. Sin esto, un POST legitimo con "cc" terminaria en 400 en vez de 409/202.
+    // CA-4: TipoIdentificacion en minusculas ("cc") DEBE seguir siendo valido -- el validator no
+    // juzga formato del codigo de tipo; la normalizacion (trim+MAYUSCULAS) vive dentro de
+    // TipoIdentificacion.Desde (issue #371). Sin ella, un POST legitimo con "cc" terminaria en 400
+    // en vez de 409/202.
     [Fact]
     public async Task Validar_Aprueba_CuandoTipoIdentificacionLlegaEnMinusculas()
     {

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ReingresarColaboradorFunction/ReingresarColaboradorCommandHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ReingresarColaboradorFunction/ReingresarColaboradorCommandHandlerTests.cs
@@ -90,9 +90,9 @@ public class ReingresarColaboradorCommandHandlerTests : CommandHandlerAsyncTest<
     // CA-1 (borde de identidad, MEF-ADR-0037): "cc" en minusculas + numero con espacios sobre un
     // colaborador ya registrado -> el reingreso alcanza el MISMO stream ("CC:79543210") y tiene
     // exito. La normalizacion del numero la garantiza Identificacion.Crear (#348); la del codigo de
-    // tipo ("cc" -> "CC") es responsabilidad del handler en el borde, porque TipoIdentificacion.Desde
-    // es case-sensitive por diseno (#348). Sin ella el handler computaria otra clave y responderia
-    // 404 sobre un colaborador que si existe.
+    // tipo ("cc" -> "CC") la garantiza TipoIdentificacion.Desde, que normaliza internamente (issue
+    // #371 -- supersede el racional de #348, ver TipoIdentificacionTests). Sin esa normalizacion el
+    // handler computaria otra clave y responderia 404 sobre un colaborador que si existe.
     [Fact]
     public async Task ReingresarColaborador_EmiteVinculacionIniciada_CuandoTipoYNumeroLleganSinNormalizar()
     {

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ReingresarColaboradorFunction/ReingresarColaboradorValidatorTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ReingresarColaboradorFunction/ReingresarColaboradorValidatorTests.cs
@@ -53,9 +53,9 @@ public class ReingresarColaboradorValidatorTests
             e.PropertyName == nameof(ReingresarColaborador.TipoIdentificacion));
     }
 
-    // TipoIdentificacion en minusculas ("cc") DEBE seguir siendo valido -- la normalizacion de
-    // entrada (trim+MAYUSCULAS antes de TipoIdentificacion.Desde) es responsabilidad del borde, no
-    // un rechazo (mismo criterio que los demas validators del dominio).
+    // TipoIdentificacion en minusculas ("cc") DEBE seguir siendo valido -- el validator no juzga
+    // formato del codigo de tipo; la normalizacion (trim+MAYUSCULAS) vive ahora dentro de
+    // TipoIdentificacion.Desde (issue #371, mismo criterio que los demas validators del dominio).
     [Fact]
     public async Task Validar_Aprueba_CuandoTipoIdentificacionLlegaEnMinusculas()
     {

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/RetirarEtiquetaFunction/RetirarEtiquetaValidatorTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/RetirarEtiquetaFunction/RetirarEtiquetaValidatorTests.cs
@@ -52,9 +52,9 @@ public class RetirarEtiquetaValidatorTests
             e.PropertyName == nameof(RetirarEtiqueta.TipoIdentificacion));
     }
 
-    // TipoIdentificacion en minusculas ("cc") DEBE seguir siendo valido -- la normalizacion de
-    // entrada es responsabilidad del borde, no un rechazo (mismo criterio que los demas validators
-    // del dominio).
+    // TipoIdentificacion en minusculas ("cc") DEBE seguir siendo valido -- el validator no juzga
+    // formato del codigo de tipo; la normalizacion (trim+MAYUSCULAS) vive dentro de
+    // TipoIdentificacion.Desde (issue #371, mismo criterio que los demas validators del dominio).
     [Fact]
     public async Task Validar_Aprueba_CuandoTipoIdentificacionLlegaEnMinusculas()
     {

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/TerminarVinculacionFunction/TerminarVinculacionValidatorTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/TerminarVinculacionFunction/TerminarVinculacionValidatorTests.cs
@@ -52,9 +52,9 @@ public class TerminarVinculacionValidatorTests
             e.PropertyName == nameof(TerminarVinculacion.TipoIdentificacion));
     }
 
-    // TipoIdentificacion en minusculas ("cc") DEBE seguir siendo valido -- la normalizacion de
-    // entrada (trim+MAYUSCULAS antes de TipoIdentificacion.Desde) es responsabilidad del borde,
-    // no un rechazo (mismo criterio que RegistrarColaboradorValidator, issue #330 CA-4).
+    // TipoIdentificacion en minusculas ("cc") DEBE seguir siendo valido -- el validator no juzga
+    // formato del codigo de tipo; la normalizacion (trim+MAYUSCULAS) vive ahora dentro de
+    // TipoIdentificacion.Desde (issue #371, mismo criterio que RegistrarColaboradorValidator).
     [Fact]
     public async Task Validar_Aprueba_CuandoTipoIdentificacionLlegaEnMinusculas()
     {

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ValueObjects/IdentificacionSerializacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ValueObjects/IdentificacionSerializacionTests.cs
@@ -66,6 +66,24 @@ public class IdentificacionSerializacionTests
         documento.RootElement.GetProperty("numero").GetString().Should().Be("1098765432");
     }
 
+    // Issue #371: unica consecuencia observable del refactor FUERA del borde HTTP. La rehidratacion
+    // llama TipoIdentificacion.Desde con el valor crudo del payload, y Desde ahora normaliza: un
+    // "tipo": "cc" corrupto en mt_events (que antes reventaba con ArgumentException) rehidrata a la
+    // instancia canonica CC, preservando la identidad. El issue lo declara comportamiento aceptable
+    // -- el write path nunca lo produce (solo persiste el codigo canonico, ver
+    // Serializar_PersisteElTipoComoCodigoLiteral_...); este test fija que la tolerancia es
+    // deliberada y no un descuido.
+    [Fact]
+    public void Deserializar_RehidrataAlTipoCanonico_CuandoElTipoPersistidoNoEstaNormalizado()
+    {
+        const string jsonCorrupto = """{"tipo":"cc","numero":"1098765432"}""";
+
+        var restaurado = JsonSerializer.Deserialize<Identificacion>(jsonCorrupto, CrearOpciones());
+
+        restaurado.Should().Be(Identificacion.Crear(TipoIdentificacion.CC, "1098765432"));
+        restaurado!.ToString().Should().Be("CC:1098765432", "la clave de stream siempre es la canonica");
+    }
+
     // Barrera anti-regresion: sin el resolver custom (equivalente a olvidar registrar el VO), STJ
     // no puede reconstruir Identificacion -- su unico constructor es privado y no hay
     // [JsonConstructor] (proscrito por MEF-ADR-0012).

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ValueObjects/TipoIdentificacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ValueObjects/TipoIdentificacionTests.cs
@@ -8,6 +8,9 @@ namespace Bitakora.ControlAsistencia.Colaboradores.Tests.ValueObjects;
 /// TipoIdentificacion es una lista cerrada de instancias estaticas (CC, CE, TI, PA, PT) -- NUNCA
 /// un enum C#: lo persistido y lo que compone claves de stream es siempre el codigo literal.
 /// Interfaz publica: instancias estaticas CC/CE/TI/PA/PT, Desde(codigo), ToString().
+/// Issue #371: Desde() ahora normaliza (trim + MAYUSCULAS invariante) antes del lookup -- el
+/// conocimiento de como normalizar la entrada pertenece al VO (Tell-don't-Ask, MEF-ADR-0012), no a
+/// los 16 callers de src/Colaboradores/ que antes repetian Trim().ToUpperInvariant().
 /// </summary>
 public class TipoIdentificacionTests
 {
@@ -64,7 +67,8 @@ public class TipoIdentificacionTests
 
     // Desde() es el boundary de rehidratacion desde el payload persistido: un "tipo": null en el
     // JSON debe fallar con el mensaje de dominio, no con el ArgumentNullException que el
-    // diccionario lanzaria por su cuenta (que no dice nada del contrato roto).
+    // diccionario lanzaria por su cuenta (que no dice nada del contrato roto). El null-check se
+    // evalua ANTES de normalizar -- no se puede invocar Trim() sobre null.
     [Fact]
     public void Desde_LanzaArgumentException_CuandoCodigoEsNull()
     {
@@ -74,15 +78,58 @@ public class TipoIdentificacionTests
             .WithMessage($"*{TipoIdentificacion.Mensajes.CodigoNoReconocido}*");
     }
 
-    // El codigo canonico es el unico aceptado: tolerar "cc" abriria dos representaciones para la
-    // misma identidad y, con ellas, dos claves de stream distintas para el mismo colaborador.
+    // CA-2: la cadena vacia normaliza a "" (Trim() de "" sigue siendo ""), que no esta en la lista
+    // cerrada -- sigue rechazada, no colapsa a ninguna instancia por accidente.
     [Fact]
-    public void Desde_LanzaArgumentException_CuandoCodigoVieneEnMinusculas()
+    public void Desde_LanzaArgumentException_CuandoCodigoEsVacio()
     {
-        var act = () => TipoIdentificacion.Desde("cc");
+        var act = () => TipoIdentificacion.Desde(string.Empty);
 
         act.Should().ThrowExactly<ArgumentException>()
             .WithMessage($"*{TipoIdentificacion.Mensajes.CodigoNoReconocido}*");
+    }
+
+    // CA-2: solo espacios normaliza (Trim) a "" -- mismo resultado que la cadena vacia, sigue
+    // rechazada.
+    [Fact]
+    public void Desde_LanzaArgumentException_CuandoCodigoEsSoloEspacios()
+    {
+        var act = () => TipoIdentificacion.Desde("   ");
+
+        act.Should().ThrowExactly<ArgumentException>()
+            .WithMessage($"*{TipoIdentificacion.Mensajes.CodigoNoReconocido}*");
+    }
+
+    // ---------- Issue #371 (CA-1): Desde() normaliza -- supersede el racional de #348 ----------
+    // #348 argumentaba que aceptar "cc" abriria dos representaciones para la misma identidad y dos
+    // claves de stream distintas. Ese racional no se sostiene con el diseno actual: Desde() nunca
+    // almacena el input, siempre retorna la instancia canonica de la lista cerrada (_codigo es
+    // siempre "CC"), y la clave de stream se compone desde esa instancia canonica -- nunca desde el
+    // input crudo. Decision de planning (2026-08-11): un solo Desde() que normaliza, sin factory
+    // estricta/tolerante adicional.
+
+    [Fact]
+    public void Desde_RetornaInstanciaCC_CuandoCodigoTieneEspaciosYMinusculas()
+    {
+        var resultado = TipoIdentificacion.Desde(" cc ");
+
+        resultado.Should().BeSameAs(TipoIdentificacion.CC);
+    }
+
+    [Fact]
+    public void Desde_RetornaInstanciaCC_CuandoCodigoEsMixedCase()
+    {
+        var resultado = TipoIdentificacion.Desde("Cc");
+
+        resultado.Should().BeSameAs(TipoIdentificacion.CC);
+    }
+
+    [Fact]
+    public void Desde_RetornaInstanciaPT_CuandoCodigoEstaEnMinusculas()
+    {
+        var resultado = TipoIdentificacion.Desde("pt");
+
+        resultado.Should().BeSameAs(TipoIdentificacion.PT);
     }
 
     // ---------- ToString(): el codigo literal, contrato de persistencia y de clave de stream ----------


### PR DESCRIPTION
## Resumen

Pipeline TDD completado:
- Fase roja: tests escritos con stubs
- Fase verde: implementación completa
- Smoke tests: escritos para endpoints detectados
- Fase refactor: revisión de calidad

## Decisiones del pipeline

<details>
<summary>Test Writer (fase roja) — 7m 32s</summary>

## ES Test Writer - Decisiones

### Tipo de tarea
NO es refactoring puro (seccion 2 del rol). Aunque el issue se titula "refactor" y el modelo de
eventos no cambia, CA-1 introduce comportamiento nuevo **observable a nivel de unidad**:
`TipoIdentificacion.Desde(" cc ")` y `Desde("Cc")` hoy (antes de la fase verde) lanzan
`ArgumentException`; con la implementacion pedida deben retornar `TipoIdentificacion.CC`. Existe
un estado rojo que compila (la firma `Desde(string)` no cambia), asi que el carril de senal de
refactor puro (MEF-ADR-0017) no aplica -- se sigue el flujo normal de TDD.

### Tests creados/modificados
- `ValueObjects/TipoIdentificacionTests.cs` (14 tests, 2 nuevos + 1 reemplazado + 2 agregados por CA-2):
  - `Desde_RetornaInstanciaCC_CuandoCodigoTieneEspaciosYMinusculas` - CA-1 (" cc " -> CC)
  - `Desde_RetornaInstanciaCC_CuandoCodigoEsMixedCase` - CA-1 ("Cc" -> CC)
  - `Desde_RetornaInstanciaPT_CuandoCodigoEstaEnMinusculas` - CA-1, generalizacion a otra instancia distinta de CC
  - `Desde_LanzaArgumentException_CuandoCodigoEsVacio` - CA-2 ("" sigue rechazado tras normalizar)
  - `Desde_LanzaArgumentException_CuandoCodigoEsSoloEspacios` - CA-2 ("   " sigue rechazado tras Trim)
  - Se **elimino** `Desde_LanzaArgumentException_CuandoCodigoVieneEnMinusculas` (CA-4, reemplazado por los 3 tests de normalizacion arriba)
  - Se mantienen sin cambios: los 5 tests `Desde_RetornaInstancia{CC,CE,TI,PA,PT}_CuandoCodigoEs{XX}`, `Desde_LanzaArgumentException_CuandoCodigoFueraDeLaListaCerrada`, `Desde_LanzaArgumentException_CuandoCodigoEsNull`, `ToString_Retorna...` (2)

- 13 archivos de tests de handlers/validators (**sin cambios de comportamiento, solo comentarios**):
  actualizan el racional citado de "case-sensitive por diseno (#348)" / "responsabilidad del borde"
  al nuevo racional "TipoIdentificacion.Desde normaliza internamente (issue #371)". Los asserts y
  la logica de estos tests no cambian -- ya pasaban antes del issue y siguen pasando porque el
  resultado observable (mismo stream, mismo evento) es identico sin importar si quien normaliza es
  el handler o el VO:
  - `AnularTerminacionFunction/AnularTerminacionCommandHandlerTests.cs`
  - `AnularTerminacionFunction/AnularTerminacionValidatorTests.cs`
  - `AsignarEtiquetaFunction/AsignarEtiquetaValidatorTests.cs`
  - `CorregirFechaInicioVinculacionFunction/CorregirFechaInicioVinculacionCommandHandlerTests.cs`
  - `CorregirFechaInicioVinculacionFunction/CorregirFechaInicioVinculacionValidatorTests.cs`
  - `CorregirNombresFunction/CorregirNombresCommandHandlerTests.cs`
  - `CorregirNombresFunction/CorregirNombresValidatorTests.cs`
  - `RegistrarColaboradorFunction/RegistrarColaboradorCommandHandlerTests.cs`
  - `RegistrarColaboradorFunction/RegistrarColaboradorValidatorTests.cs`
  - `ReingresarColaboradorFunction/ReingresarColaboradorCommandHandlerTests.cs`
  - `ReingresarColaboradorFunction/ReingresarColaboradorValidatorTests.cs`
  - `RetirarEtiquetaFunction/RetirarEtiquetaValidatorTests.cs`
  - `TerminarVinculacionFunction/TerminarVinculacionValidatorTests.cs`

### Estructura elegida
- Una sola clase de test (`TipoIdentificacionTests`), consistente con la existente -- no hay
  multiples handlers involucrados, es un VO plano testeado via interfaz publica (`Desde`,
  `ToString`), sin Given/When/Then del harness de event sourcing (no aplica: no es un command
  handler).
- Nueva seccion delimitada con comentario `// ---------- Issue #371 (CA-1) ...` que documenta
  explicitamente por que el racional de #348 se supersede, para que quien lea el archivo entienda
  la evolucion sin tener que ir al issue.

### Stubs creados
Ninguno. `TipoIdentificacion.Desde(string)` ya existe con implementacion real y firma sin cambios;
no hay tipos nuevos que testear. Esta tarea es 100% tests -- la fase verde solo toca la
implementacion interna de `Desde` y los 16 call sites de produccion.

### Decisiones de diseno
- No se agrego cobertura para las 5 instancias (CC/CE/TI/PA/PT) en minusculas -- CA-1 solo exige el
  caso CC explicitamente; se agrego un tercer test con PT para confirmar que la normalizacion no es
  un caso especial de CC, sin sobre-testear las 5 combinaciones (redundante con los 5 tests
  existentes de lookup exacto).
- El null-check se sigue verificando ANTES de la normalizacion (test
  `Desde_LanzaArgumentException_CuandoCodigoEsNull` sin cambios) -- confirma la nota tecnica del
  issue de que el null-check debe evaluarse antes de `Trim()`.
- Se agregaron los dos tests de CA-2 (`""` y `"   "`) que no existian previamente, para blindar que
  la normalizacion no abre un agujero nuevo (una cadena que colapsa a "" tras Trim sigue fuera de
  la lista cerrada).

### Cobertura de criterios
| Criterio de aceptacion | Test(s) |
|---|---|
| CA-1: `Desde(" cc ")` / `Desde("Cc")` retornan CC | `Desde_RetornaInstanciaCC_CuandoCodigoTieneEspaciosYMinusculas`, `Desde_RetornaInstanciaCC_CuandoCodigoEsMixedCase` |
| CA-2: `Desde(null)`, `Desde("")`, `Desde("   ")`, `Desde("XX")` siguen lanzando | `Desde_LanzaArgumentException_CuandoCodigoEsNull` (ya existia), `Desde_LanzaArgumentException_CuandoCodigoEsVacio` (nuevo), `Desde_LanzaArgumentException_CuandoCodigoEsSoloEspacios` (nuevo), `Desde_LanzaArgumentException_CuandoCodigoFueraDeLaListaCerrada` (ya existia) |
| CA-3: ningun call site con `Trim().ToUpperInvariant()` sobre `TipoIdentificacion` | No aplica a tests -- verificacion de codigo de produccion, responsabilidad del implementer/reviewer via grep |
| CA-4: reemplazar test viejo + corregir comentarios (VO, handlers, validators) | Test viejo eliminado y reemplazado (ver arriba); 13 archivos de comentarios corregidos |
| CA-5: `dotnet test` completo en verde | Responsabilidad de la fase verde + reviewer; no verificable en fase roja |

### Desviaciones del plan del planner

| Sugerencia del issue | Desviacion aplicada | Razon tecnica | Consecuencia |
|---|---|---|---|
| "Ocurrencias verificadas con grep: los 6 handlers ... y sus 6 validators" (12 archivos) | Se trataron 16 call sites de produccion (8 handlers + 8 validators, incluyendo `AsignarEtiqueta`/`RetirarEtiqueta`) | El issue #355 (dependencia declarada, secuencial) ya se mergeo antes de esta ejecucion y agrego 2 handlers + 2 validators mas con el mismo patron `Trim().ToUpperInvariant()`. Verificado con grep: `grep -rln "Trim().ToUpperInvariant()" src/.../Colaboradores/` devuelve 16 archivos, no 12. El planner investigo antes del merge de #355. | CA-3 (responsabilidad del implementer) debe limpiar los 16 archivos, no 12. Actualice comentarios en los 2 archivos de test de validators adicionales (`AsignarEtiquetaValidatorTests.cs`, `RetirarEtiquetaValidatorTests.cs`) que citan el mismo racional ("responsabilidad del borde"), por consistencia -- no los deje con el racional viejo mientras el resto se actualiza. Los tests de handler de estos dos comandos (`AsignarEtiquetaCommandHandlerTests.cs`, `RetirarEtiquetaCommandHandlerTests.cs`) NO citan "case-sensitive por diseno (#348)" explicitamente (confirmado por grep), asi que no requirieron cambio de comentario. |
| "Impacto esperado ... Modifica: ... tests/.../ValueObjects/TipoIdentificacionTests.cs" (sin mencionar otros archivos de test explicitamente en la lista corta) | Se modificaron ademas 13 archivos de test de handlers/validators | El propio issue lo exige en "Notas tecnicas" ("Comentarios a actualizar ademas del codigo: ... los headers de los 6 validators y los comentarios de los tests de handlers que citan 'case-sensitive por diseno (#348)'") y en CA-4 ("se corrigen los comentarios que citan el racional viejo ... VO, handlers y validators tests"). No es una desviacion real, es una instruccion explicita del issue que la lista corta de "Impacto esperado" no detallaba archivo por archivo. | Cobertura completa de CA-4; no quedan comentarios que citen el racional superado (verificado con grep final: 0 coincidencias de "case-sensitive por diseno" y "responsabilidad del borde" en tests). |

No hubo cuestionamientos a la "Interfaz publica propuesta" (no aplica -- el issue declara
explicitamente "sin metodos nuevos", y la firma unica de `Desde` se preserva sin cambios).

</details>

<details>
<summary>Implementer (fase verde) — 7m 22s</summary>

## ES Implementer - Decisiones

### Enfoque de implementacion
Se movio la normalizacion `Trim().ToUpperInvariant()` desde los 16 call sites (8
command handlers + 8 validators del dominio Colaboradores) al unico punto donde
debia vivir segun Tell-don't-Ask (MEF-ADR-0012): `TipoIdentificacion.Desde(string)`.

`Desde` ahora aplica `codigo.Trim().ToUpperInvariant()` al valor recibido **antes**
de consultar el diccionario `PorCodigo`, pero solo despues de verificar
`codigo is not null` (el null-check se preserva exactamente en el mismo lugar y con
la misma prioridad que antes, para no convertir un `"tipo": null` persistido en un
`NullReferenceException` en vez del `ArgumentException` de dominio esperado).

En cada uno de los 16 callers se elimino el `.Trim().ToUpperInvariant()` que
antecedia a `TipoIdentificacion.Desde(...)`, dejando el argumento crudo
(`command.TipoIdentificacion` o `tipo`, segun el caso). El comportamiento externo
observable no cambia: el borde HTTP ya normalizaba, ahora es el VO quien lo hace,
con el mismo resultado para toda entrada previamente aceptada.

### Decisiones de diseno
- Un solo `Desde(string)`, sin factory adicional (estricto/tolerante) -- tal como
  decidio la sesion de planning documentada en el issue. No se agrego superficie
  publica nueva al VO.
- El orden de las dos guardas dentro de `Desde` es deliberado: primero
  `codigo is not null`, luego `.Trim().ToUpperInvariant()` sobre el valor ya sabido
  no-nulo, luego el lookup. Invertir el orden habria causado
  `NullReferenceException` en vez de `ArgumentException` de dominio para
  `Desde(null!)`.
- Se actualizaron los comentarios en los 3 archivos donde el racional viejo era
  explicito y accionable (`CorregirNombresCommandHandler`, `CorregirNombresValidator`,
  `RegistrarColaboradorCommandHandler`): dejaron de decir "case-sensitive por diseno
  (#348), normalizar es responsabilidad del borde" y ahora dicen que
  `TipoIdentificacion.Desde` normaliza internamente (issue #371). Los comentarios
  genericos "Consulta la lista cerrada (#348) sin propagar la excepcion..." en los
  demas validators no citaban el racional de case-sensitivity especificamente y
  siguen siendo ciertos sin cambios, asi que se dejaron intactos.
- No se toco `Identificacion.ConfigurarSerializacion` (rehidratacion): sigue
  llamando `TipoIdentificacion.Desde` con el valor crudo del JSON persistido; como
  lo persistido es siempre el codigo canonico ("CC"), `Trim().ToUpperInvariant()`
  sobre "CC" es idempotente y no cambia el comportamiento de rehidratacion.

### ADRs consultados
- MEF-ADR-0012: Tell-don't-Ask / encapsulamiento -- fundamento de mover la
  normalizacion al VO.
- MEF-ADR-0018: Rule of Three -- la duplicacion en 16 call sites (documentada en
  el issue como 12, verificada como 16 por grep, contando los sitios de
  AsignarEtiqueta/RetirarEtiqueta que el issue no habia enumerado explicitamente
  pero que el docstring del propio test de TipoIdentificacion si menciona) excede
  ampliamente el umbral.
- MEF-ADR-0009: mensajes en .resx -- no se creo ningun mensaje nuevo, se sigue
  usando `Mensajes.CodigoNoReconocido` existente.
- MEF-ADR-0016: convencion de nombres de tests -- no aplica cambios de mi parte,
  el test-writer ya siguio la convencion en los tests modificados/agregados.
- MEF-ADR-0017: archivo senal de refactor puro -- no aplica: el test-writer no
  dejo senal en `pipeline-state/` (vacio), correctamente, porque este issue si
  agrega tests nuevos (normalizacion, CA-1) y no es un refactor sin
  comportamiento nuevo que testear.

### Desviaciones de ADRs
Ninguna desviacion -- todos los ADRs aplicados al pie de la letra.

### Desviaciones del plan del planner
- El planner documento "12 archivos" en el Contexto del issue (6 handlers + 6
  validators). La verificacion con grep en el repo real mostro 16 archivos (8
  handlers + 8 validators), incluyendo `AsignarEtiqueta`/`RetirarEtiqueta` que no
  estaban en la lista original del planner pero si en la seccion "Interfaz publica
  propuesta"/docstring del test `TipoIdentificacionTests` ("16 callers"). Se
  trataron los 16 archivos reales, no los 12 citados en el Contexto -- el numero
  correcto es el que confirma el propio test-writer en el comentario del test
  (issue #371, docstring de `TipoIdentificacionTests.cs`).

### Precedentes consultados
- Ninguno replicado tal cual; el propio VO `TipoIdentificacion.cs` (creado en
  #348) fue el punto de partida y se modifico directamente segun la nueva
  decision de planning, no como precedente de otro dominio.

### Infraestructura modificada
Ninguna -- refactor puro sin cambios de comandos, eventos ni topics/subscriptions.

### Complejidad encontrada
Ninguna significativa. El cambio es mecanico: mover una linea de normalizacion
de 16 call sites a 1 punto unico, mas actualizar 3 comentarios que citaban el
racional superado. `dotnet format` no produjo cambios de contenido adicionales
mas alla del ajuste de espaciado esperado por la edicion.

### Resultado
- Tests pasando: 1174/1174 ejecutables (42 omitidos por falta de Postgres local,
  comportamiento esperado en smoke tests sin infraestructura).
- Tests del dominio Colaboradores: 294/294 en verde.

</details>
<details>
<summary>Smoke Test Writer — 7m 38s</summary>

_(El agente no generó resumen)_

</details>
<details>
<summary>Reviewer (fase refactor) — 9m 20s</summary>

## ES Reviewer - Revision

### Evaluacion general
- Calidad: **buena**
- Cambios realizados: **si** (commit `193aa2f`)

Baseline verde al inicio (1225 tests, 0 errores, 46 omitidos por falta de Postgres local) y
verde al final (1226 tests, 0 errores, 46 omitidos). Sin `blockage-report.md`: no hubo tests
rojos heredados.

El refactor esta bien ejecutado en su nucleo: `TipoIdentificacion.Desde` absorbe la
normalizacion en una sola linea idiomatica y los 16 call sites (8 handlers + 8 validators,
verificados por grep) pasan el valor crudo. El hallazgo que corregi es de **coherencia
documental con efecto practico**: seis comentarios de produccion seguian instruyendo a
normalizar en el borde.

### Cumplimiento de ADRs aplicables

| ADR | Cumplimiento | Observacion |
|---|---|---|
| MEF-ADR-0012: Tell-don't-Ask / encapsulamiento | ok | El refactor *aumenta* el cumplimiento: el conocimiento de como normalizar la entrada deja de vivir replicado en 16 callers y pasa al VO. Recorri el checklist de 7 antipatrones: ninguna propiedad publica nueva, ninguna clase estatica sobre datos crudos del VO, ningun getter para tests, ningun `InternalsVisibleTo`, ningun `[JsonConstructor]`, ningun `record` con `IReadOnlyList`, ningun evento con marker de bus tocado. `TipoIdentificacion` sigue siendo `sealed partial class` con ctor privado, campo privado `_codigo` y unico observable `ToString()`. |
| MEF-ADR-0018: Rule of Three | ok | 16 sitios identicos y mecanicos, muy por encima del umbral; ademas el issue previo (#355) los toco en bloque -- el "momento natural para proponer la extraccion" que el ADR describe. La iniciativa partio del planner/implementer, no del reviewer (autoridad de extraccion respetada). |
| MEF-ADR-0009: mensajes en .resx | ok | No se creo ningun mensaje: sigue usandose `TipoIdentificacion.Mensajes.CodigoNoReconocido` existente, cubierto por `ValueObjects/MensajesResxTests.cs`. |
| MEF-ADR-0016: convencion de naming de tests | ok | Todos los tests nuevos siguen `<Sujeto>_<LoQuePasa>_Cuando<Condicion>` (`Desde_RetornaInstanciaCC_CuandoCodigoTieneEspaciosYMinusculas`, `RegistrarColaborador_Retorna409YNoDuplicaEvento_Cuando...`). Solo `[Fact]`, cero `[Theory]`. |
| MEF-ADR-0017: senal de refactor puro | ok | `pipeline-state/` vacio, correctamente: el test-writer razono que CA-1 introduce comportamiento nuevo observable a nivel de unidad (`Desde(" cc ")` pasa de lanzar a retornar CC) con estado rojo que compila, asi que el carril TDD normal aplicaba y el de senal no. Comparto el criterio. |

### Desviaciones de ADRs

**Desviaciones declaradas por el implementer**: ninguna ("Ninguna desviacion -- todos los ADRs
aplicados al pie de la letra").

**Desviaciones detectadas por el reviewer (NO declaradas por el implementer)**: ninguna
desviacion de ADR. Lo que si detecte es un **incumplimiento de CA del issue**, no de ADR, que
documento abajo en "Criticas y hallazgos" (hallazgo mayor #1).

Ninguna desviacion -- todos los ADRs aplicables se cumplen.

### Precedentes consultados por el implementer

| Precedente | ADR aplicable | Veredicto |
|---|---|---|
| `TipoIdentificacion.cs` (creado en #348) como punto de partida, no replicado de otro dominio | MEF-ADR-0012 | alineado -- el VO ya cumplia la forma canonica (sealed class, ctor privado, factory static, campo privado); el issue solo movio la normalizacion hacia adentro |
| `Identificacion.Crear` como referencia de normalizacion del numero | MEF-ADR-0012 | alineado -- mismo patron Tell-don't-Ask que ahora se replica para el codigo de tipo; la simetria entre ambos VOs quedo completa |

Nota sobre el racional superado de #348: el implementer y el test-writer documentaron
correctamente **por que** se supersede (el VO nunca almacena el input, siempre colapsa a la
instancia canonica, y la clave de stream sale de esa instancia). Verifique la cadena en el
codigo: `Identificacion.ToString()` -> `$"{_tipo}:{_numero}"` -> `TipoIdentificacion.ToString()`
-> `_codigo` canonico. El racional se sostiene: no hay forma de que un input no normalizado
produzca una segunda clave de stream.

### Convenciones del pipeline (no ADRs)

| Convencion | Estado | Observacion |
|---|---|---|
| Cada test con `Then()` + `And<>()` | ok | Los 5 archivos de tests de handler tocados mantienen `Then` + `And<>` (conteos: 9/14, 13/14, 6/6, 3/7, 9/12). Solo cambiaron comentarios, ninguna asercion. |
| Overloads correctos para stream IDs compuestos | ok | `ColaboradorAggregateRoot` tiene stream id compuesto (`"CC:79543210"`); los tests usan `Then(StreamIdEsperado)` y `And<T,P>(StreamIdEsperado, selector, valor)`. Verificado en el test critico de CA-4. |
| Fakes manuales (no NSubstitute) | ok | Cero referencias a NSubstitute en los archivos de test tocados. |
| Feature folders (produccion y tests) | ok | Espejo exacto; el archivo nuevo de smoke tests vive en `RegistrarColaboradorFunction/`, coherente con los 7 pares existentes. |
| Smoke tests: SkipWhen, secrets, cobertura | ok (con 2 correcciones) | `Assert.SkipWhen` (xUnit v3, no `Skip.When`) presente en los 4 tests que dependen de Postgres y ausente -- correctamente -- en los 4 de validacion 400 que no lo necesitan. Filtrado por identificador unico (`Guid.CreateVersion7()` por test), nunca por posicion. Sin archivos duplicados por comando. Sin secrets. Cobertura de efectos: lei `RegistrarColaboradorCommandHandler` -- unico efecto es `StartStream` con 2 eventos, sin `PublishAsync` ni `SendAsync`, y ambos eventos se verifican en Postgres. **No aplica el carve-out de "n/a por falta de suscripcion"**: aqui no hay publicacion a Service Bus que verificar (event-sourcing puro, CA-ADR-0030), y lo verificable -- la persistencia -- esta cubierto. |
| Proyecciones read-side | n/a | El diff no toca `ReadModels`/`Projections` ni ninguna Function GET. |
| Antipatrones de habilitacion (MEF-ADR-0039) | n/a | `git diff main...HEAD -- '**/*.csproj'` vacio y ningun tipo de evento nuevo declarado. |
| Compatibilidad Marten write-side/read-side | n/a | El diff no toca version de `Cosmos.EventSourcing.*` ni `ComposicionServicios*`/`ConfiguracionMarten*`/`ConfiguracionSerializacion*`/`IdentidadEventos*` ni ninguna linea de config de Marten. Sin decompilar. |
| Identidad de stream (MEF-ADR-0037) | ok | El gate **si aplica** (el diff cambia como se deriva la identidad). Punto 1: ningun `ToString("N"/"B"/...)` ni `ToUpper/ToLower` sobre un `Guid`; la identidad aqui es string compuesta, no Guid. Punto 2: los 8 handlers usan `ColaboradorAggregateRoot.ComputarStreamId(identificacion)` -- punto unico de conversion intacto, cero reconstruccion manual en produccion. Punto 3: n/a, no hay GET de read-side en el diff. |
| Control de volumen de telemetria (MEF-ADR-0038) | n/a | El diff no toca `ComposicionServicios*`, `ConfiguracionObservabilidad*` ni el callback de Wolverine. |
| Tests via ToString/comportamiento | ok | Los tests del VO verifican via `BeSameAs` sobre las instancias publicas y `ToString()`; no se expuso ningun getter para test. |
| Sin numeros magicos | ok | El smoke test nuevo usa constantes con nombre (`RutaRegistrar`, `SchemaColaboradores`, `TipoEventoColaboradorRegistrado`, `TipoIdentificacionCc`, `Timeout`). |
| Condiciones en positivo (guardas if/else afirmativas) | ok | `Desde` es una expresion ternaria en positivo (`codigo is not null && TryGetValue(...)` -> instancia : throw); no hay bifurcacion en negativo. |

### Elegancia del codigo

- **Compacto**: `Desde` sigue siendo una unica expresion de 4 lineas; la normalizacion entro sin
  agregar ramas ni superficie publica. El issue evaluo y descarto el par estricto/tolerante
  (`Desde`/`DesdeEntrada`) -- comparto la decision: habria duplicado la API sin proteger nada.
- **Legible**: el orden de las guardas (`codigo is not null` antes de `.Trim()`) es correcto y
  esta documentado; invertirlo cambiaria `ArgumentException` de dominio por
  `NullReferenceException`. Es el tipo de detalle que un comentario si justifica.
- **Idiomatico**: lookup map (`IReadOnlyDictionary`) sobre `switch`/cadena de `if`, ternario con
  `throw` expression, `TryGetValue` con `out var`. Todo idiomatico C#.
- **Robusto**: el boundary de rehidratacion (`Identificacion.ConfigurarSerializacion` ->
  `Desde`) queda cubierto; verifique que `Trim().ToUpperInvariant()` es idempotente sobre el
  codigo canonico persistido, asi que ningun stream existente cambia de interpretacion.
- **Eficiente**: `O(1)` por lookup; el `Trim().ToUpperInvariant()` asigna un string por llamada,
  irrelevante a esta escala (una vez por comando/rehidratacion).
- **Limpio**: cero warnings nuevos. Las 4 advertencias del build (`NU1902`, OpenTelemetry.Api en
  `Programacion`) y los 4 `IDE0005` de `dotnet format` viven en `ControlHoras.Tests` y
  `Programacion` -- confirmado que el diff **no toca** esos proyectos, son preexistentes en
  `main` y quedan fuera de alcance (regla 4: no refactorizar codigo no relacionado). Sin
  caracteres U+2500 en ningun archivo del diff.

### Criticas y hallazgos

1. **[MAYOR - corregido] CA-3/CA-4 incompletos: 6 comentarios de produccion seguian atribuyendo
   la normalizacion al borde.** El CA-3 pide explicitamente "se eliminan tambien los comentarios
   que atribuyen la normalizacion al borde" y las Notas tecnicas nombran "los headers de los 6
   validators". El implementer actualizo solo 3 archivos y declaro en su resumen que los demas
   "no citaban el racional de case-sensitivity especificamente y siguen siendo ciertos sin
   cambios". **Eso es incorrecto**: cinco headers de validator y el flujo documentado de
   `TerminarVinculacionCommandHandler` decian literalmente *"normalizar trim+MAYUSCULAS antes de
   TipoIdentificacion.Desde"*. No es cosmetico -- es una instruccion activa para reintroducir
   exactamente la duplicacion que este issue elimina, en los mismos archivos donde se elimino.
   Archivos corregidos: `RegistrarColaboradorValidator`, `AnularTerminacionValidator`,
   `ReingresarColaboradorValidator`, `CorregirFechaInicioVinculacionValidator`,
   `TerminarVinculacionValidator`, `TerminarVinculacionCommandHandler`. Verificado con grep:
   0 coincidencias restantes de "normalizar trim" / "normalizacion de entrada" en `src/`.

2. **[MENOR - corregido] Dos smoke tests descartaban el resultado de `ExisteEventoAsync`.** En
   `RegistrarColaborador_Retorna409_...` y `..._CuandoSegundoRegistroLlegaConTipoIdentificacionSinNormalizar`,
   la barrera de espera se invocaba como `await postgres.ExisteEventoAsync(...)` sin usar el
   `bool`. Si el evento del arrange nunca aterriza dentro del timeout, el fallo aparece despues
   como `registros.Should().Be(1)` recibiendo `0` -- un mensaje que culpa al codigo bajo prueba
   en vez de al arrange. El peer `AsignarEtiquetaSmokeTests` (lineas 227-230, 262-265) ya afirma
   `existePrimeraEtiqueta.Should().BeTrue(...)`. Alineado.

3. **[MENOR - corregido, ver "Tests agregados"] La rehidratacion tolerante no tenia guardrail.**
   Es la unica consecuencia del refactor observable **fuera** del borde HTTP y el issue la
   declara aceptable de forma explicita ("un hipotetico 'cc' corrupto rehidrataria a la instancia
   CC preservando identidad -- comportamiento aceptable y discutido con el usuario"). Ningun test
   la fijaba: los round-trips existentes solo pasan por el codigo canonico. Sin ese test, la
   tolerancia queda como efecto colateral no documentado en codigo, indistinguible de un
   descuido para quien lea el archivo en seis meses.

4. **[COSMETICO - no corregido] Duplicacion de helpers entre los 8 archivos de smoke test.**
   `NuevoNumeroIdentificacion()`, `NuevoCodigoColaborador()`, `ComputarStreamId(...)` y las
   constantes de schema/timeout se repiten en los 8 archivos del dominio. Excede la Rule of
   Three, pero **no lo toco**: MEF-ADR-0018 ("Autoridad de extraccion") reserva la iniciativa al
   implementer salvo evidencia documentada de evolucion conjunta, y este issue no toco los otros
   7 archivos -- extraer aqui seria refactor de codigo no relacionado (regla 4). Queda como
   candidato a issue propio.

5. **[OBSERVACION - no corregido] El smoke test reconstruye la clave de stream por interpolacion
   (`$"CC:{numero}"`).** No cae bajo MEF-ADR-0037 punto 2, que acota el punto unico de conversion
   a CommandHandlers, EventHandlers y endpoints. Ademas es deseable en un test black-box: afirmar
   el formato canonico de forma independiente, en vez de reusar el codigo de produccion que
   podria estar equivocado, es justamente lo que le da valor a la asercion. Los 7 smoke tests
   peer hacen lo mismo. Sin accion.

6. **[OBSERVACION - no corregido] El health check se repite en cada archivo de smoke test.**
   `DebeEstarDisponible_CuandoSeConsultaHealthCheck` ya existe en `Health/HealthSmokeTests.cs` y
   se duplica en los 13 archivos de smoke test del repo (3 dominios). Convencion establecida del
   proyecto, no algo que introduzca este diff. Sin accion.

### Refactorings aplicados

1. Reescritura de los 6 comentarios de produccion obsoletos (hallazgo 1). Solo comentarios: cero
   cambio de comportamiento, cero cambio de firma.
2. Aserción explícita del resultado de `ExisteEventoAsync` en los 2 smoke tests de duplicado
   (hallazgo 2), alineando con el patron de `AsignarEtiquetaSmokeTests`.

No se aplico ningun rename (`rename_refactoring` no era necesario: ningun simbolo cambia de
nombre en este issue, y en particular **ningun tipo de `IdentidadEventos.TiposPersistidos` se
renombra** -- no aplica el protocolo de alias de MEF-ADR-0036).

`dotnet test` corrido despues de los cambios: verde. Ningun cambio hubo que revertir.

### Cobertura de criterios de aceptacion

| Criterio | Estado | Test(s) |
|---|---|---|
| CA-1: `Desde(" cc ")` y `Desde("Cc")` retornan la instancia `CC` (misma referencia) | cubierto | `Desde_RetornaInstanciaCC_CuandoCodigoTieneEspaciosYMinusculas`, `Desde_RetornaInstanciaCC_CuandoCodigoEsMixedCase`, `Desde_RetornaInstanciaPT_CuandoCodigoEstaEnMinusculas` (generaliza a otra instancia); end-to-end en `RegistrarColaborador_Retorna202YPersisteEnElStreamCanonico_CuandoTipoIdentificacionLlegaEnMinusculasConEspacios` |
| CA-2: `null`, `""`, `"   "`, `"XX"` siguen lanzando `ArgumentException` con `Mensajes.CodigoNoReconocido` | cubierto | `Desde_LanzaArgumentException_CuandoCodigoEsNull`, `..._CuandoCodigoEsVacio`, `..._CuandoCodigoEsSoloEspacios`, `..._CuandoCodigoFueraDeLaListaCerrada`; borde HTTP en `RegistrarColaborador_Retorna400_CuandoTipoIdentificacionNoEsReconocido` |
| CA-3: ningun archivo de `src/.../Colaboradores/` normaliza `TipoIdentificacion`; se eliminan los comentarios que atribuyen la normalizacion al borde | cubierto (completado en esta fase) | Verificacion por grep: 16/16 call sites pasan el valor crudo; las 2 unicas ocurrencias restantes de `Trim().ToUpperInvariant()` son legitimas (dentro del propio `Desde` y en `Identificacion.Crear` sobre el numero). Los 6 comentarios faltantes se corrigieron en el commit `193aa2f` |
| CA-4: el test `Desde_LanzaArgumentException_CuandoCodigoVieneEnMinusculas` se reemplaza; se corrigen los comentarios con el racional viejo (VO, handlers y validators tests) | cubierto (completado en esta fase) | Test viejo eliminado y reemplazado por los 3 de normalizacion; 13 archivos de test actualizados por el test-writer; los 6 comentarios de **produccion** faltantes se corrigieron aqui. Grep final: 0 coincidencias de "case-sensitive por diseno" / "responsabilidad del borde" en el dominio Colaboradores |
| CA-5: `dotnet test` completo en verde sin modificar ningun evento persistido ni el aggregate | cubierto | 1226 tests, 0 errores, 46 omitidos (Postgres no configurado localmente). `git diff main...HEAD` no toca ningun evento persistido ni `ColaboradorAggregateRoot` |

### Tests agregados

- `IdentificacionSerializacionTests.Deserializar_RehidrataAlTipoCanonico_CuandoElTipoPersistidoNoEstaNormalizado`
  (hallazgo 3): deserializa `{"tipo":"cc","numero":"1098765432"}` con el resolver real y afirma
  igualdad con `Identificacion.Crear(TipoIdentificacion.CC, "1098765432")` mas
  `ToString() == "CC:1098765432"`. Es un **test de contrato** del boundary de deserializacion
  (no de comportamiento de negocio), asi que generarlo en fase refactor no viola TDD -- misma
  categoria que los round-trips y los tests de `IEquatable` que ya viven en ese archivo.
  Fija que la tolerancia de la rehidratacion es deliberada y que la clave de stream sigue siendo
  siempre la canonica.

- Tests de contrato de VOs (paso 4b): **no se requirieron adicionales**. `TipoIdentificacion` no
  implementa `IEquatable<T>` (igualdad por referencia deliberada, documentada en su `<remarks>`:
  `Desde` siempre retorna la instancia canonica) ni declara `ConfigurarSerializacion` propio --
  se persiste como codigo literal a traves del resolver de `Identificacion`, que ya tiene
  `IdentificacionIgualdadTests` e `IdentificacionSerializacionTests`, incluida la barrera
  anti-regresion "sin resolver, falla" que exige MEF-ADR-0012.

- Eventos con marker de bus (`IPrivateEvent`/`IPublicEvent`): n/a, el diff no declara ni modifica
  ninguno; no aplica el guardrail de round-trip con serializador por defecto.

</details>

## Cobertura

| Archivo | Cobertura | Umbral | Estado |
|---|---|---|---|
| TerminarVinculacionCommandHandler.cs | 100.0% | 95% | ok |
| TerminarVinculacionValidator.cs | 100.0% | 95% | ok |
| RetirarEtiquetaCommandHandler.cs | 100.0% | 95% | ok |
| RetirarEtiquetaValidator.cs | 100.0% | 95% | ok |
| ReingresarColaboradorCommandHandler.cs | 100.0% | 95% | ok |
| ReingresarColaboradorValidator.cs | 100.0% | 95% | ok |
| RegistrarColaboradorCommandHandler.cs | 100.0% | 95% | ok |
| RegistrarColaboradorValidator.cs | 100.0% | 95% | ok |
| CorregirNombresCommandHandler.cs | 100.0% | 95% | ok |
| CorregirNombresValidator.cs | 100.0% | 95% | ok |
| CorregirFechaInicioVinculacionCommandHandler.cs | 100.0% | 95% | ok |
| CorregirFechaInicioVinculacionValidator.cs | 100.0% | 95% | ok |
| AsignarEtiquetaCommandHandler.cs | 100.0% | 95% | ok |
| AsignarEtiquetaValidator.cs | 100.0% | 95% | ok |
| AnularTerminacionCommandHandler.cs | 100.0% | 95% | ok |
| AnularTerminacionValidator.cs | 100.0% | 95% | ok |
| TipoIdentificacion.cs | - | sin clasificar | ⚠ revisar |

> **Archivos sin clasificar** (`⚠ revisar`): ninguna regla de clasificacion los reconocio — el gate **no los midio**. No es una exclusion deliberada (a diferencia de `excluido`, donde si se decidio que no requieren cobertura): requieren revision humana para confirmar si necesitan tests.
## Commits

193aa2f refactor(hu-371): completar CA-3/CA-4 y blindar la rehidratacion tolerante
d2a0eba test(hu-371): smoke tests para endpoints
d8170dc feat(hu-371): mover normalizacion de TipoIdentificacion al VO (fase verde)
105faa0 test(issue-371): tests de normalizacion en TipoIdentificacion.Desde (fase roja)

Closes #371