### PR TITLE
Cambiar el separador de la llave de Colaborador a guion y limpiar el numero de identificacion a alfanumerico

### DIFF
--- a/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/Identificacion.Mensajes.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/Identificacion.Mensajes.cs
@@ -10,6 +10,8 @@ public sealed partial class Identificacion
 
     public static class Mensajes
     {
+        // "Vacio" significa vacio DESPUES de la limpieza del issue #381, no solo un string vacio:
+        // "---" o ".." tambien lo disparan porque no dejan ningun caracter alfanumerico.
         public static string NumeroVacio =>
             ResourceManager.GetString(nameof(NumeroVacio))!;
     }

--- a/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/Identificacion.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/Identificacion.cs
@@ -8,9 +8,12 @@ namespace Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
 /// </summary>
 /// <remarks>
 /// Issue #348: compone la clave del stream del futuro ColaboradorAggregateRoot (#349+) --
-/// ToString() -> "{Tipo}:{Numero}" es CONTRATO, no detalle de presentacion. El numero es
-/// alfanumerico (los pasaportes traen letras), se normaliza trim + MAYUSCULAS para que
-/// " ab-123 " y "AB-123" produzcan el mismo stream (CA-1).
+/// ToString() -> "{Tipo}-{Numero}" es CONTRATO, no detalle de presentacion (separador "-" desde el
+/// issue #381: ":" es hostil como segmento de URI). El numero es alfanumerico (los pasaportes
+/// traen letras); se LIMPIA (issue #381) eliminando todo caracter fuera de [A-Za-z0-9] y llevando
+/// las letras a MAYUSCULAS -- no se rechaza por caracteres invalidos, se limpian antes de
+/// registrar. Esto hace inequivoca la llave "{Tipo}-{Numero}": tras la limpieza el numero jamas
+/// contiene "-", y ademas unifica identidad (" ab-12.3 " y "AB123" producen el mismo stream, CA-1).
 /// MEF-ADR-0012: sealed class, constructor privado real + constructor vacio para STJ/Marten,
 /// factory Crear() con validacion, ConfigurarSerializacion registrando campos privados (patron
 /// SubFranja) -- proscrito [JsonConstructor].
@@ -44,17 +47,25 @@ public sealed partial class Identificacion : IEquatable<Identificacion>
         _numero = string.Empty;
     }
 
-    // CA-1, CA-2: normaliza (trim + MAYUSCULAS) y valida que el numero no sea vacio ni whitespace.
+    // CA-2: limpia el numero (elimina todo caracter fuera de [A-Za-z0-9], letras a MAYUSCULAS) y
+    // valida que el resultado no quede vacio (CA-4). No hay rechazo por caracteres invalidos: se
+    // limpian antes de registrar, sin excepcion. El trim de #348 queda subsumido -- los espacios
+    // son caracteres invalidos y se eliminan igual que un guion o un punto.
     public static Identificacion Crear(TipoIdentificacion tipo, string numero)
     {
-        if (string.IsNullOrWhiteSpace(numero))
+        var numeroLimpio = new string((numero ?? string.Empty)
+            .Where(char.IsAsciiLetterOrDigit)
+            .Select(char.ToUpperInvariant)
+            .ToArray());
+
+        if (numeroLimpio.Length == 0)
             throw new ArgumentException(Mensajes.NumeroVacio, nameof(numero));
 
-        return new Identificacion(tipo, numero.Trim().ToUpperInvariant());
+        return new Identificacion(tipo, numeroLimpio);
     }
 
-    // Contrato: clave del stream de Colaborador.
-    public override string ToString() => $"{_tipo}:{_numero}";
+    // Contrato: clave del stream de Colaborador (separador "-" desde el issue #381).
+    public override string ToString() => $"{_tipo}-{_numero}";
 
     // Igualdad por valor. _tipo se compara por referencia (deliberado, ver remarks de
     // TipoIdentificacion): Desde() siempre retorna la instancia canonica de la lista cerrada.

--- a/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/IdentificacionMensajes.resx
+++ b/src/Bitakora.ControlAsistencia.Colaboradores.DomainEvents/IdentificacionMensajes.resx
@@ -21,6 +21,6 @@
   <resheader name="reader"><value>System.Resources.ResXResourceReader</value></resheader>
   <resheader name="writer"><value>System.Resources.ResXResourceWriter</value></resheader>
   <data name="NumeroVacio" xml:space="preserve">
-    <value>El numero de identificacion no puede estar vacio ni contener solo espacios</value>
+    <value>El numero de identificacion debe contener al menos una letra o un digito</value>
   </data>
 </root>

--- a/src/Bitakora.ControlAsistencia.Colaboradores/AnularTerminacionFunction/AnularTerminacion.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/AnularTerminacionFunction/AnularTerminacion.cs
@@ -7,8 +7,9 @@ namespace Bitakora.ControlAsistencia.Colaboradores.AnularTerminacionFunction;
 // 27 decide quedarse) y la fecha de terminacion errada (se compone con TerminarVinculacion, ver
 // ColaboradorAggregateRoot.AnularTerminacion).
 // Trigger: HTTP POST, Route: Colaboradores/Terminaciones/Anulaciones (la anulacion como
-// sub-recurso de las terminaciones, #349; la identificacion viaja en el body porque su
-// representacion "CC:79543210" contiene ":", hostil como segmento de URL).
+// sub-recurso de las terminaciones, #349; la identificacion viaja en el body, decision vigente
+// hasta #378 -- rutas orientadas a recurso --: el issue #381 cambio la representacion a
+// "CC-79543210" justamente para que la llave sea apta como segmento de URI).
 // Payload primitivo -- igual que los demas comandos del ciclo de vida (MEF-ADR-0039 decision 6,
 // payload por rol): NUNCA reusa un tipo de Colaboradores.DomainEvents como campo. El handler
 // construye TipoIdentificacion/Identificacion a partir de estos primitivos (parseo tipado unico en

--- a/src/Bitakora.ControlAsistencia.Colaboradores/AnularTerminacionFunction/FunctionEndpoint.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/AnularTerminacionFunction/FunctionEndpoint.cs
@@ -11,8 +11,9 @@ namespace Bitakora.ControlAsistencia.Colaboradores.AnularTerminacionFunction;
 // mismo criterio que los demas comandos del ciclo de vida: el record del comando es homonimo del
 // feature folder.
 // Route = "Colaboradores/Terminaciones/Anulaciones": la anulacion como sub-recurso de las
-// terminaciones (#349) -- identificacion en el body porque su representacion ("CC:79543210")
-// contiene ":", hostil como segmento de URL.
+// terminaciones (#349) -- identificacion en el body, decision vigente hasta #378 (rutas orientadas
+// a recurso): el issue #381 cambio la representacion a "CC-79543210" justamente para que la llave
+// sea apta como segmento de URI.
 // CA-ADR-0030 / MEF-ADR-0004 (precedente TerminarVinculacionFunction.FunctionEndpoint): validar
 // request (400 via IRequestValidator) -> despachar comando -> InvalidOperationException -> 409
 // Conflict, KeyNotFoundException -> 404 NotFound; exito -> 202 Accepted.

--- a/src/Bitakora.ControlAsistencia.Colaboradores/AsignarEtiquetaFunction/AsignarEtiqueta.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/AsignarEtiquetaFunction/AsignarEtiqueta.cs
@@ -3,9 +3,10 @@ namespace Bitakora.ControlAsistencia.Colaboradores.AsignarEtiquetaFunction;
 // Issue #355: comando para asignar (o sobrescribir) una etiqueta dinamica -- par categoria:valor
 // libre, sin catalogo previo -- a la vinculacion vigente de un colaborador. Septimo comando del
 // ciclo de vida de ColaboradorAggregateRoot (desglose #348-#357).
-// Trigger: HTTP POST, Route: Colaboradores/Etiquetas (identificacion en el body porque su
-// representacion "CC:79543210" contiene ":", hostil como segmento de URL -- mismo criterio que el
-// resto del ciclo de vida).
+// Trigger: HTTP POST, Route: Colaboradores/Etiquetas (identificacion en el body, decision vigente
+// hasta #378 -- rutas orientadas a recurso --, mismo criterio que el resto del ciclo de vida: el
+// issue #381 cambio la representacion a "CC-79543210" justamente para que la llave sea apta como
+// segmento de URI).
 // Payload primitivo -- igual que los demas comandos del ciclo de vida (MEF-ADR-0039 decision 6,
 // payload por rol): NUNCA reusa un tipo de Colaboradores.DomainEvents como campo. El handler
 // construye Etiqueta a partir de Categoria/Valor (parseo tipado unico en el borde, MEF-ADR-0037

--- a/src/Bitakora.ControlAsistencia.Colaboradores/AsignarEtiquetaFunction/FunctionEndpoint.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/AsignarEtiquetaFunction/FunctionEndpoint.cs
@@ -10,8 +10,9 @@ namespace Bitakora.ControlAsistencia.Colaboradores.AsignarEtiquetaFunction;
 // vinculacion vigente de un colaborador. MEF-ADR-0006: [Function("AsignarEtiqueta")]; carpeta CON
 // sufijo "Function" -- mismo criterio que los demas comandos del ciclo de vida: el record del
 // comando es homonimo del feature folder.
-// Route = "Colaboradores/Etiquetas": identificacion en el body porque su representacion
-// ("CC:79543210") contiene ":", hostil como segmento de URL.
+// Route = "Colaboradores/Etiquetas": identificacion en el body, decision vigente hasta #378 (rutas
+// orientadas a recurso): el issue #381 cambio la representacion a "CC-79543210" justamente para que
+// la llave sea apta como segmento de URI.
 // CA-ADR-0030 / MEF-ADR-0004 (precedente AnularTerminacionFunction.FunctionEndpoint): validar
 // request (400 via IRequestValidator) -> despachar comando -> InvalidOperationException -> 409
 // Conflict, KeyNotFoundException -> 404 NotFound; exito -> 202 Accepted.

--- a/src/Bitakora.ControlAsistencia.Colaboradores/CorregirFechaInicioVinculacionFunction/CorregirFechaInicioVinculacion.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/CorregirFechaInicioVinculacionFunction/CorregirFechaInicioVinculacion.cs
@@ -6,8 +6,9 @@ namespace Bitakora.ControlAsistencia.Colaboradores.CorregirFechaInicioVinculacio
 // requerido que puede nacer errado (caso real: se registro ayer con la fecha mal) y necesita su
 // enmienda.
 // Trigger: HTTP POST, Route: Colaboradores/FechasInicio (el recurso que se reemplaza, gemelo de
-// Colaboradores/Nombres #351; la identificacion viaja en el body porque su representacion
-// "CC:79543210" contiene ":", hostil como segmento de URL).
+// Colaboradores/Nombres #351; la identificacion viaja en el body, decision vigente hasta #378 --
+// rutas orientadas a recurso --: el issue #381 cambio la representacion a "CC-79543210" justamente
+// para que la llave sea apta como segmento de URI).
 // Payload primitivo -- igual que los demas comandos del ciclo de vida (MEF-ADR-0039 decision 6,
 // payload por rol): NUNCA reusa un tipo de Colaboradores.DomainEvents como campo. El handler
 // construye TipoIdentificacion/Identificacion a partir de estos primitivos (parseo tipado unico en

--- a/src/Bitakora.ControlAsistencia.Colaboradores/CorregirFechaInicioVinculacionFunction/FunctionEndpoint.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/CorregirFechaInicioVinculacionFunction/FunctionEndpoint.cs
@@ -11,8 +11,9 @@ namespace Bitakora.ControlAsistencia.Colaboradores.CorregirFechaInicioVinculacio
 // "Function" -- mismo criterio que los demas comandos del ciclo de vida: el record del comando es
 // homonimo del feature folder.
 // Route = "Colaboradores/FechasInicio": el recurso que se reemplaza, gemelo de
-// Colaboradores/Nombres (#351) -- identificacion en el body porque su representacion
-// ("CC:79543210") contiene ":", hostil como segmento de URL.
+// Colaboradores/Nombres (#351) -- identificacion en el body, decision vigente hasta #378 (rutas
+// orientadas a recurso): el issue #381 cambio la representacion a "CC-79543210" justamente para que
+// la llave sea apta como segmento de URI.
 // CA-ADR-0030 / MEF-ADR-0004 (precedente ReingresarColaboradorFunction.FunctionEndpoint): validar
 // request (400 via IRequestValidator) -> despachar comando -> InvalidOperationException -> 409
 // Conflict, KeyNotFoundException -> 404 NotFound; exito -> 202 Accepted.

--- a/src/Bitakora.ControlAsistencia.Colaboradores/CorregirNombresFunction/CorregirNombres.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/CorregirNombresFunction/CorregirNombres.cs
@@ -5,8 +5,9 @@ namespace Bitakora.ControlAsistencia.Colaboradores.CorregirNombresFunction;
 // estado -- solo exige existencia del colaborador, nunca vigencia de su vinculacion (los nombres
 // son de la PERSONA, no de la vinculacion, decision de refinamiento 2026-08-11).
 // Trigger: HTTP POST, Route: Colaboradores/Nombres (el recurso que se reemplaza; la identificacion
-// viaja en el body porque su representacion "CC:79543210" contiene ":", hostil como segmento de
-// URL, mismo criterio que TerminarVinculacion/ReingresarColaborador).
+// viaja en el body, decision vigente hasta #378 -- rutas orientadas a recurso --, mismo criterio
+// que TerminarVinculacion/ReingresarColaborador: el issue #381 cambio la representacion a
+// "CC-79543210" justamente para que la llave sea apta como segmento de URI).
 // Payload primitivo -- igual que RegistrarColaborador/TerminarVinculacion (MEF-ADR-0039 decision 6,
 // payload por rol): NUNCA reusa un tipo de Colaboradores.DomainEvents como campo. El handler
 // construye TipoIdentificacion/Identificacion/NombreColaborador a partir de estos primitivos

--- a/src/Bitakora.ControlAsistencia.Colaboradores/CorregirNombresFunction/FunctionEndpoint.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/CorregirNombresFunction/FunctionEndpoint.cs
@@ -10,8 +10,9 @@ namespace Bitakora.ControlAsistencia.Colaboradores.CorregirNombresFunction;
 // MEF-ADR-0006: [Function("CorregirNombres")]; carpeta CON sufijo "Function" -- mismo criterio que
 // RegistrarColaboradorFunction/TerminarVinculacionFunction/ReingresarColaboradorFunction: el
 // record del comando es homonimo del feature folder.
-// Route = "Colaboradores/Nombres": el recurso que se reemplaza -- identificacion en el body porque
-// su representacion ("CC:79543210") contiene ":", hostil como segmento de URL.
+// Route = "Colaboradores/Nombres": el recurso que se reemplaza -- identificacion en el body,
+// decision vigente hasta #378 (rutas orientadas a recurso): el issue #381 cambio la representacion
+// a "CC-79543210" justamente para que la llave sea apta como segmento de URI.
 // CA-ADR-0030 / MEF-ADR-0004 (precedente TerminarVinculacionFunction.FunctionEndpoint): validar
 // request (400 via IRequestValidator) -> despachar comando -> KeyNotFoundException -> 404 NotFound
 // (sin 409: este comando no tiene reglas de estado); exito -> 202 Accepted.

--- a/src/Bitakora.ControlAsistencia.Colaboradores/Entities/ColaboradorAggregateRoot.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/Entities/ColaboradorAggregateRoot.cs
@@ -6,7 +6,7 @@ namespace Bitakora.ControlAsistencia.Colaboradores.Entities;
 // Issue #330: aggregate root que representa a un colaborador bajo control de asistencia. Nace con
 // este issue -- primer aggregate y primeros dos eventos persistidos del dominio Colaboradores.
 //
-// Identidad: Identificacion.ToString() ("CC:79543210"), no un Guid. ComputarStreamId es el punto
+// Identidad: Identificacion.ToString() ("CC-79543210"), no un Guid. ComputarStreamId es el punto
 // unico de conversion de la clave del stream (MEF-ADR-0037): ningun handler/endpoint la concatena.
 //
 // Estado observable: internal, no publico (InternalsVisibleTo hacia Colaboradores.Tests, ver el

--- a/src/Bitakora.ControlAsistencia.Colaboradores/ReingresarColaboradorFunction/FunctionEndpoint.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/ReingresarColaboradorFunction/FunctionEndpoint.cs
@@ -11,8 +11,9 @@ namespace Bitakora.ControlAsistencia.Colaboradores.ReingresarColaboradorFunction
 // criterio que RegistrarColaboradorFunction/TerminarVinculacionFunction: el record del comando es
 // homonimo del feature folder.
 // Route = "Colaboradores/Reingresos": sub-recurso gemelo de Colaboradores/Terminaciones (#349) --
-// la identificacion viaja en el body porque su representacion ("CC:79543210") contiene ":",
-// hostil como segmento de URL.
+// la identificacion viaja en el body, decision vigente hasta #378 (rutas orientadas a recurso): el
+// issue #381 cambio la representacion a "CC-79543210" justamente para que la llave sea apta como
+// segmento de URI.
 // CA-ADR-0030 / MEF-ADR-0004 (precedente TerminarVinculacionFunction.FunctionEndpoint): validar
 // request (400 via IRequestValidator) -> despachar comando -> InvalidOperationException -> 409
 // Conflict, KeyNotFoundException -> 404 NotFound; exito -> 202 Accepted.

--- a/src/Bitakora.ControlAsistencia.Colaboradores/RetirarEtiquetaFunction/FunctionEndpoint.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/RetirarEtiquetaFunction/FunctionEndpoint.cs
@@ -11,8 +11,9 @@ namespace Bitakora.ControlAsistencia.Colaboradores.RetirarEtiquetaFunction;
 // mismo criterio que los demas comandos del ciclo de vida: el record del comando es homonimo del
 // feature folder.
 // Route = "Colaboradores/Etiquetas/Retiros": sub-recurso de las etiquetas (patron
-// AnularTerminacion/TerminarVinculacion #349/#354) -- identificacion en el body porque su
-// representacion ("CC:79543210") contiene ":", hostil como segmento de URL.
+// AnularTerminacion/TerminarVinculacion #349/#354) -- identificacion en el body, decision vigente
+// hasta #378 (rutas orientadas a recurso): el issue #381 cambio la representacion a "CC-79543210"
+// justamente para que la llave sea apta como segmento de URI.
 // CA-ADR-0030 / MEF-ADR-0004 (precedente AnularTerminacionFunction.FunctionEndpoint): validar
 // request (400 via IRequestValidator) -> despachar comando -> InvalidOperationException -> 409
 // Conflict, KeyNotFoundException -> 404 NotFound; exito -> 202 Accepted.

--- a/src/Bitakora.ControlAsistencia.Colaboradores/RetirarEtiquetaFunction/RetirarEtiqueta.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/RetirarEtiquetaFunction/RetirarEtiqueta.cs
@@ -4,8 +4,9 @@ namespace Bitakora.ControlAsistencia.Colaboradores.RetirarEtiquetaFunction;
 // colaborador. Octavo comando del ciclo de vida de ColaboradorAggregateRoot (desglose #348-#357),
 // gemelo de AsignarEtiqueta sobre el mismo diccionario.
 // Trigger: HTTP POST, Route: Colaboradores/Etiquetas/Retiros (sub-recurso de las etiquetas, patron
-// de AnularTerminacion/TerminarVinculacion #349/#354; identificacion en el body porque su
-// representacion "CC:79543210" contiene ":", hostil como segmento de URL). DELETE descartado --
+// de AnularTerminacion/TerminarVinculacion #349/#354; identificacion en el body, decision vigente
+// hasta #378 -- rutas orientadas a recurso --: el issue #381 cambio la representacion a
+// "CC-79543210" justamente para que la llave sea apta como segmento de URI). DELETE descartado --
 // identidad en el body, consistencia POST del BC (decision del planner).
 // Payload primitivo -- SIN Valor (retirar solo necesita la categoria, MEF-ADR-0039 decision 6): el
 // handler obtiene la forma normalizada via Etiqueta.NormalizarCategoria (#355, ver Etiqueta.cs).

--- a/src/Bitakora.ControlAsistencia.Colaboradores/TerminarVinculacionFunction/FunctionEndpoint.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/TerminarVinculacionFunction/FunctionEndpoint.cs
@@ -11,8 +11,9 @@ namespace Bitakora.ControlAsistencia.Colaboradores.TerminarVinculacionFunction;
 // que RegistrarColaboradorFunction (issue #330, refactor 63270fa): el record del comando es
 // homonimo del feature folder, y las carpetas sin sufijo son queries GET sin ese conflicto.
 // Route = "Colaboradores/Terminaciones": la terminacion como sub-recurso (estilo
-// programacion/solicitudes) -- la identificacion viaja en el body porque su representacion
-// ("CC:79543210") contiene ":", hostil como segmento de URL.
+// programacion/solicitudes) -- la identificacion viaja en el body, decision vigente hasta #378
+// (rutas orientadas a recurso): el issue #381 cambio la representacion a "CC-79543210" justamente
+// para que la llave sea apta como segmento de URI.
 // CA-ADR-0030 / MEF-ADR-0004 (precedente SolicitarProgramacionTurnoFunction.FunctionEndpoint):
 // validar request (400 via IRequestValidator) -> despachar comando -> InvalidOperationException
 // -> 409 Conflict, KeyNotFoundException -> 404 NotFound; exito -> 202 Accepted.

--- a/src/Bitakora.ControlAsistencia.ReadModels/Colaboradores/FichaColaborador.cs
+++ b/src/Bitakora.ControlAsistencia.ReadModels/Colaboradores/FichaColaborador.cs
@@ -29,7 +29,7 @@ public sealed record EtiquetaFicha(string Categoria, string Valor);
 /// precedente TurnoVigente #328).
 ///
 /// Id es el stream key que compone ColaboradorAggregateRoot.ComputarStreamId(Identificacion):
-/// "{Tipo}:{Numero}" (ej. "CC:123456") -- contrato de Identificacion.ToString(), nunca aplanado en
+/// "{Tipo}-{Numero}" (ej. "CC-123456") -- contrato de Identificacion.ToString(), nunca aplanado en
 /// Tipo/Numero separados (decision de refinamiento 2026-08-12: redundantes con el Id).
 ///
 /// CodigoColaborador, VigenteDesde y VigenteHasta reflejan siempre la ULTIMA vinculacion -- la

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/AnularTerminacionFunction/AnularTerminacionSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/AnularTerminacionFunction/AnularTerminacionSmokeTests.cs
@@ -53,15 +53,20 @@ public class AnularTerminacionSmokeTests(ApiFixture api, PostgresFixture postgre
     private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
 
     // Numero unico por test -- evita colisiones entre ejecuciones repetidas del smoke test: la
-    // identidad del stream es Identificacion.ToString() ("CC:<numero>"), no un Guid nuevo por
+    // identidad del stream es Identificacion.ToString() ("CC-<numero>"), no un Guid nuevo por
     // llamada, asi que reusar un numero fijo haria que el arrange (RegistrarColaborador) choque con
-    // 409 en la segunda corrida.
+    // 409 en la segunda corrida. El formato "N" en MAYUSCULAS ya es alfanumerico ASCII, asi que
+    // sobrevive intacto a la limpieza del numero (#381) y la llave esperada de abajo coincide con
+    // la que arma el backend.
     private static string NuevoNumeroIdentificacion() => Guid.CreateVersion7().ToString("N").ToUpperInvariant();
 
     private static string NuevoCodigoColaborador() => $"[TEST]-{Guid.CreateVersion7()}";
 
+    // Oraculo independiente de la clave de stream (MEF-ADR-0002): se recompone aqui a mano, no se
+    // deriva de Identificacion.ToString(), para que un cambio de formato en el VO no se auto-valide.
+    // Separador "-" desde el issue #381.
     private static string ComputarStreamId(string numeroIdentificacion) =>
-        $"{TipoIdentificacionCc}:{numeroIdentificacion}";
+        $"{TipoIdentificacionCc}-{numeroIdentificacion}";
 
     private static string FormatearFecha(DateOnly fecha) =>
         fecha.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/AsignarEtiquetaFunction/AsignarEtiquetaSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/AsignarEtiquetaFunction/AsignarEtiquetaSmokeTests.cs
@@ -66,15 +66,20 @@ public class AsignarEtiquetaSmokeTests(ApiFixture api, PostgresFixture postgres)
         ConfiguracionSerializacionColaboradores.CrearOpcionesMarten();
 
     // Numero unico por test -- evita colisiones entre ejecuciones repetidas del smoke test: la
-    // identidad del stream es Identificacion.ToString() ("CC:<numero>"), no un Guid nuevo por
+    // identidad del stream es Identificacion.ToString() ("CC-<numero>"), no un Guid nuevo por
     // llamada, asi que reusar un numero fijo haria que el arrange (RegistrarColaborador) choque con
-    // 409 en la segunda corrida.
+    // 409 en la segunda corrida. El formato "N" en MAYUSCULAS ya es alfanumerico ASCII, asi que
+    // sobrevive intacto a la limpieza del numero (#381) y la llave esperada de abajo coincide con
+    // la que arma el backend.
     private static string NuevoNumeroIdentificacion() => Guid.CreateVersion7().ToString("N").ToUpperInvariant();
 
     private static string NuevoCodigoColaborador() => $"[TEST]-{Guid.CreateVersion7()}";
 
+    // Oraculo independiente de la clave de stream (MEF-ADR-0002): se recompone aqui a mano, no se
+    // deriva de Identificacion.ToString(), para que un cambio de formato en el VO no se auto-valide.
+    // Separador "-" desde el issue #381.
     private static string ComputarStreamId(string numeroIdentificacion) =>
-        $"{TipoIdentificacionCc}:{numeroIdentificacion}";
+        $"{TipoIdentificacionCc}-{numeroIdentificacion}";
 
     private static object PayloadRegistro(string numeroIdentificacion, DateOnly fechaInicio) => new
     {

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/CorregirFechaInicioVinculacionFunction/CorregirFechaInicioVinculacionSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/CorregirFechaInicioVinculacionFunction/CorregirFechaInicioVinculacionSmokeTests.cs
@@ -48,15 +48,20 @@ public class CorregirFechaInicioVinculacionSmokeTests(ApiFixture api, PostgresFi
     private static readonly TimeSpan TimeoutAusencia = TimeSpan.FromSeconds(3);
 
     // Numero unico por test -- evita colisiones entre ejecuciones repetidas del smoke test: la
-    // identidad del stream es Identificacion.ToString() ("CC:<numero>"), no un Guid nuevo por
+    // identidad del stream es Identificacion.ToString() ("CC-<numero>"), no un Guid nuevo por
     // llamada, asi que reusar un numero fijo haria que el arrange (RegistrarColaborador) choque con
-    // 409 en la segunda corrida.
+    // 409 en la segunda corrida. El formato "N" en MAYUSCULAS ya es alfanumerico ASCII, asi que
+    // sobrevive intacto a la limpieza del numero (#381) y la llave esperada de abajo coincide con
+    // la que arma el backend.
     private static string NuevoNumeroIdentificacion() => Guid.CreateVersion7().ToString("N").ToUpperInvariant();
 
     private static string NuevoCodigoColaborador() => $"[TEST]-{Guid.CreateVersion7()}";
 
+    // Oraculo independiente de la clave de stream (MEF-ADR-0002): se recompone aqui a mano, no se
+    // deriva de Identificacion.ToString(), para que un cambio de formato en el VO no se auto-valide.
+    // Separador "-" desde el issue #381.
     private static string ComputarStreamId(string numeroIdentificacion) =>
-        $"{TipoIdentificacionCc}:{numeroIdentificacion}";
+        $"{TipoIdentificacionCc}-{numeroIdentificacion}";
 
     private static string FormatearFecha(DateOnly fecha) =>
         fecha.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/CorregirNombresFunction/CorregirNombresSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/CorregirNombresFunction/CorregirNombresSmokeTests.cs
@@ -67,15 +67,20 @@ public class CorregirNombresSmokeTests(ApiFixture api, PostgresFixture postgres)
         ConfiguracionSerializacionColaboradores.CrearOpcionesMarten();
 
     // Numero unico por test -- evita colisiones entre ejecuciones repetidas del smoke test: la
-    // identidad del stream es Identificacion.ToString() ("CC:<numero>"), no un Guid nuevo por
+    // identidad del stream es Identificacion.ToString() ("CC-<numero>"), no un Guid nuevo por
     // llamada, asi que reusar un numero fijo haria que el arrange (RegistrarColaborador) choque con
-    // 409 en la segunda corrida.
+    // 409 en la segunda corrida. El formato "N" en MAYUSCULAS ya es alfanumerico ASCII, asi que
+    // sobrevive intacto a la limpieza del numero (#381) y la llave esperada de abajo coincide con
+    // la que arma el backend.
     private static string NuevoNumeroIdentificacion() => Guid.CreateVersion7().ToString("N").ToUpperInvariant();
 
     private static string NuevoCodigoColaborador() => $"[TEST]-{Guid.CreateVersion7()}";
 
+    // Oraculo independiente de la clave de stream (MEF-ADR-0002): se recompone aqui a mano, no se
+    // deriva de Identificacion.ToString(), para que un cambio de formato en el VO no se auto-valide.
+    // Separador "-" desde el issue #381.
     private static string ComputarStreamId(string numeroIdentificacion) =>
-        $"{TipoIdentificacionCc}:{numeroIdentificacion}";
+        $"{TipoIdentificacionCc}-{numeroIdentificacion}";
 
     private static object PayloadRegistro(
         string numeroIdentificacion, DateOnly fechaInicio,

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/RegistrarColaboradorFunction/RegistrarColaboradorSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/RegistrarColaboradorFunction/RegistrarColaboradorSmokeTests.cs
@@ -14,7 +14,7 @@
 // EXTERNO no cambia (ya normalizaba antes en el borde), pero el punto donde vive el conocimiento
 // si cambio, y eso es exactamente lo que las CA-1/CA-1-bis de abajo verifican end-to-end contra el
 // entorno real: un TipoIdentificacion con espacios y minusculas debe seguir colapsando a la MISMA
-// clave de stream canonica ("CC:<numero>"), nunca abrir una segunda clave ("cc:<numero>").
+// clave de stream canonica ("CC-<numero>"), nunca abrir una segunda clave ("cc-<numero>").
 //
 // CA-1 (ruta de exito): identificacion nueva -> 202 y el stream recibe, en un solo commit,
 // ColaboradorRegistrado + VinculacionIniciada (issue #330).
@@ -47,18 +47,22 @@ public class RegistrarColaboradorSmokeTests(ApiFixture api, PostgresFixture post
     private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
 
     // Numero unico por test -- evita colisiones entre ejecuciones repetidas del smoke test: la
-    // identidad del stream es Identificacion.ToString() ("CC:<numero>"), no un Guid nuevo por
+    // identidad del stream es Identificacion.ToString() ("CC-<numero>"), no un Guid nuevo por
     // llamada, asi que reusar un numero fijo haria que el segundo registro choque con 409 en la
-    // segunda corrida.
+    // segunda corrida. El formato "N" en MAYUSCULAS ya es alfanumerico ASCII, asi que sobrevive
+    // intacto a la limpieza del numero (#381) y la llave esperada de abajo coincide con la que
+    // arma el backend.
     private static string NuevoNumeroIdentificacion() => Guid.CreateVersion7().ToString("N").ToUpperInvariant();
 
     private static string NuevoCodigoColaborador() => $"[TEST]-{Guid.CreateVersion7()}";
 
-    // Siempre canonico ("CC:<numero>"): TipoIdentificacion.Desde nunca almacena el input crudo, solo
-    // retorna la instancia canonica de la lista cerrada (issue #371) -- por eso el streamId esperado
-    // no varia sin importar el casing con el que llego el TipoIdentificacion en el payload.
+    // Siempre canonico ("CC-<numero>", separador "-" desde el issue #381): TipoIdentificacion.Desde
+    // nunca almacena el input crudo, solo retorna la instancia canonica de la lista cerrada (issue
+    // #371) -- por eso el streamId esperado no varia sin importar el casing con el que llego el
+    // TipoIdentificacion en el payload. Oraculo independiente (MEF-ADR-0002): se recompone a mano,
+    // no se deriva de Identificacion.ToString().
     private static string ComputarStreamId(string numeroIdentificacion) =>
-        $"{TipoIdentificacionCc}:{numeroIdentificacion}";
+        $"{TipoIdentificacionCc}-{numeroIdentificacion}";
 
     private static object PayloadRegistro(
         string numeroIdentificacion, DateOnly fechaInicio,
@@ -119,7 +123,7 @@ public class RegistrarColaboradorSmokeTests(ApiFixture api, PostgresFixture post
 
     // CA-1-bis (issue #371): la normalizacion vive ahora en TipoIdentificacion.Desde -- un
     // TipoIdentificacion con espacios y minusculas debe colapsar a la misma clave de stream
-    // canonica ("CC:<numero>"), nunca abrir una segunda clave ("cc:<numero>"). Verificacion
+    // canonica ("CC-<numero>"), nunca abrir una segunda clave ("cc-<numero>"). Verificacion
     // end-to-end del refactor: el borde ya no normaliza, asi que si el VO dejara de hacerlo este
     // test dejaria de encontrar el evento en el stream canonico.
     [Fact]
@@ -185,7 +189,7 @@ public class RegistrarColaboradorSmokeTests(ApiFixture api, PostgresFixture post
 
     // CA-2-bis (issue #371, corazon del refactor): el duplicado tambien se detecta cuando el
     // segundo request llega con TipoIdentificacion sin normalizar -- "CC" y " cc " colapsan a la
-    // MISMA clave de stream ("CC:<numero>") porque Desde normaliza antes del lookup, asi que el
+    // MISMA clave de stream ("CC-<numero>") porque Desde normaliza antes del lookup, asi que el
     // aggregate ya existe y el segundo registro se rechaza igual que con el mismo casing exacto.
     [Fact]
     [Trait("Category", "Smoke")]

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/ReingresarColaboradorFunction/ReingresarColaboradorSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/ReingresarColaboradorFunction/ReingresarColaboradorSmokeTests.cs
@@ -11,7 +11,7 @@
 //
 // Evento reutilizado (CA-ADR-0029/MEF-ADR-0039: un evento no conoce su comando): el exito NO crea
 // un tipo nuevo -- persiste otra VinculacionIniciada (tipo persistido "vinculacion_iniciada") en el
-// stream existente "{Tipo}:{Numero}", con el codigo transaccional nuevo del reingreso.
+// stream existente "{Tipo}-{Numero}", con el codigo transaccional nuevo del reingreso.
 //
 // CA-1/CA-4 (rutas de exito): 202 + una segunda VinculacionIniciada persistida con el Codigo y la
 // FechaInicio exactos del request -- ya sea sobre una terminacion pasada (CA-1) o sobre un preaviso
@@ -44,15 +44,20 @@ public class ReingresarColaboradorSmokeTests(ApiFixture api, PostgresFixture pos
     private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
 
     // Numero unico por test -- evita colisiones entre ejecuciones repetidas del smoke test: la
-    // identidad del stream es Identificacion.ToString() ("CC:<numero>"), no un Guid nuevo por
+    // identidad del stream es Identificacion.ToString() ("CC-<numero>"), no un Guid nuevo por
     // llamada, asi que reusar un numero fijo haria que el arrange (RegistrarColaborador) choque con
-    // 409 en la segunda corrida.
+    // 409 en la segunda corrida. El formato "N" en MAYUSCULAS ya es alfanumerico ASCII, asi que
+    // sobrevive intacto a la limpieza del numero (#381) y la llave esperada de abajo coincide con
+    // la que arma el backend.
     private static string NuevoNumeroIdentificacion() => Guid.CreateVersion7().ToString("N").ToUpperInvariant();
 
     private static string NuevoCodigoColaborador() => $"[TEST]-{Guid.CreateVersion7()}";
 
+    // Oraculo independiente de la clave de stream (MEF-ADR-0002): se recompone aqui a mano, no se
+    // deriva de Identificacion.ToString(), para que un cambio de formato en el VO no se auto-valide.
+    // Separador "-" desde el issue #381.
     private static string ComputarStreamId(string numeroIdentificacion) =>
-        $"{TipoIdentificacionCc}:{numeroIdentificacion}";
+        $"{TipoIdentificacionCc}-{numeroIdentificacion}";
 
     private static string FormatearFecha(DateOnly fecha) =>
         fecha.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/RetirarEtiquetaFunction/RetirarEtiquetaSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/RetirarEtiquetaFunction/RetirarEtiquetaSmokeTests.cs
@@ -56,15 +56,20 @@ public class RetirarEtiquetaSmokeTests(ApiFixture api, PostgresFixture postgres)
     private static readonly TimeSpan TimeoutAusencia = TimeSpan.FromSeconds(3);
 
     // Numero unico por test -- evita colisiones entre ejecuciones repetidas del smoke test: la
-    // identidad del stream es Identificacion.ToString() ("CC:<numero>"), no un Guid nuevo por
+    // identidad del stream es Identificacion.ToString() ("CC-<numero>"), no un Guid nuevo por
     // llamada, asi que reusar un numero fijo haria que el arrange (RegistrarColaborador) choque con
-    // 409 en la segunda corrida.
+    // 409 en la segunda corrida. El formato "N" en MAYUSCULAS ya es alfanumerico ASCII, asi que
+    // sobrevive intacto a la limpieza del numero (#381) y la llave esperada de abajo coincide con
+    // la que arma el backend.
     private static string NuevoNumeroIdentificacion() => Guid.CreateVersion7().ToString("N").ToUpperInvariant();
 
     private static string NuevoCodigoColaborador() => $"[TEST]-{Guid.CreateVersion7()}";
 
+    // Oraculo independiente de la clave de stream (MEF-ADR-0002): se recompone aqui a mano, no se
+    // deriva de Identificacion.ToString(), para que un cambio de formato en el VO no se auto-valide.
+    // Separador "-" desde el issue #381.
     private static string ComputarStreamId(string numeroIdentificacion) =>
-        $"{TipoIdentificacionCc}:{numeroIdentificacion}";
+        $"{TipoIdentificacionCc}-{numeroIdentificacion}";
 
     private static object PayloadRegistro(string numeroIdentificacion, DateOnly fechaInicio) => new
     {

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/TerminarVinculacionFunction/TerminarVinculacionSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/TerminarVinculacionFunction/TerminarVinculacionSmokeTests.cs
@@ -8,7 +8,7 @@
 // comando que lo origina, #330), nunca sembrando datos por fuera del API.
 //
 // CA-1/CA-2/CA-4 (rutas de exito): 202 + el evento vinculacion_terminada queda persistido en el
-// stream "{Tipo}:{Numero}" con la FechaEfectiva exacta del request -- pasada, futura (preaviso, sin
+// stream "{Tipo}-{Numero}" con la FechaEfectiva exacta del request -- pasada, futura (preaviso, sin
 // validacion contra el reloj del servidor en ninguna direccion) o igual a la FechaInicio (vinculacion
 // de un solo dia).
 // CA-3/CA-4 (rutas de rechazo): el aggregate declina con resultado (nunca lanza, nunca emite un
@@ -37,13 +37,18 @@ public class TerminarVinculacionSmokeTests(ApiFixture api, PostgresFixture postg
     private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
 
     // Numero unico por test -- evita colisiones entre ejecuciones repetidas del smoke test: la
-    // identidad del stream es Identificacion.ToString() ("CC:<numero>"), no un Guid nuevo por
+    // identidad del stream es Identificacion.ToString() ("CC-<numero>"), no un Guid nuevo por
     // llamada, asi que reusar un numero fijo haria que el arrange (RegistrarColaborador) choque con
-    // 409 en la segunda corrida.
+    // 409 en la segunda corrida. El formato "N" en MAYUSCULAS ya es alfanumerico ASCII, asi que
+    // sobrevive intacto a la limpieza del numero (#381) y la llave esperada de abajo coincide con
+    // la que arma el backend.
     private static string NuevoNumeroIdentificacion() => Guid.CreateVersion7().ToString("N").ToUpperInvariant();
 
+    // Oraculo independiente de la clave de stream (MEF-ADR-0002): se recompone aqui a mano, no se
+    // deriva de Identificacion.ToString(), para que un cambio de formato en el VO no se auto-valide.
+    // Separador "-" desde el issue #381.
     private static string ComputarStreamId(string numeroIdentificacion) =>
-        $"{TipoIdentificacionCc}:{numeroIdentificacion}";
+        $"{TipoIdentificacionCc}-{numeroIdentificacion}";
 
     private static string FormatearFecha(DateOnly fecha) =>
         fecha.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/AnularTerminacionFunction/AnularTerminacionCommandHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/AnularTerminacionFunction/AnularTerminacionCommandHandlerTests.cs
@@ -17,7 +17,7 @@ using Cosmos.EventSourcing.Testing.Utilities;
 
 namespace Bitakora.ControlAsistencia.Colaboradores.Tests.AnularTerminacionFunction;
 
-// El aggregate usa un stream ID compuesto (Identificacion.ToString(), "CC:79543210"), no el
+// El aggregate usa un stream ID compuesto (Identificacion.ToString(), "CC-79543210"), no el
 // GuidAggregateId del harness -- overloads explicitos de Given/Then/And (regla 18 del
 // test-writer, mismo criterio que el resto de la cadena #349-#352).
 public class AnularTerminacionCommandHandlerTests : CommandHandlerAsyncTest<AnularTerminacion>
@@ -26,7 +26,7 @@ public class AnularTerminacionCommandHandlerTests : CommandHandlerAsyncTest<Anul
 
     // Oraculo independiente de la clave de stream (MEF-ADR-0002 + MEF-ADR-0037): literal, no
     // derivado de ColaboradorAggregateRoot.ComputarStreamId.
-    private const string StreamIdEsperado = "CC:79543210";
+    private const string StreamIdEsperado = "CC-79543210";
 
     private const string CodigoVinculacionVigente = "COL-001";
     private const string CodigoVinculacionReingreso = "COL-002";
@@ -114,7 +114,7 @@ public class AnularTerminacionCommandHandlerTests : CommandHandlerAsyncTest<Anul
     }
 
     // CA-1 (borde de identidad, MEF-ADR-0037): "cc" en minusculas + numero con espacios sobre un
-    // colaborador ya registrado -> la anulacion alcanza el MISMO stream ("CC:79543210") y tiene
+    // colaborador ya registrado -> la anulacion alcanza el MISMO stream ("CC-79543210") y tiene
     // exito. La normalizacion del numero la garantiza Identificacion.Crear (#348); la del codigo de
     // tipo ("cc" -> "CC") la garantiza TipoIdentificacion.Desde, que normaliza internamente (issue
     // #371 -- supersede el racional de #348, ver TipoIdentificacionTests).

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/AnularTerminacionFunction/ComposicionAnularYTerminarVinculacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/AnularTerminacionFunction/ComposicionAnularYTerminarVinculacionTests.cs
@@ -33,13 +33,13 @@ using Cosmos.EventSourcing.Testing.Utilities;
 
 namespace Bitakora.ControlAsistencia.Colaboradores.Tests.AnularTerminacionFunction;
 
-// El aggregate usa un stream ID compuesto (Identificacion.ToString(), "CC:79543210"), no el
+// El aggregate usa un stream ID compuesto (Identificacion.ToString(), "CC-79543210"), no el
 // GuidAggregateId del harness -- overloads explicitos de Given/Then/And (regla 18 del
 // test-writer, mismo criterio que el resto de la cadena #349-#352).
 public class ComposicionAnularYTerminarVinculacionTests : CommandHandlerAsyncTest<TerminarVinculacion>
 {
     private const string NumeroValido = "79543210";
-    private const string StreamIdEsperado = "CC:79543210";
+    private const string StreamIdEsperado = "CC-79543210";
     private const string CodigoVinculacionVigente = "COL-001";
     private static readonly DateOnly FechaInicioVinculacionVigente = new(2026, 1, 15);
     private static readonly DateOnly FechaEfectivaErrada = new(2026, 6, 1);

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/AsignarEtiquetaFunction/AsignarEtiquetaCommandHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/AsignarEtiquetaFunction/AsignarEtiquetaCommandHandlerTests.cs
@@ -14,7 +14,7 @@ using Cosmos.EventSourcing.Testing.Utilities;
 
 namespace Bitakora.ControlAsistencia.Colaboradores.Tests.AsignarEtiquetaFunction;
 
-// El aggregate usa un stream ID compuesto (Identificacion.ToString(), "CC:79543210"), no el
+// El aggregate usa un stream ID compuesto (Identificacion.ToString(), "CC-79543210"), no el
 // GuidAggregateId del harness -- overloads explicitos de Given/Then/And (regla 18 del
 // test-writer, mismo criterio que el resto de la cadena #349-#354).
 public class AsignarEtiquetaCommandHandlerTests : CommandHandlerAsyncTest<AsignarEtiqueta>
@@ -23,7 +23,7 @@ public class AsignarEtiquetaCommandHandlerTests : CommandHandlerAsyncTest<Asigna
 
     // Oraculo independiente de la clave de stream (MEF-ADR-0002 + MEF-ADR-0037): literal, no
     // derivado de ColaboradorAggregateRoot.ComputarStreamId.
-    private const string StreamIdEsperado = "CC:79543210";
+    private const string StreamIdEsperado = "CC-79543210";
 
     private const string CodigoVinculacionVigente = "COL-001";
     private const string CodigoVinculacionReingreso = "COL-002";
@@ -89,7 +89,7 @@ public class AsignarEtiquetaCommandHandlerTests : CommandHandlerAsyncTest<Asigna
     }
 
     // CA-1 (borde de identidad, MEF-ADR-0037): "cc" en minusculas + numero con espacios sobre un
-    // colaborador ya registrado -> la asignacion alcanza el MISMO stream ("CC:79543210") y emite el
+    // colaborador ya registrado -> la asignacion alcanza el MISMO stream ("CC-79543210") y emite el
     // evento.
     [Fact]
     public async Task AsignarEtiqueta_EmiteEtiquetaAsignada_CuandoTipoYNumeroLleganSinNormalizar()

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/CorregirFechaInicioVinculacionFunction/CorregirFechaInicioVinculacionCommandHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/CorregirFechaInicioVinculacionFunction/CorregirFechaInicioVinculacionCommandHandlerTests.cs
@@ -15,7 +15,7 @@ using Cosmos.EventSourcing.Testing.Utilities;
 
 namespace Bitakora.ControlAsistencia.Colaboradores.Tests.CorregirFechaInicioVinculacionFunction;
 
-// El aggregate usa un stream ID compuesto (Identificacion.ToString(), "CC:79543210"), no el
+// El aggregate usa un stream ID compuesto (Identificacion.ToString(), "CC-79543210"), no el
 // GuidAggregateId del harness -- overloads explicitos de Given/Then/And (regla 18 del
 // test-writer, mismo criterio que TerminarVinculacionCommandHandlerTests/
 // ReingresarColaboradorCommandHandlerTests/CorregirNombresCommandHandlerTests).
@@ -26,7 +26,7 @@ public class CorregirFechaInicioVinculacionCommandHandlerTests
 
     // Oraculo independiente de la clave de stream (MEF-ADR-0002 + MEF-ADR-0037): literal, no
     // derivado de ColaboradorAggregateRoot.ComputarStreamId.
-    private const string StreamIdEsperado = "CC:79543210";
+    private const string StreamIdEsperado = "CC-79543210";
 
     private const string CodigoVinculacionOriginal = "COL-001";
     private const string CodigoReingreso = "COL-002";
@@ -120,7 +120,7 @@ public class CorregirFechaInicioVinculacionCommandHandlerTests
     }
 
     // CA-1 (borde de identidad, MEF-ADR-0037): "cc" en minusculas + numero con espacios sobre un
-    // colaborador ya registrado -> la correccion alcanza el MISMO stream ("CC:79543210") y emite
+    // colaborador ya registrado -> la correccion alcanza el MISMO stream ("CC-79543210") y emite
     // el evento. La normalizacion del numero la garantiza Identificacion.Crear (#348); la del
     // codigo de tipo ("cc" -> "CC") la garantiza TipoIdentificacion.Desde, que normaliza
     // internamente (issue #371 -- supersede el racional de #348, ver TipoIdentificacionTests).

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/CorregirNombresFunction/CorregirNombresCommandHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/CorregirNombresFunction/CorregirNombresCommandHandlerTests.cs
@@ -14,7 +14,7 @@ using Cosmos.EventSourcing.Testing.Utilities;
 
 namespace Bitakora.ControlAsistencia.Colaboradores.Tests.CorregirNombresFunction;
 
-// El aggregate usa un stream ID compuesto (Identificacion.ToString(), "CC:79543210"), no el
+// El aggregate usa un stream ID compuesto (Identificacion.ToString(), "CC-79543210"), no el
 // GuidAggregateId del harness -- overloads explicitos de Given/Then/And (regla 18 del
 // test-writer, mismo criterio que TerminarVinculacionCommandHandlerTests/
 // ReingresarColaboradorCommandHandlerTests).
@@ -24,7 +24,7 @@ public class CorregirNombresCommandHandlerTests : CommandHandlerAsyncTest<Correg
 
     // Oraculo independiente de la clave de stream (MEF-ADR-0002 + MEF-ADR-0037): literal, no
     // derivado de ColaboradorAggregateRoot.ComputarStreamId.
-    private const string StreamIdEsperado = "CC:79543210";
+    private const string StreamIdEsperado = "CC-79543210";
 
     private const string CodigoVinculacionOriginal = "COL-001";
     private static readonly DateOnly FechaInicioOriginal = new(2026, 1, 15);
@@ -91,7 +91,7 @@ public class CorregirNombresCommandHandlerTests : CommandHandlerAsyncTest<Correg
     }
 
     // CA-1 (borde de identidad, MEF-ADR-0037): "cc" en minusculas + numero con espacios sobre un
-    // colaborador ya registrado -> la correccion alcanza el MISMO stream ("CC:79543210") y emite el
+    // colaborador ya registrado -> la correccion alcanza el MISMO stream ("CC-79543210") y emite el
     // evento. La normalizacion del numero la garantiza Identificacion.Crear (#348); la del codigo
     // de tipo ("cc" -> "CC") la garantiza TipoIdentificacion.Desde, que normaliza internamente
     // (issue #371 -- supersede el racional de #348, ver TipoIdentificacionTests). Sin esa

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ObtenerFichaColaborador/FichaColaboradorRespuestaTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ObtenerFichaColaborador/FichaColaboradorRespuestaTests.cs
@@ -25,7 +25,7 @@ public class FichaColaboradorRespuestaTests
 
     private static FichaColaborador FichaConVigenteHasta(DateOnly vigenteHasta) =>
         new(
-            "CC:123456",
+            "CC-123456",
             "Ana Ramirez",
             "EMP-001",
             new DateOnly(2026, 8, 1),
@@ -62,7 +62,7 @@ public class FichaColaboradorRespuestaTests
 
         var respuesta = FichaColaboradorRespuesta.DesdeVista(ficha);
 
-        respuesta.Id.Should().Be("CC:123456");
+        respuesta.Id.Should().Be("CC-123456");
         respuesta.NombreCompleto.Should().Be("Ana Ramirez");
         respuesta.CodigoColaborador.Should().Be("EMP-001");
         respuesta.VigenteDesde.Should().Be(new DateOnly(2026, 8, 1));

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/RegistrarColaboradorFunction/Eventos/ColaboradorRegistradoSerializacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/RegistrarColaboradorFunction/Eventos/ColaboradorRegistradoSerializacionTests.cs
@@ -41,7 +41,7 @@ public class ColaboradorRegistradoSerializacionTests
 
         deserializado.Should().NotBeNull();
         deserializado!.Identificacion.Should().Be(IdentificacionValida);
-        deserializado.Identificacion.ToString().Should().Be("CC:79543210");
+        deserializado.Identificacion.ToString().Should().Be("CC-79543210");
         deserializado.Nombre.Should().Be(NombreValido);
         deserializado.Nombre.NombreCompleto.Should().Be("Luis Augusto Barreto Prieto");
     }

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/RegistrarColaboradorFunction/RegistrarColaboradorCommandHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/RegistrarColaboradorFunction/RegistrarColaboradorCommandHandlerTests.cs
@@ -11,7 +11,7 @@ using Cosmos.EventSourcing.Testing.Utilities;
 
 namespace Bitakora.ControlAsistencia.Colaboradores.Tests.RegistrarColaboradorFunction;
 
-// El aggregate usa un stream ID compuesto (Identificacion.ToString(), "CC:79543210"), no el
+// El aggregate usa un stream ID compuesto (Identificacion.ToString(), "CC-79543210"), no el
 // GuidAggregateId del harness -- overloads explicitos de Given/Then/And (regla 18 del test-writer).
 public class RegistrarColaboradorCommandHandlerTests : CommandHandlerAsyncTest<RegistrarColaborador>
 {
@@ -24,7 +24,7 @@ public class RegistrarColaboradorCommandHandlerTests : CommandHandlerAsyncTest<R
     // ColaboradorAggregateRoot.ComputarStreamId(...): derivarlo del propio codigo bajo prueba haria
     // tautologica la clave con la que Given/Then/And direccionan el stream, y un cambio de formato
     // -- otro separador, otro orden, otro casing -- pasaria en verde partiendo streams en produccion.
-    private const string StreamIdEsperado = "CC:79543210";
+    private const string StreamIdEsperado = "CC-79543210";
 
     // Vinculacion previa del stream ya registrado (CA-2/CA-4): distinta de la del comando, para que
     // el And posterior distinga "no cambio nada" de "coincide por casualidad".
@@ -57,7 +57,7 @@ public class RegistrarColaboradorCommandHandlerTests : CommandHandlerAsyncTest<R
             new ColaboradorRegistrado(IdentificacionValida(), NombreValido()),
             new VinculacionIniciada(CodigoVinculacionPrevia, FechaInicioVinculacionPrevia));
 
-    // CA-1: nace el stream con clave "CC:79543210" conteniendo ColaboradorRegistrado +
+    // CA-1: nace el stream con clave "CC-79543210" conteniendo ColaboradorRegistrado +
     // VinculacionIniciada persistidos en un solo commit, en ese orden.
     // CA-5: VinculacionIniciada persiste Codigo/FechaInicio tal como llegaron del request.
     [Fact]

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ReingresarColaboradorFunction/ReingresarColaboradorCommandHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ReingresarColaboradorFunction/ReingresarColaboradorCommandHandlerTests.cs
@@ -15,7 +15,7 @@ using Cosmos.EventSourcing.Testing.Utilities;
 
 namespace Bitakora.ControlAsistencia.Colaboradores.Tests.ReingresarColaboradorFunction;
 
-// El aggregate usa un stream ID compuesto (Identificacion.ToString(), "CC:79543210"), no el
+// El aggregate usa un stream ID compuesto (Identificacion.ToString(), "CC-79543210"), no el
 // GuidAggregateId del harness -- overloads explicitos de Given/Then/And (regla 18 del
 // test-writer, mismo criterio que TerminarVinculacionCommandHandlerTests).
 public class ReingresarColaboradorCommandHandlerTests : CommandHandlerAsyncTest<ReingresarColaborador>
@@ -24,7 +24,7 @@ public class ReingresarColaboradorCommandHandlerTests : CommandHandlerAsyncTest<
 
     // Oraculo independiente de la clave de stream (MEF-ADR-0002 + MEF-ADR-0037): literal, no
     // derivado de ColaboradorAggregateRoot.ComputarStreamId.
-    private const string StreamIdEsperado = "CC:79543210";
+    private const string StreamIdEsperado = "CC-79543210";
 
     private const string CodigoVinculacionOriginal = "COL-001";
     private const string CodigoReingreso = "COL-002";
@@ -88,7 +88,7 @@ public class ReingresarColaboradorCommandHandlerTests : CommandHandlerAsyncTest<
     }
 
     // CA-1 (borde de identidad, MEF-ADR-0037): "cc" en minusculas + numero con espacios sobre un
-    // colaborador ya registrado -> el reingreso alcanza el MISMO stream ("CC:79543210") y tiene
+    // colaborador ya registrado -> el reingreso alcanza el MISMO stream ("CC-79543210") y tiene
     // exito. La normalizacion del numero la garantiza Identificacion.Crear (#348); la del codigo de
     // tipo ("cc" -> "CC") la garantiza TipoIdentificacion.Desde, que normaliza internamente (issue
     // #371 -- supersede el racional de #348, ver TipoIdentificacionTests). Sin esa normalizacion el

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/RetirarEtiquetaFunction/RetirarEtiquetaCommandHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/RetirarEtiquetaFunction/RetirarEtiquetaCommandHandlerTests.cs
@@ -15,7 +15,7 @@ using Cosmos.EventSourcing.Testing.Utilities;
 
 namespace Bitakora.ControlAsistencia.Colaboradores.Tests.RetirarEtiquetaFunction;
 
-// El aggregate usa un stream ID compuesto (Identificacion.ToString(), "CC:79543210"), no el
+// El aggregate usa un stream ID compuesto (Identificacion.ToString(), "CC-79543210"), no el
 // GuidAggregateId del harness -- overloads explicitos de Given/Then/And (regla 18 del
 // test-writer, mismo criterio que el resto de la cadena #349-#354).
 public class RetirarEtiquetaCommandHandlerTests : CommandHandlerAsyncTest<RetirarEtiqueta>
@@ -24,7 +24,7 @@ public class RetirarEtiquetaCommandHandlerTests : CommandHandlerAsyncTest<Retira
 
     // Oraculo independiente de la clave de stream (MEF-ADR-0002 + MEF-ADR-0037): literal, no
     // derivado de ColaboradorAggregateRoot.ComputarStreamId.
-    private const string StreamIdEsperado = "CC:79543210";
+    private const string StreamIdEsperado = "CC-79543210";
 
     private const string CodigoVinculacionVigente = "COL-001";
     private const string CodigoVinculacionReingreso = "COL-002";
@@ -90,7 +90,7 @@ public class RetirarEtiquetaCommandHandlerTests : CommandHandlerAsyncTest<Retira
     }
 
     // CA-3 (borde de identidad, MEF-ADR-0037): "cc" en minusculas + numero con espacios sobre un
-    // colaborador ya registrado -> el retiro alcanza el MISMO stream ("CC:79543210") y emite el
+    // colaborador ya registrado -> el retiro alcanza el MISMO stream ("CC-79543210") y emite el
     // evento.
     [Fact]
     public async Task RetirarEtiqueta_EmiteEtiquetaRetirada_CuandoTipoYNumeroLleganSinNormalizar()

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/TerminarVinculacionFunction/TerminarVinculacionCommandHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/TerminarVinculacionFunction/TerminarVinculacionCommandHandlerTests.cs
@@ -13,7 +13,7 @@ using Cosmos.EventSourcing.Testing.Utilities;
 
 namespace Bitakora.ControlAsistencia.Colaboradores.Tests.TerminarVinculacionFunction;
 
-// El aggregate usa un stream ID compuesto (Identificacion.ToString(), "CC:79543210"), no el
+// El aggregate usa un stream ID compuesto (Identificacion.ToString(), "CC-79543210"), no el
 // GuidAggregateId del harness -- overloads explicitos de Given/Then/And (regla 18 del test-writer,
 // mismo criterio que RegistrarColaboradorCommandHandlerTests).
 public class TerminarVinculacionCommandHandlerTests : CommandHandlerAsyncTest<TerminarVinculacion>
@@ -22,7 +22,7 @@ public class TerminarVinculacionCommandHandlerTests : CommandHandlerAsyncTest<Te
 
     // Oraculo independiente de la clave de stream (MEF-ADR-0002 + MEF-ADR-0037): literal, no
     // derivado de ColaboradorAggregateRoot.ComputarStreamId (mismo criterio que #330).
-    private const string StreamIdEsperado = "CC:79543210";
+    private const string StreamIdEsperado = "CC-79543210";
 
     private const string CodigoVinculacionVigente = "COL-001";
     private static readonly DateOnly FechaInicioVinculacionVigente = new(2026, 1, 15);

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ValueObjects/IdentificacionIgualdadTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ValueObjects/IdentificacionIgualdadTests.cs
@@ -1,20 +1,24 @@
-// HU-348: Igualdad por valor de Identificacion (CA-1, CA-5).
+// HU-348: Igualdad por valor de Identificacion.
+// Issue #381 (CA-3): la limpieza del numero (elimina no-alfanumerico, letras a MAYUSCULAS)
+// REEMPLAZA la normalizacion trim+MAYUSCULAS de #348 -- ahora "AB-123" y "ab123" son la MISMA
+// identidad porque ambos limpian a "AB123", no porque el guion se conserve entre ambos.
 using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
 
 namespace Bitakora.ControlAsistencia.Colaboradores.Tests.ValueObjects;
 
 /// <summary>
 /// Hereda los 8 tests de IgualdadTestBase que verifican el contrato IEquatable completo.
-/// CA-1: la normalizacion (trim + MAYUSCULAS) hace que " ab-123 " y "AB-123" sean la misma
-/// identidad. CA-5: CC:123 != CE:123 (difiere el tipo).
+/// CA-3: la limpieza (elimina no-alfanumerico + MAYUSCULAS) hace que "AB-123" y "ab123" sean la
+/// misma identidad (ambos limpian a "AB123"). El tipo tambien participa en la igualdad: CC-AB123
+/// != CE-AB123.
 /// </summary>
 public class IdentificacionIgualdadTests : IgualdadTestBase<Identificacion>
 {
     protected override Identificacion CrearInstancia() =>
-        Identificacion.Crear(TipoIdentificacion.CC, " ab-123 ");
+        Identificacion.Crear(TipoIdentificacion.CC, "AB-123");
 
     protected override Identificacion CrearInstanciaCopia() =>
-        Identificacion.Crear(TipoIdentificacion.CC, "AB-123");
+        Identificacion.Crear(TipoIdentificacion.CC, "ab123");
 
     protected override IEnumerable<(string, Identificacion)> CrearInstanciasDiferentes()
     {

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ValueObjects/IdentificacionSerializacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ValueObjects/IdentificacionSerializacionTests.cs
@@ -4,6 +4,9 @@
 // arma localmente con Identificacion.ConfigurarSerializacion, igual que
 // Programacion.Tests/ValueObjects/SubFranjaSerializacionTests.cs hace con SubFranja antes de que
 // un evento persistido la reclame como payload.
+// Issue #381 (CA-5): el numero persistido y rehidratado es SIEMPRE el YA LIMPIO -- la limpieza es
+// invariante del VO (se aplica en Crear), asi que lo que llega a JSON nunca contiene el original
+// con caracteres invalidos.
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
 using AwesomeAssertions;
@@ -46,6 +49,26 @@ public class IdentificacionSerializacionTests
         restaurado.Numero.Should().Be("AB1234567");
     }
 
+    // CA-5: el numero persistido y rehidratado es el YA LIMPIO -- Crear limpia ANTES de que el VO
+    // exista, asi que el JSON nunca ve el original con espacios/guiones/puntos.
+    [Fact]
+    public void RoundTrip_PersisteYRehidrataElNumeroYaLimpio_CuandoElOriginalTraiaCaracteresInvalidos()
+    {
+        var original = Identificacion.Crear(TipoIdentificacion.CC, " ab-12.3 ");
+        var opciones = CrearOpciones();
+
+        var json = JsonSerializer.Serialize(original, opciones);
+        var restaurado = JsonSerializer.Deserialize<Identificacion>(json, opciones);
+
+        using var documento = JsonDocument.Parse(json);
+        documento.RootElement.GetProperty("numero").GetString().Should().Be("AB123",
+            "el numero persistido debe ser el ya limpio, nunca el original con caracteres invalidos");
+
+        restaurado.Should().NotBeNull();
+        restaurado!.Numero.Should().Be("AB123");
+        restaurado.ToString().Should().Be("CC-AB123");
+    }
+
     // El contrato central de TipoIdentificacion es la FORMA de lo persistido, no solo que el
     // round-trip cierre: "lo persistido es SIEMPRE el codigo literal, jamas un numero" (issue #348,
     // razon por la que el tipo no es un enum C#). El round-trip de arriba pasaria en verde aunque
@@ -81,7 +104,7 @@ public class IdentificacionSerializacionTests
         var restaurado = JsonSerializer.Deserialize<Identificacion>(jsonCorrupto, CrearOpciones());
 
         restaurado.Should().Be(Identificacion.Crear(TipoIdentificacion.CC, "1098765432"));
-        restaurado!.ToString().Should().Be("CC:1098765432", "la clave de stream siempre es la canonica");
+        restaurado!.ToString().Should().Be("CC-1098765432", "la clave de stream siempre es la canonica");
     }
 
     // Barrera anti-regresion: sin el resolver custom (equivalente a olvidar registrar el VO), STJ

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ValueObjects/IdentificacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ValueObjects/IdentificacionTests.cs
@@ -49,9 +49,11 @@ public class IdentificacionTests
         identificacion.Numero.Should().Be("79543210");
     }
 
-    // Desviacion documentada respecto a la propuesta del planner: el issue deja explicito que el
-    // alcance de "letras" es alfanumerico ASCII ([A-Z0-9]) -- una letra acentuada o una enie es
-    // caracter invalido y se elimina igual que un guion, no se conserva como letra valida.
+    // Fija el alcance exacto de "letras" que el issue #381 deja explicito: alfanumerico ASCII
+    // ([A-Z0-9]) -- una letra acentuada o una enie es caracter invalido y se elimina igual que un
+    // guion, no se conserva como letra valida. No es una desviacion del plan: es la regla del
+    // issue, clavada aqui para que una implementacion con char.IsLetterOrDigit (que SI acepta
+    // no-ASCII) falle en vez de pasar en verde.
     [Fact]
     public void Crear_EliminaLetrasAcentuadasYEnies_CuandoNumeroTraeCaracteresNoAscii()
     {
@@ -105,6 +107,19 @@ public class IdentificacionTests
     public void Crear_LanzaArgumentException_CuandoNumeroSoloTraePuntos()
     {
         var act = () => Identificacion.Crear(TipoIdentificacion.CC, "..");
+
+        act.Should().ThrowExactly<ArgumentException>()
+            .WithMessage($"*{Identificacion.Mensajes.NumeroVacio}*");
+    }
+
+    // El parametro es non-nullable, pero STJ no honra las anotaciones de nulabilidad al deserializar
+    // el body de un comando: un "numeroIdentificacion": null llega aqui como null real. Este test
+    // fija que ese borde termina en el mismo ArgumentException del contrato (traducido a 400 por el
+    // endpoint), nunca en un NullReferenceException sin mensaje de dominio.
+    [Fact]
+    public void Crear_LanzaArgumentException_CuandoNumeroEsNull()
+    {
+        var act = () => Identificacion.Crear(TipoIdentificacion.CC, null!);
 
         act.Should().ThrowExactly<ArgumentException>()
             .WithMessage($"*{Identificacion.Mensajes.NumeroVacio}*");

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ValueObjects/IdentificacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ValueObjects/IdentificacionTests.cs
@@ -1,4 +1,8 @@
 // HU-348: Value object Identificacion -- compone la clave del stream de Colaborador.
+// Issue #381: separador de la llave cambia de ":" a "-"; el numero se limpia a alfanumerico ASCII
+// (letras a MAYUSCULAS, cualquier otro caracter -- incluidas letras acentuadas/enie -- se ELIMINA
+// silenciosamente). El trim de #348 queda SUBSUMIDO por la limpieza: los espacios son caracteres
+// invalidos y se eliminan igual que un guion o un punto.
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
 
@@ -9,36 +13,66 @@ namespace Bitakora.ControlAsistencia.Colaboradores.Tests.ValueObjects;
 /// </summary>
 public class IdentificacionTests
 {
-    // ---------- CA-1: normalizacion trim + MAYUSCULAS garantiza el mismo stream ----------
+    // ---------- CA-1: ToString() compone la llave con guion ----------
 
     [Fact]
-    public void Crear_NormalizaNumeroATrimYMayusculas_CuandoNumeroTraeEspaciosYMinusculas()
+    public void ToString_ComponeTipoYNumeroConGuion_CuandoIdentificacionValida()
     {
-        var identificacion = Identificacion.Crear(TipoIdentificacion.CC, " ab-123 ");
+        var identificacion = Identificacion.Crear(TipoIdentificacion.CC, "79543210");
 
-        identificacion.ToString().Should().Be("CC:AB-123");
+        identificacion.ToString().Should().Be("CC-79543210");
+    }
+
+    // ---------- CA-2: limpieza del numero (letras a MAYUSCULAS, no-alfanumerico eliminado) ----------
+
+    [Fact]
+    public void Crear_LimpiaElNumero_CuandoTraeEspaciosGuionesYPuntos()
+    {
+        var identificacion = Identificacion.Crear(TipoIdentificacion.CC, " ab-12.3 ");
+
+        identificacion.Numero.Should().Be("AB123");
     }
 
     [Fact]
-    public void ToString_ComponeTipoYNumeroConDosPuntos_CuandoIdentificacionValida()
+    public void Crear_ConvierteLetrasAMayusculas_CuandoNumeroLlegaEnMinusculas()
     {
-        var identificacion = Identificacion.Crear(TipoIdentificacion.CE, "1098765432");
-
-        identificacion.ToString().Should().Be("CE:1098765432");
-    }
-
-    // ---------- CA-2: numero alfanumerico aceptado (pasaportes traen letras) ----------
-
-    [Fact]
-    public void Crear_AceptaNumeroAlfanumerico_CuandoEsPasaporte()
-    {
-        var identificacion = Identificacion.Crear(TipoIdentificacion.PA, "AB1234567");
+        var identificacion = Identificacion.Crear(TipoIdentificacion.PA, "ab1234567");
 
         identificacion.Numero.Should().Be("AB1234567");
-        identificacion.Tipo.Should().BeSameAs(TipoIdentificacion.PA);
     }
 
-    // ---------- CA-2: numero vacio o whitespace rechazado con mensaje .resx ----------
+    [Fact]
+    public void Crear_EliminaEspaciosInternos_CuandoNumeroLosTraeEntreDigitos()
+    {
+        var identificacion = Identificacion.Crear(TipoIdentificacion.CC, "795 432 10");
+
+        identificacion.Numero.Should().Be("79543210");
+    }
+
+    // Desviacion documentada respecto a la propuesta del planner: el issue deja explicito que el
+    // alcance de "letras" es alfanumerico ASCII ([A-Z0-9]) -- una letra acentuada o una enie es
+    // caracter invalido y se elimina igual que un guion, no se conserva como letra valida.
+    [Fact]
+    public void Crear_EliminaLetrasAcentuadasYEnies_CuandoNumeroTraeCaracteresNoAscii()
+    {
+        var identificacion = Identificacion.Crear(TipoIdentificacion.PA, "AÑ123É");
+
+        identificacion.Numero.Should().Be("A123");
+    }
+
+    // ---------- CA-3: la limpieza unifica la identidad (ToString / llave del stream) ----------
+
+    [Fact]
+    public void Crear_ComponeLaMismaLlave_CuandoNumerosDifierenSoloPorCaracteresInvalidos()
+    {
+        var conGuion = Identificacion.Crear(TipoIdentificacion.CC, "AB-123");
+        var sinGuion = Identificacion.Crear(TipoIdentificacion.CC, "ab123");
+
+        conGuion.ToString().Should().Be("CC-AB123");
+        sinGuion.ToString().Should().Be("CC-AB123");
+    }
+
+    // ---------- CA-4: numero que queda vacio tras la limpieza lanza ArgumentException ----------
 
     [Fact]
     public void Crear_LanzaArgumentException_CuandoNumeroEsVacio()
@@ -58,6 +92,35 @@ public class IdentificacionTests
             .WithMessage($"*{Identificacion.Mensajes.NumeroVacio}*");
     }
 
+    [Fact]
+    public void Crear_LanzaArgumentException_CuandoNumeroSoloTraeGuiones()
+    {
+        var act = () => Identificacion.Crear(TipoIdentificacion.CC, "---");
+
+        act.Should().ThrowExactly<ArgumentException>()
+            .WithMessage($"*{Identificacion.Mensajes.NumeroVacio}*");
+    }
+
+    [Fact]
+    public void Crear_LanzaArgumentException_CuandoNumeroSoloTraePuntos()
+    {
+        var act = () => Identificacion.Crear(TipoIdentificacion.CC, "..");
+
+        act.Should().ThrowExactly<ArgumentException>()
+            .WithMessage($"*{Identificacion.Mensajes.NumeroVacio}*");
+    }
+
+    // ---------- Numero alfanumerico sin caracteres a limpiar (pasaportes traen letras) ----------
+
+    [Fact]
+    public void Crear_AceptaNumeroAlfanumerico_CuandoEsPasaporte()
+    {
+        var identificacion = Identificacion.Crear(TipoIdentificacion.PA, "AB1234567");
+
+        identificacion.Numero.Should().Be("AB1234567");
+        identificacion.Tipo.Should().BeSameAs(TipoIdentificacion.PA);
+    }
+
     // ---------- Tipo/Numero: observables de solo lectura (identidad misma, no dato intermedio) ----------
 
     [Fact]
@@ -69,10 +132,10 @@ public class IdentificacionTests
     }
 
     [Fact]
-    public void Numero_ExponeElNumeroNormalizado_CuandoIdentificacionCreada()
+    public void Numero_ExponeElNumeroYaLimpio_CuandoIdentificacionCreada()
     {
         var identificacion = Identificacion.Crear(TipoIdentificacion.CC, " ab-123 ");
 
-        identificacion.Numero.Should().Be("AB-123");
+        identificacion.Numero.Should().Be("AB123");
     }
 }

--- a/tests/Bitakora.ControlAsistencia.Projections.Tests/Colaboradores/FichaColaboradorProjectionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Projections.Tests/Colaboradores/FichaColaboradorProjectionTests.cs
@@ -40,7 +40,7 @@ public class FichaColaboradorProjectionTests
     // --- CA-1 (primera mitad): Create nace la ficha con Id y NombreCompleto ---
 
     // Create toma IEvent<ColaboradorRegistrado>, no el evento a secas: la identidad del documento
-    // es el StreamKey del stream de ColaboradorAggregateRoot ("CC:123456"), nunca recomputada a
+    // es el StreamKey del stream de ColaboradorAggregateRoot ("CC-123456"), nunca recomputada a
     // mano desde el payload (skills/projections/modelos-marten.md, ejemplo SeguimientoTurnoProjection).
     [Fact]
     public void Create_ProyectaIdYNombreCompleto_DesdeColaboradorRegistrado()
@@ -56,7 +56,7 @@ public class FichaColaboradorProjectionTests
 
         var vista = FichaColaboradorProjection.Create(evento);
 
-        vista.Id.Should().Be("CC:123456");
+        vista.Id.Should().Be("CC-123456");
         vista.NombreCompleto.Should().Be("Ana Ramirez");
     }
 
@@ -67,14 +67,14 @@ public class FichaColaboradorProjectionTests
     public void Apply_AsignaCodigoYFechaInicioYAbreLaVigencia_CuandoVinculacionIniciada()
     {
         var vistaPrevia = new FichaColaborador(
-            "CC:123456", "Ana Ramirez", string.Empty, default, CentinelaVigenciaAbierta,
+            "CC-123456", "Ana Ramirez", string.Empty, default, CentinelaVigenciaAbierta,
             [], new Dictionary<string, string>());
         var fechaInicio = new DateOnly(2026, 8, 1);
         var evento = new VinculacionIniciada("EMP-001", fechaInicio);
 
         var vista = FichaColaboradorProjection.Apply(evento, vistaPrevia);
 
-        vista.Id.Should().Be("CC:123456");
+        vista.Id.Should().Be("CC-123456");
         vista.NombreCompleto.Should().Be("Ana Ramirez");
         vista.CodigoColaborador.Should().Be("EMP-001");
         vista.VigenteDesde.Should().Be(fechaInicio);
@@ -89,7 +89,7 @@ public class FichaColaboradorProjectionTests
     public void Apply_CierraLaVigencia_CuandoVinculacionTerminada()
     {
         var vistaPrevia = new FichaColaborador(
-            "CC:123456", "Ana Ramirez", "EMP-001", new DateOnly(2026, 8, 1), CentinelaVigenciaAbierta,
+            "CC-123456", "Ana Ramirez", "EMP-001", new DateOnly(2026, 8, 1), CentinelaVigenciaAbierta,
             [], new Dictionary<string, string>());
         var fechaEfectiva = new DateOnly(2026, 9, 30);
         var evento = new VinculacionTerminada(fechaEfectiva);
@@ -98,7 +98,7 @@ public class FichaColaboradorProjectionTests
 
         vista.VigenteHasta.Should().Be(fechaEfectiva);
         // El resto de la ficha (identidad, codigo y fecha de inicio) no cambia con la terminacion.
-        vista.Id.Should().Be("CC:123456");
+        vista.Id.Should().Be("CC-123456");
         vista.CodigoColaborador.Should().Be("EMP-001");
         vista.VigenteDesde.Should().Be(new DateOnly(2026, 8, 1));
     }
@@ -109,7 +109,7 @@ public class FichaColaboradorProjectionTests
     public void Apply_ReabreLaVigencia_CuandoTerminacionAnulada()
     {
         var vistaPrevia = new FichaColaborador(
-            "CC:123456", "Ana Ramirez", "EMP-001", new DateOnly(2026, 8, 1), new DateOnly(2026, 9, 30),
+            "CC-123456", "Ana Ramirez", "EMP-001", new DateOnly(2026, 8, 1), new DateOnly(2026, 9, 30),
             [], new Dictionary<string, string>());
         var evento = new TerminacionAnulada();
 
@@ -126,7 +126,7 @@ public class FichaColaboradorProjectionTests
     public void Apply_ReemplazaElNombreCompleto_CuandoNombresCorregidos()
     {
         var vistaPrevia = new FichaColaborador(
-            "CC:123456", "Ana Ramirez", "EMP-001", new DateOnly(2026, 8, 1), CentinelaVigenciaAbierta,
+            "CC-123456", "Ana Ramirez", "EMP-001", new DateOnly(2026, 8, 1), CentinelaVigenciaAbierta,
             [], new Dictionary<string, string>());
         var nombreCorregido = NombreColaborador.Crear("Ana Maria", null, "Ramirez", "Solano");
         var evento = new NombresCorregidos(nombreCorregido);
@@ -134,7 +134,7 @@ public class FichaColaboradorProjectionTests
         var vista = FichaColaboradorProjection.Apply(evento, vistaPrevia);
 
         vista.NombreCompleto.Should().Be("Ana Maria Ramirez Solano");
-        vista.Id.Should().Be("CC:123456");
+        vista.Id.Should().Be("CC-123456");
         vista.CodigoColaborador.Should().Be("EMP-001");
     }
 
@@ -144,7 +144,7 @@ public class FichaColaboradorProjectionTests
     public void Apply_ReemplazaVigenteDesde_CuandoFechaInicioVinculacionCorregida()
     {
         var vistaPrevia = new FichaColaborador(
-            "CC:123456", "Ana Ramirez", "EMP-001", new DateOnly(2026, 8, 1), CentinelaVigenciaAbierta,
+            "CC-123456", "Ana Ramirez", "EMP-001", new DateOnly(2026, 8, 1), CentinelaVigenciaAbierta,
             [], new Dictionary<string, string>());
         var fechaCorregida = new DateOnly(2026, 7, 15);
         var evento = new FechaInicioVinculacionCorregida(fechaCorregida);
@@ -164,7 +164,7 @@ public class FichaColaboradorProjectionTests
     public void Apply_AgregaLaEtiquetaEnAmbasEstructuras_CuandoEtiquetaAsignadaEsUnaCategoriaNueva()
     {
         var vistaPrevia = new FichaColaborador(
-            "CC:123456", "Ana Ramirez", "EMP-001", new DateOnly(2026, 8, 1), CentinelaVigenciaAbierta,
+            "CC-123456", "Ana Ramirez", "EMP-001", new DateOnly(2026, 8, 1), CentinelaVigenciaAbierta,
             [new EtiquetaFicha("sede", "Suba")],
             new Dictionary<string, string> { ["sede"] = "suba" });
         var evento = new EtiquetaAsignada(Etiqueta.Crear("Área", "Tecnología"));
@@ -190,7 +190,7 @@ public class FichaColaboradorProjectionTests
     public void Apply_SobrescribeElValorDeLaCategoria_CuandoEtiquetaAsignadaReutilizaLaMismaCategoriaNormalizada()
     {
         var vistaPrevia = new FichaColaborador(
-            "CC:123456", "Ana Ramirez", "EMP-001", new DateOnly(2026, 8, 1), CentinelaVigenciaAbierta,
+            "CC-123456", "Ana Ramirez", "EMP-001", new DateOnly(2026, 8, 1), CentinelaVigenciaAbierta,
             [new EtiquetaFicha("Área", "Tecnología")],
             new Dictionary<string, string> { ["area"] = "tecnologia" });
         var evento = new EtiquetaAsignada(Etiqueta.Crear("area", "Sistemas"));
@@ -209,7 +209,7 @@ public class FichaColaboradorProjectionTests
     public void Apply_RemueveSoloLaCategoriaIndicada_CuandoEtiquetaRetirada()
     {
         var vistaPrevia = new FichaColaborador(
-            "CC:123456", "Ana Ramirez", "EMP-001", new DateOnly(2026, 8, 1), CentinelaVigenciaAbierta,
+            "CC-123456", "Ana Ramirez", "EMP-001", new DateOnly(2026, 8, 1), CentinelaVigenciaAbierta,
             [new EtiquetaFicha("area", "Sistemas"), new EtiquetaFicha("sede", "Suba")],
             new Dictionary<string, string> { ["area"] = "sistemas", ["sede"] = "suba" });
         var evento = new EtiquetaRetirada("area");
@@ -230,7 +230,7 @@ public class FichaColaboradorProjectionTests
     public void Apply_NaceLimpio_CuandoVinculacionIniciadaEsUnReingresoConEtiquetasPrevias()
     {
         var vistaPrevia = new FichaColaborador(
-            "CC:123456", "Ana Ramirez", "EMP-001", new DateOnly(2025, 1, 1), new DateOnly(2025, 12, 31),
+            "CC-123456", "Ana Ramirez", "EMP-001", new DateOnly(2025, 1, 1), new DateOnly(2025, 12, 31),
             [new EtiquetaFicha("area", "Sistemas")],
             new Dictionary<string, string> { ["area"] = "sistemas" });
         var nuevaFechaInicio = new DateOnly(2026, 3, 1);
@@ -238,7 +238,7 @@ public class FichaColaboradorProjectionTests
 
         var vista = FichaColaboradorProjection.Apply(evento, vistaPrevia);
 
-        vista.Id.Should().Be("CC:123456");
+        vista.Id.Should().Be("CC-123456");
         vista.NombreCompleto.Should().Be("Ana Ramirez");
         vista.CodigoColaborador.Should().Be("EMP-002");
         vista.VigenteDesde.Should().Be(nuevaFechaInicio);

--- a/tests/Bitakora.ControlAsistencia.Projections.Tests/ConfiguracionMartenProjectionsTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Projections.Tests/ConfiguracionMartenProjectionsTests.cs
@@ -406,7 +406,8 @@ public class ConfiguracionMartenProjectionsTests
             .DeserializarConResolverDeSerializacionCustom(evento);
 
         restaurado.Should().NotBeNull();
-        restaurado.Identificacion.ToString().Should().Be("CC:79543210");
+        // Issue #381: el separador de la llave de Identificacion cambia de ":" a "-".
+        restaurado.Identificacion.ToString().Should().Be("CC-79543210");
         restaurado.Nombre.NombreCompleto.Should().Be("Luis Augusto Barreto Prieto");
     }
 


### PR DESCRIPTION
## Resumen

Pipeline TDD completado:
- Fase roja: tests escritos con stubs
- Fase verde: implementación completa
- Fase refactor: revisión de calidad

## Decisiones del pipeline

<details>
<summary>Test Writer (fase roja) — 7m 48s</summary>

## ES Test Writer - Decisiones (Issue #381)

### Tests creados/actualizados

- `ValueObjects/IdentificacionTests.cs` (reescrito): 15 tests
  - `ToString_ComponeTipoYNumeroConGuion_CuandoIdentificacionValida` - CA-1
  - `Crear_LimpiaElNumero_CuandoTraeEspaciosGuionesYPuntos` - CA-2
  - `Crear_ConvierteLetrasAMayusculas_CuandoNumeroLlegaEnMinusculas` - CA-2
  - `Crear_EliminaEspaciosInternos_CuandoNumeroLosTraeEntreDigitos` - CA-2
  - `Crear_EliminaLetrasAcentuadasYEnies_CuandoNumeroTraeCaracteresNoAscii` - alcance ASCII de "letras" (nota del issue)
  - `Crear_ComponeLaMismaLlave_CuandoNumerosDifierenSoloPorCaracteresInvalidos` - CA-3
  - `Crear_LanzaArgumentException_CuandoNumeroEsVacio` - CA-4 (conservado de #348)
  - `Crear_LanzaArgumentException_CuandoNumeroEsWhitespace` - CA-4 (conservado de #348)
  - `Crear_LanzaArgumentException_CuandoNumeroSoloTraeGuiones` - CA-4 ("---")
  - `Crear_LanzaArgumentException_CuandoNumeroSoloTraePuntos` - CA-4 ("..")
  - `Crear_AceptaNumeroAlfanumerico_CuandoEsPasaporte` - conservado de #348 (numero ya limpio)
  - `Tipo_ExponeElTipoDeIdentificacion_CuandoIdentificacionCreada` - conservado de #348
  - `Numero_ExponeElNumeroYaLimpio_CuandoIdentificacionCreada` - actualizado a la nueva expectativa

- `ValueObjects/IdentificacionIgualdadTests.cs` (actualizado): `CrearInstancia`/`CrearInstanciaCopia`
  ahora usan "AB-123" / "ab123" (ambos limpian a "AB123") en vez de la vieja pareja
  trim+MAYUSCULAS, para que los 8 tests heredados de `IgualdadTestBase<T>` ejerzan CA-3
  correctamente.

- `ValueObjects/IdentificacionSerializacionTests.cs` (actualizado): agrega
  `RoundTrip_PersisteYRehidrataElNumeroYaLimpio_CuandoElOriginalTraiaCaracteresInvalidos` (CA-5) y
  corrige el separador en `Deserializar_RehidrataAlTipoCanonico_...` ("CC:1098765432" ->
  "CC-1098765432").

- 8 `*CommandHandlerTests.cs` + `ComposicionAnularYTerminarVinculacionTests.cs` (Colaboradores):
  literal `StreamIdEsperado`/comentarios de "CC:79543210" -> "CC-79543210" (sin cambio de
  comportamiento probado, solo el formato de la llave que estos tests ya fijaban como oraculo
  independiente).

- `RegistrarColaboradorFunction/Eventos/ColaboradorRegistradoSerializacionTests.cs`: literal
  `"CC:79543210"` -> `"CC-79543210"` en la asercion de `Identificacion.ToString()`.

- `Bitakora.ControlAsistencia.Projections.Tests/ConfiguracionMartenProjectionsTests.cs`: literal
  `"CC:79543210"` -> `"CC-79543210"` en `ConfigurarColaboradores_ConservaElResolverDeSerializacionCustom`.

### Estructura elegida

- Una clase por archivo existente (sin nested classes nuevas): el issue no introduce comando ni
  handler nuevo, solo cambia el comportamiento de un VO ya existente (`Identificacion`) que
  compone el streamId. Se preservo la organizacion previa de #348/#354 en los tres archivos de
  `ValueObjects/`.
- No se crearon stubs de produccion: `Identificacion.cs` ya existe (no es un tipo nuevo). Los
  tests fallan hoy porque la produccion actual todavia usa ":" y no limpia el numero -- eso es
  exactamente la fase roja esperada; el implementer cambia `Crear`/`ToString`, no yo.

### Stubs creados

Ninguno. Este issue no introduce comando, evento, aggregate ni handler nuevo (declarado
explicitamente en "Modelo de eventos" del issue) -- solo cambia el comportamiento de
`Identificacion.Crear`/`ToString`, que ya existe en produccion. No hay tipos nuevos que
compilar via stub.

### Decisiones de diseno

- La limpieza (CA-2) se probo con casos separados por preocupacion (espacios, guiones/puntos,
  mayusculas, espacios internos, caracteres no-ASCII) ademas del ejemplo compuesto del propio
  issue (`" ab-12.3 "` -> `"AB123"`), para que una implementacion parcial (ej. solo trim, o solo
  mayusculas) falle en el test especifico que no cubre, no solo en el compuesto.
- Se agrego `Crear_EliminaLetrasAcentuadasYEnies_CuandoNumeroTraeCaracteresNoAscii` siguiendo la
  nota de la "Interfaz publica propuesta" del issue: el alcance de "letras" es alfanumerico ASCII
  ([A-Z0-9]); una eñe o vocal acentuada se elimina igual que un guion. No encontre un
  contraejemplo real de documento de identidad colombiano con letra no-ASCII en el numero (el PILA
  solo define CC/CE/TI/PA/PT, y los pasaportes colombianos e internacionales de uso comun no usan
  diacriticos en el numero), asi que se siguio la propuesta del planner sin desviacion, fijandola
  con un test explicito.
- `IdentificacionIgualdadTests`: se reemplazo la pareja "trim+MAYUSCULAS" (" ab-123 "/"AB-123")
  por "AB-123"/"ab123" -- bajo el nuevo contrato ambas limpian a "AB123" por razones distintas
  (una por el guion, otra por el casing), lo cual ejercita CA-3 con mas fidelidad que dejar la
  pareja vieja (que tambien seguiria dando igual, pero por trim, no por la limpieza nueva).

### Cobertura de criterios

| Criterio de aceptacion | Test(s) |
|---|---|
| CA-1: separador guion en ToString() | `ToString_ComponeTipoYNumeroConGuion_CuandoIdentificacionValida` |
| CA-2: limpieza sin error (elimina no-alfanumerico, MAYUSCULAS) | `Crear_LimpiaElNumero_CuandoTraeEspaciosGuionesYPuntos`, `Crear_ConvierteLetrasAMayusculas_CuandoNumeroLlegaEnMinusculas`, `Crear_EliminaEspaciosInternos_CuandoNumeroLosTraeEntreDigitos` |
| CA-3: la limpieza unifica la identidad (Equals/GetHashCode + misma llave) | `Crear_ComponeLaMismaLlave_CuandoNumerosDifierenSoloPorCaracteresInvalidos` + los 8 tests heredados de `IdentificacionIgualdadTests` |
| CA-4: numero vacio tras limpieza lanza ArgumentException | `Crear_LanzaArgumentException_CuandoNumeroSoloTraeGuiones`, `Crear_LanzaArgumentException_CuandoNumeroSoloTraePuntos`, `Crear_LanzaArgumentException_CuandoNumeroEsVacio`, `Crear_LanzaArgumentException_CuandoNumeroEsWhitespace` |
| CA-5: round-trip persiste/rehidrata el numero ya limpio | `RoundTrip_PersisteYRehidrataElNumeroYaLimpio_CuandoElOriginalTraiaCaracteresInvalidos` |

### Desviaciones del plan del planner

| Sugerencia del issue | Desviacion aplicada | Razon tecnica | Consecuencia |
|---|---|---|---|
| "Impacto/Modifica": no menciona `Bitakora.ControlAsistencia.Projections.Tests/ConfiguracionMartenProjectionsTests.cs` | Se actualizo igual el literal `"CC:79543210"` -> `"CC-79543210"` en ese archivo | Ese test tambien asersiona `Identificacion.ToString()` (mismo contrato que cambia); dejarlo con el separador viejo lo habria dejado en un estado inconsistente: pasaria hoy (falso verde) y quedaria roto sin relacion aparente con este issue una vez el implementer cambie `ToString()` | Cubierto: el literal ya refleja el nuevo contrato; sin este archivo el pipeline hubiera reportado un test roto "misterioso" fuera del dominio Colaboradores.Tests, dificil de rastrear al issue #381 |
| El issue lista "smoke tests... ~6 archivos: actualizar el literal" como parte del impacto en tests | NO se tocaron los smoke tests (7 archivos en `Colaboradores.SmokeTests/` con `$"{cc}:{numero}"`) | Los smoke tests son responsabilidad exclusiva de `smoke-test-writer` (Stage 2b del pipeline), no del test-writer (Stage 1). Ademas, el pipeline solo dispara Stage 2b si el diff incluye archivos bajo una carpeta `Function/` -- este issue no toca ningun endpoint, asi que Stage 2b se saltara automaticamente ("No se detectaron Function Apps modificadas") | Riesgo declarado, no resuelto por mi: los smoke tests quedaran con el separador viejo tras este issue salvo que el reviewer (Stage 3) o una intervencion manual los actualice. Lo señalo aqui para que no se pierda -- no es una contradiccion que yo pueda resolver dentro de mi alcance (test-writer no escribe smoke tests) |

</details>

<details>
<summary>Implementer (fase verde) — 4m 17s</summary>

## ES Implementer - Decisiones

### Enfoque de implementacion
Cambio acotado a `Identificacion` (unico punto de conversion de la llave del stream de
`ColaboradorAggregateRoot`, MEF-ADR-0037):

- `ToString()`: separador de `":"` a `"-"` -- `"{Tipo}-{Numero}"`.
- `Crear(tipo, numero)`: reemplaza la normalizacion `trim + ToUpperInvariant()` de #348 por una
  limpieza alfanumerica ASCII -- `numero.Where(char.IsAsciiLetterOrDigit).Select(char.ToUpperInvariant)`
  reconstruido en un `string` nuevo. La validacion de vacio se mueve a *despues* de la limpieza
  (`numeroLimpio.Length == 0`), reusando el mismo `Mensajes.NumeroVacio` -- no hay excepcion por
  caracteres invalidos, se eliminan en silencio antes de registrar (tal como pide el issue).

`ComputarStreamId` de `ColaboradorAggregateRoot` no se toco: sigue delegando en `Identificacion.ToString()`
sin recomponer nada a mano, el cambio de separador se propaga automaticamente.

### Decisiones de diseno
- Se uso LINQ (`Where`/`Select`) en vez de un bucle `for`/`foreach` para la limpieza del numero,
  siguiendo la regla del harness de preferir LINQ sobre iteracion manual.
- `char.IsAsciiLetterOrDigit` (predicado de .NET) fija el alcance exacto pedido por el issue:
  alfanumerico ASCII -- una letra acentuada o una enie no pasa el filtro y se elimina, igual que un
  guion o un espacio. Se evito una regex (`Regex.Replace`) porque el predicado por caracter es mas
  directo aqui y no requiere compilar un patron.
- `numero ?? string.Empty` como guarda defensiva minima: el issue y los tests no ejercitan `null`
  explicitamente, pero evita un `NullReferenceException` no controlado si algun llamador futuro pasa
  `null` -- el comportamiento resultante (numero vacio -> `ArgumentException` con `Mensajes.NumeroVacio`)
  es coherente con el resto del contrato.
- Los remarks XML de `Identificacion` y el comentario de cabecera de `ColaboradorAggregateRoot.cs` se
  actualizaron para reflejar el nuevo contrato ("-" en vez de ":", limpieza en vez de solo trim),
  segun lo pedido explicitamente en "Notas tecnicas" del issue.

### ADRs consultados
- MEF-ADR-0012: modelado del VO -- la limpieza es invariante del VO (se aplica en `Crear`, antes de
  que la instancia exista), no un truco de base de datos ni una validacion de forma en el borde HTTP.
  `ConfigurarSerializacion` no cambio: el resolver ya opera sobre `_numero` como campo privado, y el
  valor que persiste es siempre el ya limpio (verificado por CA-5 / `IdentificacionSerializacionTests`).
- MEF-ADR-0037: punto unico de conversion de la identidad de stream. El separador vive exclusivamente
  en `Identificacion.ToString()`; no se toco `ComputarStreamId` ni ningun handler/endpoint que
  recomponga la llave.
- MEF-ADR-0009: se reuso `Mensajes.NumeroVacio` existente (`Identificacion.Mensajes.cs` /
  `IdentificacionMensajes.resx`) -- no se creo mensaje nuevo, tal como fija el issue.
- MEF-ADR-0016: no aplica directamente (no se escribieron tests), pero se verifico que los tests del
  test-writer siguen la convencion `<Sujeto>_<LoQuePasa>_Cuando<Condicion>`.
- MEF-ADR-0013: smoke tests contra dev -- ver seccion "Complejidad encontrada" abajo, gap detectado
  pero no resuelto por este agente.

### Desviaciones de ADRs
Ninguna desviacion -- todos los ADRs aplicados al pie de la letra.

### Desviaciones del plan del planner
Ninguna -- la propuesta del planner (limpiar con `char.IsAsciiLetterOrDigit` o regex, criterio
alfanumerico ASCII estricto) se siguio literalmente. No hubo contraejemplo real de documento con
letra no-ASCII que ameritara desviacion (el propio issue ya preveia esa posibilidad y no aplico).

### Precedentes consultados
- `Identificacion.cs` previo a este issue (`trim + ToUpperInvariant` + `IsNullOrWhiteSpace`, del
  issue #348): alineado con MEF-ADR-0012, se reemplazo su logica de normalizacion sin heredar ningun
  patron incorrecto.
- Patron de resolver `ConfigurarSerializacion` (patron "SubFranja" citado en el propio archivo): no
  se toco, ya alineado con MEF-ADR-0012 (ctor privado + reflexion sobre campos, sin `[JsonConstructor]`).

### Infraestructura modificada
Ninguna -- este issue no introduce comando, evento ni topic/subscription nuevos (confirmado en la
seccion "Modelado de eventos" del issue).

### Complejidad encontrada
- **Gap detectado, no resuelto por este agente (fuera de mi rol)**: el issue ("Notas tecnicas" e
  "Impacto esperado en archivos") esperaba que los smoke tests de Colaboradores
  (`tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/*`, 8 archivos) actualizaran la
  recomposicion manual de la llave `$"{TipoIdentificacionCc}:{numeroIdentificacion}"` a `"-"`. El
  test-writer **no** modifico esos archivos (no aparecen en la lista de archivos entregada a este
  agente), y mi regla absoluta es "Nunca modificas tests". No los toque. Efecto: hoy compilan y
  pasan en verde localmente porque estan `omitido` (requieren el entorno dev real, MEF-ADR-0013),
  pero si se ejecutaran contra dev con este cambio desplegado, fallarian porque la llave real que
  arma el backend ahora es `"CC-<numero>"` y el smoke test sigue comparando/armando contra
  `"CC:<numero>"`. Reportar para seguimiento: hace falta que el smoke-test-writer (o una pasada de
  `/implement` posterior) actualice esos 8 literales antes de correr smoke tests contra dev para
  este flujo.
- El resto de la implementacion fue directo: un solo VO, dos miembros con comportamiento nuevo, sin
  ambiguedad en los tests del test-writer.

### Resultado
- Tests pasando: 1233/1233 (suite completa, `dotnet test --solution ControlAsistencias.slnx`), 46
  omitidos (smoke tests contra dev, esperado sin conexion al entorno).
- Tests del proyecto `Bitakora.ControlAsistencia.Colaboradores.Tests`: 302/302.

</details>
<details>
<summary>Reviewer (fase refactor) — 14m 44s</summary>

## ES Reviewer - Revision

### Evaluacion general
- Calidad: **aceptable** (el nucleo del cambio es correcto y elegante; habia un gap bloqueante declarado
  pero no resuelto por las fases anteriores, mas documentacion obsoleta derivada del propio cambio)
- Cambios realizados: **si** (commit `77bbe4d`)
- Suite: 1234/1234 verde, 46 omitidos (smoke tests sin entorno dev, esperado). Baseline al iniciar la
  revision: 1233 verde, 0 rojos -- no hubo bloqueo heredado, no existe `blockage-report.md`.

### Cumplimiento de ADRs aplicables

| ADR | Cumplimiento | Observacion |
|---|---|---|
| MEF-ADR-0012: modelado del VO | ok | `Identificacion` sigue siendo `sealed class` con `IEquatable<T>` manual (no `record`, correcto), ctor privado real + ctor vacio para STJ/Marten, factory `Crear` con la invariante, `ConfigurarSerializacion` con resolver + campos por reflexion. **Sin `[JsonConstructor]`**. La limpieza se aplica en `Crear`, antes de que la instancia exista: es invariante del VO, no validacion de forma en el borde ni truco de base de datos. Recorri el checklist completo de 7 antipatrones: ninguno presente (detalle abajo). |
| MEF-ADR-0037: punto unico de conversion | ok | El separador vive **solo** en `Identificacion.ToString()`. `ComputarStreamId` no cambio de codigo (delega). Verifique los 8 CommandHandlers del dominio: todos entran por `ColaboradorAggregateRoot.ComputarStreamId(identificacion)`, ninguno concatena. Sin `GroupId` (Colaboradores no publica al bus). |
| MEF-ADR-0009: mensajes en `.resx` | ok, con correccion del reviewer | Se reuso la clave `NumeroVacio` existente, no se creo mensaje nuevo (como exige el issue). **Pero el texto quedo factualmente incompleto**: ver "Criticas y hallazgos" #3. Corregido sobre la misma clave. |
| MEF-ADR-0016: naming de tests | ok | Todos los tests nuevos/renombrados siguen `<Sujeto>_<LoQuePasa>[_Cuando<Condicion>]` con el sujeto = miembro bajo prueba (`ToString_...`, `Crear_...`, `Numero_...`). Solo `[Fact]`, ningun `[Theory]`. |
| MEF-ADR-0013: smoke tests contra dev | **desviacion NO declarada -> corregida** | Los 8 smoke tests de Colaboradores seguian recomponiendo la llave con `":"`. Ver "Desviaciones detectadas por el reviewer". |

### Desviaciones de ADRs

**Desviaciones declaradas por el implementer** (de `stage-2-implementer.md`):

Ninguna. El implementer declaro explicitamente "Ninguna desviacion -- todos los ADRs aplicados al pie de
la letra", y lo verifique contra el diff: es cierto para el codigo que si toco.

Lo que el implementer **si** declaro fue un **gap de alcance**, no una desviacion: en "Complejidad
encontrada" dejo escrito que los smoke tests quedaban con el separador viejo y que su regla absoluta
("nunca modificas tests") le impedia tocarlos. El test-writer lo declaro simetricamente en su tabla de
desviaciones del plan ("los smoke tests son responsabilidad de `smoke-test-writer`, Stage 2b, que no se
dispara porque el diff no toca ninguna carpeta `Function/`"). **Ambos tenian razon en su alcance
individual, y el resultado combinado era un issue incompleto**: el pipeline no tenia ninguna etapa que
lo cerrara salvo esta. Evaluacion: los dos reportes son correctos y bien razonados; el defecto es de
reparto de responsabilidades del pipeline, no de juicio de los agentes.

**Desviaciones detectadas por el reviewer (NO declaradas)**:

#### Desviacion: MEF-ADR-0013 (+ "Notas tecnicas" del issue)
- **Regla del ADR**: los smoke tests verifican el comportamiento real contra el entorno dev; el issue
  ademas lo pide literal -- *"En los smoke tests la llave se recompone a mano (`$"{cc}:{numero}"`) en ~6
  archivos: actualizar el literal, sin introducir nuevos puntos de conversion"*, y lista
  `Colaboradores.SmokeTests/*` en "Impacto esperado en archivos".
- **Desviacion encontrada en el diff**: 8 archivos (no 6) seguian con `$"{TipoIdentificacionCc}:{numeroIdentificacion}"`:
  `RegistrarColaborador`, `TerminarVinculacion`, `ReingresarColaborador`, `AnularTerminacion`,
  `CorregirNombres`, `CorregirFechaInicioVinculacion`, `AsignarEtiqueta`, `RetirarEtiqueta`. Mas ~14
  comentarios con `"CC:<numero>"` / `"{Tipo}:{Numero}"`.
- **Por que no lo caza ningun test**: los smoke tests estan `omitido` sin `Postgres__ConnectionString`,
  asi que la suite quedaba **verde con el defecto adentro** -- exactamente el falso verde que el issue
  advierte. El sintoma real habria aparecido tras el deploy a dev: el backend escribiendo `CC-<numero>`
  y el smoke test buscando `CC:<numero>` en `mt_events`, con un fallo cuya causa no apunta al codigo.
- **Accion tomada**: corregida. Los 8 literales pasan a `"-"`, los comentarios al nuevo contrato.
  Mantuve la recomposicion manual (no la sustitui por `Identificacion.ToString()`): es el **oraculo
  independiente** que exige MEF-ADR-0002 -- derivarla del codigo bajo prueba haria que un cambio futuro
  de formato se auto-valide. Es lo que el issue pide con "sin introducir nuevos puntos de conversion".
  Anadi en cada archivo la nota de por que la llave esperada sigue siendo valida: el numero sintetico se
  genera con `Guid...ToString("N").ToUpperInvariant()`, ya alfanumerico ASCII, asi que sobrevive intacto
  a la limpieza de #381. Si alguien lo cambiara a `ToString("D")`, los guiones se eliminarian y el
  oraculo divergiria en silencio.
- **Status**: pendiente de evaluacion del usuario

#### Desviacion: documentacion de produccion contradictoria con el contrato nuevo
- **Regla**: no hay ADR que gobierne comentarios, pero un comentario que documenta una premisa **falsa**
  es peor que ninguno (objetivo de elegancia: limpieza/legibilidad). El propio issue pide en "Notas
  tecnicas" actualizar el comentario analogo de `ColaboradorAggregateRoot.cs` -- mismo criterio.
- **Desviacion encontrada**: 12 archivos de produccion (7 `FunctionEndpoint.cs` + 5 records de comando)
  afirman que *"la identificacion viaja en el body porque su representacion ("CC:79543210") contiene
  ":", hostil como segmento de URL"*. Tras #381 esa frase es doblemente falsa: la representacion ya no
  contiene `":"`, y la razon citada es justo la que este issue **elimina** para habilitar #378.
- **Accion tomada**: corregida. Fije el hecho vigente (`"CC-79543210"`) y reformule la razon como
  *"decision vigente hasta #378 (rutas orientadas a recurso)"*. **No re-decidi el diseno**: donde viaja
  la identificacion le corresponde a #378, no a esta revision.
- **Status**: pendiente de evaluacion del usuario

### Precedentes consultados por el implementer

| Precedente | ADR aplicable | Veredicto |
|---|---|---|
| `Identificacion.cs` previo (#348: `trim + ToUpperInvariant` + `IsNullOrWhiteSpace`) | MEF-ADR-0012 | alineado -- se reemplazo su logica sin heredar ningun patron incorrecto |
| Patron `ConfigurarSerializacion` "SubFranja" | MEF-ADR-0012 | alineado -- ctor privado + reflexion sobre campos, sin `[JsonConstructor]`; no se toco |

Verifique ambos directamente contra MEF-ADR-0012 (no los acepte por ser precedente): ninguno arrastra la
clase de violacion que documentan los field notes de PR 142/144/155.

### Convenciones del pipeline (no ADRs)

| Convencion | Estado | Observacion |
|---|---|---|
| Cada test con `Then()` + `And<>()` | n/a | El issue no agrega ni modifica ningun test de CommandHandler: cambia el comportamiento de un VO. Los `*CommandHandlerTests` tocados solo actualizan el literal `StreamIdEsperado`, y ya traian `Then(streamId, null, ...)` + `And<>(streamId, ...)` de #330-#355. Verificado. |
| Overloads correctos para stream IDs compuestos | ok | `ColaboradorAggregateRoot` tiene clave compuesta, y los 9 archivos de test tocados usan `Given(streamId, ...)`, `Then(streamId, null, ...)`, `And<T,P>(streamId, ...)`. Ningun overload sin `aggregateId`. |
| Fakes manuales (no NSubstitute) | n/a | No se introdujo ninguna dependencia nueva de handler. |
| Feature folders (produccion y tests) | ok | Sin archivos nuevos; la estructura espejo se conserva. |
| Smoke tests: SkipWhen, secrets, cobertura | **falla -> corregida** | Ver desviacion MEF-ADR-0013. El resto de la convencion ya se cumplia y se conserva: `Assert.SkipWhen(!postgres.IsConfigured, ...)` en todos, `appsettings.json` sin secrets, filtrado por `streamId` unico por test (no por posicion), un archivo por comando. |
| Proyecciones read-side | n/a | El diff no toca `ReadModels`/`Projections` (solo el **test** `ConfiguracionMartenProjectionsTests`, actualizando un literal). Sin read model nuevo, sin GET. |
| Antipatrones de habilitacion (MEF-ADR-0039) | n/a | `git diff main...HEAD -- '**/*.csproj'` -> **0 archivos**. Ningun tipo de evento nuevo. Ninguna de las 5 puertas (a)-(e) esta abierta. |
| Compatibilidad Marten write-side/read-side | n/a | El diff no toca la version de `Cosmos.EventSourcing.*` ni `ComposicionServicios*`/`ConfiguracionMartenProjections*.cs`/`ConfiguracionSerializacion*.cs`/`IdentidadEventos*.cs` ni ninguna linea de config de Marten. El unico archivo con "ConfiguracionMartenProjections" en el diff es su **test**, cambiando un literal de asercion. Gate no disparado: no decompile. |
| Identidad de stream (MEF-ADR-0037) | ok | Gate **si** disparado (el diff es sobre la identidad de stream). Los 3 puntos evaluados abajo. |
| Control de volumen de telemetria (MEF-ADR-0038) | n/a | El diff no toca `ComposicionServicios*`, `ConfiguracionObservabilidad*`, `AddOpenTelemetry`, `UseAzureMonitorExporter`, `SetSampler` ni `AgregarWolverineParaComandosServerless`. |
| Tests via ToString/comportamiento | ok | `IdentificacionTests` verifica por `ToString()`, `Numero` y `Tipo` -- observables que ya existian desde #348 con razon documentada (insumo del mapeo rico->plano), no getters abiertos para el test. No se expuso nada nuevo. |
| Sin numeros magicos | ok | La regla de limpieza se expresa con `char.IsAsciiLetterOrDigit` (predicado con nombre), no con rangos de codigos. Los literales de test (`"79543210"`, `"AB-123"`) son datos de ejemplo, no constantes de dominio. |
| Condiciones en positivo | ok | La unica guarda es `if (numeroLimpio.Length == 0) throw` -- guard clause con early-exit, la excepcion explicita de la regla. Sin `if`/`else` en negativo. |

#### Detalle del gate MEF-ADR-0037 (los 3 puntos)

1. **Formato explicito sobre una identidad de stream**: sin hallazgo. La clave compuesta no tiene ningun
   componente `Guid` (es `TipoIdentificacion` + `string`), asi que la regla del canonico "D" no aplica;
   dentro de `ToString()` no hay especificador ni transformacion sobre un Guid.
   **Caso que evalue y descarte deliberadamente**: los smoke tests usan
   `Guid.CreateVersion7().ToString("N").ToUpperInvariant()`. Un chequeo mecanico lo marcaria, pero **no
   es hallazgo**: ese Guid no es una identidad de stream sino la fuente de un *numero de documento*
   sintetico (dato de dominio, componente de la clave), analogo a `NuevoCodigoColaborador()`. El
   `.ToUpperInvariant()` ahi no tuerce ninguna identidad: la hace superviviente de la limpieza del VO.
2. **Construccion manual fuera de `ComputarStreamId`**: sin hallazgo en produccion -- verifique los 8
   handlers, todos delegan. En los smoke tests la recomposicion manual es deliberada y sancionada por el
   issue (oraculo independiente, MEF-ADR-0002); el checklist apunta a CommandHandler/EventHandler/
   endpoint, no a un oraculo de test.
3. **GET de read-side sin parseo**: n/a, el diff no toca ningun endpoint de consulta.

#### Detalle del checklist de antipatrones MEF-ADR-0012 (los 7)

1. Propiedad publica nueva con consumidor externo unico: **no** -- no hay miembros publicos nuevos.
2. Clase estatica operando sobre datos crudos del VO: **no** -- la limpieza vive dentro de `Crear`.
3. Getter expuesto solo para tests: **no** -- `Tipo`/`Numero` preexisten (#348) con razon documentada.
4. `InternalsVisibleTo` desde un ensamblado de eventos hacia el dominio: **no** -- sin cambios.
5. `[JsonConstructor]` en ctor privado: **no** -- `ConfigurarSerializacion` con resolver.
6. `record` con `IReadOnlyList<T>`: **n/a** -- es `sealed class` con `IEquatable` manual.
7. Evento con marker de bus cargando modelo rico: **n/a** -- ningun evento de Colaboradores implementa
   `IPrivateEvent`/`IPublicEvent` (los 7 lo declaran explicitamente en sus remarks: event-sourcing puro
   sin consumidores). `ColaboradorRegistrado` lleva `Identificacion` rica, que es **correcto** para el
   event store y no cruza ningun bus.

### Elegancia del codigo

- **El nucleo del cambio es elegante y lo dejo intacto.** `Crear` resuelve la limpieza con una expresion
  LINQ idiomatica (`Where(char.IsAsciiLetterOrDigit).Select(char.ToUpperInvariant)`), sin regex que
  compilar ni bucle manual. `char.IsAsciiLetterOrDigit` es la eleccion exacta: expresa el alcance ASCII
  del issue en el nombre del predicado, en vez de dejarlo implicito en rangos de codigos. Evalue
  compactarla a `string.Concat(...)` y **decidi no hacerlo**: `new string(...ToArray())` es igual de
  legible y el cambio seria churn sin ganancia (regla 5, no refactorizar por refactorizar).
- `ToString()` se mantiene como una sola expresion interpolada -- el contrato completo cabe en una linea.
- Complejidad algoritmica: O(n) sobre un string corto. Sin loops anidados ni trabajo dentro de bucles.
- Limpieza: `dotnet build` sin warnings nuevos (los 4 `NU1902` de `OpenTelemetry.Api` son preexistentes
  en `main` y ajenos a este dominio). Sin `Console.WriteLine`, sin codigo comentado, sin usings sobrantes
  en los archivos del diff. Sin caracteres U+2500 (verificado explicitamente).
- `dotnet format --verify-no-changes`: **ningun** hallazgo en archivos de Colaboradores. Reporta 4
  `IDE0005` (usings innecesarios) en `ControlHoras.Tests`, **preexistentes y fuera del alcance de este
  issue** -- no los toque (regla 4).

### Criticas y hallazgos

1. **[MAYOR - corregido]** Smoke tests con el separador viejo en 8 archivos. Detalle completo en
   "Desviaciones detectadas por el reviewer". Habria fallado contra dev tras el deploy, con la suite
   local en verde. Ambas fases previas lo detectaron y lo declararon con precision; ninguna podia
   resolverlo dentro de su alcance.
2. **[MAYOR - corregido]** 12 comentarios de produccion documentando una premisa que este issue elimina
   ("la representacion contiene ':', hostil como segmento de URL"). Detalle arriba.
3. **[MENOR - corregido]** `IdentificacionMensajes.resx`: el texto reusado era *"El numero de
   identificacion no puede estar vacio ni contener solo espacios"*. Tras #381 la misma excepcion se lanza
   con `"---"` o `".."`, que **no** estan vacios ni son solo espacios: el usuario recibiria un 400 cuyo
   mensaje no describe su error. Cambie el texto a *"El numero de identificacion debe contener al menos
   una letra o un digito"*, que cubre los tres casos, **sobre la misma clave `NumeroVacio`** -- el issue
   prohibe crear un mensaje nuevo, no corregir la redaccion del existente, y MEF-ADR-0009 gobierna la
   sede del mensaje (`.resx`), no su texto. Ningun test asserta el literal (todos referencian
   `Identificacion.Mensajes.NumeroVacio`), verificado antes de cambiarlo. Anadi un comentario en
   `Identificacion.Mensajes.cs` aclarando que "Vacio" en el nombre de la clave significa "vacio **tras**
   la limpieza". **Si el usuario prefiere el texto anterior, este es el punto a revertir**: es la unica
   decision de la revision con efecto observable para un cliente del API.
4. **[MENOR - corregido]** Rama sin cobertura: el implementer agrego `numero ?? string.Empty` como guarda
   defensiva y lo declaro honestamente ("el issue y los tests no ejercitan `null`"). La guarda **es
   correcta y la conserve** -- STJ no honra las anotaciones de nulabilidad al deserializar, asi que un
   `"numeroIdentificacion": null` llega como null real y sin la guarda seria un `NullReferenceException`
   en vez del `ArgumentException` con mensaje de dominio. Pero sin test es codigo que un futuro refactor
   borra por "innecesario". Agregue `Crear_LanzaArgumentException_CuandoNumeroEsNull`.
5. **[COSMETICO - corregido]** El comentario de
   `Crear_EliminaLetrasAcentuadasYEnies_CuandoNumeroTraeCaracteresNoAscii` decia "Desviacion documentada
   respecto a la propuesta del planner" y a continuacion describia **cumplimiento** de esa propuesta (el
   issue fija explicitamente el alcance ASCII). El resumen del test-writer lo reporta bien ("sin
   desviacion"); solo el comentario en codigo estaba mal redactado. Lo reescribi explicando ademas que el
   test existe para que una implementacion con `char.IsLetterOrDigit` (que **si** acepta no-ASCII) falle.
6. **[OBSERVACION - no corregido, deliberado]** Los 8 smoke tests duplican verbatim `TipoIdentificacionCc`,
   `NuevoNumeroIdentificacion()` y `ComputarStreamId(...)`. Por MEF-ADR-0018 (Rule of Three) 8 copias
   piden consolidacion en un helper de `Fixtures/`. **No lo hice**: (a) es duplicacion preexistente, no
   introducida por este issue; (b) la auto-contencion por archivo es la convencion vigente que genera
   `smoke-test-writer` (cada archivo re-declara tambien sus constantes de schema y tipo de evento);
   cambiarla unilateralmente en una pasada de review seria scope creep sobre una decision de convencion.
   **Recomendacion para el planner**: issue aparte para consolidar la identidad sintetica de los smoke
   tests de Colaboradores en un helper compartido.
7. **[OBSERVACION - fuera de alcance]** `Etiqueta.ToString()` sigue usando `":"` (`"{Categoria}:{Valor}"`).
   El planner ya lo verifico y lo declaro fuera de alcance (display/debug, no es llave de stream ni viaja
   en URI). Lo re-verifique: correcto, no es hallazgo.

### Refactorings aplicados

- Ninguno estructural sobre el codigo de produccion del diff: **el nucleo estaba bien y no lo toque**.
  `Crear` y `ToString()` quedan exactamente como los dejo el implementer.
- Los cambios de esta fase son: correccion del gap de smoke tests (8 archivos), correccion de
  documentacion factualmente falsa (12 archivos de produccion + 1 comentario de test), correccion del
  texto del mensaje `.resx`, y un test de cobertura de la guarda defensiva.
- Ningun cambio rompio la suite: corri `dotnet test` despues de cada bloque (baseline 1233 -> 1233 tras
  smoke tests -> 1234 tras el test nuevo -> 1234 tras el `.resx`). No hubo que revertir nada.

### Cobertura de criterios de aceptacion

| Criterio | Estado | Test(s) |
|---|---|---|
| CA-1: `ToString()` compone la llave con guion (`"CC-79543210"`) | cubierto | `ToString_ComponeTipoYNumeroConGuion_CuandoIdentificacionValida`; ademas el literal `StreamIdEsperado = "CC-79543210"` como oraculo independiente en los 8 `*CommandHandlerTests` + `ComposicionAnularYTerminarVinculacionTests` |
| CA-2: `Crear` limpia el numero sin error (`" ab-12.3 "` -> `"AB123"`) | cubierto | `Crear_LimpiaElNumero_CuandoTraeEspaciosGuionesYPuntos`, `Crear_ConvierteLetrasAMayusculas_CuandoNumeroLlegaEnMinusculas`, `Crear_EliminaEspaciosInternos_CuandoNumeroLosTraeEntreDigitos`, `Crear_EliminaLetrasAcentuadasYEnies_CuandoNumeroTraeCaracteresNoAscii`, `Numero_ExponeElNumeroYaLimpio_CuandoIdentificacionCreada` |
| CA-3: la limpieza unifica la identidad (`Equals`/`GetHashCode` + misma llave) | cubierto | `Crear_ComponeLaMismaLlave_CuandoNumerosDifierenSoloPorCaracteresInvalidos` (la llave) + los 8 tests heredados de `IdentificacionIgualdadTests : IgualdadTestBase<Identificacion>`, cuyo par ahora es `"AB-123"` / `"ab123"` -- eleccion acertada del test-writer: bajo el contrato nuevo son iguales **por la limpieza**, no por el trim de #348 |
| CA-4: numero vacio tras la limpieza lanza `ArgumentException` con `Mensajes.NumeroVacio` | cubierto | `Crear_LanzaArgumentException_CuandoNumeroSoloTraeGuiones` (`"---"`), `..._CuandoNumeroSoloTraePuntos` (`".."`), `..._CuandoNumeroEsVacio`, `..._CuandoNumeroEsWhitespace`, `..._CuandoNumeroEsNull` (agregado en esta fase) |
| CA-5: round-trip de serializacion persiste/rehidrata el numero YA limpio | cubierto | `RoundTrip_PersisteYRehidrataElNumeroYaLimpio_CuandoElOriginalTraiaCaracteresInvalidos` -- verifica ademas la **forma** del JSON (`documento.RootElement.GetProperty("numero") == "AB123"`), no solo que el round-trip cierre; mas `Deserializar_RehidrataAlTipoCanonico_...` con la llave nueva |

Casos borde revisados y ya cubiertos, sin necesidad de test nuevo: numero alfanumerico que no requiere
limpieza (pasaporte), tipo distinto con mismo numero (`CC` != `CE`, en `CrearInstanciasDiferentes`),
rehidratacion desde JSON corrupto al tipo canonico.

### Tests agregados

- `IdentificacionTests.Crear_LanzaArgumentException_CuandoNumeroEsNull` -- cubre la guarda
  `numero ?? string.Empty` que el implementer agrego sin test (hallazgo #4). Test de contrato sobre
  codigo ya existente: generarlo en fase refactor no viola TDD.
- **Contratos de VO ya presentes, verificados y no duplicados**: `IdentificacionIgualdadTests` (hereda
  los 8 de `IgualdadTestBase<T>`) e `IdentificacionSerializacionTests` (round-trip + forma del JSON +
  barrera anti-regresion sin el resolver custom) ya existian desde #348 y el test-writer los actualizo
  correctamente al contrato nuevo. No hizo falta generarlos.
- No agregue el guardrail de round-trip con serializador **por defecto**: no aplica aqui -- ningun evento
  de Colaboradores implementa `IPrivateEvent`/`IPublicEvent`, asi que ningun payload cruza el bus.

</details>

## Cobertura

| Archivo | Cobertura | Umbral | Estado |
|---|---|---|---|
| FunctionEndpoint.cs | 100.0% | 95% | ok |
| ColaboradorAggregateRoot.cs | 100.0% | 95% | ok |
| Identificacion.cs | 100.0% | 95% | ok |
| Identificacion.Mensajes.cs | - | excluido | - |
| AnularTerminacion.cs | - | excluido | - |
| AsignarEtiqueta.cs | - | excluido | - |
| CorregirFechaInicioVinculacion.cs | - | excluido | - |
| CorregirNombres.cs | - | excluido | - |
| RetirarEtiqueta.cs | - | excluido | - |
## Commits

77bbe4d refactor(hu-381): cerrar el gap de smoke tests y la documentacion obsoleta del separador
f4abfb6 feat(hu-381): separador guion en llave de Identificacion y limpieza alfanumerica del numero (fase verde)
b2d1ea1 test(hu-381): tests para separador guion y limpieza alfanumerica de Identificacion (fase roja)

Closes #381