### PR TITLE
Crear el read model FichaColaborador con su proyeccion y consulta puntual

### DIFF
--- a/src/Bitakora.ControlAsistencia.Colaboradores/Bitakora.ControlAsistencia.Colaboradores.csproj
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/Bitakora.ControlAsistencia.Colaboradores.csproj
@@ -30,6 +30,7 @@
     <ProjectReference Include="..\Bitakora.ControlAsistencia.PublicEvents\Bitakora.ControlAsistencia.PublicEvents.csproj" />
     <ProjectReference Include="..\Bitakora.ControlAsistencia.PrivateEvents\Bitakora.ControlAsistencia.PrivateEvents.csproj" />
     <ProjectReference Include="..\Bitakora.ControlAsistencia.Colaboradores.DomainEvents\Bitakora.ControlAsistencia.Colaboradores.DomainEvents.csproj" />
+    <ProjectReference Include="..\Bitakora.ControlAsistencia.ReadModels\Bitakora.ControlAsistencia.ReadModels.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Bitakora.ControlAsistencia.Colaboradores/Infraestructura/ComposicionServicios.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/Infraestructura/ComposicionServicios.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
 using Azure.Monitor.OpenTelemetry.Exporter;
 using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+using Bitakora.ControlAsistencia.ReadModels.Colaboradores;
 using Cosmos.EventDriven.CritterStack;
 using Cosmos.EventDriven.CritterStack.AzureServiceBus;
 using Cosmos.EventSourcing.CritterStack;
@@ -85,6 +86,33 @@ public static class ComposicionServicios
             // el EventGraph. Lista vacia al nacer -- se llena a medida que ColaboradorAggregateRoot
             // aplique sus primeros eventos.
             options.Events.AddEventTypes(IdentidadEventosColaboradores.TiposPersistidos);
+
+            // Issue #294 (aplicado a FichaColaborador por #356, mismo patron que #328 aplico a
+            // TurnoVigente en ControlHoras): declara del lado LECTURA la forma de mt_version que el
+            // worker ya impone del lado escritura -- aqui la tabla la posee la proyeccion y este
+            // Function App solo la consulta (ObtenerFichaColaborador).
+            //
+            // Marten aplica ProjectionDocumentPolicy a todo documento que sea target de una
+            // proyeccion registrada en ese store: UseNumericRevisions = true, Metadata.Revision
+            // (mt_version bigint) habilitada y Metadata.Version (mt_version uuid) DESHABILITADA. No
+            // es opt-in ni depende de IRevisioned ni del lifecycle: la doc lo declara como la
+            // excepcion a que el versionado sea opt-in
+            // (https://martendb.io/documents/concurrency, "Numeric Revisioned Documents") y el
+            // codigo lo hace incondicional (Marten/Events/Projections/ProjectionDocumentPolicy.cs).
+            //
+            // El worker registra FichaColaboradorProjection, asi que crea mt_version como bigint.
+            // Este store NO la registra ni puede hacerlo -- FichaColaboradorProjection vive en el
+            // ensamblado del worker y referenciarlo violaria CA-ADR-0029 --, asi que sin esta linea
+            // esperaria mt_version uuid sobre la MISMA tabla fisica. Con AutoCreate en su default
+            // CreateOrUpdate el sintoma no es un 404: Marten intenta "alter column mt_version type
+            // uuid" en CADA request, Postgres lo rechaza con 42804 (no hay cast automatico
+            // bigint -> uuid) y los GET responden 500 de forma permanente. Eso fue lo que ocurrio en
+            // dev tras el deploy de #290 sobre el read model que #323 ya retiro.
+            //
+            // Se declara por documento y no via Policies para no alterar la forma de ningun otro
+            // documento de este store. El par de config-tests (este lado y el del worker) congela
+            // los mismos valores literales.
+            options.Schema.For<FichaColaborador>().UseNumericRevisions(true);
 
             // Issue #330: registra la serializacion custom de los VOs con ctor privado que aparecen
             // como payload de eventos persistidos (Identificacion, NombreColaborador) -- AQUI

--- a/src/Bitakora.ControlAsistencia.Colaboradores/ObtenerFichaColaborador/FunctionEndpoint.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/ObtenerFichaColaborador/FunctionEndpoint.cs
@@ -1,0 +1,32 @@
+using Cosmos.MultiTenancy;
+using Marten;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.ObtenerFichaColaborador;
+
+// Issue #356: Function GET del read model FichaColaborador (via (a) proyeccion materializada,
+// skills/projections/naming.md, MEF-ADR-0006 enmienda #363). Feature folder sin sufijo Function, un
+// namespace por query (skills/projections/read-apis.md): esta clase FunctionEndpoint no colisiona
+// con ninguna otra del mismo ensamblado porque cada query vive en su propio namespace.
+//
+// Stub de fase roja (projection-test-writer, MEF-ADR-0033): el constructor fija la forma que el
+// test de composicion (Colaboradores.Tests/Infraestructura/ComposicionServiciosTests.cs,
+// AgregarServiciosColaboradores_ResuelveElEndpointDeObtenerFichaColaborador_...) resuelve del
+// contenedor DI real -- IDocumentStore y ITenantResolver, ya registrados por
+// ComposicionServicios.AgregarServiciosColaboradores. El parseo tipado de tipoIdentificacion/numero
+// (MEF-ADR-0037: ComputarStreamId, nunca una concatenacion propia del endpoint), la apertura de la
+// QuerySession, el 400/404/200 y la traduccion centinela -> vacio (CA-6) son responsabilidad de
+// projection-implementer -- Run solo lanza NotImplementedException.
+public class FunctionEndpoint(IDocumentStore store, ITenantResolver tenantResolver)
+{
+    [Function("ObtenerFichaColaborador")]
+    public Task<IActionResult> Run(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "colaboradores/fichas/{tipoIdentificacion}/{numero}")]
+        HttpRequest req,
+        string tipoIdentificacion,
+        string numero,
+        CancellationToken ct) =>
+        throw new NotImplementedException();
+}

--- a/src/Bitakora.ControlAsistencia.Colaboradores/ObtenerFichaColaborador/FunctionEndpoint.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/ObtenerFichaColaborador/FunctionEndpoint.cs
@@ -1,3 +1,6 @@
+using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+using Bitakora.ControlAsistencia.Colaboradores.Entities;
+using Bitakora.ControlAsistencia.ReadModels.Colaboradores;
 using Cosmos.MultiTenancy;
 using Marten;
 using Microsoft.AspNetCore.Http;
@@ -11,22 +14,77 @@ namespace Bitakora.ControlAsistencia.Colaboradores.ObtenerFichaColaborador;
 // namespace por query (skills/projections/read-apis.md): esta clase FunctionEndpoint no colisiona
 // con ninguna otra del mismo ensamblado porque cada query vive en su propio namespace.
 //
-// Stub de fase roja (projection-test-writer, MEF-ADR-0033): el constructor fija la forma que el
-// test de composicion (Colaboradores.Tests/Infraestructura/ComposicionServiciosTests.cs,
-// AgregarServiciosColaboradores_ResuelveElEndpointDeObtenerFichaColaborador_...) resuelve del
-// contenedor DI real -- IDocumentStore y ITenantResolver, ya registrados por
-// ComposicionServicios.AgregarServiciosColaboradores. El parseo tipado de tipoIdentificacion/numero
-// (MEF-ADR-0037: ComputarStreamId, nunca una concatenacion propia del endpoint), la apertura de la
-// QuerySession, el 400/404/200 y la traduccion centinela -> vacio (CA-6) son responsabilidad de
-// projection-implementer -- Run solo lanza NotImplementedException.
+// La ruta recibe tipoIdentificacion/numero como los componentes tipados de la clave natural
+// compuesta -- la clave se reconstruye con ColaboradorAggregateRoot.ComputarStreamId, nunca con una
+// concatenacion propia del endpoint (MEF-ADR-0037). tipoIdentificacion invalido (fuera de la lista
+// cerrada PILA) o numero vacio/whitespace -> 400 explicito (TipoIdentificacion.Desde/
+// Identificacion.Crear rechazan con ArgumentException, capturada aqui como unico punto de
+// traduccion a 400).
+//
+// CA-6: consulta puntual, INCLUYE no-vigentes (sin filtro de vigencia -- a diferencia del listado,
+// que es responsabilidad del issue hermano). 404 sin body cuando la ficha no existe.
 public class FunctionEndpoint(IDocumentStore store, ITenantResolver tenantResolver)
 {
     [Function("ObtenerFichaColaborador")]
-    public Task<IActionResult> Run(
+    public async Task<IActionResult> Run(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "colaboradores/fichas/{tipoIdentificacion}/{numero}")]
         HttpRequest req,
         string tipoIdentificacion,
         string numero,
-        CancellationToken ct) =>
-        throw new NotImplementedException();
+        CancellationToken ct)
+    {
+        Identificacion identificacionTipada;
+        try
+        {
+            var tipo = TipoIdentificacion.Desde(tipoIdentificacion);
+            identificacionTipada = Identificacion.Crear(tipo, numero);
+        }
+        catch (ArgumentException)
+        {
+            return new BadRequestObjectResult(
+                "El tipoIdentificacion o el numero de la ruta son invalidos");
+        }
+
+        var streamKey = ColaboradorAggregateRoot.ComputarStreamId(identificacionTipada);
+
+        // CA-6: la QuerySession se abre SIEMPRE acotada al tenant que resuelve ITenantResolver --
+        // nunca a un tenant id que llegara por ruta o query string (mitigacion estructural contra
+        // BOLA/IDOR, MEF-ADR-0028/skills/projections/read-apis.md). tipoIdentificacion/numero SI
+        // vienen de la ruta: son el recurso, no el tenant.
+        await using var session = store.QuerySession(tenantResolver.TenantId);
+        var ficha = await session.LoadAsync<FichaColaborador>(streamKey, ct);
+
+        if (ficha is null)
+            return new NotFoundResult();
+
+        return new OkObjectResult(FichaColaboradorRespuesta.DesdeVista(ficha));
+    }
+}
+
+// Issue #356 CA-6: DTO de respuesta HTTP, excepcion bajo Rule of Three (MEF-ADR-0018,
+// skills/projections/read-apis.md "El GET serializa la vista; el DTO de respuesta es excepcion"):
+// el unico proposito de este tipo es ocultar el centinela de vigencia abierta (9999-12-31), que es
+// estructura INTERNA de filtrado/indexacion del read model y jamas debe salir por la API (CA-6,
+// "el centinela jamas aparece en la API"). Vive en el namespace del endpoint, no en ReadModels: el
+// read model no conoce su presentacion HTTP.
+public sealed record FichaColaboradorRespuesta(
+    string Id,
+    string NombreCompleto,
+    string CodigoColaborador,
+    DateOnly VigenteDesde,
+    DateOnly? VigenteHasta,
+    IReadOnlyList<EtiquetaFicha> Etiquetas,
+    IReadOnlyDictionary<string, string> EtiquetasNormalizadas)
+{
+    private static readonly DateOnly CentinelaVigenciaAbierta = new(9999, 12, 31);
+
+    public static FichaColaboradorRespuesta DesdeVista(FichaColaborador ficha) =>
+        new(
+            ficha.Id,
+            ficha.NombreCompleto,
+            ficha.CodigoColaborador,
+            ficha.VigenteDesde,
+            ficha.VigenteHasta == CentinelaVigenciaAbierta ? null : ficha.VigenteHasta,
+            ficha.Etiquetas,
+            ficha.EtiquetasNormalizadas);
 }

--- a/src/Bitakora.ControlAsistencia.Colaboradores/ObtenerFichaColaborador/FunctionEndpoint.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/ObtenerFichaColaborador/FunctionEndpoint.cs
@@ -76,15 +76,17 @@ public sealed record FichaColaboradorRespuesta(
     IReadOnlyList<EtiquetaFicha> Etiquetas,
     IReadOnlyDictionary<string, string> EtiquetasNormalizadas)
 {
-    private static readonly DateOnly CentinelaVigenciaAbierta = new(9999, 12, 31);
-
+    // El centinela se lee de la propia vista (FichaColaborador.CentinelaVigenciaAbierta), nunca de
+    // un literal repetido aqui: quien lo escribe es el worker, en otro proceso, y ReadModels es el
+    // unico ensamblado que ambos ven (cuarta isla, MEF-ADR-0041 decision 2). Con dos literales, un
+    // cambio de un solo lado compila, pasa todos los tests unitarios y filtra 9999-12-31 por la API.
     public static FichaColaboradorRespuesta DesdeVista(FichaColaborador ficha) =>
         new(
             ficha.Id,
             ficha.NombreCompleto,
             ficha.CodigoColaborador,
             ficha.VigenteDesde,
-            ficha.VigenteHasta == CentinelaVigenciaAbierta ? null : ficha.VigenteHasta,
+            ficha.VigenteHasta == FichaColaborador.CentinelaVigenciaAbierta ? null : ficha.VigenteHasta,
             ficha.Etiquetas,
             ficha.EtiquetasNormalizadas);
 }

--- a/src/Bitakora.ControlAsistencia.Projections/Colaboradores/FichaColaboradorProjection.cs
+++ b/src/Bitakora.ControlAsistencia.Projections/Colaboradores/FichaColaboradorProjection.cs
@@ -31,39 +31,85 @@ namespace Bitakora.ControlAsistencia.Projections.Colaboradores;
 /// </summary>
 public sealed partial class FichaColaboradorProjection : SingleStreamProjection<FichaColaborador, string>
 {
+    // Centinela de vigencia abierta (issue #356, "Vista a materializar"): estructura interna de
+    // filtrado/indexacion, jamas expuesta por la API (esa traduccion es responsabilidad del
+    // endpoint ObtenerFichaColaborador, CA-6).
+    private static readonly DateOnly CentinelaVigenciaAbierta = new(9999, 12, 31);
+
+    // CA-1 (primera mitad): la ficha nace con Id (StreamKey del stream de ColaboradorAggregateRoot)
+    // y NombreCompleto -- el resto de los campos queda en su forma "vacia" hasta que
+    // Apply(VinculacionIniciada) los complete (mismo commit, ver abajo).
     public static FichaColaborador Create(IEvent<ColaboradorRegistrado> e) =>
-        throw new NotImplementedException();
+        new(
+            e.StreamKey!,
+            e.Data.Nombre.NombreCompleto,
+            string.Empty,
+            default,
+            CentinelaVigenciaAbierta,
+            [],
+            new Dictionary<string, string>());
 
     // CA-1 (segunda mitad) / CA-5: codigo y VigenteDesde nuevos, VigenteHasta al centinela y AMBAS
     // estructuras de etiquetas vaciadas -- "reingreso nace limpio" (espejo de Apply(VinculacionIniciada)
     // en ColaboradorAggregateRoot, #355 CA-6). En el registro inicial (mismo commit que
     // ColaboradorRegistrado) el vaciado es inocuo: la ficha todavia no tiene etiquetas.
     public static FichaColaborador Apply(VinculacionIniciada e, FichaColaborador vista) =>
-        throw new NotImplementedException();
+        vista with
+        {
+            CodigoColaborador = e.Codigo,
+            VigenteDesde = e.FechaInicio,
+            VigenteHasta = CentinelaVigenciaAbierta,
+            Etiquetas = [],
+            EtiquetasNormalizadas = new Dictionary<string, string>()
+        };
 
     // CA-2 (primera mitad): VigenteHasta = FechaEfectiva.
     public static FichaColaborador Apply(VinculacionTerminada e, FichaColaborador vista) =>
-        throw new NotImplementedException();
+        vista with { VigenteHasta = e.FechaEfectiva };
 
     // CA-2 (segunda mitad): reabre -- VigenteHasta vuelve al centinela.
     public static FichaColaborador Apply(TerminacionAnulada e, FichaColaborador vista) =>
-        throw new NotImplementedException();
+        vista with { VigenteHasta = CentinelaVigenciaAbierta };
 
     // CA-3 (primera mitad): reemplaza NombreCompleto.
     public static FichaColaborador Apply(NombresCorregidos e, FichaColaborador vista) =>
-        throw new NotImplementedException();
+        vista with { NombreCompleto = e.Nombre.NombreCompleto };
 
     // CA-3 (segunda mitad): reemplaza VigenteDesde.
     public static FichaColaborador Apply(FechaInicioVinculacionCorregida e, FichaColaborador vista) =>
-        throw new NotImplementedException();
+        vista with { VigenteDesde = e.FechaInicio };
 
     // CA-4 (primera mitad): upsert en AMBAS estructuras por categoria normalizada -- un valor por
     // categoria (espejo de la invariante de EtiquetaAsignada, #355 CA-2: el evento siempre
-    // representa el estado final de esa categoria).
-    public static FichaColaborador Apply(EtiquetaAsignada e, FichaColaborador vista) =>
-        throw new NotImplementedException();
+    // representa el estado final de esa categoria). Tell-don't-Ask (MEF-ADR-0012): la normalizacion
+    // de la categoria de cada EtiquetaFicha existente se recalcula via Etiqueta.NormalizarCategoria
+    // (VO de DomainEvents) en vez de reimplementarla aqui; e.Etiqueta ya trae su propia forma
+    // normalizada, persistida por el aggregate.
+    public static FichaColaborador Apply(EtiquetaAsignada e, FichaColaborador vista)
+    {
+        var etiquetas = vista.Etiquetas
+            .Where(existente => Etiqueta.NormalizarCategoria(existente.Categoria) != e.Etiqueta.CategoriaNormalizada)
+            .Append(new EtiquetaFicha(e.Etiqueta.Categoria, e.Etiqueta.Valor))
+            .ToList();
+
+        var normalizadas = new Dictionary<string, string>(vista.EtiquetasNormalizadas)
+        {
+            [e.Etiqueta.CategoriaNormalizada] = e.Etiqueta.ValorNormalizado
+        };
+
+        return vista with { Etiquetas = etiquetas, EtiquetasNormalizadas = normalizadas };
+    }
 
     // CA-4 (segunda mitad): remueve la categoria de ambas estructuras.
-    public static FichaColaborador Apply(EtiquetaRetirada e, FichaColaborador vista) =>
-        throw new NotImplementedException();
+    public static FichaColaborador Apply(EtiquetaRetirada e, FichaColaborador vista)
+    {
+        var etiquetas = vista.Etiquetas
+            .Where(existente => Etiqueta.NormalizarCategoria(existente.Categoria) != e.CategoriaNormalizada)
+            .ToList();
+
+        var normalizadas = new Dictionary<string, string>(vista.EtiquetasNormalizadas);
+        normalizadas.Remove(e.CategoriaNormalizada);
+
+        return vista with { Etiquetas = etiquetas, EtiquetasNormalizadas = normalizadas };
+    }
 }

--- a/src/Bitakora.ControlAsistencia.Projections/Colaboradores/FichaColaboradorProjection.cs
+++ b/src/Bitakora.ControlAsistencia.Projections/Colaboradores/FichaColaboradorProjection.cs
@@ -1,0 +1,69 @@
+using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+using Bitakora.ControlAsistencia.ReadModels.Colaboradores;
+using JasperFx.Events; // IEvent<T> vive aqui, NO en Marten.Events (MEF-ADR-0034 seccion 6)
+using Marten.Events.Aggregation; // SingleStreamProjection<,> vive aqui, NO en Marten.Events.Projections
+
+namespace Bitakora.ControlAsistencia.Projections.Colaboradores;
+
+/// <summary>
+/// Clase de proyeccion companion de FichaColaborador (issue #356, receta N1 -- un solo stream, el
+/// del colaborador; MEF-ADR-0035). Vive en el worker (Bitakora.ControlAsistencia.Projections), el
+/// ensamblado que si referencia Marten y el analizador JasperFx.Events.SourceGenerator.
+///
+/// partial es obligatorio (skills/projections/modelos-marten.md): el source generator descubre
+/// Create/Apply por convencion y emite el dispatcher [GeneratedEvolver]. Sin partial el build queda
+/// limpio pero falla en RUNTIME al registrar la proyeccion (InvalidProjectionException) -- error
+/// que el config-test detecta al resolver el named store
+/// (ConfigurarColaboradores_RegistraFichaColaboradorProjectionComoAsync).
+///
+/// Se registra en ConfiguracionMartenProjectionsColaboradores.ConfigurarColaboradores con
+/// opts.Projections.Add&lt;FichaColaboradorProjection&gt;(ProjectionLifecycle.Async) -- lifecycle
+/// canonico del worker (MEF-ADR-0034 seccion 3). Ese seam ya existe (issue #360) y no se toca desde
+/// esta fase roja: la linea de registro es responsabilidad de projection-implementer.
+///
+/// Create toma IEvent&lt;ColaboradorRegistrado&gt;, no ColaboradorRegistrado a secas: la identidad
+/// del documento (un string, "{Tipo}:{Numero}") es exactamente el StreamKey del stream de
+/// ColaboradorAggregateRoot (Events.StreamIdentity = AsString) -- IEvent&lt;T&gt;.StreamKey es quien
+/// la expone, sin recomputarla a mano desde el payload (mismo criterio que
+/// skills/projections/modelos-marten.md, ejemplo SeguimientoTurnoProjection.Create).
+///
+/// Sin ShouldDelete: la ficha nunca se borra (issue #356, "Receta").
+/// </summary>
+public sealed partial class FichaColaboradorProjection : SingleStreamProjection<FichaColaborador, string>
+{
+    public static FichaColaborador Create(IEvent<ColaboradorRegistrado> e) =>
+        throw new NotImplementedException();
+
+    // CA-1 (segunda mitad) / CA-5: codigo y VigenteDesde nuevos, VigenteHasta al centinela y AMBAS
+    // estructuras de etiquetas vaciadas -- "reingreso nace limpio" (espejo de Apply(VinculacionIniciada)
+    // en ColaboradorAggregateRoot, #355 CA-6). En el registro inicial (mismo commit que
+    // ColaboradorRegistrado) el vaciado es inocuo: la ficha todavia no tiene etiquetas.
+    public static FichaColaborador Apply(VinculacionIniciada e, FichaColaborador vista) =>
+        throw new NotImplementedException();
+
+    // CA-2 (primera mitad): VigenteHasta = FechaEfectiva.
+    public static FichaColaborador Apply(VinculacionTerminada e, FichaColaborador vista) =>
+        throw new NotImplementedException();
+
+    // CA-2 (segunda mitad): reabre -- VigenteHasta vuelve al centinela.
+    public static FichaColaborador Apply(TerminacionAnulada e, FichaColaborador vista) =>
+        throw new NotImplementedException();
+
+    // CA-3 (primera mitad): reemplaza NombreCompleto.
+    public static FichaColaborador Apply(NombresCorregidos e, FichaColaborador vista) =>
+        throw new NotImplementedException();
+
+    // CA-3 (segunda mitad): reemplaza VigenteDesde.
+    public static FichaColaborador Apply(FechaInicioVinculacionCorregida e, FichaColaborador vista) =>
+        throw new NotImplementedException();
+
+    // CA-4 (primera mitad): upsert en AMBAS estructuras por categoria normalizada -- un valor por
+    // categoria (espejo de la invariante de EtiquetaAsignada, #355 CA-2: el evento siempre
+    // representa el estado final de esa categoria).
+    public static FichaColaborador Apply(EtiquetaAsignada e, FichaColaborador vista) =>
+        throw new NotImplementedException();
+
+    // CA-4 (segunda mitad): remueve la categoria de ambas estructuras.
+    public static FichaColaborador Apply(EtiquetaRetirada e, FichaColaborador vista) =>
+        throw new NotImplementedException();
+}

--- a/src/Bitakora.ControlAsistencia.Projections/Colaboradores/FichaColaboradorProjection.cs
+++ b/src/Bitakora.ControlAsistencia.Projections/Colaboradores/FichaColaboradorProjection.cs
@@ -18,8 +18,10 @@ namespace Bitakora.ControlAsistencia.Projections.Colaboradores;
 ///
 /// Se registra en ConfiguracionMartenProjectionsColaboradores.ConfigurarColaboradores con
 /// opts.Projections.Add&lt;FichaColaboradorProjection&gt;(ProjectionLifecycle.Async) -- lifecycle
-/// canonico del worker (MEF-ADR-0034 seccion 3). Ese seam ya existe (issue #360) y no se toca desde
-/// esta fase roja: la linea de registro es responsabilidad de projection-implementer.
+/// canonico del worker (MEF-ADR-0034 seccion 3). Ese registro es ademas lo que hace que Marten
+/// aplique ProjectionDocumentPolicy sobre FichaColaborador (mt_version bigint): el Function App que
+/// la consulta debe declarar la misma forma con Schema.For&lt;FichaColaborador&gt;()
+/// .UseNumericRevisions(true), y el par de config-tests de ambos lados congela esos literales.
 ///
 /// Create toma IEvent&lt;ColaboradorRegistrado&gt;, no ColaboradorRegistrado a secas: la identidad
 /// del documento (un string, "{Tipo}:{Numero}") es exactamente el StreamKey del stream de
@@ -31,10 +33,10 @@ namespace Bitakora.ControlAsistencia.Projections.Colaboradores;
 /// </summary>
 public sealed partial class FichaColaboradorProjection : SingleStreamProjection<FichaColaborador, string>
 {
-    // Centinela de vigencia abierta (issue #356, "Vista a materializar"): estructura interna de
-    // filtrado/indexacion, jamas expuesta por la API (esa traduccion es responsabilidad del
-    // endpoint ObtenerFichaColaborador, CA-6).
-    private static readonly DateOnly CentinelaVigenciaAbierta = new(9999, 12, 31);
+    // El centinela de vigencia abierta (issue #356, "Vista a materializar") vive con la vista, no
+    // aqui: es la codificacion de uno de SUS campos y el endpoint ObtenerFichaColaborador -- en
+    // otro proceso, sin referencia a este ensamblado -- tiene que leer exactamente el mismo valor
+    // para traducirlo a vacio antes de responder (CA-6). Ver FichaColaborador.CentinelaVigenciaAbierta.
 
     // CA-1 (primera mitad): la ficha nace con Id (StreamKey del stream de ColaboradorAggregateRoot)
     // y NombreCompleto -- el resto de los campos queda en su forma "vacia" hasta que
@@ -45,7 +47,7 @@ public sealed partial class FichaColaboradorProjection : SingleStreamProjection<
             e.Data.Nombre.NombreCompleto,
             string.Empty,
             default,
-            CentinelaVigenciaAbierta,
+            FichaColaborador.CentinelaVigenciaAbierta,
             [],
             new Dictionary<string, string>());
 
@@ -58,7 +60,7 @@ public sealed partial class FichaColaboradorProjection : SingleStreamProjection<
         {
             CodigoColaborador = e.Codigo,
             VigenteDesde = e.FechaInicio,
-            VigenteHasta = CentinelaVigenciaAbierta,
+            VigenteHasta = FichaColaborador.CentinelaVigenciaAbierta,
             Etiquetas = [],
             EtiquetasNormalizadas = new Dictionary<string, string>()
         };
@@ -69,7 +71,7 @@ public sealed partial class FichaColaboradorProjection : SingleStreamProjection<
 
     // CA-2 (segunda mitad): reabre -- VigenteHasta vuelve al centinela.
     public static FichaColaborador Apply(TerminacionAnulada e, FichaColaborador vista) =>
-        vista with { VigenteHasta = CentinelaVigenciaAbierta };
+        vista with { VigenteHasta = FichaColaborador.CentinelaVigenciaAbierta };
 
     // CA-3 (primera mitad): reemplaza NombreCompleto.
     public static FichaColaborador Apply(NombresCorregidos e, FichaColaborador vista) =>

--- a/src/Bitakora.ControlAsistencia.Projections/Infraestructura/ConfiguracionMartenProjectionsColaboradores.cs
+++ b/src/Bitakora.ControlAsistencia.Projections/Infraestructura/ConfiguracionMartenProjectionsColaboradores.cs
@@ -1,7 +1,9 @@
 using System.Text.Json.Serialization.Metadata;
 using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+using Bitakora.ControlAsistencia.Projections.Colaboradores;
 using JasperFx.Events; // StreamIdentity, EventNamingStyle (NO Marten.Events, mismo gotcha que DaemonMode)
 using JasperFx.Events.Daemon; // DaemonMode (NO Marten.Events.Daemon: compila pero deja DaemonMode sin resolver)
+using JasperFx.Events.Projections; // ProjectionLifecycle (NO Marten.Events.Projections)
 using JasperFx.MultiTenancy; // TenancyStyle (NO Marten.*, mismo gotcha que StreamIdentity/DaemonMode)
 using Marten;
 using Weasel.Core; // EnumStorage, Casing (NO Marten.*: viven en Weasel.Core)
@@ -105,11 +107,11 @@ public static class ConfiguracionMartenProjectionsColaboradores
                     jsonOptions.TypeInfoResolver = resolver;
                 });
 
-                // El dominio ya persiste eventos (issue #330) pero todavia no tiene ninguna vista de
-                // lectura. Cuando aparezca la primera proyeccion se agrega aqui con
-                // opts.Projections.Add<TProjection>(ProjectionLifecycle.Async) -- lifecycle Async es
-                // el canonico del worker (MEF-ADR-0034 seccion 3); Inline solo seria valido con
-                // justificacion explicita en el issue correspondiente.
+                // Issue #356: primera proyeccion concreta del dominio -- FichaColaborador, N1
+                // (SingleStreamProjection<FichaColaborador, string>). Lifecycle Async es el canonico
+                // del worker (MEF-ADR-0034 seccion 3); Inline exigiria justificacion explicita en el
+                // issue, ausente aqui.
+                opts.Projections.Add<FichaColaboradorProjection>(ProjectionLifecycle.Async);
             })
             // Registrar el store no basta: sin esta llamada el daemon queda apagado y ninguna
             // proyeccion se materializa. HotCold elige lider sobre advisory locks de PostgreSQL,

--- a/src/Bitakora.ControlAsistencia.Projections/Infraestructura/ConfiguracionMartenProjectionsColaboradores.cs
+++ b/src/Bitakora.ControlAsistencia.Projections/Infraestructura/ConfiguracionMartenProjectionsColaboradores.cs
@@ -20,11 +20,10 @@ public interface IColaboradoresProjectionStore : IDocumentStore;
 /// MEF-ADR-0006/MEF-ADR-0034 secciones 2 y 6) -- hermano read-side de ComposicionServicios
 /// (write-side, MEF-ADR-0029): fuente unica que comparten Program.cs del worker y el config-test.
 ///
-/// Registra el named store sobre la misma conexion y el mismo schema "colaboradores" que ya usa
-/// (o usara) el write-side (ComposicionServicios.AgregarServiciosColaboradores) -- el read-side no
-/// crea base ni schema nuevos. El dominio nace sin ninguna proyeccion concreta: se suman
-/// aditivamente dentro de este mismo AddMartenStore cuando el desglose de issues (#348, #349-#357)
-/// materialice el primer read model.
+/// Registra el named store sobre la misma conexion y el mismo schema "colaboradores" que ya usa el
+/// write-side (ComposicionServicios.AgregarServiciosColaboradores) -- el read-side no crea base ni
+/// schema nuevos. Las proyecciones concretas se suman aditivamente dentro de este mismo
+/// AddMartenStore; la primera es FichaColaboradorProjection (issue #356).
 ///
 /// El seam se declara con modificadores de acceso y sin partial: un metodo partial sin
 /// modificadores desaparece en silencio al compilar si nadie lo implementa, y ademas seria

--- a/src/Bitakora.ControlAsistencia.ReadModels/Colaboradores/FichaColaborador.cs
+++ b/src/Bitakora.ControlAsistencia.ReadModels/Colaboradores/FichaColaborador.cs
@@ -38,12 +38,12 @@ public sealed record EtiquetaFicha(string Categoria, string Valor);
 /// estructuras de etiquetas ("reingreso nace limpio", espejo de la regla que #355 fijo en el
 /// aggregate para Apply(VinculacionIniciada)).
 ///
-/// VigenteHasta usa el CENTINELA 9999-12-31 cuando la vinculacion esta abierta -- estructura
-/// INTERNA de filtrado/indexacion (el issue hermano de listado filtra "VigenteHasta >= fecha" como
-/// una sola operacion de rango): jamas sale por la API (ObtenerFichaColaborador lo traduce a vacio,
-/// CA-6; el mecanismo de esa traduccion es decision del implementer). Sin booleano de estado
-/// materializado: el preaviso voltea de vigente a no-vigente sin evento de reloj, la vigencia se
-/// evalua en la consulta, no aqui.
+/// VigenteHasta usa el CENTINELA <see cref="CentinelaVigenciaAbierta"/> cuando la vinculacion esta
+/// abierta -- estructura INTERNA de filtrado/indexacion (el issue hermano de listado filtra
+/// "VigenteHasta >= fecha" como una sola operacion de rango): jamas sale por la API
+/// (ObtenerFichaColaborador lo traduce a vacio, CA-6). Sin booleano de estado materializado: el
+/// preaviso voltea de vigente a no-vigente sin evento de reloj, la vigencia se evalua en la
+/// consulta, no aqui.
 ///
 /// EtiquetasNormalizadas es la estructura de filtrado por containment JSONB que consumira el issue
 /// hermano de listado; Etiquetas son las formas ORIGINALES para presentacion. Ambas se mantienen en
@@ -57,4 +57,25 @@ public sealed record FichaColaborador(
     DateOnly VigenteDesde,
     DateOnly VigenteHasta,
     IReadOnlyList<EtiquetaFicha> Etiquetas,
-    IReadOnlyDictionary<string, string> EtiquetasNormalizadas);
+    IReadOnlyDictionary<string, string> EtiquetasNormalizadas)
+{
+    /// <summary>
+    /// Valor de <see cref="VigenteHasta"/> que significa "vinculacion abierta" (sin terminacion
+    /// registrada).
+    /// </summary>
+    /// <remarks>
+    /// Vive aqui, con la vista, porque es la codificacion de uno de SUS campos y la comparten dos
+    /// procesos que no se referencian entre si: el worker que materializa la ficha
+    /// (FichaColaboradorProjection) y el Function App que la consulta y lo traduce a vacio antes de
+    /// responder (ObtenerFichaColaborador, CA-6). ReadModels es el unico ensamblado que ambos ven
+    /// (cuarta isla, MEF-ADR-0041 decision 2), asi que declararlo dos veces -- uno por proceso --
+    /// dejaria la coherencia del contrato a la disciplina: una divergencia compila, pasa todos los
+    /// tests unitarios (cada lado con su propio literal) y solo aflora en dev como un 9999-12-31
+    /// filtrado por la API. Un solo literal la vuelve imposible por construccion.
+    ///
+    /// No es comportamiento (MEF-ADR-0035: el read model no tiene logica de proyeccion, que sigue
+    /// viviendo integra en la clase companion del worker): es una constante del propio contrato de
+    /// dato de la vista.
+    /// </remarks>
+    public static readonly DateOnly CentinelaVigenciaAbierta = new(9999, 12, 31);
+}

--- a/src/Bitakora.ControlAsistencia.ReadModels/Colaboradores/FichaColaborador.cs
+++ b/src/Bitakora.ControlAsistencia.ReadModels/Colaboradores/FichaColaborador.cs
@@ -1,0 +1,60 @@
+namespace Bitakora.ControlAsistencia.ReadModels.Colaboradores;
+
+/// <summary>
+/// Etiqueta dinamica (categoria:valor) tal como se muestra en la ficha -- forma ORIGINAL para
+/// display, sin normalizar.
+/// </summary>
+/// <remarks>
+/// Issue #356: tipo propio de ReadModels, SIN relacion de tipo con el VO Etiqueta de
+/// Colaboradores.DomainEvents (islas, CA-ADR-0029; precedente Bloque/TipoBloque de #328). Record
+/// plano, sin comportamiento: la normalizacion y el upsert por categoria viven en
+/// FichaColaboradorProjection (worker), nunca aqui.
+/// </remarks>
+public sealed record EtiquetaFicha(string Categoria, string Valor);
+
+/// <summary>
+/// Read model de la ficha de un colaborador (issue #356) -- consulta puntual por identificacion,
+/// base del flujo de reingreso (los adaptadores la consultan antes de decidir registrar-vs-
+/// reingresar, por eso INCLUYE colaboradores no-vigentes). Primera vista materializada del dominio
+/// Colaboradores.
+/// </summary>
+/// <remarks>
+/// Record plano SIN partial (MEF-ADR-0035, skills/projections/modelos-marten.md): el comportamiento
+/// de proyeccion vive en la clase companion FichaColaboradorProjection, en el worker
+/// (Bitakora.ControlAsistencia.Projections). Este tipo vive en ReadModels (MEF-ADR-0034 seccion 5),
+/// la cuarta isla del repo: cero referencias de proyecto (ver el .csproj) -- EtiquetaFicha es
+/// propio, sin relacion de tipo con Colaboradores.DomainEvents.
+///
+/// Sin sufijo "View" (MEF-ADR-0041 decision 3, extension del issue #317 CA-2 al read-side,
+/// precedente TurnoVigente #328).
+///
+/// Id es el stream key que compone ColaboradorAggregateRoot.ComputarStreamId(Identificacion):
+/// "{Tipo}:{Numero}" (ej. "CC:123456") -- contrato de Identificacion.ToString(), nunca aplanado en
+/// Tipo/Numero separados (decision de refinamiento 2026-08-12: redundantes con el Id).
+///
+/// CodigoColaborador, VigenteDesde y VigenteHasta reflejan siempre la ULTIMA vinculacion -- la
+/// ficha NO acumula historial de vinculaciones (el historial completo vive en el stream). Un
+/// reingreso (VinculacionIniciada tras terminacion) sobrescribe estos tres campos y VACIA ambas
+/// estructuras de etiquetas ("reingreso nace limpio", espejo de la regla que #355 fijo en el
+/// aggregate para Apply(VinculacionIniciada)).
+///
+/// VigenteHasta usa el CENTINELA 9999-12-31 cuando la vinculacion esta abierta -- estructura
+/// INTERNA de filtrado/indexacion (el issue hermano de listado filtra "VigenteHasta >= fecha" como
+/// una sola operacion de rango): jamas sale por la API (ObtenerFichaColaborador lo traduce a vacio,
+/// CA-6; el mecanismo de esa traduccion es decision del implementer). Sin booleano de estado
+/// materializado: el preaviso voltea de vigente a no-vigente sin evento de reloj, la vigencia se
+/// evalua en la consulta, no aqui.
+///
+/// EtiquetasNormalizadas es la estructura de filtrado por containment JSONB que consumira el issue
+/// hermano de listado; Etiquetas son las formas ORIGINALES para presentacion. Ambas se mantienen en
+/// paralelo (upsert/retiro por categoria normalizada, un valor por categoria -- espejo de la
+/// invariante que #355 fijo en el aggregate).
+/// </remarks>
+public sealed record FichaColaborador(
+    string Id,
+    string NombreCompleto,
+    string CodigoColaborador,
+    DateOnly VigenteDesde,
+    DateOnly VigenteHasta,
+    IReadOnlyList<EtiquetaFicha> Etiquetas,
+    IReadOnlyDictionary<string, string> EtiquetasNormalizadas);

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/ObtenerFichaColaborador/ObtenerFichaColaboradorSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/ObtenerFichaColaborador/ObtenerFichaColaboradorSmokeTests.cs
@@ -1,0 +1,250 @@
+// Issue #356: smoke tests de ObtenerFichaColaborador, GET
+// colaboradores/fichas/{tipoIdentificacion}/{numero}. Function GET read-side sobre la proyeccion
+// FichaColaborador (receta N1, MEF-ADR-0034/0035): la primera vista materializada del dominio
+// Colaboradores, consultable puntualmente por identificacion y base del flujo de reingreso (por eso
+// la consulta puntual INCLUYE no-vigentes, a diferencia de un futuro listado).
+//
+// Arrange via API, nunca sembrando el event store por fuera de ella: el colaborador se crea con
+// POST Colaboradores (#330) y, cuando aplica, se termina su vinculacion con POST
+// Colaboradores/Terminaciones (#349) -- los mismos comandos que #356 usa como fuente de eventos
+// para la proyeccion.
+//
+// Lifecycle Async (MEF-ADR-0034 seccion 3): el worker materializa FichaColaborador DESPUES de que
+// Colaboradores persiste sus eventos. Los casos de exito envuelven la consulta en
+// Polling.WaitUntilAsync (timeout estandar 30s) -- unica excepcion documentada al "no usar Polling
+// directo en tests": si el timeout se agota es un fallo real (worker no desplegado o proyeccion sin
+// registrar en el named store), nunca un skip.
+//
+// Estos tests quedan ROJOS hasta que el deploy publique ObtenerFichaColaborador en dev: mientras la
+// revision anterior siga corriendo, la ruta no existe y el host responde 404 a todo -- el caso 400
+// falla y el caso 404 pasa por la razon equivocada (mismo precedente que ObtenerTurnoVigenteSmokeTests
+// en ControlHoras). El CI de PR no los ejecuta (solo corre *.Tests); su veredicto real se lee
+// despues del deploy.
+//
+// Formas locales DESACOPLADAS del read model de produccion
+// (Bitakora.ControlAsistencia.ReadModels.Colaboradores.FichaColaborador/EtiquetaFicha): el smoke
+// test no referencia ReadModels (isla, MEF-ADR-0034 seccion 5) ni el Function App.
+// FichaColaboradorRespuestaSmoke replica solo el shape de la respuesta HTTP (DTO propio del
+// endpoint, ObtenerFichaColaborador.FichaColaboradorRespuesta), no el read model.
+//
+// No se repite aqui el detalle de upsert/normalizacion de etiquetas (CA-4), ni el mapeo exhaustivo
+// de reingreso (CA-5): esas reglas de negocio de la proyeccion ya las cubre el unit test de
+// FichaColaboradorProjection (projection-test-writer). Este smoke test es black-box: solo verifica
+// que el endpoint desplegado responde con la vista materializada y que el contrato HTTP propio del
+// endpoint (CA-6: centinela oculto, no-vigentes incluidos, bordes 404/400) se cumple contra el
+// entorno real.
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.SmokeTests.Fixtures;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.SmokeTests.ObtenerFichaColaborador;
+
+public class ObtenerFichaColaboradorSmokeTests(ApiFixture api)
+{
+    private readonly HttpClient _client = api.Client;
+
+    private const string RutaRegistrar = "/api/Colaboradores";
+    private const string RutaTerminaciones = "/api/Colaboradores/Terminaciones";
+    private const string TipoIdentificacionCc = "CC";
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
+
+    // Case-insensitive: la respuesta viaja en camelCase (ComposicionServicios configura
+    // JsonNamingPolicy.CamelCase para las respuestas HTTP), mientras que las formas locales de este
+    // archivo son PascalCase.
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    private sealed record EtiquetaFichaSmoke(string Categoria, string Valor);
+
+    private sealed record FichaColaboradorRespuestaSmoke(
+        string Id,
+        string NombreCompleto,
+        string CodigoColaborador,
+        DateOnly VigenteDesde,
+        DateOnly? VigenteHasta,
+        IReadOnlyList<EtiquetaFichaSmoke> Etiquetas,
+        IReadOnlyDictionary<string, string> EtiquetasNormalizadas);
+
+    // Numero unico por test -- evita colisiones entre ejecuciones repetidas del smoke test: la
+    // identidad del stream (y por lo tanto el Id de la ficha) es Identificacion.ToString()
+    // ("CC:<numero>"), no un Guid nuevo por llamada.
+    private static string NuevoNumeroIdentificacion() => Guid.CreateVersion7().ToString("N").ToUpperInvariant();
+
+    private static string NuevoCodigoColaborador() => $"[TEST]-{Guid.CreateVersion7()}";
+
+    // Mismo formato que ColaboradorAggregateRoot.ComputarStreamId, reconstruido localmente: el
+    // smoke test no referencia el Function App (Colaboradores.Entities).
+    private static string ComputarStreamId(string numeroIdentificacion) =>
+        $"{TipoIdentificacionCc}:{numeroIdentificacion}";
+
+    private static string Ruta(string tipoIdentificacion, string numero) =>
+        $"/api/colaboradores/fichas/{tipoIdentificacion}/{numero}";
+
+    private static object PayloadRegistro(
+        string numeroIdentificacion, DateOnly fechaInicio, string codigoColaborador) => new
+        {
+            tipoIdentificacion = TipoIdentificacionCc,
+            numeroIdentificacion,
+            primerNombre = "[TEST]",
+            segundoNombre = (string?)null,
+            primerApellido = "Smoke",
+            segundoApellido = (string?)null,
+            codigoColaborador,
+            fechaInicio
+        };
+
+    private static object PayloadTerminacion(string numeroIdentificacion, DateOnly fechaEfectiva) => new
+    {
+        tipoIdentificacion = TipoIdentificacionCc,
+        numeroIdentificacion,
+        fechaEfectiva
+    };
+
+    // Arrange comun: registra un colaborador con una vinculacion abierta -- via el comando que la
+    // origina (#330), nunca sembrando el event store por fuera del API.
+    private async Task RegistrarColaboradorAsync(
+        string numeroIdentificacion, DateOnly fechaInicio, string codigoColaborador, CancellationToken ct)
+    {
+        var response = await _client.PostAsJsonAsync(
+            RutaRegistrar, PayloadRegistro(numeroIdentificacion, fechaInicio, codigoColaborador), ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted,
+            "el arrange de este smoke test depende de que RegistrarColaborador funcione");
+    }
+
+    // Arrange comun (CA-6, "INCLUYE no-vigentes"): cierra la vinculacion vigente -- via el comando
+    // que la origina (#349), nunca sembrando el event store por fuera del API.
+    private async Task TerminarVinculacionAsync(
+        string numeroIdentificacion, DateOnly fechaEfectiva, CancellationToken ct)
+    {
+        var response = await _client.PostAsJsonAsync(
+            RutaTerminaciones, PayloadTerminacion(numeroIdentificacion, fechaEfectiva), ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted,
+            "el arrange de este smoke test depende de que TerminarVinculacion funcione");
+    }
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task DebeEstarDisponible_CuandoSeConsultaHealthCheck()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var response = await _client.GetAsync("/api/health", ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    // CA-1/CA-6 (camino feliz, vinculacion abierta): registrar un colaborador nuevo materializa la
+    // ficha con Id, NombreCompleto y CodigoColaborador de la vinculacion, y CA-6 exige que el
+    // centinela de vigencia abierta (9999-12-31) jamas salga por la API -- VigenteHasta debe llegar
+    // vacio (null), nunca la fecha centinela.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ObtenerFichaColaborador_Retorna200ConVigenteHastaVacio_CuandoLaVinculacionEstaAbierta()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion();
+        var fechaInicio = new DateOnly(2026, 1, 15);
+        var codigoColaborador = NuevoCodigoColaborador();
+
+        await RegistrarColaboradorAsync(numeroIdentificacion, fechaInicio, codigoColaborador, ct);
+
+        // Act + Assert: reintentar el GET hasta que la proyeccion asincrona materialice la ficha.
+        var ruta = Ruta(TipoIdentificacionCc, numeroIdentificacion);
+        var respuesta = await Polling.WaitUntilAsync(async () =>
+        {
+            var response = await _client.GetAsync(ruta, ct);
+            if (response.StatusCode == HttpStatusCode.NotFound)
+                return null;
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            return await response.Content.ReadFromJsonAsync<FichaColaboradorRespuestaSmoke>(
+                JsonOptions, cancellationToken: ct);
+        }, Timeout);
+
+        // Sin assert de NotBeNull: WaitUntilAsync devuelve un valor no nulo o lanza TimeoutException
+        // ("el worker no materializo FichaColaborador dentro del timeout"), nunca null.
+        respuesta.Id.Should().Be(ComputarStreamId(numeroIdentificacion));
+        respuesta.NombreCompleto.Should().Be("[TEST] Smoke");
+        respuesta.CodigoColaborador.Should().Be(codigoColaborador);
+        respuesta.VigenteDesde.Should().Be(fechaInicio);
+        respuesta.VigenteHasta.Should().BeNull(
+            "el centinela de vigencia abierta (9999-12-31) jamas debe salir por la API (CA-6)");
+        respuesta.Etiquetas.Should().BeEmpty();
+        respuesta.EtiquetasNormalizadas.Should().BeEmpty();
+    }
+
+    // CA-2/CA-6 (INCLUYE no-vigentes): tras terminar la vinculacion, la consulta puntual sigue
+    // respondiendo 200 -- a diferencia de un futuro listado filtrado por vigencia, este endpoint es
+    // la base del flujo de reingreso y necesita ver la ficha aunque este cerrada. VigenteHasta debe
+    // reflejar la fecha efectiva real de la terminacion, nunca el centinela ni vacio.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ObtenerFichaColaborador_Retorna200ConVigenteHastaReal_CuandoLaVinculacionEstaTerminada()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion();
+        var fechaInicio = new DateOnly(2026, 2, 1);
+        var fechaEfectiva = new DateOnly(2026, 6, 30);
+        var codigoColaborador = NuevoCodigoColaborador();
+
+        await RegistrarColaboradorAsync(numeroIdentificacion, fechaInicio, codigoColaborador, ct);
+        await TerminarVinculacionAsync(numeroIdentificacion, fechaEfectiva, ct);
+
+        // Act + Assert: reintentar hasta que el worker aplique TAMBIEN VinculacionTerminada -- un
+        // 200 con VigenteHasta todavia nulo solo significa que la proyeccion aun no proceso el
+        // segundo evento del stream.
+        var ruta = Ruta(TipoIdentificacionCc, numeroIdentificacion);
+        var respuesta = await Polling.WaitUntilAsync(async () =>
+        {
+            var response = await _client.GetAsync(ruta, ct);
+            if (response.StatusCode == HttpStatusCode.NotFound)
+                return null;
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            var body = await response.Content.ReadFromJsonAsync<FichaColaboradorRespuestaSmoke>(
+                JsonOptions, cancellationToken: ct);
+
+            return body?.VigenteHasta is not null ? body : null;
+        }, Timeout);
+
+        respuesta.Id.Should().Be(ComputarStreamId(numeroIdentificacion));
+        respuesta.VigenteHasta.Should().Be(fechaEfectiva);
+    }
+
+    // CA-6: ficha inexistente -> 404 sin body -- distingue el NotFoundResult() del endpoint de un
+    // 404 con payload de error, y de la pagina de error del host si la ruta no existiera.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ObtenerFichaColaborador_Retorna404SinBody_CuandoLaFichaNoExiste()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        // Numero nunca registrado por ningun test -- no puede tener ficha materializada.
+        var numeroIdentificacion = NuevoNumeroIdentificacion();
+
+        var response = await _client.GetAsync(Ruta(TipoIdentificacionCc, numeroIdentificacion), ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        (await response.Content.ReadAsStringAsync(ct)).Should().BeEmpty();
+    }
+
+    // CA-6: tipoIdentificacion fuera de la lista cerrada (PILA: CC, CE, TI, PA, PT) -> 400 --
+    // TipoIdentificacion.Desde rechaza y el endpoint traduce a BadRequest (borde HTTP tipado,
+    // MEF-ADR-0037).
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ObtenerFichaColaborador_Retorna400_CuandoTipoIdentificacionNoEsReconocido()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion();
+
+        var response = await _client.GetAsync(Ruta("XX", numeroIdentificacion), ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/Infraestructura/ComposicionServiciosTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/Infraestructura/ComposicionServiciosTests.cs
@@ -18,7 +18,9 @@ using System.Text;
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
 using Bitakora.ControlAsistencia.Colaboradores.Infraestructura;
+using Bitakora.ControlAsistencia.ReadModels.Colaboradores;
 using Cosmos.EventSourcing.Abstractions.Commands;
+using JasperFx.MultiTenancy; // TenancyStyle (NO Marten.*: vive en JasperFx.MultiTenancy)
 using Marten;
 using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry.Trace;
@@ -323,10 +325,7 @@ public class ComposicionServiciosTests
     // Se prueba solo la RESOLUCION de IDocumentStore/ITenantResolver por constructor -- no el
     // comportamiento de Run (parseo de tipoIdentificacion/numero con 400 explicito,
     // session.LoadAsync y el 200/404, la traduccion centinela -> vacio de CA-6), que es
-    // responsabilidad de projection-implementer y del smoke test, no de este guardrail de wiring.
-    // Por eso este test queda en verde tan pronto exista el FunctionEndpoint stub con el
-    // constructor correcto -- no es la guarda que fuerza el rojo de este issue (esa la dan los
-    // unit tests de la proyeccion en Projections.Tests y el config-test del worker).
+    // responsabilidad del endpoint y del smoke test, no de este guardrail de wiring.
     [Fact]
     public async Task AgregarServiciosColaboradores_ResuelveElEndpointDeObtenerFichaColaborador_CuandoElContenedorEstaCompuesto()
     {
@@ -336,5 +335,61 @@ public class ComposicionServiciosTests
         var act = () => ActivatorUtilities.CreateInstance<ObtenerFichaColaboradorEndpoint>(scope.ServiceProvider);
 
         act.Should().NotThrow();
+    }
+
+    // Issue #356, mitad write-side del par 2 de compatibilidad write-side/read-side (MEF-ADR-0034
+    // seccion 6). Heredada de la guarda que #328 dejo para TurnoVigente en ControlHoras.Tests, por
+    // el incidente real del issue #294: este Function App LEE FichaColaborador con
+    // session.LoadAsync (ObtenerFichaColaborador) sin registrar la proyeccion, mientras el worker
+    // la MATERIALIZA en otro proceso sobre la misma tabla fisica.
+    //
+    // Marten aplica ProjectionDocumentPolicy a todo documento que sea target de una proyeccion
+    // registrada en ese store: UseNumericRevisions = true, Metadata.Revision (mt_version bigint)
+    // habilitada y Metadata.Version (mt_version uuid) DESHABILITADA -- incondicional, sin opt-in ni
+    // dependencia de IRevisioned (https://martendb.io/documents/concurrency, "Numeric Revisioned
+    // Documents"). Sin la declaracion explicita del lado lectura, este store espera mt_version uuid
+    // sobre la tabla que el worker creo como bigint, Marten intenta "alter column" en CADA request
+    // y Postgres responde 42804: GET en 500 permanente con el daemon funcionando.
+    //
+    // Oraculo literal, espejo del que ConfiguracionMartenProjectionsTests
+    // .ConfigurarColaboradores_MaterializaFichaColaboradorConRevisionNumerica congela desde el
+    // worker, sin que ningun ensamblado referencie al otro (CA-ADR-0029).
+    [Fact]
+    public async Task AgregarServiciosColaboradores_EsperaLaMismaColumnaDeVersionQueMaterializaraElWorker_ParaFichaColaborador()
+    {
+        await using var provider = ComponerServiceProvider();
+        await using var scope = provider.CreateAsyncScope();
+
+        var mapping = scope.ServiceProvider.GetRequiredService<IDocumentStore>()
+            .Options.FindOrResolveDocumentType(typeof(FichaColaborador));
+
+        mapping.Metadata.Revision.Enabled.Should().BeTrue();
+        mapping.Metadata.Revision.Type.Should().Be("bigint");
+        mapping.Metadata.Version.Enabled.Should().BeFalse();
+    }
+
+    // Issue #356, segunda dimension del mismo par 2 (precedente #328 sobre TurnoVigente): tabla,
+    // tenancy e IdMember tienen que converger entre el worker que materializa y este Function App
+    // que consulta, o el GET responde 404 para siempre con el daemon funcionando. Ningun compilador
+    // lo garantiza -- son dos configuraciones de Marten independientes sobre el mismo schema.
+    //
+    // Los tres valores los resuelve Marten por convencion, pero este lado ya declara un
+    // Schema.For<FichaColaborador>() propio (la linea de UseNumericRevisions del test de arriba) --
+    // justo el tipo de declaracion por documento que puede desviar la tabla o la tenancy de un solo
+    // lado. Oraculo literal, espejo del que ConfiguracionMartenProjectionsTests
+    // .ConfigurarColaboradores_MaterializaFichaColaboradorSobreLaTablaQueConsultaElWriteSide congela
+    // desde el worker.
+    [Fact]
+    public async Task AgregarServiciosColaboradores_ResuelveFichaColaboradorSobreLaTablaQueMaterializaElWorker_CuandoElContenedorEstaCompuesto()
+    {
+        await using var provider = ComponerServiceProvider();
+        await using var scope = provider.CreateAsyncScope();
+
+        var mapping = scope.ServiceProvider.GetRequiredService<IDocumentStore>()
+            .Options.FindOrResolveDocumentType(typeof(FichaColaborador));
+
+        mapping.TableName.QualifiedName.Should().Be("colaboradores.mt_doc_fichacolaborador");
+        mapping.TenancyStyle.Should().Be(TenancyStyle.Conjoined);
+        mapping.IdMember.Name.Should().Be(nameof(FichaColaborador.Id));
     }
 }

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/Infraestructura/ComposicionServiciosTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/Infraestructura/ComposicionServiciosTests.cs
@@ -23,6 +23,7 @@ using Marten;
 using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry.Trace;
 using Wolverine;
+using ObtenerFichaColaboradorEndpoint = Bitakora.ControlAsistencia.Colaboradores.ObtenerFichaColaborador.FunctionEndpoint;
 
 namespace Bitakora.ControlAsistencia.Colaboradores.Tests.Infraestructura;
 
@@ -306,5 +307,34 @@ public class ComposicionServiciosTests
 
         restaurado.Should().Be(original);
         restaurado.ToString().Should().Be(original.ToString());
+    }
+
+    // Issue #356 CA-6: test de composicion de una Function GET, hermano de MEF-ADR-0029 -- misma
+    // idea que las guardas de arriba (grafo de DI real, sin infra desplegada), pero sobre un
+    // FunctionEndpoint en vez de un router de Wolverine. Precedente: ObtenerTurnoVigente/
+    // ListarTurnosVigentes en ControlHoras.Tests (issue #328/#329).
+    //
+    // Ninguna Function de este ensamblado se registra explicitamente en el contenedor -- el host
+    // de Azure Functions isolated worker las activa por tipo, resolviendo su constructor contra el
+    // mismo ServiceProvider que arma Program.cs. ActivatorUtilities.CreateInstance reproduce esa
+    // misma activacion sin levantar el host real (Alt 1 de MEF-ADR-0029: no existe un
+    // WebApplicationFactory para Functions isolated worker).
+    //
+    // Se prueba solo la RESOLUCION de IDocumentStore/ITenantResolver por constructor -- no el
+    // comportamiento de Run (parseo de tipoIdentificacion/numero con 400 explicito,
+    // session.LoadAsync y el 200/404, la traduccion centinela -> vacio de CA-6), que es
+    // responsabilidad de projection-implementer y del smoke test, no de este guardrail de wiring.
+    // Por eso este test queda en verde tan pronto exista el FunctionEndpoint stub con el
+    // constructor correcto -- no es la guarda que fuerza el rojo de este issue (esa la dan los
+    // unit tests de la proyeccion en Projections.Tests y el config-test del worker).
+    [Fact]
+    public async Task AgregarServiciosColaboradores_ResuelveElEndpointDeObtenerFichaColaborador_CuandoElContenedorEstaCompuesto()
+    {
+        await using var provider = ComponerServiceProvider();
+        await using var scope = provider.CreateAsyncScope();
+
+        var act = () => ActivatorUtilities.CreateInstance<ObtenerFichaColaboradorEndpoint>(scope.ServiceProvider);
+
+        act.Should().NotThrow();
     }
 }

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ObtenerFichaColaborador/FichaColaboradorRespuestaTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ObtenerFichaColaborador/FichaColaboradorRespuestaTests.cs
@@ -1,0 +1,73 @@
+// Issue #356 CA-6: la regla mas distintiva del contrato HTTP de ObtenerFichaColaborador -- "el
+// centinela jamas aparece en la API" -- vive en la traduccion vista -> respuesta
+// (FichaColaboradorRespuesta.DesdeVista), una funcion pura. Sin estas guardas su unica verificacion
+// seria el smoke test contra dev, que solo emite veredicto DESPUES del deploy: una regresion aqui
+// (quitar la traduccion, comparar contra otra fecha) compilaria, pasaria el resto de la suite y
+// filtraria 9999-12-31 a los clientes.
+//
+// El test de composicion hermano (ComposicionServiciosTests
+// .AgregarServiciosColaboradores_ResuelveElEndpointDeObtenerFichaColaborador_...) cubre el wiring
+// del endpoint; el resto de Run (parseo con 400, LoadAsync, 200/404) es black-box del smoke test.
+//
+// Oraculo independiente (MEF-ADR-0002, no-tautologia): el centinela se escribe como literal aqui,
+// nunca se importa de FichaColaborador.CentinelaVigenciaAbierta -- si alguien cambiara esa
+// constante en produccion, estos tests deben ponerse rojos, no seguirla en silencio.
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.ObtenerFichaColaborador;
+using Bitakora.ControlAsistencia.ReadModels.Colaboradores;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Tests.ObtenerFichaColaborador;
+
+public class FichaColaboradorRespuestaTests
+{
+    private static readonly DateOnly CentinelaVigenciaAbierta = new(9999, 12, 31);
+
+    private static FichaColaborador FichaConVigenteHasta(DateOnly vigenteHasta) =>
+        new(
+            "CC:123456",
+            "Ana Ramirez",
+            "EMP-001",
+            new DateOnly(2026, 8, 1),
+            vigenteHasta,
+            [new EtiquetaFicha("Área", "Tecnología")],
+            new Dictionary<string, string> { ["area"] = "tecnologia" });
+
+    [Fact]
+    public void DesdeVista_DejaVigenteHastaVacio_CuandoLaVinculacionEstaAbierta()
+    {
+        var respuesta = FichaColaboradorRespuesta.DesdeVista(FichaConVigenteHasta(CentinelaVigenciaAbierta));
+
+        respuesta.VigenteHasta.Should().BeNull();
+    }
+
+    // Contracara del anterior: la traduccion no puede degenerar en "VigenteHasta siempre vacio" --
+    // CA-6 exige que la consulta puntual INCLUYA no-vigentes mostrando su fecha real de terminacion.
+    [Fact]
+    public void DesdeVista_ConservaLaFechaDeTerminacion_CuandoLaVinculacionEstaTerminada()
+    {
+        var fechaEfectiva = new DateOnly(2026, 9, 30);
+
+        var respuesta = FichaColaboradorRespuesta.DesdeVista(FichaConVigenteHasta(fechaEfectiva));
+
+        respuesta.VigenteHasta.Should().Be(fechaEfectiva);
+    }
+
+    // El resto de la vista viaja sin transformacion: el DTO existe UNICAMENTE para ocultar el
+    // centinela (MEF-ADR-0041 decision 4, excepcion bajo Rule of Three), no para remodelar la ficha.
+    [Fact]
+    public void DesdeVista_CopiaElRestoDeLaVistaSinTransformar_CuandoTraduceLaFicha()
+    {
+        var ficha = FichaConVigenteHasta(CentinelaVigenciaAbierta);
+
+        var respuesta = FichaColaboradorRespuesta.DesdeVista(ficha);
+
+        respuesta.Id.Should().Be("CC:123456");
+        respuesta.NombreCompleto.Should().Be("Ana Ramirez");
+        respuesta.CodigoColaborador.Should().Be("EMP-001");
+        respuesta.VigenteDesde.Should().Be(new DateOnly(2026, 8, 1));
+        respuesta.Etiquetas.Should().BeEquivalentTo([new EtiquetaFicha("Área", "Tecnología")]);
+        respuesta.EtiquetasNormalizadas.Should().BeEquivalentTo(
+            new Dictionary<string, string> { ["area"] = "tecnologia" });
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Projections.Tests/Colaboradores/FichaColaboradorProjectionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Projections.Tests/Colaboradores/FichaColaboradorProjectionTests.cs
@@ -1,0 +1,249 @@
+// Issue #356: fase roja de la primera proyeccion concreta del dominio Colaboradores. Invocacion
+// DIRECTA de los metodos estaticos de FichaColaboradorProjection (N1, MEF-ADR-0035) -- no el DSL
+// Given/When/Then de CommandHandlerTestBase (MEF-ADR-0002, testea command handlers contra el event
+// store): aqui se testean funciones puras evento -> vista, sin abrir ningun stream.
+//
+// Cada assert compara contra un oraculo armado a mano (MEF-ADR-0002, no-tautologia): nunca se
+// reusa la logica de Create/Apply bajo prueba para construir el valor esperado -- ni siquiera el
+// centinela de vigencia abierta se referencia desde produccion, se escribe el literal
+// new DateOnly(9999, 12, 31) en cada test.
+//
+// Dos ejes cohesivos (issue #356, "Nota de complejidad"): CA-1..CA-5 son variaciones del mismo eje
+// (materializacion Create/Apply); CA-6 (el endpoint) no se prueba aqui -- ver el test de
+// composicion en Colaboradores.Tests.
+//
+// Dato de vistaPrevia en los tests de Apply: se construye a mano, simulando el documento que Marten
+// ya habria materializado -- nunca se obtiene invocando Create/Apply, para no encadenar el oraculo
+// de un test con la logica bajo prueba de otro.
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+using Bitakora.ControlAsistencia.Projections.Colaboradores;
+using Bitakora.ControlAsistencia.ReadModels.Colaboradores;
+using JasperFx.Events;
+
+namespace Bitakora.ControlAsistencia.Projections.Tests.Colaboradores;
+
+public class FichaColaboradorProjectionTests
+{
+    // Centinela de vigencia abierta (issue #356, "Vista a materializar"): estructura interna de
+    // filtrado, jamas expuesta por la API (eso es CA-6, responsabilidad del endpoint). Se repite
+    // como literal en cada test -- ninguno lo importa desde produccion (oraculo independiente).
+    private static readonly DateOnly CentinelaVigenciaAbierta = new(9999, 12, 31);
+
+    private static Identificacion IdentificacionDePrueba() =>
+        Identificacion.Crear(TipoIdentificacion.CC, "123456");
+
+    private static NombreColaborador NombreDePrueba() =>
+        NombreColaborador.Crear("Ana", null, "Ramirez", null);
+
+    // --- CA-1 (primera mitad): Create nace la ficha con Id y NombreCompleto ---
+
+    // Create toma IEvent<ColaboradorRegistrado>, no el evento a secas: la identidad del documento
+    // es el StreamKey del stream de ColaboradorAggregateRoot ("CC:123456"), nunca recomputada a
+    // mano desde el payload (skills/projections/modelos-marten.md, ejemplo SeguimientoTurnoProjection).
+    [Fact]
+    public void Create_ProyectaIdYNombreCompleto_DesdeColaboradorRegistrado()
+    {
+        var identificacion = IdentificacionDePrueba();
+        var evento = new Event<ColaboradorRegistrado>(
+            new ColaboradorRegistrado(identificacion, NombreDePrueba()))
+        {
+            StreamKey = identificacion.ToString(),
+            Version = 1,
+            Timestamp = DateTimeOffset.UtcNow,
+        };
+
+        var vista = FichaColaboradorProjection.Create(evento);
+
+        vista.Id.Should().Be("CC:123456");
+        vista.NombreCompleto.Should().Be("Ana Ramirez");
+    }
+
+    // --- CA-1 (segunda mitad): Apply(VinculacionIniciada) completa codigo, fechas y deja las
+    // etiquetas vacias sobre la ficha recien nacida (mismo commit que ColaboradorRegistrado) ---
+
+    [Fact]
+    public void Apply_AsignaCodigoYFechaInicioYAbreLaVigencia_CuandoVinculacionIniciada()
+    {
+        var vistaPrevia = new FichaColaborador(
+            "CC:123456", "Ana Ramirez", string.Empty, default, CentinelaVigenciaAbierta,
+            [], new Dictionary<string, string>());
+        var fechaInicio = new DateOnly(2026, 8, 1);
+        var evento = new VinculacionIniciada("EMP-001", fechaInicio);
+
+        var vista = FichaColaboradorProjection.Apply(evento, vistaPrevia);
+
+        vista.Id.Should().Be("CC:123456");
+        vista.NombreCompleto.Should().Be("Ana Ramirez");
+        vista.CodigoColaborador.Should().Be("EMP-001");
+        vista.VigenteDesde.Should().Be(fechaInicio);
+        vista.VigenteHasta.Should().Be(CentinelaVigenciaAbierta);
+        vista.Etiquetas.Should().BeEmpty();
+        vista.EtiquetasNormalizadas.Should().BeEmpty();
+    }
+
+    // --- CA-2 (primera mitad): VinculacionTerminada cierra la vigencia ---
+
+    [Fact]
+    public void Apply_CierraLaVigencia_CuandoVinculacionTerminada()
+    {
+        var vistaPrevia = new FichaColaborador(
+            "CC:123456", "Ana Ramirez", "EMP-001", new DateOnly(2026, 8, 1), CentinelaVigenciaAbierta,
+            [], new Dictionary<string, string>());
+        var fechaEfectiva = new DateOnly(2026, 9, 30);
+        var evento = new VinculacionTerminada(fechaEfectiva);
+
+        var vista = FichaColaboradorProjection.Apply(evento, vistaPrevia);
+
+        vista.VigenteHasta.Should().Be(fechaEfectiva);
+        // El resto de la ficha (identidad, codigo y fecha de inicio) no cambia con la terminacion.
+        vista.Id.Should().Be("CC:123456");
+        vista.CodigoColaborador.Should().Be("EMP-001");
+        vista.VigenteDesde.Should().Be(new DateOnly(2026, 8, 1));
+    }
+
+    // --- CA-2 (segunda mitad): TerminacionAnulada reabre -- vuelve al centinela ---
+
+    [Fact]
+    public void Apply_ReabreLaVigencia_CuandoTerminacionAnulada()
+    {
+        var vistaPrevia = new FichaColaborador(
+            "CC:123456", "Ana Ramirez", "EMP-001", new DateOnly(2026, 8, 1), new DateOnly(2026, 9, 30),
+            [], new Dictionary<string, string>());
+        var evento = new TerminacionAnulada();
+
+        var vista = FichaColaboradorProjection.Apply(evento, vistaPrevia);
+
+        vista.VigenteHasta.Should().Be(CentinelaVigenciaAbierta);
+        vista.CodigoColaborador.Should().Be("EMP-001");
+        vista.VigenteDesde.Should().Be(new DateOnly(2026, 8, 1));
+    }
+
+    // --- CA-3 (primera mitad): NombresCorregidos reemplaza NombreCompleto ---
+
+    [Fact]
+    public void Apply_ReemplazaElNombreCompleto_CuandoNombresCorregidos()
+    {
+        var vistaPrevia = new FichaColaborador(
+            "CC:123456", "Ana Ramirez", "EMP-001", new DateOnly(2026, 8, 1), CentinelaVigenciaAbierta,
+            [], new Dictionary<string, string>());
+        var nombreCorregido = NombreColaborador.Crear("Ana Maria", null, "Ramirez", "Solano");
+        var evento = new NombresCorregidos(nombreCorregido);
+
+        var vista = FichaColaboradorProjection.Apply(evento, vistaPrevia);
+
+        vista.NombreCompleto.Should().Be("Ana Maria Ramirez Solano");
+        vista.Id.Should().Be("CC:123456");
+        vista.CodigoColaborador.Should().Be("EMP-001");
+    }
+
+    // --- CA-3 (segunda mitad): FechaInicioVinculacionCorregida reemplaza VigenteDesde ---
+
+    [Fact]
+    public void Apply_ReemplazaVigenteDesde_CuandoFechaInicioVinculacionCorregida()
+    {
+        var vistaPrevia = new FichaColaborador(
+            "CC:123456", "Ana Ramirez", "EMP-001", new DateOnly(2026, 8, 1), CentinelaVigenciaAbierta,
+            [], new Dictionary<string, string>());
+        var fechaCorregida = new DateOnly(2026, 7, 15);
+        var evento = new FechaInicioVinculacionCorregida(fechaCorregida);
+
+        var vista = FichaColaboradorProjection.Apply(evento, vistaPrevia);
+
+        vista.VigenteDesde.Should().Be(fechaCorregida);
+        vista.CodigoColaborador.Should().Be("EMP-001");
+        vista.VigenteHasta.Should().Be(CentinelaVigenciaAbierta);
+    }
+
+    // --- CA-4 (primera mitad): EtiquetaAsignada agrega en AMBAS estructuras, sin tocar categorias
+    // existentes (oraculo mas fuerte que "agregar sobre lista vacia": descarta una implementacion
+    // que sobrescriba todo el listado en vez de agregar) ---
+
+    [Fact]
+    public void Apply_AgregaLaEtiquetaEnAmbasEstructuras_CuandoEtiquetaAsignadaEsUnaCategoriaNueva()
+    {
+        var vistaPrevia = new FichaColaborador(
+            "CC:123456", "Ana Ramirez", "EMP-001", new DateOnly(2026, 8, 1), CentinelaVigenciaAbierta,
+            [new EtiquetaFicha("sede", "Suba")],
+            new Dictionary<string, string> { ["sede"] = "suba" });
+        var evento = new EtiquetaAsignada(Etiqueta.Crear("Área", "Tecnología"));
+
+        var vista = FichaColaboradorProjection.Apply(evento, vistaPrevia);
+
+        vista.Etiquetas.Should().BeEquivalentTo(
+        [
+            new EtiquetaFicha("sede", "Suba"),
+            new EtiquetaFicha("Área", "Tecnología")
+        ]);
+        vista.EtiquetasNormalizadas.Should().BeEquivalentTo(new Dictionary<string, string>
+        {
+            ["sede"] = "suba",
+            ["area"] = "tecnologia"
+        });
+    }
+
+    // --- CA-4 (segunda mitad): upsert -- reasignar la MISMA categoria normalizada (distinta forma
+    // original, "area" en vez de "Área") deja UNA sola entrada con el valor nuevo, no dos ---
+
+    [Fact]
+    public void Apply_SobrescribeElValorDeLaCategoria_CuandoEtiquetaAsignadaReutilizaLaMismaCategoriaNormalizada()
+    {
+        var vistaPrevia = new FichaColaborador(
+            "CC:123456", "Ana Ramirez", "EMP-001", new DateOnly(2026, 8, 1), CentinelaVigenciaAbierta,
+            [new EtiquetaFicha("Área", "Tecnología")],
+            new Dictionary<string, string> { ["area"] = "tecnologia" });
+        var evento = new EtiquetaAsignada(Etiqueta.Crear("area", "Sistemas"));
+
+        var vista = FichaColaboradorProjection.Apply(evento, vistaPrevia);
+
+        vista.Etiquetas.Should().BeEquivalentTo([new EtiquetaFicha("area", "Sistemas")]);
+        vista.EtiquetasNormalizadas.Should().BeEquivalentTo(
+            new Dictionary<string, string> { ["area"] = "sistemas" });
+    }
+
+    // --- CA-4 (tercera mitad): EtiquetaRetirada remueve SOLO la categoria indicada de ambas
+    // estructuras, dejando intactas las demas ---
+
+    [Fact]
+    public void Apply_RemueveSoloLaCategoriaIndicada_CuandoEtiquetaRetirada()
+    {
+        var vistaPrevia = new FichaColaborador(
+            "CC:123456", "Ana Ramirez", "EMP-001", new DateOnly(2026, 8, 1), CentinelaVigenciaAbierta,
+            [new EtiquetaFicha("area", "Sistemas"), new EtiquetaFicha("sede", "Suba")],
+            new Dictionary<string, string> { ["area"] = "sistemas", ["sede"] = "suba" });
+        var evento = new EtiquetaRetirada("area");
+
+        var vista = FichaColaboradorProjection.Apply(evento, vistaPrevia);
+
+        vista.Etiquetas.Should().BeEquivalentTo([new EtiquetaFicha("sede", "Suba")]);
+        vista.EtiquetasNormalizadas.Should().BeEquivalentTo(
+            new Dictionary<string, string> { ["sede"] = "suba" });
+    }
+
+    // --- CA-5: reingreso nace limpio -- un colaborador terminado, CON etiquetas, que reingresa
+    // (VinculacionIniciada de nuevo sobre el mismo stream) recibe codigo y VigenteDesde nuevos,
+    // VigenteHasta vuelve al centinela y AMBAS estructuras de etiquetas se vacian. Espejo de
+    // Apply(VinculacionIniciada) en ColaboradorAggregateRoot (#355 CA-6). ---
+
+    [Fact]
+    public void Apply_NaceLimpio_CuandoVinculacionIniciadaEsUnReingresoConEtiquetasPrevias()
+    {
+        var vistaPrevia = new FichaColaborador(
+            "CC:123456", "Ana Ramirez", "EMP-001", new DateOnly(2025, 1, 1), new DateOnly(2025, 12, 31),
+            [new EtiquetaFicha("area", "Sistemas")],
+            new Dictionary<string, string> { ["area"] = "sistemas" });
+        var nuevaFechaInicio = new DateOnly(2026, 3, 1);
+        var evento = new VinculacionIniciada("EMP-002", nuevaFechaInicio);
+
+        var vista = FichaColaboradorProjection.Apply(evento, vistaPrevia);
+
+        vista.Id.Should().Be("CC:123456");
+        vista.NombreCompleto.Should().Be("Ana Ramirez");
+        vista.CodigoColaborador.Should().Be("EMP-002");
+        vista.VigenteDesde.Should().Be(nuevaFechaInicio);
+        vista.VigenteHasta.Should().Be(CentinelaVigenciaAbierta);
+        vista.Etiquetas.Should().BeEmpty();
+        vista.EtiquetasNormalizadas.Should().BeEmpty();
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Projections.Tests/Colaboradores/FichaColaboradorProjectionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Projections.Tests/Colaboradores/FichaColaboradorProjectionTests.cs
@@ -1,4 +1,4 @@
-// Issue #356: fase roja de la primera proyeccion concreta del dominio Colaboradores. Invocacion
+// Issue #356: primera proyeccion concreta del dominio Colaboradores. Invocacion
 // DIRECTA de los metodos estaticos de FichaColaboradorProjection (N1, MEF-ADR-0035) -- no el DSL
 // Given/When/Then de CommandHandlerTestBase (MEF-ADR-0002, testea command handlers contra el event
 // store): aqui se testean funciones puras evento -> vista, sin abrir ningun stream.

--- a/tests/Bitakora.ControlAsistencia.Projections.Tests/ConfiguracionMartenProjectionsTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Projections.Tests/ConfiguracionMartenProjectionsTests.cs
@@ -410,6 +410,24 @@ public class ConfiguracionMartenProjectionsTests
         restaurado.Nombre.NombreCompleto.Should().Be("Luis Augusto Barreto Prieto");
     }
 
+    // Issue #356 CA-1..CA-5: primera proyeccion concreta del dominio Colaboradores (N1,
+    // SingleStreamProjection<FichaColaborador, string> sobre el stream de ColaboradorAggregateRoot).
+    // Complementa ConfigurarColaboradores_RegistraLosTiposDeEventoPersistidos: aquella prueba que
+    // los TIPOS de evento estan registrados, esta prueba que la PROYECCION concreta que los
+    // consume esta registrada en el named store con lifecycle Async, el canonico del worker
+    // (MEF-ADR-0034 seccion 3). El seam (ConfiguracionMartenProjectionsColaboradores.
+    // ConfigurarColaboradores) ya existe desde el issue #360 sin ninguna proyeccion concreta
+    // registrada -- este test queda rojo hasta que projection-implementer agregue
+    // opts.Projections.Add<FichaColaboradorProjection>(ProjectionLifecycle.Async) ahi.
+    [Fact]
+    public void ConfigurarColaboradores_RegistraFichaColaboradorProjectionComoAsync()
+    {
+        using var provider = ProviderDeColaboradores();
+
+        provider.GetRequiredService<IColaboradoresProjectionStore>()
+            .AssertProyeccionAsyncRegistrada("FichaColaborador");
+    }
+
     // --- Seam de nivel BC (CA-4) ---
 
     // Las guardas de arriba invocan cada Configurar{Dominio} directamente, asi que quedan verdes

--- a/tests/Bitakora.ControlAsistencia.Projections.Tests/ConfiguracionMartenProjectionsTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Projections.Tests/ConfiguracionMartenProjectionsTests.cs
@@ -4,6 +4,7 @@ using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 using Bitakora.ControlAsistencia.Programacion.DomainEvents;
 using Bitakora.ControlAsistencia.Projections.Infraestructura;
 using Bitakora.ControlAsistencia.Projections.Tests.Infraestructura;
+using Bitakora.ControlAsistencia.ReadModels.Colaboradores;
 using Bitakora.ControlAsistencia.ReadModels.ControlHoras;
 using JasperFx.MultiTenancy; // TenancyStyle (NO Marten.*: vive en JasperFx.MultiTenancy)
 using Microsoft.Extensions.DependencyInjection;
@@ -416,9 +417,8 @@ public class ConfiguracionMartenProjectionsTests
     // los TIPOS de evento estan registrados, esta prueba que la PROYECCION concreta que los
     // consume esta registrada en el named store con lifecycle Async, el canonico del worker
     // (MEF-ADR-0034 seccion 3). El seam (ConfiguracionMartenProjectionsColaboradores.
-    // ConfigurarColaboradores) ya existe desde el issue #360 sin ninguna proyeccion concreta
-    // registrada -- este test queda rojo hasta que projection-implementer agregue
-    // opts.Projections.Add<FichaColaboradorProjection>(ProjectionLifecycle.Async) ahi.
+    // ConfigurarColaboradores) existe desde el issue #360; este issue le agrega la unica linea
+    // opts.Projections.Add<FichaColaboradorProjection>(ProjectionLifecycle.Async).
     [Fact]
     public void ConfigurarColaboradores_RegistraFichaColaboradorProjectionComoAsync()
     {
@@ -426,6 +426,60 @@ public class ConfiguracionMartenProjectionsTests
 
         provider.GetRequiredService<IColaboradoresProjectionStore>()
             .AssertProyeccionAsyncRegistrada("FichaColaborador");
+    }
+
+    // Issue #356, mismo gotcha de "Numeric Revisioned Documents" que el issue #294 peno en dev y
+    // que #328 ya cerro para TurnoVigente: Marten aplica ProjectionDocumentPolicy SOLO a los
+    // documentos que son target de una proyeccion REGISTRADA en el store (UseNumericRevisions =
+    // true, Metadata.Revision -- mt_version bigint -- habilitada, Metadata.Version -- mt_version
+    // uuid -- deshabilitada). Si FichaColaboradorProjection dejara de registrarse arriba, este
+    // mapping caeria al default y este test se pondria rojo.
+    //
+    // Este lado NO declara nada para que los valores sean asi: los impone Marten al registrar la
+    // proyeccion (https://martendb.io/documents/concurrency, "Numeric Revisioned Documents";
+    // Marten/Events/Projections/ProjectionDocumentPolicy.cs). O sea que este es el lado que DEFINE
+    // la forma fisica de la tabla y el write-side el que debe replicarla -- por eso el oraculo se
+    // congela aqui tambien: si una version futura de Marten cambiara el tipo por defecto de
+    // Metadata.Revision, ambos lados se pondrian rojos juntos en vez de dejar que la divergencia
+    // llegue a dev como un 42804 por request.
+    //
+    // Espejo de ComposicionServiciosTests (Colaboradores.Tests)
+    // .AgregarServiciosColaboradores_EsperaLaMismaColumnaDeVersionQueMaterializaraElWorker_ParaFichaColaborador.
+    [Fact]
+    public void ConfigurarColaboradores_MaterializaFichaColaboradorConRevisionNumerica()
+    {
+        using var provider = ProviderDeColaboradores();
+
+        var mapping = provider.GetRequiredService<IColaboradoresProjectionStore>()
+            .Options.FindOrResolveDocumentType(typeof(FichaColaborador));
+
+        mapping.Metadata.Revision.Enabled.Should().BeTrue();
+        mapping.Metadata.Revision.Type.Should().Be("bigint");
+        mapping.Metadata.Version.Enabled.Should().BeFalse();
+    }
+
+    // Issue #356, mitad worker del par 2 de compatibilidad write-side/read-side (MEF-ADR-0034
+    // seccion 6), replica de la guarda que #328 dejo para TurnoVigente: el daemon materializa
+    // FichaColaborador desde este named store y el Function App de Colaboradores la lee, en otro
+    // proceso, con session.LoadAsync. Que ambos lados converjan en la MISMA tabla fisica, la MISMA
+    // tenancy y el MISMO IdMember no lo garantiza ningun compilador -- son dos configuraciones de
+    // Marten independientes sobre el mismo schema, y una divergencia deja el GET en 404 permanente
+    // con el daemon funcionando (fallo silencioso que solo veria el smoke test contra dev).
+    //
+    // Espejo de ComposicionServiciosTests (Colaboradores.Tests)
+    // .AgregarServiciosColaboradores_ResuelveFichaColaboradorSobreLaTablaQueMaterializaElWorker_...,
+    // sin que ningun ensamblado referencie al otro (CA-ADR-0029).
+    [Fact]
+    public void ConfigurarColaboradores_MaterializaFichaColaboradorSobreLaTablaQueConsultaElWriteSide()
+    {
+        using var provider = ProviderDeColaboradores();
+
+        var mapping = provider.GetRequiredService<IColaboradoresProjectionStore>()
+            .Options.FindOrResolveDocumentType(typeof(FichaColaborador));
+
+        mapping.TableName.QualifiedName.Should().Be("colaboradores.mt_doc_fichacolaborador");
+        mapping.TenancyStyle.Should().Be(TenancyStyle.Conjoined);
+        mapping.IdMember.Name.Should().Be(nameof(FichaColaborador.Id));
     }
 
     // --- Seam de nivel BC (CA-4) ---


### PR DESCRIPTION
## Resumen

Pipeline TDD completado:
- Fase roja: tests escritos con stubs
- Fase verde: implementación completa
- Smoke tests: escritos para endpoints detectados
- Fase refactor: revisión de calidad

## Decisiones del pipeline

<details>
<summary>Projection Test Writer (fase roja) — 12m 51s</summary>

# Stage 1 -- projection-test-writer (issue #356)

## Tests creados

### 1. Unit tests de la proyeccion (fase roja real)
`tests/Bitakora.ControlAsistencia.Projections.Tests/Colaboradores/FichaColaboradorProjectionTests.cs`
-- 10 tests, invocacion directa de los metodos estaticos de `FichaColaboradorProjection` (sin
`CommandHandlerTestBase`, MEF-ADR-0002). Cubren los dos ejes del issue:

- **CA-1**: `Create_ProyectaIdYNombreCompleto_DesdeColaboradorRegistrado` (Id + NombreCompleto desde
  `IEvent<ColaboradorRegistrado>.StreamKey`) y `Apply_AsignaCodigoYFechaInicioYAbreLaVigencia_
  CuandoVinculacionIniciada` (codigo, VigenteDesde, VigenteHasta al centinela, etiquetas vacias).
- **CA-2**: `Apply_CierraLaVigencia_CuandoVinculacionTerminada`,
  `Apply_ReabreLaVigencia_CuandoTerminacionAnulada`.
- **CA-3**: `Apply_ReemplazaElNombreCompleto_CuandoNombresCorregidos`,
  `Apply_ReemplazaVigenteDesde_CuandoFechaInicioVinculacionCorregida`.
- **CA-4**: `Apply_AgregaLaEtiquetaEnAmbasEstructuras_CuandoEtiquetaAsignadaEsUnaCategoriaNueva`,
  `Apply_SobrescribeElValorDeLaCategoria_CuandoEtiquetaAsignadaReutilizaLaMismaCategoriaNormalizada`
  (upsert "Área"->"area"), `Apply_RemueveSoloLaCategoriaIndicada_CuandoEtiquetaRetirada`.
- **CA-5**: `Apply_NaceLimpio_CuandoVinculacionIniciadaEsUnReingresoConEtiquetasPrevias` (codigo y
  fecha nuevos, vigencia reabierta, ambas estructuras de etiquetas vaciadas).

Cada oraculo se armo a mano (literal `new DateOnly(9999, 12, 31)` repetido en cada test, nunca
importado desde produccion) -- ninguno reusa la logica de `Create`/`Apply` bajo prueba.

### 2. Config-test del worker
`tests/Bitakora.ControlAsistencia.Projections.Tests/ConfiguracionMartenProjectionsTests.cs` gano
`ConfigurarColaboradores_RegistraFichaColaboradorProjectionComoAsync` (mismo patron que
`ConfigurarControlHoras_RegistraTurnoVigenteProjectionComoAsync`, precedente #328). El seam
`ConfiguracionMartenProjectionsColaboradores.ConfigurarColaboradores` (issue #360) no se toco: la
linea `opts.Projections.Add<FichaColaboradorProjection>(...)` queda para projection-implementer.

### 3. Test de composicion de la Function GET
`tests/Bitakora.ControlAsistencia.Colaboradores.Tests/Infraestructura/ComposicionServiciosTests.cs`
gano `AgregarServiciosColaboradores_ResuelveElEndpointDeObtenerFichaColaborador_
CuandoElContenedorEstaCompuesto` (mismo patron que el precedente de `ObtenerTurnoVigente` en
ControlHoras.Tests, issue #328). Solo prueba la resolucion de `IDocumentStore`/`ITenantResolver` por
constructor via `ActivatorUtilities.CreateInstance` -- no el comportamiento de `Run` (parseo,
400/404/200, traduccion centinela->vacio), responsabilidad de projection-implementer y del smoke
test.

## Stubs de compilacion creados

- `src/Bitakora.ControlAsistencia.ReadModels/Colaboradores/FichaColaborador.cs`: record plano `
  FichaColaborador` + `EtiquetaFicha` (sin `partial`, sin comportamiento, cero `ProjectReference`
  de la cuarta isla).
- `src/Bitakora.ControlAsistencia.Projections/Colaboradores/FichaColaboradorProjection.cs`: clase
  companion `partial` `: SingleStreamProjection<FichaColaborador, string>` con `Create(IEvent<
  ColaboradorRegistrado>)` y 7 `Apply` (uno por evento de la tabla del issue), todos
  `throw new NotImplementedException()`. Sin `ShouldDelete` (la ficha nunca se borra).
- `src/Bitakora.ControlAsistencia.Colaboradores/ObtenerFichaColaborador/FunctionEndpoint.cs`: stub
  con constructor `(IDocumentStore store, ITenantResolver tenantResolver)`, atributo `[Function(
  "ObtenerFichaColaborador")]` y ruta `colaboradores/fichas/{tipoIdentificacion}/{numero}` (ya
  fijados por el issue), `Run` lanza `NotImplementedException`.

Ningun `.csproj` se modifico: el worker ya referenciaba `ReadModels` y `Colaboradores.DomainEvents`
(issue #360); el stub del `FunctionEndpoint` no usa `FichaColaborador` todavia, asi que la
referencia de `Colaboradores.csproj` hacia `ReadModels` (impacto esperado del issue) queda para
projection-implementer, cuando el `Run` real la necesite.

## Verificacion

`dotnet build` limpio (solo warnings preexistentes + 2 `CS9113` de parametros sin leer en el stub
del `FunctionEndpoint`, esperados en un stub). `dotnet test` confirma la fase roja: 11 tests en rojo
(10 unit tests de proyeccion + el config-test de registro Async), 61 en verde en el resto de
`Projections.Tests`; `Colaboradores.Tests`, `ControlHoras.Tests` y `Programacion.Tests` completos en
verde (296/442/227), sin regresiones.

## Desviaciones del plan del planner

Ninguna. No se detecto contradiccion estructural entre el issue y la doctrina del Skill/ADRs. No
aplica senal no-red: el issue crea una clase de proyeccion nueva con `Create`/`Apply` reales por
implementar, asi que la fase roja es alcanzable.

No se agregaron las guardas adicionales de "Numeric Revisioned Documents" / "materializa sobre la
tabla que consulta el write-side" que el precedente de `TurnoVigente` (#328) sumo en una revision
posterior -- esas guardas no tienen potencial de rojo (Marten las resuelve por convencion en cuanto
el read model existe con el nombre correcto) y quedan fuera del alcance explicito de "Capas de test
esperadas" del issue #356. Quedan disponibles para que el reviewer las proponga si lo considera
necesario.

</details>

<details>
<summary>Projection Implementer (fase verde) — 7m 50s</summary>

# Resumen -- projection-implementer (issue #356)

## Enfoque

Fase verde read-side sobre los stubs que dejo `projection-test-writer`. Trabajo en tres capas,
en el orden que pide el rol:

1. **Clase de proyeccion** (`FichaColaboradorProjection`, worker): implemente `Create` (nace la
   ficha desde `ColaboradorRegistrado`, via `IEvent<TEvento>.StreamKey`/`.Data`, receta N1) y los
   siete `Apply` (`VinculacionIniciada`, `VinculacionTerminada`, `TerminacionAnulada`,
   `NombresCorregidos`, `FechaInicioVinculacionCorregida`, `EtiquetaAsignada`,
   `EtiquetaRetirada`). El read model `FichaColaborador` no se toco (ya lo dejo
   `projection-test-writer` con la forma correcta, record plano sin comportamiento).
2. **Seam de registro** (`ConfiguracionMartenProjectionsColaboradores.ConfigurarColaboradores`):
   el seam ya existia implementado desde el issue #360 (no era stub `partial`); solo agregue
   `opts.Projections.Add<FichaColaboradorProjection>(ProjectionLifecycle.Async)` dentro del mismo
   `AddMartenStore` que ya registraba tipos de evento, tenancy y serializacion. Namespace correcto
   de `ProjectionLifecycle`: `JasperFx.Events.Projections` (no `Marten.Events.Projections`,
   gotcha ya documentado en el precedente `ConfiguracionMartenProjectionsControlHoras.cs`).
3. **Function GET** (`ObtenerFichaColaborador`): parseo tipado unico del borde
   (`TipoIdentificacion.Desde` + `Identificacion.Crear`, capturando `ArgumentException` como
   unico canal de traduccion a 400 -- ver "Desviaciones"), `ColaboradorAggregateRoot
   .ComputarStreamId` para reconstruir la clave (MEF-ADR-0037), `QuerySession` acotada al tenant
   de `ITenantResolver` (MEF-ADR-0028), `LoadAsync<FichaColaborador>` (via (a), default).
   Agregue la `ProjectReference` de `Bitakora.ControlAsistencia.Colaboradores` hacia `ReadModels`
   (el issue ya la senalaba como faltante).

## Decisiones de diseno

- **DTO de respuesta HTTP (`FichaColaboradorRespuesta`)**: CA-6 exige que el centinela
  9999-12-31 "jamas aparezca en la API". `MEF-ADR-0041 decision 4` fija que el GET serializa la
  vista directamente por defecto y que un DTO propio es excepcion bajo Rule of Three, valida
  solo con evidencia real de divergencia -- "ocultar un campo interno que la vista necesita para
  su propia logica de proyeccion pero que no debe salir por HTTP" es exactamente ese caso, asi
  que introduje `FichaColaboradorRespuesta` (record en el namespace del endpoint, no en
  `ReadModels`) que traduce `VigenteHasta == centinela -> null` y pasa el resto de los campos tal
  cual (incluyendo `EtiquetasNormalizadas`, que el issue no pide ocultar explicitamente -- lo dejo
  pasar para no inventar una restriccion sin evidencia en el CA).
- **Upsert de etiquetas Tell-don't-Ask**: `Apply(EtiquetaAsignada, ...)`/`Apply(EtiquetaRetirada,
  ...)` normalizan la categoria de cada `EtiquetaFicha` existente invocando
  `Etiqueta.NormalizarCategoria` (VO de `Colaboradores.DomainEvents`) en vez de reimplementar el
  algoritmo de normalizacion en el worker (MEF-ADR-0012). `e.Etiqueta.CategoriaNormalizada`/
  `ValorNormalizado` ya vienen calculados en el evento persistido, asi que tampoco se
  recalculan ahi.
- **`Create` fija la forma "vacia" de la ficha antes de `VinculacionIniciada`**: mismo commit de
  eventos que persiste el aggregate (`ColaboradorRegistrado` + `VinculacionIniciada`), asi que
  `Create` deja `CodigoColaborador = string.Empty`, `VigenteDesde = default`, `VigenteHasta =
  centinela`, etiquetas vacias -- forma que el propio test de `Apply(VinculacionIniciada)`
  arma a mano como `vistaPrevia` (oraculo independiente, no reusa produccion).

## ADRs y recursos consultados

- MEF-ADR-0035 (doctrina read-side, receta N1 Create/Apply).
- MEF-ADR-0034 secciones 3 y 6 (lifecycle Async, config-test, pares de compatibilidad).
- MEF-ADR-0037 (parseo tipado del borde, `ComputarStreamId`).
- MEF-ADR-0028 (QuerySession acotada al tenant del resolver).
- MEF-ADR-0012 (Tell-don't-Ask -- normalizacion vive en el VO `Etiqueta`).
- MEF-ADR-0041 decision 4 (DTO de respuesta HTTP como excepcion, Rule of Three).
- CA-ADR-0029 (islas: `EtiquetaFicha` sin relacion de tipo con `Etiqueta`; cero referencias
  worker -> Function App).
- `skills/projections/modelos-marten.md`, `naming.md`, `read-apis.md`, `config-test.md`.

## Desviaciones

- **Regla**: `skills/projections/read-apis.md` ejemplifica el parseo tipado del borde con
  `Guid.TryParse`/`DateOnly.TryParseExact` (sin excepcion), devolviendo 400 sobre el resultado
  booleano.
  **Desviacion aplicada**: `TipoIdentificacion.Desde(string)` e `Identificacion.Crear(...)` no
  exponen una variante `Try*` -- solo lanzan `ArgumentException`. El endpoint captura esa
  excepcion como unico mecanismo de traduccion a 400.
  **Razon tecnica**: es el mismo patron que ya usan los ocho `CommandHandler` del dominio para
  el mismo VO (ninguno declara una superficie `Try*` alternativa); introducir una en este issue
  hubiera side-purpose de VO no pedido por el issue.
  **Consecuencia**: el `try/catch` es mas ancho que un `TryParse` (captura cualquier
  `ArgumentException` de ambas llamadas con un solo mensaje generico, sin distinguir cual de los
  dos componentes de la ruta fallo). Documentado tambien en el mensaje del commit para que el
  reviewer lo confirme explicitamente.

## Resultado

- `dotnet build` sobre la solucion completa: sin errores.
- `dotnet test` (Projections.Tests): 72/72 verde, incluye las 6 pruebas nuevas de
  `FichaColaboradorProjectionTests` y `ConfigurarColaboradores_RegistraFichaColaboradorProjectionComoAsync`.
- `dotnet test` (Colaboradores.Tests): 296/296 verde, incluye la nueva guarda de composicion
  `AgregarServiciosColaboradores_ResuelveElEndpointDeObtenerFichaColaborador_...`.
- Suite completa de la solucion: 1192 correctos / 46 omitidos (smoke tests sin infra
  desplegada, esperado) / 0 errores.
- `dotnet format` corrido sobre los cuatro archivos tocados -- sin cambios adicionales (ya
  formateados).
- Commit `feat(hu-356): ...` creado sobre `src/` (proyeccion, seam, endpoint, `.csproj`).

</details>
<details>
<summary>Smoke Test Writer — 3m 37s</summary>

_(El agente no generó resumen)_

</details>
<details>
<summary>Reviewer (fase refactor) — 19m 6s</summary>

## ES Reviewer - Revision

### Evaluacion general
- Calidad: **aceptable** -- el diseño de la proyeccion y del endpoint es correcto y bien
  fundamentado, pero faltaba una guarda de infraestructura cuya ausencia habria dejado el GET en
  500 permanente en dev (hallazgo bloqueante, corregido).
- Cambios realizados: **si** (commit `7052e2c`).

### Cumplimiento de ADRs aplicables

| ADR | Cumplimiento | Observacion |
|---|---|---|
| MEF-ADR-0035: doctrina read-side (N1, Create/Apply, QuerySession) | ok | `SingleStreamProjection<FichaColaborador, string>`, `partial` sobre la clase companion (no sobre el record), `Create`/`Apply` estaticos que retornan `vista with { ... }`, sin `ShouldDelete`. Consulta via (a) con `LoadAsync`. |
| MEF-ADR-0034: worker, lifecycle Async, config-test seccion 6 | **desviacion NO declarada (corregida)** | Lifecycle `Async` ok; el **par 2** (worker -> query-side sobre read models) quedaba abierto: ver "Desviaciones detectadas por el reviewer". |
| MEF-ADR-0006 (+ enmienda #363): naming de la Function de query | ok | `ObtenerFichaColaborador`, feature folder `ObtenerFichaColaborador/` sin sufijo `Function`, clase `FunctionEndpoint`, un namespace por query. |
| MEF-ADR-0037: identidad de stream, borde HTTP tipado | ok | `ComputarStreamId(Identificacion)` es el unico punto de conversion; ningun `ToString(...)` con formato explicito ni concatenacion paralela; los dos componentes llegan en segmentos separados, se parsean una sola vez (`TipoIdentificacion.Desde` + `Identificacion.Crear`, que ademas **normaliza** trim+mayusculas) y el fallo responde `BadRequestObjectResult` **con mensaje**, no `BadRequestResult` pelado. |
| MEF-ADR-0028 / CA-ADR-0027: tenancy | ok | `store.QuerySession(tenantResolver.TenantId)`; `tipoIdentificacion`/`numero` son recurso, nunca tenant. Ningun tenant id de ruta/query string. |
| MEF-ADR-0012: Tell-don't-Ask | ok | `NombreCompleto` lo compone el VO; `Etiqueta.NormalizarCategoria` se invoca en vez de reimplementar la normalizacion en el worker; el evento ya trae `CategoriaNormalizada`/`ValorNormalizado` y no se recalculan. Ninguna propiedad nueva en un VO, ninguna clase estatica operando sobre datos crudos, ningun getter solo-para-test, ningun `InternalsVisibleTo` desde ensamblados de eventos. |
| CA-ADR-0029 / MEF-ADR-0039: islas | ok | `EtiquetaFicha` es tipo propio de `ReadModels`, sin relacion de tipo con el VO `Etiqueta`. `ReadModels.csproj` sigue con **cero** `ProjectReference` (cuarta isla, MEF-ADR-0041 decision 2). El worker referencia solo `*.DomainEvents` + `ReadModels`. La `ProjectReference` nueva (`Colaboradores.csproj` -> `ReadModels`) es del **Function App**, punto de composicion legitimo del write-side y espejo exacto de `ControlHoras.csproj`. |
| MEF-ADR-0041: forma propia de la vista, naming sin sufijo | ok | Sin sufijo `View`. **No es vista-espejo**: compone 8 eventos, deriva `NombreCompleto` del VO, agrega `EtiquetasNormalizadas` (estructura de filtrado que ningun evento trae) y codifica la vigencia abierta con centinela. DTO de respuesta como excepcion bajo Rule of Three, con evidencia real (ocultar el centinela, CA-6) -- decision 4 satisfecha. |
| MEF-ADR-0016: naming de tests | ok | `Create_<LoQuePasa>_<Desde/Cuando>`, `Apply_<LoQuePasa>_Cuando<Condicion>`, `ConfigurarColaboradores_<LoQuePasa>`, `AgregarServiciosColaboradores_<LoQuePasa>_Cuando<Condicion>`. Solo `[Fact]`. |

### Desviaciones de ADRs

**Desviaciones declaradas por el implementer** (de `stage-2-projection-implementer.md`):

#### Desviacion: `skills/projections/read-apis.md` (parseo tipado del borde)
- **Regla**: el ejemplo canonico parsea el segmento de ruta con `Guid.TryParse`/`DateOnly.TryParseExact` y decide el 400 sobre el resultado booleano.
- **Desviacion aplicada**: `TipoIdentificacion.Desde` / `Identificacion.Crear` no exponen variante `Try*`; el endpoint captura `ArgumentException` como unico canal de traduccion a 400.
- **Razon del implementer**: los ocho `CommandHandler`/validators del dominio ya usan ese mismo mecanismo sobre el mismo VO; introducir una superficie `Try*` seria alcance no pedido.
- **Consecuencia conocida**: el `catch` es mas ancho que un `TryParse` y el mensaje no distingue cual de los dos componentes fallo.
- **Evaluacion del reviewer**: **aceptable**. Verifique el precedente citado (`RetirarEtiquetaValidator.EsTipoIdentificacionReconocido`, issue #355) y **cumple** los ADRs: MEF-ADR-0037 seccion 2 exige parseo tipado unico y `400` explicito, no prescribe el mecanismo. El `try` envuelve exclusivamente las dos llamadas al VO (sin riesgo de enmascarar un bug ajeno) y responde con `BadRequestObjectResult` **y mensaje**, que es lo que el chequeo del reviewer exige. La rama de `numero` vacio ademas es casi inalcanzable: un segmento de ruta vacio no hace match con la plantilla. No corregido a proposito: separar en dos `catch` daria un mensaje mas preciso a costa de duplicar la ceremonia, sin ganancia real.

**Desviaciones detectadas por el reviewer (NO declaradas por el implementer)**:

#### Desviacion: MEF-ADR-0034 seccion 6, "par 2" (write-side vs read-side sobre read models)
- **Regla del ADR**: lo que determina como se interpreta lo ya persistido/materializado debe coincidir entre el proceso que escribe la vista (worker) y el que la consulta (Function App). El par 2 es exactamente ese contrato sobre read models.
- **Desviacion encontrada en el diff**: `src/Bitakora.ControlAsistencia.Colaboradores/Infraestructura/ComposicionServicios.cs` no declaraba `Schema.For<FichaColaborador>().UseNumericRevisions(true)`. Marten aplica `ProjectionDocumentPolicy` (`Metadata.Revision` = `mt_version bigint` habilitada, `Metadata.Version` uuid deshabilitada) **solo** en el store que registra la proyeccion: el worker. El Function App resolvia el mapping por default (uuid) sobre la **misma tabla fisica** que el worker crea como `bigint`. Con `AutoCreate` en `CreateOrUpdate` el sintoma no es un 404: Marten intenta `alter column mt_version type uuid` en **cada** request y Postgres lo rechaza con 42804 -- todos los GET en 500 permanente, con el daemon funcionando. Es el incidente real del issue #294 (deploy de #290) que #328 ya cerro para `TurnoVigente`, no replicado aqui.
- **Verificacion**: rojo reproducido antes de corregir (`Expected mapping.Metadata.Revision.Enabled to be True, but found False`).
- **Accion tomada**: **corregida en refactor**. Declaracion agregada al `ConfigureMarten` del Function App + **cuatro guardas espejo** (dos por lado, oraculo literal, sin que ningun ensamblado referencie al otro): revision numerica y tabla/tenancy/`IdMember`, replica exacta del par que #328 dejo para `TurnoVigente`.
- **Nota**: ninguna capa de test previa lo detectaba -- `dotnet build` limpio, 1192 tests verdes, y el smoke test solo habria emitido veredicto **despues** del deploy a dev.
- **Status**: corregida; pendiente de evaluacion del usuario.

El resto de las filas del gate de compatibilidad Marten (par 1: schema `colaboradores`, `StreamIdentity.AsString`, `EventNamingStyle.SmarterTypeName`, `TenancyStyle.Conjoined`, las tres banderas de `MetadataConfig`, serializador `EnumStorage.AsInteger`/`Casing.Default` + resolver, `AddEventTypes`) ya estaban alineadas y con guarda desde #360/#330. `Policies.AllDocumentsAreMultiTenanted()` (la otra instancia conocida del par 2) tambien estaba y quedo cubierta por la guarda nueva de tenancy sobre `FichaColaborador`.

### Precedentes consultados por el implementer

| Precedente | ADR aplicable | Veredicto |
|---|---|---|
| `TurnoVigente` / `TurnoVigenteProjection` / `ObtenerTurnoVigente` (#328) | MEF-ADR-0034/0035/0041 | alineado -- y **mas completo que la replica**: incluia la declaracion `UseNumericRevisions` del par 2 que este issue omitio (ver desviacion de arriba). |
| `RetirarEtiquetaValidator.EsTipoIdentificacionReconocido` (#355) | MEF-ADR-0037 seccion 2 | alineado (mecanismo `try/catch` sobre el VO sin `Try*`). |
| `Bloque`/`TipoBloque` en `ReadModels.ControlHoras` (#328) | MEF-ADR-0041 decision 2 | alineado (tipos propios de la isla). |
| `ColaboradorAggregateRoot.Apply(VinculacionIniciada)` (#355 CA-6) | -- | alineado: la proyeccion espeja fielmente el vaciado incondicional de etiquetas. |

### Convenciones del pipeline (no ADRs)

| Convencion | Estado | Observacion |
|---|---|---|
| Cada test con `Then()` + `And<>()` | n/a | No hay tests de command handler nuevos; los de proyeccion son funciones puras (invocacion directa, no DSL) y los de composicion/config interrogan el contenedor. |
| Overloads correctos para stream IDs compuestos | n/a | Sin tests de DSL en este diff. |
| Fakes manuales (no NSubstitute) | ok | Ningun mock; los tests de composicion usan el contenedor real con connection strings dummy. |
| Feature folders (produccion y tests) | ok | `ObtenerFichaColaborador/` en produccion, smoke tests y (agregado en la revision) `Colaboradores.Tests/ObtenerFichaColaborador/`. |
| Smoke tests: SkipWhen, secrets, cobertura | ok | `ApiFixture` es assembly fixture que falla explicito si falta `Api:BaseUrl` (mismo patron que el resto del proyecto; `SkipWhen` aplica a los tests con fixture opcional de Postgres/ServiceBus, no a este GET). `appsettings.json` sin secrets. `smoke-tests-dominio.yml` pasa `Api__BaseUrl`/`ServiceBus__`/`Postgres__`. Sin archivos duplicados. Numero de identificacion unico por test (sin colisiones entre corridas). Cobertura: 200 vigencia abierta, 200 no-vigente, 404 sin body, 400 tipo desconocido. |
| Proyecciones read-side: partial, inmutabilidad, read APIs, naming sin sufijo (MEF-ADR-0041), cuarta isla | ok | `partial` sobre la companion (no sobre el record); `Create`/`Apply` estaticos que copian con `with`; `LoadAsync` via (a); sin sufijo de implementacion; `ReadModels.csproj` intacto con cero `ProjectReference`. El analizador `JasperFx.Events.SourceGenerator` llega al worker transitivamente via `JasperFx.Events` 2.18.1 (verificado en `project.assets.json`). |
| Antipatrones de habilitacion (MEF-ADR-0039) | ok | Unico `.csproj` tocado: el del **Function App** (no una isla) sumando `ReadModels`, espejo de `ControlHoras.csproj`. Sin `PackageReference` nuevo en `DomainEvents`, sin referencia worker -> Function App, sin tipo de bus homonimo, sin referencia ajena en `*Events.Tests`. |
| Compatibilidad Marten write-side/read-side | **falla -> corregida** | Gate aplicado (el diff toca `ConfiguracionMartenProjectionsColaboradores.cs`). Par 1 alineado; par 2 con la divergencia de `UseNumericRevisions` descrita arriba, ya corregida y con guardas en ambos lados. |
| Identidad de stream (MEF-ADR-0037) | ok | Sin formato explicito sobre `Guid` (la clave no lleva ninguno), punto unico via `ComputarStreamId`, GET con parseo tipado por componente y 400 con mensaje. |
| Control de volumen de telemetria (MEF-ADR-0038) | ok | El gate aplica porque la revision toco `ComposicionServicios.cs`: `SetSampler` sigue en un segundo `.WithTracing(...)` **despues** de `UseAzureMonitorExporter()`, `Durability.DurabilityMetricsEnabled = false` intacto, `Durability.Mode` sin tocar dentro del callback. El guardrail de composicion del sampler existe y no es vacuo (`ObtenerSamplerEfectivo` por reflection + `ApagaLaRecoleccionDeMetricasDeDurabilidad`). El seam del worker no se toco. |
| Tests via ToString/comportamiento | ok | Ningun getter expuesto para test; los tests verifican la vista/respuesta que la API realmente produce. |
| Sin numeros magicos | **falla -> corregida** | El centinela `9999-12-31` estaba escrito como literal en **dos procesos distintos** (worker y Function App). Unificado en `FichaColaborador.CentinelaVigenciaAbierta`. |
| Condiciones en positivo (guardas if/else afirmativas) | ok | `if (ficha is null) return NotFound;` es guard clause de early-return, no una bifurcacion invertida. |

### Elegancia del codigo
- **Legibilidad e idiomatismo**: alto. `record` inmutable + `with`, colecciones con expresion `[]`, LINQ en los dos `Apply` de etiquetas, primary constructor en el endpoint. Los comentarios explican el *por que* (no el *que*) y citan ADR e issue.
- **Compacidad**: sin codigo muerto ni repeticion evitable, salvo el centinela duplicado que se corrigio.
- **Robustez**: el unico hueco real era el par 2 de Marten (corregido). El `try/catch` esta acotado a las dos llamadas del VO, sin swallowing silencioso (traduce a 400 explicito con mensaje).
- **Eficiencia**: los `Apply` de etiquetas son O(n) sobre una lista de cardinalidad de dominio muy baja (una entrada por categoria). La renormalizacion de la categoria almacenada es inherente a la forma de dos estructuras paralelas que fijo el issue, no un descuido.
- **Limpieza**: compilacion sin warnings nuevos; `dotnet format --verify-no-changes` no reporta nada sobre ningun archivo de este diff (las 4 advertencias IDE0005 son preexistentes en `ControlHoras.Tests`, fuera del alcance). Sin `U+2500`, sin debug cruft.

### Criticas y hallazgos
1. **[mayor -- corregido]** Par 2 de MEF-ADR-0034 abierto: `UseNumericRevisions` ausente del lado lectura (detalle completo en "Desviaciones detectadas por el reviewer"). Habria producido HTTP 500 permanente en dev tras el deploy.
2. **[menor -- corregido]** Centinela `9999-12-31` duplicado como literal en dos ensamblados desplegados por separado. Divergencia silenciosa: compila, pasa todos los tests unitarios (cada lado con su propio literal) y filtra el centinela por la API, rompiendo CA-6.
3. **[menor -- corregido]** La traduccion centinela -> vacio (la regla mas distintiva de CA-6) no tenia ninguna verificacion antes del deploy: solo el smoke test la cubria. Agregados tres tests unitarios sobre `FichaColaboradorRespuesta.DesdeVista`.
4. **[cosmetico -- corregido]** Comentarios de fase roja ya superados ("no se toca desde esta fase roja", "es responsabilidad de projection-implementer", "el dominio nace sin ninguna proyeccion concreta") afirmaban lo contrario de lo que el codigo hace hoy.
5. **[observacion -- NO corregido, decision del usuario]** `EtiquetasNormalizadas` viaja en la respuesta HTTP. El issue la describe como *"estructura de filtrado por containment JSONB que consumira el issue de listado"* -- es decir, mecanica interna del read-side, de la misma familia que el centinela que el DTO si oculta. Exponerla duplica `Etiquetas` en forma normalizada y ata el contrato HTTP al algoritmo de normalizacion de `Etiqueta`. **No lo corregi** porque ningun CA lo exige (a diferencia del centinela, que CA-6 nombra explicitamente), el implementer lo declaro como decision deliberada, y retirarla obligaria a cambiar una asercion del smoke test -- es decir, a mover la especificacion, no a corregir un defecto. Queda para tu criterio antes de que el issue hermano de listado consolide el contrato.
6. **[informativo]** Los 3 smoke tests de `ObtenerFichaColaborador` quedan **rojos** hasta que el deploy publique la ruta en dev (la revision desplegada devuelve 404 a todo: el caso 400 falla y el 404 pasa por la razon equivocada). Es exactamente lo que el `smoke-test-writer` documento en la cabecera del archivo y el mismo estado con que se integraron `ObtenerTurnoVigenteSmokeTests`/`ListarTurnosVigentesSmokeTests` en ControlHoras. El CI de PR no los ejecuta (solo corre `tests/*.Tests/`); su veredicto real se lee tras el deploy. **Toda la suite unitaria esta verde: 1201 correctos, 46 omitidos, 0 errores fuera de esos 3.**

### Refactorings aplicados
1. `ComposicionServicios` (Colaboradores): `options.Schema.For<FichaColaborador>().UseNumericRevisions(true)` con el racional del incidente #294 documentado inline.
2. `FichaColaborador`: centinela promovido a `public static readonly DateOnly CentinelaVigenciaAbierta`, con el argumento de por que vive con la vista (unico ensamblado que ambos procesos ven) y por que no es "comportamiento" en el sentido que MEF-ADR-0035 proscribe.
3. `FichaColaboradorProjection` y `FichaColaboradorRespuesta`: consumen esa constante en vez de sus propios literales. Se elimino el alias local redundante en la proyeccion (tres usos, referencia calificada directa).
4. Comentarios de fase roja actualizados en `FichaColaboradorProjection`, `ConfiguracionMartenProjectionsColaboradores`, `FichaColaboradorProjectionTests` y `ComposicionServiciosTests`.

Cada cambio se verifico con `dotnet test` inmediatamente despues; ninguno hubo que revertir.

### Cobertura de criterios de aceptacion
| Criterio | Estado | Test(s) |
|---|---|---|
| CA-1: registro -- Id, NombreCompleto, codigo, VigenteDesde, centinela, etiquetas vacias | cubierto | `Create_ProyectaIdYNombreCompleto_DesdeColaboradorRegistrado`, `Apply_AsignaCodigoYFechaInicioYAbreLaVigencia_CuandoVinculacionIniciada` + smoke `ObtenerFichaColaborador_Retorna200ConVigenteHastaVacio_CuandoLaVinculacionEstaAbierta` |
| CA-2: terminacion y anulacion | cubierto | `Apply_CierraLaVigencia_CuandoVinculacionTerminada`, `Apply_ReabreLaVigencia_CuandoTerminacionAnulada` + smoke `..._Retorna200ConVigenteHastaReal_CuandoLaVinculacionEstaTerminada` |
| CA-3: correcciones de nombre y fecha de inicio | cubierto | `Apply_ReemplazaElNombreCompleto_CuandoNombresCorregidos`, `Apply_ReemplazaVigenteDesde_CuandoFechaInicioVinculacionCorregida` |
| CA-4: upsert y retiro de etiquetas en ambas estructuras | cubierto | `Apply_AgregaLaEtiquetaEnAmbasEstructuras_CuandoEtiquetaAsignadaEsUnaCategoriaNueva`, `Apply_SobrescribeElValorDeLaCategoria_CuandoEtiquetaAsignadaReutilizaLaMismaCategoriaNormalizada` ("Área"->"area"), `Apply_RemueveSoloLaCategoriaIndicada_CuandoEtiquetaRetirada` |
| CA-5: reingreso nace limpio | cubierto | `Apply_NaceLimpio_CuandoVinculacionIniciadaEsUnReingresoConEtiquetasPrevias` |
| CA-6: `ObtenerFichaColaborador` (200 incl. no-vigentes, centinela oculto, 404 sin body, 400) | cubierto | **agregado en la revision**: `DesdeVista_DejaVigenteHastaVacio_CuandoLaVinculacionEstaAbierta`, `DesdeVista_ConservaLaFechaDeTerminacion_CuandoLaVinculacionEstaTerminada`, `DesdeVista_CopiaElRestoDeLaVistaSinTransformar_CuandoTraduceLaFicha`; wiring: `AgregarServiciosColaboradores_ResuelveElEndpointDeObtenerFichaColaborador_...`; extremo a extremo: los 4 smoke tests (rojos hasta el deploy) |
| Registro de la proyeccion como Async | cubierto | `ConfigurarColaboradores_RegistraFichaColaboradorProjectionComoAsync` |
| Compatibilidad worker <-> Function App sobre la vista (par 2) | **cubierto tras la revision** | `ConfigurarColaboradores_MaterializaFichaColaboradorConRevisionNumerica`, `ConfigurarColaboradores_MaterializaFichaColaboradorSobreLaTablaQueConsultaElWriteSide`, `AgregarServiciosColaboradores_EsperaLaMismaColumnaDeVersionQueMaterializaraElWorker_ParaFichaColaborador`, `AgregarServiciosColaboradores_ResuelveFichaColaboradorSobreLaTablaQueMaterializaElWorker_...` |

### Tests agregados
- **4 guardas del par 2 de compatibilidad Marten** (2 en `Projections.Tests/ConfiguracionMartenProjectionsTests.cs`, 2 en `Colaboradores.Tests/Infraestructura/ComposicionServiciosTests.cs`), con oraculo literal congelado en ambos lados y sin referencia cruzada entre ensamblados. Una de ellas nacio **roja** y probo el defecto antes de corregirlo.
- **3 tests de contrato del DTO de respuesta** (`Colaboradores.Tests/ObtenerFichaColaborador/FichaColaboradorRespuestaTests.cs`): centinela -> vacio, fecha real conservada (contracara: la traduccion no puede degenerar en "siempre vacio"), y el resto de la vista sin transformar. Oraculo independiente: el centinela se escribe como literal, nunca se importa de produccion.
- No aplican tests de igualdad ni de round-trip de serializacion: el diff no introduce ningun `IEquatable<T>`, ningun `ConfigurarSerializacion` ni ningun evento con marker de bus (`IPublicEvent`/`IPrivateEvent`).

</details>

## Commits

7052e2c refactor(hu-356): cierra el par 2 de FichaColaborador y unifica el centinela de vigencia
637e9aa test(hu-356): smoke tests para endpoints
9124409 feat(hu-356): proyeccion read-side FichaColaborador y su consulta puntual (fase verde)
db609d8 test(hu-356): tests read-side para FichaColaborador y su proyeccion (fase roja)

Closes #356