### PR TITLE
Listar las fichas de colaboradores vigentes con filtro por etiquetas

### DIFF
--- a/src/Bitakora.ControlAsistencia.Colaboradores/ListarFichasColaborador/FunctionEndpoint.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/ListarFichasColaborador/FunctionEndpoint.cs
@@ -1,0 +1,56 @@
+using Cosmos.MultiTenancy;
+using Marten;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.ListarFichasColaborador;
+
+// Issue #373: listado QUERY (RFC 10008, MEF-ADR-0042) de fichas vigentes con filtro AND por
+// etiquetas y paginacion keyset -- segunda mitad del desglose de #356 (ya en main: la vista
+// FichaColaborador, la consulta puntual ObtenerFichaColaborador y su proyeccion). Este issue NO
+// crea proyeccion ni read model nuevos -- consulta la MISMA vista materializada via (a')
+// (session.Query<FichaColaborador>(), skills/projections/read-apis.md), sumando los indices del
+// seam del worker (CA-5, ConfiguracionMartenProjectionsColaboradores).
+//
+// Mismo segmento de recurso que ObtenerFichaColaborador ("colaboradores/fichas") -- el verbo QUERY
+// distingue, el nombre/ruta no cambian (MEF-ADR-0006 enmienda MEF-ADR-0042 seccion 5,
+// skills/projections/naming.md).
+//
+// Stub de fase roja (projection-test-writer, MEF-ADR-0033): Run() lanza NotImplementedException a
+// proposito -- 415/400/422, el filtro AND por etiquetas (Etiqueta.Crear, normalizacion simetrica),
+// la paginacion keyset (OrderBy(NombreCompleto).ThenBy(Id)) y el clamp del Take son responsabilidad
+// de projection-implementer. Los tests de FunctionEndpointTests.cs fallan contra este stub por
+// diseno.
+public class FunctionEndpoint(IDocumentStore store, ITenantResolver tenantResolver)
+{
+    [Function("ListarFichasColaborador")]
+    public Task<IActionResult> Run(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "query", Route = "colaboradores/fichas")]
+        HttpRequest req,
+        CancellationToken ct)
+    {
+        throw new NotImplementedException();
+    }
+}
+
+// Issue #373: DTO de filtro tipado del body QUERY (MEF-ADR-0042 seccion 3, contrato fijado por el
+// issue) -- vive en el feature folder de esta query, no en ReadModels: es contrato de REQUEST, no
+// la vista (MEF-ADR-0041 -- el DTO de filtro de MEF-ADR-0042 no reabre la excepcion del DTO de
+// RESPUESTA). FechaReferencia es OBLIGATORIA -- el back jamas resuelve "hoy" (decision de
+// refinamiento del issue): el "hoy" lo resuelve quien consulta, en su propia zona horaria.
+public sealed record FiltroListarFichasColaborador(
+    DateOnly FechaReferencia,
+    IReadOnlyList<FiltroEtiqueta>? Etiquetas,
+    CursorFicha? Cursor,
+    int Take = 50);
+
+// Par categoria:valor SIN normalizar -- el endpoint construye Etiqueta.Crear(Categoria, Valor) con
+// cada par (Tell-don't-Ask, MEF-ADR-0012: un solo algoritmo de normalizacion, el del VO). Si
+// Etiqueta.Crear rechaza el par (categoria/valor vacios), la respuesta es 422.
+public sealed record FiltroEtiqueta(string Categoria, string Valor);
+
+// Cursor keyset: los dos campos visibles de la ultima fila recibida (orden
+// OrderBy(NombreCompleto).ThenBy(Id) -- decision de refinamiento del issue). Cursor con un solo
+// campo presente (el otro ausente/null) es 422 -- "cursor incompleto".
+public sealed record CursorFicha(string NombreCompleto, string Id);

--- a/src/Bitakora.ControlAsistencia.Colaboradores/ListarFichasColaborador/FunctionEndpoint.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/ListarFichasColaborador/FunctionEndpoint.cs
@@ -1,5 +1,10 @@
+using System.Text.Json;
+using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+using Bitakora.ControlAsistencia.Colaboradores.ObtenerFichaColaborador;
+using Bitakora.ControlAsistencia.ReadModels.Colaboradores;
 using Cosmos.MultiTenancy;
 using Marten;
+using Marten.Linq.MatchesSql; // MatchesSql: unica forma verificada de containment JSONB elegible para GIN sobre Dictionary
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
@@ -16,21 +21,157 @@ namespace Bitakora.ControlAsistencia.Colaboradores.ListarFichasColaborador;
 // Mismo segmento de recurso que ObtenerFichaColaborador ("colaboradores/fichas") -- el verbo QUERY
 // distingue, el nombre/ruta no cambian (MEF-ADR-0006 enmienda MEF-ADR-0042 seccion 5,
 // skills/projections/naming.md).
-//
-// Stub de fase roja (projection-test-writer, MEF-ADR-0033): Run() lanza NotImplementedException a
-// proposito -- 415/400/422, el filtro AND por etiquetas (Etiqueta.Crear, normalizacion simetrica),
-// la paginacion keyset (OrderBy(NombreCompleto).ThenBy(Id)) y el clamp del Take son responsabilidad
-// de projection-implementer. Los tests de FunctionEndpointTests.cs fallan contra este stub por
-// diseno.
 public class FunctionEndpoint(IDocumentStore store, ITenantResolver tenantResolver)
 {
+    // CA-3: tope de pagina (MEF-ADR-0042 seccion 2) -- el Take del cliente jamas llega crudo a
+    // Marten.
+    private const int TakeMaximo = 200;
+
     [Function("ListarFichasColaborador")]
-    public Task<IActionResult> Run(
+    public async Task<IActionResult> Run(
         [HttpTrigger(AuthorizationLevel.Anonymous, "query", Route = "colaboradores/fichas")]
         HttpRequest req,
         CancellationToken ct)
     {
-        throw new NotImplementedException();
+        // CA-4/RFC 10008 seccion 2.1: 415 ANTES de leer el body -- ReadFromJsonAsync lanza si el
+        // Content-Type no es un tipo JSON conocido, y esa excepcion NO es JsonException (se
+        // escaparia como 500 sin este guard).
+        if (!req.HasJsonContentType())
+            return new ObjectResult("La query exige Content-Type: application/json")
+            {
+                StatusCode = StatusCodes.Status415UnsupportedMediaType
+            };
+
+        FiltroListarFichasColaborador? filtro;
+        try
+        {
+            filtro = await req.ReadFromJsonAsync<FiltroListarFichasColaborador>(ct);
+        }
+        catch (JsonException)
+        {
+            return new BadRequestObjectResult("El body de la query no es un JSON valido");
+        }
+
+        if (filtro is null)
+            return new BadRequestObjectResult("El body de la query es obligatorio");
+
+        // CA-4: FechaReferencia es OBLIGATORIA -- el back jamas resuelve "hoy" (decision de
+        // refinamiento del issue). STJ no lanza por su ausencia (el campo queda en default,
+        // 0001-01-01), asi que el 422 depende de esta validacion explicita.
+        if (filtro.FechaReferencia == default)
+            return new ObjectResult("FechaReferencia es obligatoria")
+            {
+                StatusCode = StatusCodes.Status422UnprocessableEntity
+            };
+
+        // CA-4: cursor keyset con un solo campo presente (el otro ausente/null) -> 422 "incompleto".
+        // Un cursor con AMBOS campos ausentes cae en la misma rama -- un cliente que no quiere
+        // paginar debe omitir "cursor" por completo (null), no enviar un objeto vacio.
+        if (filtro.Cursor is { } cursorRecibido
+            && (cursorRecibido.NombreCompleto is null || cursorRecibido.Id is null))
+        {
+            return new ObjectResult("El cursor debe traer NombreCompleto e Id, o ninguno de los dos")
+            {
+                StatusCode = StatusCodes.Status422UnprocessableEntity
+            };
+        }
+
+        // CA-2: normalizacion simetrica -- Tell-don't-Ask (MEF-ADR-0012). El endpoint construye
+        // Etiqueta.Crear(Categoria, Valor) con cada par recibido; es el VO quien decide como se
+        // normaliza (un solo algoritmo de normalizacion en el sistema), nunca el endpoint
+        // reimplementandolo. Etiqueta.Crear rechaza categoria/valor vacios con ArgumentException
+        // -> 422.
+        var etiquetasNormalizadas = new Dictionary<string, string>();
+        if (filtro.Etiquetas is { Count: > 0 })
+        {
+            foreach (var par in filtro.Etiquetas)
+            {
+                Etiqueta etiqueta;
+                try
+                {
+                    etiqueta = Etiqueta.Crear(par.Categoria, par.Valor);
+                }
+                catch (ArgumentException)
+                {
+                    return new ObjectResult(
+                        "Una etiqueta del filtro es invalida (categoria o valor vacios)")
+                    {
+                        StatusCode = StatusCodes.Status422UnprocessableEntity
+                    };
+                }
+
+                // Un valor por categoria (misma invariante que el aggregate/la proyeccion, #355):
+                // si el cliente repite la misma categoria dos veces, la ultima gana.
+                etiquetasNormalizadas[etiqueta.CategoriaNormalizada] = etiqueta.ValorNormalizado;
+            }
+        }
+
+        // CA-1/CA-2 (MEF-ADR-0028): la QuerySession se abre SIEMPRE acotada al tenant que resuelve
+        // ITenantResolver -- nunca a un tenant id que llegara por el body.
+        await using var session = store.QuerySession(tenantResolver.TenantId);
+
+        // CA-1: vigente a FechaReferencia = VigenteHasta >= FechaReferencia (el dia efectivo de
+        // terminacion es el ULTIMO dia vigente, inclusive -- semantica verificada en el aggregate,
+        // #349). El centinela de vinculacion abierta siempre satisface esta condicion.
+        IQueryable<FichaColaborador> query = session.Query<FichaColaborador>()
+            .Where(f => f.VigenteHasta >= filtro.FechaReferencia);
+
+        // CA-2: filtro AND por etiquetas como UNA sola operacion de containment JSONB (precedente
+        // #337: Marten traduce una igualdad de campo a containment @>, elegible para GIN) --
+        // sin filtro de etiquetas (Etiquetas null/vacio) retorna todos los vigentes.
+        //
+        // Verificado por spike propio (Marten 9.12.0 + Postgres 16 real, EXPLAIN con
+        // enable_seqscan=off): el indexer LINQ sobre Dictionary (f.EtiquetasNormalizadas[cat] ==
+        // val, AND por cada par via multiples Where) SI traduce correctamente contra el dato real
+        // -- pero como comparaciones ->> por clave, nunca como containment, y por eso NUNCA usa un
+        // indice GIN (Seq Scan incluso forzando enable_seqscan=off). Contains(KeyValuePair) SI
+        // genera containment (@>) pero contra un shape de JSON equivocado ([{"Key":...,"Value":...}])
+        // que jamas calza con la representacion real de un Dictionary<string,string> serializado
+        // por STJ ({"area":"tecnologia"}) -- devuelve 0 resultados siempre, sea que el par exista o
+        // no. La forma verificada que SI usa el indice GIN que declara CA-5
+        // (ConfiguracionMartenProjectionsColaboradores, .Index(x => x.EtiquetasNormalizadas, gin))
+        // es MatchesSql reproduciendo el MISMO shape de expresion que Marten genera para ese
+        // indice: (data->>'EtiquetasNormalizadas')::jsonb @> ?::jsonb (confirmado con EXPLAIN:
+        // Bitmap Index Scan sobre el indice GIN, Recheck Cond identico).
+        if (etiquetasNormalizadas.Count > 0)
+        {
+            var etiquetasJson = JsonSerializer.Serialize(etiquetasNormalizadas);
+            query = query.Where(f =>
+                f.MatchesSql("(data->>'EtiquetasNormalizadas')::jsonb @> ?::jsonb", etiquetasJson));
+        }
+
+        // CA-3: paginacion keyset -- orden OrderBy(NombreCompleto).ThenBy(Id), predicado compuesto
+        // "nombre > cursor.NombreCompleto OR (nombre == cursor.NombreCompleto AND id >
+        // cursor.Id)". Verificado por spike propio: CompareTo(...) > 0 SI traduce a SQL sobre
+        // campos string (d.data ->> 'NombreCompleto' > :p0 / d.id > :p0 para el Id, que es columna
+        // dedicada del documento) -- a diferencia de string.Compare(...), que Marten no puede
+        // reducir y lanza BadLinqExpressionException. Cierra el NO VERIFICADO de
+        // skills/projections/read-apis.md para este dominio.
+        if (filtro.Cursor is { NombreCompleto: { } cursorNombre, Id: { } cursorId })
+        {
+            query = query.Where(f =>
+                f.NombreCompleto.CompareTo(cursorNombre) > 0
+                || (f.NombreCompleto == cursorNombre && f.Id.CompareTo(cursorId) > 0));
+        }
+
+        // CA-3: Take se acota en el servidor -- nunca se pasa crudo a Marten.
+        var take = Math.Clamp(filtro.Take, 1, TakeMaximo);
+
+        var fichas = await query
+            .OrderBy(f => f.NombreCompleto).ThenBy(f => f.Id)
+            .Take(take)
+            .ToListAsync(ct);
+
+        // CA-4: VigenteHasta vacio en la respuesta de vinculacion abierta -- el centinela jamas
+        // sale por la API (misma regla que #356 CA-6). Reutiliza FichaColaboradorRespuesta.DesdeVista
+        // de ObtenerFichaColaborador en vez de duplicar la misma traduccion (MEF-ADR-0018): es el
+        // mismo DTO de respuesta -- ya excepcion bajo MEF-ADR-0041 decision 4 -- para el mismo read
+        // model, ahora con un segundo consumidor.
+        //
+        // CA-4: nunca 404 -- una pagina sin resultados es 200 con lista vacia. Sin envelope
+        // (propuesta del issue, MEF-ADR-0018): el cliente deriva el cursor de NombreCompleto/Id de
+        // la ultima fila; fin de la lista = pagina con menos de Take filas.
+        return new OkObjectResult(fichas.Select(FichaColaboradorRespuesta.DesdeVista).ToList());
     }
 }
 

--- a/src/Bitakora.ControlAsistencia.Colaboradores/ListarFichasColaborador/FunctionEndpoint.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/ListarFichasColaborador/FunctionEndpoint.cs
@@ -27,6 +27,11 @@ public class FunctionEndpoint(IDocumentStore store, ITenantResolver tenantResolv
     // Marten.
     private const int TakeMaximo = 200;
 
+    // Containment JSONB del filtro AND por etiquetas (CA-2). Ver el comentario en Run para por que
+    // es MatchesSql y no LINQ, y por que el nombre del campo se interpola con nameof.
+    private const string SqlContenimientoEtiquetas =
+        $"(data->>'{nameof(FichaColaborador.EtiquetasNormalizadas)}')::jsonb @> ?::jsonb";
+
     [Function("ListarFichasColaborador")]
     public async Task<IActionResult> Run(
         [HttpTrigger(AuthorizationLevel.Anonymous, "query", Route = "colaboradores/fichas")]
@@ -59,52 +64,19 @@ public class FunctionEndpoint(IDocumentStore store, ITenantResolver tenantResolv
         // refinamiento del issue). STJ no lanza por su ausencia (el campo queda en default,
         // 0001-01-01), asi que el 422 depende de esta validacion explicita.
         if (filtro.FechaReferencia == default)
-            return new ObjectResult("FechaReferencia es obligatoria")
-            {
-                StatusCode = StatusCodes.Status422UnprocessableEntity
-            };
+            return NoProcesable("FechaReferencia es obligatoria");
 
         // CA-4: cursor keyset con un solo campo presente (el otro ausente/null) -> 422 "incompleto".
         // Un cursor con AMBOS campos ausentes cae en la misma rama -- un cliente que no quiere
         // paginar debe omitir "cursor" por completo (null), no enviar un objeto vacio.
         if (filtro.Cursor is { } cursorRecibido
             && (cursorRecibido.NombreCompleto is null || cursorRecibido.Id is null))
-        {
-            return new ObjectResult("El cursor debe traer NombreCompleto e Id, o ninguno de los dos")
-            {
-                StatusCode = StatusCodes.Status422UnprocessableEntity
-            };
-        }
+            return NoProcesable("El cursor debe traer NombreCompleto e Id, o ninguno de los dos");
 
-        // CA-2: normalizacion simetrica -- Tell-don't-Ask (MEF-ADR-0012). El endpoint construye
-        // Etiqueta.Crear(Categoria, Valor) con cada par recibido; es el VO quien decide como se
-        // normaliza (un solo algoritmo de normalizacion en el sistema), nunca el endpoint
-        // reimplementandolo. Etiqueta.Crear rechaza categoria/valor vacios con ArgumentException
-        // -> 422.
-        var etiquetasNormalizadas = new Dictionary<string, string>();
-        if (filtro.Etiquetas is { Count: > 0 })
-        {
-            foreach (var par in filtro.Etiquetas)
-            {
-                Etiqueta etiqueta;
-                try
-                {
-                    etiqueta = Etiqueta.Crear(par.Categoria, par.Valor);
-                }
-                catch (ArgumentException)
-                {
-                    return new ObjectResult(
-                        "Una etiqueta del filtro es invalida (categoria o valor vacios)")
-                    {
-                        StatusCode = StatusCodes.Status422UnprocessableEntity
-                    };
-                }
-
-                // Un valor por categoria (misma invariante que el aggregate/la proyeccion, #355):
-                // si el cliente repite la misma categoria dos veces, la ultima gana.
-                etiquetasNormalizadas[etiqueta.CategoriaNormalizada] = etiqueta.ValorNormalizado;
-            }
-        }
+        // CA-2: normalizacion simetrica -- Tell-don't-Ask (MEF-ADR-0012), ver NormalizarEtiquetas.
+        var etiquetasNormalizadas = NormalizarEtiquetas(filtro.Etiquetas);
+        if (etiquetasNormalizadas is null)
+            return NoProcesable("Una etiqueta del filtro es invalida (categoria o valor vacios)");
 
         // CA-1/CA-2 (MEF-ADR-0028): la QuerySession se abre SIEMPRE acotada al tenant que resuelve
         // ITenantResolver -- nunca a un tenant id que llegara por el body.
@@ -133,11 +105,21 @@ public class FunctionEndpoint(IDocumentStore store, ITenantResolver tenantResolv
         // es MatchesSql reproduciendo el MISMO shape de expresion que Marten genera para ese
         // indice: (data->>'EtiquetasNormalizadas')::jsonb @> ?::jsonb (confirmado con EXPLAIN:
         // Bitmap Index Scan sobre el indice GIN, Recheck Cond identico).
+        //
+        // El nombre del campo se interpola con nameof, nunca como literal suelto: este SQL crudo es
+        // el UNICO punto del sistema donde el nombre de una propiedad de la vista viaja como texto,
+        // y un rename del read model que no lo alcanzara dejaria el filtro devolviendo 0 resultados
+        // siempre, sin error de compilacion ni de runtime (mismo modo de falla silencioso que el
+        // spike encontro en Contains(KeyValuePair)).
+        //
+        // MatchesSql NO evade el filtro de tenant (verificado en la revision inspeccionando el SQL
+        // que Marten genera para esta query, via ToCommand(FetchType.FetchMany), sin Postgres): el
+        // fragmento entra como un where mas del mismo AND que ya lleva "d.tenant_id = :p0", y el
+        // JSON viaja parametrizado (":p4::jsonb"), nunca concatenado. MEF-ADR-0028 se sostiene.
         if (etiquetasNormalizadas.Count > 0)
         {
             var etiquetasJson = JsonSerializer.Serialize(etiquetasNormalizadas);
-            query = query.Where(f =>
-                f.MatchesSql("(data->>'EtiquetasNormalizadas')::jsonb @> ?::jsonb", etiquetasJson));
+            query = query.Where(f => f.MatchesSql(SqlContenimientoEtiquetas, etiquetasJson));
         }
 
         // CA-3: paginacion keyset -- orden OrderBy(NombreCompleto).ThenBy(Id), predicado compuesto
@@ -173,6 +155,47 @@ public class FunctionEndpoint(IDocumentStore store, ITenantResolver tenantResolv
         // la ultima fila; fin de la lista = pagina con menos de Take filas.
         return new OkObjectResult(fichas.Select(FichaColaboradorRespuesta.DesdeVista).ToList());
     }
+
+    // CA-2: normalizacion simetrica -- Tell-don't-Ask (MEF-ADR-0012). Construye
+    // Etiqueta.Crear(Categoria, Valor) con cada par recibido: es el VO quien decide como se
+    // normaliza (un solo algoritmo de normalizacion en el sistema), nunca el endpoint
+    // reimplementandolo. Devuelve null cuando algun par es inaceptable -- el llamador lo traduce a
+    // 422. Etiquetas null/vacio produce un diccionario vacio: sin filtro de etiquetas.
+    private static Dictionary<string, string>? NormalizarEtiquetas(IReadOnlyList<FiltroEtiqueta>? pares)
+    {
+        var normalizadas = new Dictionary<string, string>();
+
+        foreach (var par in pares ?? [])
+        {
+            // El body es entrada del cliente: STJ acepta un elemento null dentro del array
+            // ("etiquetas":[null]) pese a la anotacion no-nullable del record. Sin este guard, el
+            // acceso a par.Categoria seria una NullReferenceException que escapa del catch de
+            // ArgumentException y sale como 500 donde el RFC 10008 pide 422.
+            if (par is null)
+                return null;
+
+            Etiqueta etiqueta;
+            try
+            {
+                etiqueta = Etiqueta.Crear(par.Categoria, par.Valor);
+            }
+            catch (ArgumentException)
+            {
+                return null;
+            }
+
+            // Un valor por categoria (misma invariante que el aggregate/la proyeccion, #355): si el
+            // cliente repite la misma categoria dos veces, la ultima gana.
+            normalizadas[etiqueta.CategoriaNormalizada] = etiqueta.ValorNormalizado;
+        }
+
+        return normalizadas;
+    }
+
+    // RFC 10008 seccion 2.1 / MEF-ADR-0042 seccion 3: el 422 se emite como ObjectResult con mensaje,
+    // nunca como codigo pelado -- misma forma que el 400 del parseo del id de ruta (MEF-ADR-0037).
+    private static ObjectResult NoProcesable(string mensaje) =>
+        new(mensaje) { StatusCode = StatusCodes.Status422UnprocessableEntity };
 }
 
 // Issue #373: DTO de filtro tipado del body QUERY (MEF-ADR-0042 seccion 3, contrato fijado por el

--- a/src/Bitakora.ControlAsistencia.Projections/Infraestructura/ConfiguracionMartenProjectionsColaboradores.cs
+++ b/src/Bitakora.ControlAsistencia.Projections/Infraestructura/ConfiguracionMartenProjectionsColaboradores.cs
@@ -1,12 +1,14 @@
 using System.Text.Json.Serialization.Metadata;
 using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
 using Bitakora.ControlAsistencia.Projections.Colaboradores;
+using Bitakora.ControlAsistencia.ReadModels.Colaboradores;
 using JasperFx.Events; // StreamIdentity, EventNamingStyle (NO Marten.Events, mismo gotcha que DaemonMode)
 using JasperFx.Events.Daemon; // DaemonMode (NO Marten.Events.Daemon: compila pero deja DaemonMode sin resolver)
 using JasperFx.Events.Projections; // ProjectionLifecycle (NO Marten.Events.Projections)
 using JasperFx.MultiTenancy; // TenancyStyle (NO Marten.*, mismo gotcha que StreamIdentity/DaemonMode)
 using Marten;
 using Weasel.Core; // EnumStorage, Casing (NO Marten.*: viven en Weasel.Core)
+using Weasel.Postgresql.Tables; // IndexMethod (NO Marten.*: vive en Weasel.Postgresql.Tables)
 
 namespace Bitakora.ControlAsistencia.Projections.Infraestructura;
 
@@ -111,6 +113,30 @@ public static class ConfiguracionMartenProjectionsColaboradores
                 // del worker (MEF-ADR-0034 seccion 3); Inline exigiria justificacion explicita en el
                 // issue, ausente aqui.
                 opts.Projections.Add<FichaColaboradorProjection>(ProjectionLifecycle.Async);
+
+                // Issue #373 CA-5: indices para el listado QUERY ListarFichasColaborador
+                // (segunda mitad del desglose de #356) -- ninguna proyeccion ni read model
+                // nuevos, solo indices sobre la MISMA FichaColaborador ya registrada arriba.
+                //
+                // GIN sobre EtiquetasNormalizadas: el filtro AND por etiquetas del endpoint
+                // resuelve con UNA operacion de containment JSONB (precedente #337 sobre
+                // Bloques/SedeId). Verificado por spike propio (Marten 9.12.0 + Postgres 16,
+                // EXPLAIN con enable_seqscan=off): Schema.For<FichaColaborador>()
+                // .Index(x => x.EtiquetasNormalizadas, gin) crea el indice sobre la expresion
+                // (data->>'EtiquetasNormalizadas')::jsonb -- el endpoint reproduce ese MISMO
+                // shape de expresion via MatchesSql para que el planner efectivamente elija un
+                // Bitmap Index Scan sobre este indice (confirmado con EXPLAIN), no un Seq Scan.
+                //
+                // Btree sobre VigenteHasta: acelera "VigenteHasta >= FechaReferencia" (CA-1),
+                // el filtro de vigencia que aplica TODA consulta del listado.
+                //
+                // Btree sobre NombreCompleto: acelera el ORDER BY del keyset (CA-3,
+                // OrderBy(NombreCompleto).ThenBy(Id) -- Id ya tiene su propio indice como
+                // primary key del documento, sin necesidad de uno adicional).
+                opts.Schema.For<FichaColaborador>()
+                    .Index(x => x.EtiquetasNormalizadas, i => i.Method = IndexMethod.gin)
+                    .Index(x => x.VigenteHasta)
+                    .Index(x => x.NombreCompleto);
             })
             // Registrar el store no basta: sin esta llamada el daemon queda apagado y ninguna
             // proyeccion se materializa. HotCold elige lider sobre advisory locks de PostgreSQL,

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/ListarFichasColaborador/ListarFichasColaboradorSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/ListarFichasColaborador/ListarFichasColaboradorSmokeTests.cs
@@ -35,6 +35,7 @@
 using System.Net;
 using System.Net.Http.Json;
 using System.Text;
+using System.Text.Json;
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.Colaboradores.SmokeTests.Fixtures;
 
@@ -54,7 +55,7 @@ public class ListarFichasColaboradorSmokeTests(ApiFixture api)
 
     // Case-insensitive: la respuesta viaja en camelCase (ComposicionServicios configura
     // JsonNamingPolicy.CamelCase), mientras que las formas locales de este archivo son PascalCase.
-    private static readonly System.Text.Json.JsonSerializerOptions JsonOptions = new()
+    private static readonly JsonSerializerOptions JsonOptions = new()
     {
         PropertyNameCaseInsensitive = true
     };

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/ListarFichasColaborador/ListarFichasColaboradorSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/ListarFichasColaborador/ListarFichasColaboradorSmokeTests.cs
@@ -1,0 +1,511 @@
+// Issue #373: smoke tests de ListarFichasColaborador, verbo QUERY (RFC 10008, MEF-ADR-0042) sobre
+// colaboradores/fichas -- mismo recurso que ObtenerFichaColaborador (#356), pero el listado EXCLUYE
+// no-vigentes a la fecha de referencia y agrega filtro AND por etiquetas + paginacion keyset. No hay
+// proyeccion ni read model nuevos (issue hermano de #356): esta clase consulta la MISMA vista
+// materializada FichaColaborador via (a') session.Query<FichaColaborador>().
+//
+// Arrange via API, nunca sembrando el event store por fuera de ella: cada colaborador se crea con
+// POST Colaboradores (#330), se etiqueta con POST Colaboradores/Etiquetas (#355) y se termina con
+// POST Colaboradores/Terminaciones (#349) -- los mismos comandos que la proyeccion consume.
+//
+// Lifecycle Async (MEF-ADR-0034 seccion 3): el worker materializa/actualiza FichaColaborador
+// DESPUES de que Colaboradores persiste sus eventos. Los casos de exito envuelven la consulta en
+// Polling.WaitUntilAsync (timeout estandar 30s) -- unica excepcion documentada al "no usar Polling
+// directo en tests".
+//
+// Aislamiento de datos SIN cleanup, en un entorno que ACUMULA fichas de corridas anteriores (todas
+// las suites de este dominio registran colaboradores con NombreCompleto constante "[TEST] Smoke" y
+// jamas los borran): un listado sin filtro nunca es un oraculo confiable por si solo. Cada test de
+// aqui aisla SU propia fila de cualquier ruido historico con uno de estos dos mecanismos,
+// combinables con el paginado real del endpoint:
+//   (1) NombreCompleto UNICO (un Guid embebido en el apellido, vease NuevoApellidoUnico) + Cursor
+//       posicionado exactamente en ese nombre (con Id vacio, que ordena antes que cualquier Id real)
+//       -- aisla la fila sin necesidad de ninguna etiqueta.
+//   (2) Un par de etiqueta discriminador con un Guid embebido en el VALOR -- nadie mas, en ninguna
+//       corrida pasada o futura, puede tener ese valor exacto.
+// Ambos duplican, a proposito, el mecanismo real de paginacion keyset que CA-3/CA-6 exigen probar
+// contra el entorno real: no es un atajo de test, es la MISMA superficie publica.
+//
+// CA-6 (gate, MEF-ADR-0042 seccion 6): el primer verbo QUERY del consumidor. El test de paginacion
+// (ListarFichasColaborador_PaginaSinSaltarNiRepetir...) es el gate end-to-end: si el host de dev no
+// reenvia el verbo QUERY, o si Marten no traduce el predicado compuesto CompareTo sobre strings, ese
+// test falla -- nunca es un caso para Assert.Skip (fallo real, no ambiental). La colacion de la base
+// de dev (en_US.utf8 vs C, ver MEF-ADR-0042 seccion 6) no es observable via HTTP: se registra
+// manualmente en el resumen de esta corrida, fuera de este archivo.
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.SmokeTests.Fixtures;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.SmokeTests.ListarFichasColaborador;
+
+public class ListarFichasColaboradorSmokeTests(ApiFixture api)
+{
+    private readonly HttpClient _client = api.Client;
+
+    private const string RutaListado = "/api/colaboradores/fichas";
+    private const string RutaRegistrar = "/api/Colaboradores";
+    private const string RutaTerminaciones = "/api/Colaboradores/Terminaciones";
+    private const string RutaEtiquetas = "/api/Colaboradores/Etiquetas";
+    private const string TipoIdentificacionCc = "CC";
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
+    private static readonly HttpMethod MetodoQuery = new("QUERY");
+
+    // Case-insensitive: la respuesta viaja en camelCase (ComposicionServicios configura
+    // JsonNamingPolicy.CamelCase), mientras que las formas locales de este archivo son PascalCase.
+    private static readonly System.Text.Json.JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    // Formas locales DESACOPLADAS del read model de produccion (ReadModels.Colaboradores) y del DTO
+    // de respuesta de ObtenerFichaColaborador: replican solo el shape JSON de la respuesta HTTP de
+    // ESTE endpoint. El smoke test no referencia ReadModels ni el Function App (isla, MEF-ADR-0034
+    // seccion 5).
+    private sealed record EtiquetaFichaSmoke(string Categoria, string Valor);
+
+    private sealed record FichaColaboradorRespuestaSmoke(
+        string Id,
+        string NombreCompleto,
+        string CodigoColaborador,
+        DateOnly VigenteDesde,
+        DateOnly? VigenteHasta,
+        IReadOnlyList<EtiquetaFichaSmoke> Etiquetas,
+        IReadOnlyDictionary<string, string> EtiquetasNormalizadas);
+
+    private static string NuevoNumeroIdentificacion() => Guid.CreateVersion7().ToString("N").ToUpperInvariant();
+
+    private static string NuevoCodigoColaborador() => $"[TEST]-{Guid.CreateVersion7()}";
+
+    // Apellido con un Guid embebido -- garantiza que el NombreCompleto resultante ("[TEST]
+    // {apellido}") es unico frente a cualquier ficha creada en cualquier corrida, pasada o futura,
+    // de cualquier archivo de este dominio (todos los demas usan el literal constante "Smoke").
+    private static string NuevoApellidoUnico(string prefijo) => $"{prefijo}-{Guid.CreateVersion7():N}";
+
+    private static string NombreCompletoDe(string apellido) => $"[TEST] {apellido}";
+
+    // Mismo formato que ColaboradorAggregateRoot.ComputarStreamId (separador "-" desde #381),
+    // reconstruido localmente (oraculo independiente, MEF-ADR-0002): el smoke test no referencia el
+    // Function App.
+    private static string ComputarStreamId(string numeroIdentificacion) =>
+        $"{TipoIdentificacionCc}-{numeroIdentificacion}";
+
+    // Filtro con Cursor explicito y sin etiquetas -- el mecanismo de aislamiento (1) del encabezado:
+    // posiciona el listado exactamente en cursorNombre (con cursorId vacio, que ordena antes que
+    // cualquier Id real no vacio), aislando la fila de interes del resto del dataset acumulado.
+    private static object FiltroPorCursor(
+        DateOnly fechaReferencia, string cursorNombre, string cursorId, int take = 1) => new
+        {
+            fechaReferencia,
+            etiquetas = (object?)null,
+            cursor = new { nombreCompleto = cursorNombre, id = cursorId },
+            take
+        };
+
+    // Filtro AND por etiquetas, sin cursor (mecanismo de aislamiento (2) del encabezado: al menos
+    // una de las etiquetas trae un Guid embebido en el valor, unico para la corrida).
+    private static object FiltroPorEtiquetas(
+        DateOnly fechaReferencia, params (string Categoria, string Valor)[] etiquetas) => new
+        {
+            fechaReferencia,
+            etiquetas = etiquetas.Select(e => new { categoria = e.Categoria, valor = e.Valor }).ToArray(),
+            cursor = (object?)null,
+            take = 50
+        };
+
+    // Arrange comun: registra un colaborador con una vinculacion abierta -- via el comando que la
+    // origina (#330), nunca sembrando el event store por fuera del API.
+    private async Task RegistrarColaboradorAsync(
+        string numeroIdentificacion, DateOnly fechaInicio, string primerApellido,
+        string codigoColaborador, CancellationToken ct)
+    {
+        var response = await _client.PostAsJsonAsync(RutaRegistrar, new
+        {
+            tipoIdentificacion = TipoIdentificacionCc,
+            numeroIdentificacion,
+            primerNombre = "[TEST]",
+            segundoNombre = (string?)null,
+            primerApellido,
+            segundoApellido = (string?)null,
+            codigoColaborador,
+            fechaInicio
+        }, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted,
+            "el arrange de este smoke test depende de que RegistrarColaborador funcione");
+    }
+
+    // Arrange comun (CA-1): cierra la vinculacion vigente -- via el comando que la origina (#349).
+    private async Task TerminarVinculacionAsync(
+        string numeroIdentificacion, DateOnly fechaEfectiva, CancellationToken ct)
+    {
+        var response = await _client.PostAsJsonAsync(RutaTerminaciones, new
+        {
+            tipoIdentificacion = TipoIdentificacionCc,
+            numeroIdentificacion,
+            fechaEfectiva
+        }, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted,
+            "el arrange de este smoke test depende de que TerminarVinculacion funcione");
+    }
+
+    // Arrange comun (CA-2): asigna una etiqueta dinamica -- via el comando que la origina (#355).
+    private async Task AsignarEtiquetaAsync(
+        string numeroIdentificacion, string categoria, string valor, CancellationToken ct)
+    {
+        var response = await _client.PostAsJsonAsync(RutaEtiquetas, new
+        {
+            tipoIdentificacion = TipoIdentificacionCc,
+            numeroIdentificacion,
+            categoria,
+            valor
+        }, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted,
+            "el arrange de este smoke test depende de que AsignarEtiqueta funcione");
+    }
+
+    private Task<HttpResponseMessage> ConsultarAsync(object filtro, CancellationToken ct)
+    {
+        using var request = new HttpRequestMessage(MetodoQuery, RutaListado)
+        {
+            Content = JsonContent.Create(filtro)
+        };
+        return _client.SendAsync(request, ct);
+    }
+
+    private async Task<List<FichaColaboradorRespuestaSmoke>> ConsultarListaAsync(
+        object filtro, CancellationToken ct)
+    {
+        var response = await ConsultarAsync(filtro, ct);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var lista = await response.Content.ReadFromJsonAsync<List<FichaColaboradorRespuestaSmoke>>(
+            JsonOptions, cancellationToken: ct);
+        return lista ?? [];
+    }
+
+    // Reintenta la consulta hasta que la proyeccion asincrona satisfaga la condicion -- unica
+    // excepcion documentada al "no usar Polling directo en tests" (lifecycle Async, MEF-ADR-0034
+    // seccion 3). Si el timeout se agota es un fallo real (worker no desplegado, o el efecto del
+    // arrange nunca se materializo), Polling.WaitUntilAsync lanza TimeoutException.
+    private Task<List<FichaColaboradorRespuestaSmoke>> ConsultarHastaQueAsync(
+        object filtro, Func<List<FichaColaboradorRespuestaSmoke>, bool> condicion, CancellationToken ct) =>
+        Polling.WaitUntilAsync(async () =>
+        {
+            var lista = await ConsultarListaAsync(filtro, ct);
+            return condicion(lista) ? lista : null;
+        }, Timeout);
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task DebeEstarDisponible_CuandoSeConsultaHealthCheck()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var response = await _client.GetAsync("/api/health", ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    // CA-1 (vigencia inclusive): el dia efectivo de terminacion es el ULTIMO dia vigente. Se
+    // confirma primero que la proyeccion ya aplico VinculacionTerminada (VigenteHasta == fechaEfectiva
+    // exacto, no el centinela todavia sin procesar) y LUEGO -- de forma deterministica, sin polling,
+    // porque la proyeccion ya esta al dia -- que al dia siguiente, sin ningun evento nuevo, la misma
+    // ficha desaparece del listado.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarFichasColaborador_IncluyeElDiaEfectivoDeTerminacionYLoExcluyeAlDiaSiguiente_CuandoLaVigenciaEsInclusive()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion();
+        var streamId = ComputarStreamId(numeroIdentificacion);
+        var fechaInicio = new DateOnly(2026, 3, 1);
+        var fechaEfectiva = new DateOnly(2026, 6, 30);
+        var apellido = NuevoApellidoUnico("Vigencia373");
+        var nombreCompleto = NombreCompletoDe(apellido);
+
+        await RegistrarColaboradorAsync(
+            numeroIdentificacion, fechaInicio, apellido, NuevoCodigoColaborador(), ct);
+        await TerminarVinculacionAsync(numeroIdentificacion, fechaEfectiva, ct);
+
+        var paginaEnLaFechaEfectiva = await ConsultarHastaQueAsync(
+            FiltroPorCursor(fechaEfectiva, nombreCompleto, cursorId: ""),
+            lista => lista.Any(f => f.Id == streamId && f.VigenteHasta == fechaEfectiva),
+            ct);
+
+        paginaEnLaFechaEfectiva.Should().ContainSingle(f => f.Id == streamId,
+            "el dia efectivo de terminacion es el ULTIMO dia vigente, inclusive (CA-1)");
+
+        // Deterministico: la proyeccion ya confirmo estar al dia en el assert anterior.
+        var paginaAlDiaSiguiente = await ConsultarListaAsync(
+            FiltroPorCursor(fechaEfectiva.AddDays(1), nombreCompleto, cursorId: ""), ct);
+
+        paginaAlDiaSiguiente.Should().NotContain(f => f.Id == streamId,
+            "la vinculacion terminada desaparece del listado al dia siguiente de su fecha efectiva, sin ningun evento nuevo (CA-1)");
+    }
+
+    // CA-2 (filtro AND + normalizacion simetrica): filtrando con formas distintas (mayusculas,
+    // tildes) a las asignadas, el colaborador SI aparece -- Etiqueta.Crear normaliza ambos lados por
+    // igual (Tell-don't-Ask, MEF-ADR-0012). La categoria discriminadora lleva un Guid en el valor:
+    // si el colaborador aparece, es EL, sin ambiguedad con ninguna otra corrida.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarFichasColaborador_AplicaAndDeEtiquetasConNormalizacionSimetrica_CuandoElFiltroUsaFormasDistintasDeLasAsignadas()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var fechaReferencia = new DateOnly(2026, 4, 20);
+        var categoriaCorrida = "SmokeCorrida373";
+        var corridaId = Guid.CreateVersion7().ToString("N");
+        var apellido = NuevoApellidoUnico("Etiquetas373");
+        var numeroIdentificacion = NuevoNumeroIdentificacion();
+        var streamId = ComputarStreamId(numeroIdentificacion);
+
+        await RegistrarColaboradorAsync(
+            numeroIdentificacion, new DateOnly(2026, 1, 1), apellido, NuevoCodigoColaborador(), ct);
+        await AsignarEtiquetaAsync(numeroIdentificacion, categoriaCorrida, corridaId, ct);
+        await AsignarEtiquetaAsync(numeroIdentificacion, "Área", "Tecnología", ct);
+        await AsignarEtiquetaAsync(numeroIdentificacion, "cargo", "desarrollador", ct);
+
+        var filtroCoincide = FiltroPorEtiquetas(fechaReferencia,
+            (categoriaCorrida, corridaId), ("área", "tecnología"), ("Cargo", "Desarrollador"));
+
+        var pagina = await ConsultarHastaQueAsync(
+            filtroCoincide, lista => lista.Any(f => f.Id == streamId), ct);
+
+        pagina.Should().ContainSingle(f => f.Id == streamId,
+            "'área'/'tecnología' y 'Cargo'/'Desarrollador' deberian normalizar a las mismas claves que 'Área'/'Tecnología' y 'cargo'/'desarrollador'");
+
+        // AND estricto: cambiar SOLO el valor de una categoria (misma corridaId, unica) no debe
+        // encontrar nada -- nadie mas puede tener esa combinacion exacta.
+        var filtroSinCoincidencia = FiltroPorEtiquetas(fechaReferencia,
+            (categoriaCorrida, corridaId), ("cargo", "contador"));
+
+        var paginaSinCoincidencia = await ConsultarListaAsync(filtroSinCoincidencia, ct);
+
+        paginaSinCoincidencia.Should().BeEmpty(
+            "el AND estricto no deberia devolver un colaborador cuyo cargo es 'desarrollador', no 'contador'");
+    }
+
+    // CA-2 (sin filtro de etiquetas retorna todos los vigentes) + CA-4 (VigenteHasta vacio en
+    // vinculacion abierta): Etiquetas: null no aplica ningun containment -- el cursor posicionado en
+    // el propio NombreCompleto (unico) aisla la fila sin depender de ninguna etiqueta.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarFichasColaborador_IncluyeAlVigenteConVigenteHastaVacio_CuandoElFiltroNoTraeEtiquetas()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var fechaReferencia = new DateOnly(2026, 5, 1);
+        var apellido = NuevoApellidoUnico("SinEtiquetas373");
+        var nombreCompleto = NombreCompletoDe(apellido);
+        var numeroIdentificacion = NuevoNumeroIdentificacion();
+        var streamId = ComputarStreamId(numeroIdentificacion);
+        var codigoColaborador = NuevoCodigoColaborador();
+
+        await RegistrarColaboradorAsync(
+            numeroIdentificacion, new DateOnly(2026, 1, 1), apellido, codigoColaborador, ct);
+
+        var pagina = await ConsultarHastaQueAsync(
+            FiltroPorCursor(fechaReferencia, nombreCompleto, cursorId: ""),
+            lista => lista.Any(f => f.Id == streamId),
+            ct);
+
+        var ficha = pagina.Should().ContainSingle(f => f.Id == streamId).Subject;
+        ficha.CodigoColaborador.Should().Be(codigoColaborador);
+        ficha.NombreCompleto.Should().Be(nombreCompleto);
+        ficha.VigenteHasta.Should().BeNull(
+            "el centinela de vigencia abierta (9999-12-31) jamas debe salir por la API (misma regla que #356 CA-6)");
+    }
+
+    // CA-3 (paginacion keyset) + CA-6 (gate): el cursor de la ultima fila continua la pagina
+    // siguiente sin saltar ni repetir. Verifica end-to-end que Marten traduce el predicado compuesto
+    // CompareTo sobre strings contra el Postgres real de dev -- el NO VERIFICADO de
+    // skills/projections/read-apis.md, cerrado para este dominio por spike propio del implementer.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarFichasColaborador_PaginaSinSaltarNiRepetir_CuandoSeUsaElCursorDeLaUltimaFila()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var fechaReferencia = new DateOnly(2026, 4, 1);
+        var apellidoBase = NuevoApellidoUnico("Paginacion373");
+        var apellidoA = $"{apellidoBase}-A";
+        var apellidoB = $"{apellidoBase}-B";
+        var nombreA = NombreCompletoDe(apellidoA);
+
+        var numeroA = NuevoNumeroIdentificacion();
+        var numeroB = NuevoNumeroIdentificacion();
+        var idA = ComputarStreamId(numeroA);
+        var idB = ComputarStreamId(numeroB);
+
+        await RegistrarColaboradorAsync(
+            numeroA, new DateOnly(2026, 1, 1), apellidoA, NuevoCodigoColaborador(), ct);
+        await RegistrarColaboradorAsync(
+            numeroB, new DateOnly(2026, 1, 1), apellidoB, NuevoCodigoColaborador(), ct);
+
+        // Pagina 1: cursor posicionado exactamente en el nombre de A (Id vacio ordena antes que
+        // cualquier Id real) -- con Take: 1 trae solo a A.
+        var pagina1 = await ConsultarHastaQueAsync(
+            FiltroPorCursor(fechaReferencia, nombreA, cursorId: "", take: 1),
+            lista => lista.Any(f => f.Id == idA),
+            ct);
+
+        pagina1.Should().ContainSingle(f => f.Id == idA,
+            "el cursor posicionado en el nombre de A, con Id vacio, deberia traer solo a A");
+
+        // Pagina 2: cursor REAL de la ultima fila de la pagina 1 (NombreCompleto, Id de A) -- debe
+        // continuar exactamente en B, sin saltarlo ni repetir A.
+        var pagina2 = await ConsultarHastaQueAsync(
+            FiltroPorCursor(fechaReferencia, nombreA, cursorId: idA, take: 1),
+            lista => lista.Any(f => f.Id == idB),
+            ct);
+
+        pagina2.Should().ContainSingle(f => f.Id == idB,
+            "el cursor (NombreCompleto, Id) de A deberia continuar exactamente en B, sin saltar ni repetir");
+    }
+
+    // CA-3 (clamp del Take): Take: 0 se clampea a 1 en el servidor -- sin el clamp, un Take(0) crudo
+    // de LINQ devolveria una lista vacia SIEMPRE, sin importar que el colaborador exista y sea
+    // vigente.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarFichasColaborador_ClampeaTakeAMinimoUno_CuandoTakeLlegaEnCero()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var fechaReferencia = new DateOnly(2026, 4, 15);
+        var apellido = NuevoApellidoUnico("Clamp373");
+        var nombreCompleto = NombreCompletoDe(apellido);
+        var numeroIdentificacion = NuevoNumeroIdentificacion();
+        var streamId = ComputarStreamId(numeroIdentificacion);
+
+        await RegistrarColaboradorAsync(
+            numeroIdentificacion, new DateOnly(2026, 1, 1), apellido, NuevoCodigoColaborador(), ct);
+
+        var pagina = await ConsultarHastaQueAsync(
+            FiltroPorCursor(fechaReferencia, nombreCompleto, cursorId: "", take: 0),
+            lista => lista.Any(f => f.Id == streamId),
+            ct);
+
+        pagina.Should().ContainSingle(f => f.Id == streamId,
+            "Take: 0 deberia clampearse a 1 en el servidor -- un Take(0) crudo nunca habria devuelto esta fila");
+    }
+
+    // CA-4: sin Content-Type: application/json -> 415, verificado ANTES de leer el body.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarFichasColaborador_Retorna415_CuandoContentTypeNoEsJson()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        using var request = new HttpRequestMessage(MetodoQuery, RutaListado)
+        {
+            Content = new StringContent("{}", Encoding.UTF8, "text/plain")
+        };
+
+        var response = await _client.SendAsync(request, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnsupportedMediaType);
+    }
+
+    // CA-4: body con Content-Type json pero sintacticamente invalido -> 400.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarFichasColaborador_Retorna400_CuandoElBodyEsJsonInvalido()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        using var request = new HttpRequestMessage(MetodoQuery, RutaListado)
+        {
+            Content = new StringContent("{ esto no es json valido", Encoding.UTF8, "application/json")
+        };
+
+        var response = await _client.SendAsync(request, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    // CA-4: body ausente (Content-Type json, cero bytes) -> 400.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarFichasColaborador_Retorna400_CuandoElBodyEstaVacio()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        using var request = new HttpRequestMessage(MetodoQuery, RutaListado)
+        {
+            Content = new StringContent(string.Empty, Encoding.UTF8, "application/json")
+        };
+
+        var response = await _client.SendAsync(request, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    // CA-4: JSON valido sin FechaReferencia -> 422 (obligatoria; el back jamas resuelve "hoy").
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarFichasColaborador_Retorna422_CuandoFechaReferenciaNoLlega()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        var response = await ConsultarAsync(new { }, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    // CA-4/CA-2: una etiqueta del filtro con categoria/valor vacios -> 422 (Etiqueta.Crear rechaza).
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarFichasColaborador_Retorna422_CuandoUnaEtiquetaDelFiltroEsInvalida()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        var filtro = new
+        {
+            fechaReferencia = new DateOnly(2026, 1, 1),
+            etiquetas = new[] { new { categoria = "", valor = "Tecnologia" } }
+        };
+
+        var response = await ConsultarAsync(filtro, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    // CA-4: cursor con un solo campo presente (falta Id) -> 422.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarFichasColaborador_Retorna422_CuandoElCursorLlegaIncompleto()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        var filtro = new
+        {
+            fechaReferencia = new DateOnly(2026, 1, 1),
+            cursor = new { nombreCompleto = "[TEST] Algo" } // sin id
+        };
+
+        var response = await ConsultarAsync(filtro, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    // CA-4: sin resultados -> 200 con lista vacia, nunca 404. Categoria/valor con un Guid embebido:
+    // nadie pudo haber asignado jamas esta combinacion exacta.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarFichasColaborador_Retorna200ConListaVacia_CuandoNingunVigenteCumpleElFiltroDeEtiquetas()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        var filtro = FiltroPorEtiquetas(new DateOnly(2026, 1, 1),
+            ("smoke-inexistente-373", Guid.CreateVersion7().ToString("N")));
+
+        var response = await ConsultarAsync(filtro, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var lista = await response.Content.ReadFromJsonAsync<List<FichaColaboradorRespuestaSmoke>>(
+            JsonOptions, cancellationToken: ct);
+        (lista ?? []).Should().BeEmpty();
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/ObtenerFichaColaborador/ObtenerFichaColaboradorSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/ObtenerFichaColaborador/ObtenerFichaColaboradorSmokeTests.cs
@@ -71,15 +71,15 @@ public class ObtenerFichaColaboradorSmokeTests(ApiFixture api)
 
     // Numero unico por test -- evita colisiones entre ejecuciones repetidas del smoke test: la
     // identidad del stream (y por lo tanto el Id de la ficha) es Identificacion.ToString()
-    // ("CC:<numero>"), no un Guid nuevo por llamada.
+    // ("CC-<numero>"), no un Guid nuevo por llamada.
     private static string NuevoNumeroIdentificacion() => Guid.CreateVersion7().ToString("N").ToUpperInvariant();
 
     private static string NuevoCodigoColaborador() => $"[TEST]-{Guid.CreateVersion7()}";
 
-    // Mismo formato que ColaboradorAggregateRoot.ComputarStreamId, reconstruido localmente: el
-    // smoke test no referencia el Function App (Colaboradores.Entities).
+    // Mismo formato que ColaboradorAggregateRoot.ComputarStreamId (separador "-" desde #381),
+    // reconstruido localmente: el smoke test no referencia el Function App (Colaboradores.Entities).
     private static string ComputarStreamId(string numeroIdentificacion) =>
-        $"{TipoIdentificacionCc}:{numeroIdentificacion}";
+        $"{TipoIdentificacionCc}-{numeroIdentificacion}";
 
     private static string Ruta(string tipoIdentificacion, string numero) =>
         $"/api/colaboradores/fichas/{tipoIdentificacion}/{numero}";

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/Infraestructura/ComposicionServiciosTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/Infraestructura/ComposicionServiciosTests.cs
@@ -26,6 +26,7 @@ using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry.Trace;
 using Wolverine;
 using ObtenerFichaColaboradorEndpoint = Bitakora.ControlAsistencia.Colaboradores.ObtenerFichaColaborador.FunctionEndpoint;
+using ListarFichasColaboradorEndpoint = Bitakora.ControlAsistencia.Colaboradores.ListarFichasColaborador.FunctionEndpoint;
 
 namespace Bitakora.ControlAsistencia.Colaboradores.Tests.Infraestructura;
 
@@ -391,5 +392,27 @@ public class ComposicionServiciosTests
         mapping.TableName.QualifiedName.Should().Be("colaboradores.mt_doc_fichacolaborador");
         mapping.TenancyStyle.Should().Be(TenancyStyle.Conjoined);
         mapping.IdMember.Name.Should().Be(nameof(FichaColaborador.Id));
+    }
+
+    // Issue #373 CA-4 (segunda mitad del desglose de #356): test de composicion de la SEGUNDA
+    // Function de lectura del dominio, hermano del que #356 dejo para ObtenerFichaColaborador --
+    // misma idea (MEF-ADR-0029/ActivatorUtilities.CreateInstance, sin host real), pero ahora sobre
+    // un endpoint QUERY (MEF-ADR-0042) en vez de GET. Ninguna proyeccion ni read model nuevos: este
+    // issue consulta la MISMA vista materializada FichaColaborador via (a') (session.Query, en vez
+    // de LoadAsync por id).
+    //
+    // Se prueba solo la RESOLUCION de IDocumentStore/ITenantResolver por constructor -- no el
+    // comportamiento de Run (415/400/422, filtro AND por etiquetas, paginacion keyset), que es
+    // responsabilidad del endpoint y cubre FunctionEndpointTests.cs (validacion) y el smoke test
+    // contra dev (CA-6, camino feliz + Marten real).
+    [Fact]
+    public async Task AgregarServiciosColaboradores_ResuelveElEndpointDeListarFichasColaborador_CuandoElContenedorEstaCompuesto()
+    {
+        await using var provider = ComponerServiceProvider();
+        await using var scope = provider.CreateAsyncScope();
+
+        var act = () => ActivatorUtilities.CreateInstance<ListarFichasColaboradorEndpoint>(scope.ServiceProvider);
+
+        act.Should().NotThrow();
     }
 }

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ListarFichasColaborador/FunctionEndpointTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ListarFichasColaborador/FunctionEndpointTests.cs
@@ -50,7 +50,7 @@ public class FunctionEndpointTests
     // --- 415: Content-Type ausente o distinto de application/json (RFC 10008 seccion 2) ---
 
     [Fact]
-    public async Task Run_Retorna415_CuandoElContentTypeNoEsJson()
+    public async Task ListarFichasColaborador_Retorna415_CuandoElContentTypeNoEsJson()
     {
         var request = FakeHttpRequest(contentType: "text/plain", body: "{}");
 
@@ -62,7 +62,7 @@ public class FunctionEndpointTests
     }
 
     [Fact]
-    public async Task Run_Retorna415_CuandoElContentTypeEstaAusente()
+    public async Task ListarFichasColaborador_Retorna415_CuandoElContentTypeEstaAusente()
     {
         var request = FakeHttpRequest(contentType: null, body: "{}");
 
@@ -75,7 +75,7 @@ public class FunctionEndpointTests
     // --- 400: body ausente, JSON invalido o literal "null" (RFC 10008 seccion 2.1) ---
 
     [Fact]
-    public async Task Run_Retorna400_CuandoElBodyEstaAusente()
+    public async Task ListarFichasColaborador_Retorna400_CuandoElBodyEstaAusente()
     {
         var request = FakeHttpRequest(contentType: "application/json", body: null);
 
@@ -86,7 +86,7 @@ public class FunctionEndpointTests
     }
 
     [Fact]
-    public async Task Run_Retorna400_CuandoElBodyNoEsJsonValido()
+    public async Task ListarFichasColaborador_Retorna400_CuandoElBodyNoEsJsonValido()
     {
         var request = FakeHttpRequest(contentType: "application/json", body: "{ esto no es json");
 
@@ -96,7 +96,7 @@ public class FunctionEndpointTests
     }
 
     [Fact]
-    public async Task Run_Retorna400_CuandoElBodyEsElLiteralJsonNull()
+    public async Task ListarFichasColaborador_Retorna400_CuandoElBodyEsElLiteralJsonNull()
     {
         // JSON sintacticamente valido que deserializa a null (distinto del caso anterior, JSON
         // invalido) -- misma rama que el ejemplo canonico de skills/projections/read-apis.md:
@@ -111,7 +111,7 @@ public class FunctionEndpointTests
     // --- 422: JSON valido pero no procesable (CA-4) ---
 
     [Fact]
-    public async Task Run_Retorna422_CuandoFaltaFechaReferencia()
+    public async Task ListarFichasColaborador_Retorna422_CuandoFaltaFechaReferencia()
     {
         // FechaReferencia es obligatoria (el back jamas resuelve "hoy") -- STJ no lanza por su
         // ausencia (verificado por spike: el campo queda en 0001-01-01), asi que el 422 depende de
@@ -126,7 +126,7 @@ public class FunctionEndpointTests
     }
 
     [Fact]
-    public async Task Run_Retorna422_CuandoUnaEtiquetaDelFiltroEsInvalida()
+    public async Task ListarFichasColaborador_Retorna422_CuandoUnaEtiquetaDelFiltroEsInvalida()
     {
         // CA-2: normalizacion simetrica -- el endpoint construye Etiqueta.Crear(Categoria, Valor)
         // con cada par; un par con categoria vacia lo rechaza Etiqueta.Crear con ArgumentException
@@ -141,8 +141,26 @@ public class FunctionEndpointTests
         unprocessable.StatusCode.Should().Be(StatusCodes.Status422UnprocessableEntity);
     }
 
+    // Agregado en la revision: el body es entrada del cliente y STJ acepta un elemento null dentro
+    // del array pese a la anotacion no-nullable de FiltroEtiqueta. Sin el guard del endpoint, el
+    // acceso a par.Categoria era una NullReferenceException que escapaba del catch de
+    // ArgumentException y salia como 500 donde RFC 10008 seccion 2.1 pide 422.
     [Fact]
-    public async Task Run_Retorna422_CuandoElCursorTraeUnSoloCampo()
+    public async Task ListarFichasColaborador_Retorna422_CuandoUnaEtiquetaDelFiltroEsNula()
+    {
+        var request = FakeHttpRequest(
+            contentType: "application/json",
+            body: """{"fechaReferencia":"2026-08-14","etiquetas":[null]}""");
+
+        var resultado = await Endpoint().Run(request, CancellationToken.None);
+
+        var unprocessable = resultado.Should().BeOfType<ObjectResult>().Subject;
+        unprocessable.StatusCode.Should().Be(StatusCodes.Status422UnprocessableEntity);
+        unprocessable.Value.Should().BeOfType<string>();
+    }
+
+    [Fact]
+    public async Task ListarFichasColaborador_Retorna422_CuandoElCursorTraeUnSoloCampo()
     {
         // Cursor con NombreCompleto pero sin Id (el otro campo del cursor keyset, CursorFicha.Id
         // queda null -- verificado por spike: STJ no lanza por un campo string ausente).

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ListarFichasColaborador/FunctionEndpointTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ListarFichasColaborador/FunctionEndpointTests.cs
@@ -1,0 +1,158 @@
+// Issue #373 CA-4: validacion del borde HTTP del endpoint QUERY ListarFichasColaborador (MEF-ADR-
+// 0042, RFC 10008). Estos casos cortocircuitan ANTES de abrir la QuerySession -- store y
+// tenantResolver se pasan nulos a proposito, mismo patron que ListarTurnosVigentes/
+// FunctionEndpointTests.cs (ControlHoras.Tests, issue #329): si un cambio futuro moviera la
+// validacion DESPUES de tocar Marten, estos tests se pondrian rojos por la razon correcta.
+//
+// Fase roja (projection-test-writer): FunctionEndpoint.Run() hoy SOLO lanza NotImplementedException
+// (MEF-ADR-0033, stub minimo de compilacion) -- ninguno de estos tests puede pasar todavia. El
+// COMPORTAMIENTO (que status code y que rama dispara cada uno) es responsabilidad de
+// projection-implementer; el MECANISMO exacto (required del record, chequeo explicito de default,
+// etc., segun el propio issue) es su decision, no la de este archivo.
+//
+// Los cinco casos de deserializacion (body ausente, JSON invalido, literal "null", FechaReferencia
+// ausente, cursor incompleto) estan verificados por spike propio contra
+// HttpRequestJsonExtensions.ReadFromJsonAsync (STJ reflection-based, sin JsonOptions en
+// RequestServices): un campo string/DateOnly ausente en el JSON NO lanza -- se completa con el
+// default del tipo (null / 0001-01-01) sin excepcion -- y JsonException solo aparece con body vacio
+// o JSON sintacticamente invalido. De ahi que CA-4 exija una validacion EXPLICITA post-deserializacion
+// para el 422 (missing FechaReferencia, cursor con un solo campo): STJ por si solo no la produce.
+
+using System.Text;
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.ListarFichasColaborador;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Tests.ListarFichasColaborador;
+
+public class FunctionEndpointTests
+{
+    private static FunctionEndpoint Endpoint() => new(store: null!, tenantResolver: null!);
+
+    private static HttpRequest FakeHttpRequest(string? contentType, string? body)
+    {
+        var context = new DefaultHttpContext();
+
+        if (contentType is not null)
+            context.Request.ContentType = contentType;
+
+        if (body is not null)
+        {
+            var bytes = Encoding.UTF8.GetBytes(body);
+            context.Request.Body = new MemoryStream(bytes);
+            context.Request.ContentLength = bytes.Length;
+        }
+
+        return context.Request;
+    }
+
+    // --- 415: Content-Type ausente o distinto de application/json (RFC 10008 seccion 2) ---
+
+    [Fact]
+    public async Task Run_Retorna415_CuandoElContentTypeNoEsJson()
+    {
+        var request = FakeHttpRequest(contentType: "text/plain", body: "{}");
+
+        var resultado = await Endpoint().Run(request, CancellationToken.None);
+
+        var objectResult = resultado.Should().BeOfType<ObjectResult>().Subject;
+        objectResult.StatusCode.Should().Be(StatusCodes.Status415UnsupportedMediaType);
+        objectResult.Value.Should().BeOfType<string>();
+    }
+
+    [Fact]
+    public async Task Run_Retorna415_CuandoElContentTypeEstaAusente()
+    {
+        var request = FakeHttpRequest(contentType: null, body: "{}");
+
+        var resultado = await Endpoint().Run(request, CancellationToken.None);
+
+        var objectResult = resultado.Should().BeOfType<ObjectResult>().Subject;
+        objectResult.StatusCode.Should().Be(StatusCodes.Status415UnsupportedMediaType);
+    }
+
+    // --- 400: body ausente, JSON invalido o literal "null" (RFC 10008 seccion 2.1) ---
+
+    [Fact]
+    public async Task Run_Retorna400_CuandoElBodyEstaAusente()
+    {
+        var request = FakeHttpRequest(contentType: "application/json", body: null);
+
+        var resultado = await Endpoint().Run(request, CancellationToken.None);
+
+        var badRequest = resultado.Should().BeOfType<BadRequestObjectResult>().Subject;
+        badRequest.Value.Should().BeOfType<string>();
+    }
+
+    [Fact]
+    public async Task Run_Retorna400_CuandoElBodyNoEsJsonValido()
+    {
+        var request = FakeHttpRequest(contentType: "application/json", body: "{ esto no es json");
+
+        var resultado = await Endpoint().Run(request, CancellationToken.None);
+
+        resultado.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task Run_Retorna400_CuandoElBodyEsElLiteralJsonNull()
+    {
+        // JSON sintacticamente valido que deserializa a null (distinto del caso anterior, JSON
+        // invalido) -- misma rama que el ejemplo canonico de skills/projections/read-apis.md:
+        // "if (filtro is null) return new BadRequestObjectResult(...)".
+        var request = FakeHttpRequest(contentType: "application/json", body: "null");
+
+        var resultado = await Endpoint().Run(request, CancellationToken.None);
+
+        resultado.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    // --- 422: JSON valido pero no procesable (CA-4) ---
+
+    [Fact]
+    public async Task Run_Retorna422_CuandoFaltaFechaReferencia()
+    {
+        // FechaReferencia es obligatoria (el back jamas resuelve "hoy") -- STJ no lanza por su
+        // ausencia (verificado por spike: el campo queda en 0001-01-01), asi que el 422 depende de
+        // una validacion explicita del implementer, no de la deserializacion.
+        var request = FakeHttpRequest(contentType: "application/json", body: """{"take":10}""");
+
+        var resultado = await Endpoint().Run(request, CancellationToken.None);
+
+        var unprocessable = resultado.Should().BeOfType<ObjectResult>().Subject;
+        unprocessable.StatusCode.Should().Be(StatusCodes.Status422UnprocessableEntity);
+        unprocessable.Value.Should().BeOfType<string>();
+    }
+
+    [Fact]
+    public async Task Run_Retorna422_CuandoUnaEtiquetaDelFiltroEsInvalida()
+    {
+        // CA-2: normalizacion simetrica -- el endpoint construye Etiqueta.Crear(Categoria, Valor)
+        // con cada par; un par con categoria vacia lo rechaza Etiqueta.Crear con ArgumentException
+        // (Colaboradores.DomainEvents/Etiqueta.cs), que el endpoint traduce a 422.
+        var request = FakeHttpRequest(
+            contentType: "application/json",
+            body: """{"fechaReferencia":"2026-08-14","etiquetas":[{"categoria":"","valor":"Tecnologia"}]}""");
+
+        var resultado = await Endpoint().Run(request, CancellationToken.None);
+
+        var unprocessable = resultado.Should().BeOfType<ObjectResult>().Subject;
+        unprocessable.StatusCode.Should().Be(StatusCodes.Status422UnprocessableEntity);
+    }
+
+    [Fact]
+    public async Task Run_Retorna422_CuandoElCursorTraeUnSoloCampo()
+    {
+        // Cursor con NombreCompleto pero sin Id (el otro campo del cursor keyset, CursorFicha.Id
+        // queda null -- verificado por spike: STJ no lanza por un campo string ausente).
+        var request = FakeHttpRequest(
+            contentType: "application/json",
+            body: """{"fechaReferencia":"2026-08-14","cursor":{"nombreCompleto":"Ana Torres"}}""");
+
+        var resultado = await Endpoint().Run(request, CancellationToken.None);
+
+        var unprocessable = resultado.Should().BeOfType<ObjectResult>().Subject;
+        unprocessable.StatusCode.Should().Be(StatusCodes.Status422UnprocessableEntity);
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Projections.Tests/ConfiguracionMartenProjectionsTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Projections.Tests/ConfiguracionMartenProjectionsTests.cs
@@ -8,6 +8,7 @@ using Bitakora.ControlAsistencia.ReadModels.Colaboradores;
 using Bitakora.ControlAsistencia.ReadModels.ControlHoras;
 using JasperFx.MultiTenancy; // TenancyStyle (NO Marten.*: vive en JasperFx.MultiTenancy)
 using Microsoft.Extensions.DependencyInjection;
+using Weasel.Postgresql.Tables; // IndexMethod/IndexDefinition (NO Marten.*: viven en Weasel.Postgresql.Tables)
 
 namespace Bitakora.ControlAsistencia.Projections.Tests;
 
@@ -481,6 +482,65 @@ public class ConfiguracionMartenProjectionsTests
         mapping.TableName.QualifiedName.Should().Be("colaboradores.mt_doc_fichacolaborador");
         mapping.TenancyStyle.Should().Be(TenancyStyle.Conjoined);
         mapping.IdMember.Name.Should().Be(nameof(FichaColaborador.Id));
+    }
+
+    // Issue #373 CA-5: indices declarados en el seam del worker para el listado QUERY de fichas
+    // vigentes (ListarFichasColaborador, MEF-ADR-0042) -- rango sobre VigenteHasta, GIN sobre
+    // EtiquetasNormalizadas (containment JSONB del filtro AND por etiquetas, precedente #337 sobre
+    // Bloques/SedeId sobre TurnoVigente) y btree sobre NombreCompleto (orden del keyset). Ninguna
+    // proyeccion ni read model nuevos: este issue solo suma indices sobre la MISMA
+    // FichaColaborador ya registrada (#356).
+    //
+    // Baseline verificado por spike propio (sin este issue, StoreOptions.FindOrResolveDocumentType):
+    // FichaColaborador no declara ningun indice propio hoy -- Indexes.Count == 0 --, asi que las
+    // tres guardas de abajo fallan en la fase roja.
+    //
+    // Oraculo tolerante al MECANISMO exacto de Marten que elija projection-implementer (computed
+    // Index(x => x.Campo) vs Duplicate(...).Index(...), DocumentIndex vs ComputedIndex): ambos
+    // caminos agregan una entrada a IDocumentType.Indexes cuyo IndexDefinition expone Method y
+    // Columns publicamente (Weasel.Postgresql.Tables), pero el nombre de indice y la forma exacta
+    // del locator SQL varian segun el camino elegido -- por eso el assert busca el nombre del campo
+    // C# (o su forma snake_case) como SUBCADENA de Columns, sin fijar el locator completo. Verificado
+    // por spike propio: Schema.For<FichaColaborador>().Index(x => x.VigenteHasta) produce
+    // Columns=["(public.mt_immutable_date(data ->> 'VigenteHasta'))"]; cualquier implementacion que
+    // toque ese campo, por el camino que sea, deja el nombre del campo en alguna parte del locator.
+    private static bool IndiceMencionaCampo(IndexDefinition indice, params string[] fragmentosDelCampo) =>
+        indice.Columns is { } columnas
+        && columnas.Any(columna => fragmentosDelCampo.All(
+            fragmento => columna.Contains(fragmento, StringComparison.OrdinalIgnoreCase)));
+
+    [Fact]
+    public void ConfigurarColaboradores_DeclaraIndiceGinSobreEtiquetasNormalizadasDeFichaColaborador()
+    {
+        using var provider = ProviderDeColaboradores();
+
+        var mapping = provider.GetRequiredService<IColaboradoresProjectionStore>()
+            .Options.FindOrResolveDocumentType(typeof(FichaColaborador));
+
+        mapping.Indexes.Should().Contain(indice =>
+            indice.Method == IndexMethod.gin && IndiceMencionaCampo(indice, "etiqueta"));
+    }
+
+    [Fact]
+    public void ConfigurarColaboradores_DeclaraUnIndiceSobreVigenteHastaDeFichaColaborador()
+    {
+        using var provider = ProviderDeColaboradores();
+
+        var mapping = provider.GetRequiredService<IColaboradoresProjectionStore>()
+            .Options.FindOrResolveDocumentType(typeof(FichaColaborador));
+
+        mapping.Indexes.Should().Contain(indice => IndiceMencionaCampo(indice, "vigente", "hasta"));
+    }
+
+    [Fact]
+    public void ConfigurarColaboradores_DeclaraUnIndiceSobreNombreCompletoDeFichaColaborador()
+    {
+        using var provider = ProviderDeColaboradores();
+
+        var mapping = provider.GetRequiredService<IColaboradoresProjectionStore>()
+            .Options.FindOrResolveDocumentType(typeof(FichaColaborador));
+
+        mapping.Indexes.Should().Contain(indice => IndiceMencionaCampo(indice, "nombre", "completo"));
     }
 
     // --- Seam de nivel BC (CA-4) ---


### PR DESCRIPTION
## Resumen

Pipeline TDD completado:
- Fase roja: tests escritos con stubs
- Fase verde: implementación completa
- Smoke tests: escritos para endpoints detectados
- Fase refactor: revisión de calidad

## Decisiones del pipeline

<details>
<summary>Projection Test Writer (fase roja) — 15m 4s</summary>

# Stage 1 (read-side) -- projection-test-writer -- Issue #373

## Contexto verificado antes de escribir

- `FichaColaborador` (read model), `FichaColaboradorProjection` (N1,
  `SingleStreamProjection<FichaColaborador, string>`) y su registro en
  `ConfiguracionMartenProjectionsColaboradores` ya viven en `main` (issue #356,
  PR #375). Este issue **no** crea ni modifica `Create`/`Apply`/`ShouldDelete`
  -- por eso no toqué `FichaColaboradorProjectionTests.cs` ni escribí ningún
  test nuevo de proyección: no hay comportamiento nuevo de esa capa que
  cubrir.
- El trabajo real de este issue es: (a) tres índices nuevos en el seam del
  worker (CA-5) y (b) una Function **QUERY** nueva (`ListarFichasColaborador`,
  MEF-ADR-0042) con su propia lógica de validación -- ninguna de las dos cae
  bajo "sin potencial de rojo", así que **no apliqué la señal no-red**: hay
  tests de comportamiento genuinamente alcanzables (ver más abajo).

## Tests creados

### 1. `tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ListarFichasColaborador/FunctionEndpointTests.cs` (nuevo)

9 tests sobre el `FunctionEndpoint` real, con `store`/`tenantResolver` nulos a
propósito (mismo patrón que `ListarTurnosVigentes/FunctionEndpointTests.cs`,
issue #329): cortocircuitan antes de tocar Marten, así que un cambio futuro
que abra la `QuerySession` antes de validar los pondría rojos por la razón
correcta.

- 415: `Content-Type` ausente / distinto de `application/json` (2 tests).
- 400: body ausente, JSON inválido, y el literal JSON `"null"` (3 tests,
  cubre las tres ramas del ejemplo canónico de `read-apis.md`).
- 422: falta `FechaReferencia`, una etiqueta del filtro inválida (categoría
  vacía -- `Etiqueta.Crear` rechaza), cursor con un solo campo (3 tests).

Antes de escribir estos tests hice tres spikes desechables (`dotnet test
--filter-method` contra archivos `Scratch*Tests.cs`, borrados después de
verificar) para no adivinar el comportamiento real de
`HttpRequestJsonExtensions.ReadFromJsonAsync` sobre un `DefaultHttpContext`
sin `RequestServices` configurado:

1. Confirmé que STJ (reflection-based, sin `JsonOptions` en DI) deserializa
   camelCase case-insensitive sin lanzar, incluso sin `RequestServices`.
2. Confirmé que un campo **ausente** en el JSON (string o `DateOnly`) **no**
   lanza -- se completa con el default del tipo (`null` / `0001-01-01`).
   Esto es lo que hace inevitable que el 422 de `FechaReferencia`
   ausente/cursor incompleto dependa de una validación explícita del
   implementer (tal como el propio issue lo deja abierto: "Mecanismo exacto
   de validación del 422 ... decisión del implementer").
3. Confirmé los `JsonException` exactos para body vacío/ausente y JSON mal
   formado (ambos caen en la misma rama 400).

Corrí estos 9 tests contra el stub: **8 fallan** con `NotImplementedException`
(rojo esperado) y 1 pasa (el de composición, ver abajo -- un wiring guard no
tiene que estar rojo).

### 2. `tests/Bitakora.ControlAsistencia.Colaboradores.Tests/Infraestructura/ComposicionServiciosTests.cs` (editado)

Un test nuevo,
`AgregarServiciosColaboradores_ResuelveElEndpointDeListarFichasColaborador_CuandoElContenedorEstaCompuesto`,
hermano exacto del que #356 dejó para `ObtenerFichaColaborador`
(`ActivatorUtilities.CreateInstance` sobre el `ServiceProvider` real del
write-side, MEF-ADR-0029). Pasa en verde de inmediato -- es un guardrail de
wiring, no un test de comportamiento; el rojo de este issue lo aportan los
tests de validación de arriba.

### 3. `tests/Bitakora.ControlAsistencia.Projections.Tests/ConfiguracionMartenProjectionsTests.cs` (editado, CA-5)

Tres facts nuevos verificando los índices que el issue pide sobre
`FichaColaborador` en `ConfiguracionMartenProjectionsColaboradores`: GIN sobre
`EtiquetasNormalizadas`, un índice sobre `VigenteHasta` y uno sobre
`NombreCompleto`.

**Decisión documentada (regla 6, "Desviaciones del plan del planner"):** antes
de escribir el oráculo hice un spike con `ilspycmd` sobre `Marten.dll`/
`Weasel.Postgresql.dll` (9.12.0/9.3.0) y confirmé por ejecución real
(`StoreOptions.Schema.For<T>().Index(...)`) que:

- `IDocumentType.Indexes` (`IList<IndexDefinition>`) es pública y alcanzable
  sin cast desde `store.Options.FindOrResolveDocumentType(...)` -- ya usado
  por el archivo para `Metadata`/`TableName`/`TenancyStyle`/`IdMember`.
- Marten ofrece **más de un mecanismo válido** para declarar estos tres
  índices (`Index(expr)` computado sobre JSONB vs `Duplicate(expr).Index(...)`
  sobre una columna duplicada), y cada uno produce un `Name`/`Columns` con
  forma distinta (verificado por spike: `Index(x => x.VigenteHasta)` produce
  `Columns=["(public.mt_immutable_date(data ->> 'VigenteHasta'))"]`).

Fijar el oráculo sobre el nombre/columna exactos de **un** mecanismo habría
significado prescribir la implementación (terreno de
`projection-implementer`, no mío). Por eso el assert es **tolerante al
mecanismo**: busca el nombre del campo C# como subcadena case-insensitive de
`IndexDefinition.Columns` (`IndiceMencionaCampo`, helper local), y para el GIN
además exige `Method == IndexMethod.gin`. Es más débil que un literal exacto,
pero es un oráculo real (no un `Count() > 0` ciego) y no le dicta al
implementer cuál de los dos caminos de Marten usar.

Verifiqué el baseline con un spike propio (`Indexes.Count == 0` hoy sobre
`FichaColaborador`, sin este issue) antes de escribir el assert, así que los
tres facts fallan legítimamente contra el código actual (confirmado
ejecutando `dotnet test --filter-method "*Indice*"`: 3/3 rojos).

## Stubs de compilación creados

- `src/Bitakora.ControlAsistencia.Colaboradores/ListarFichasColaborador/FunctionEndpoint.cs`:
  - `FunctionEndpoint` con constructor `(IDocumentStore, ITenantResolver)` y
    `[Function("ListarFichasColaborador")]` sobre
    `HttpTrigger(AuthorizationLevel.Anonymous, "query", Route =
    "colaboradores/fichas")` -- mismo segmento de recurso que
    `ObtenerFichaColaborador`, MEF-ADR-0006 enmienda MEF-ADR-0042 sección 5.
    `Run` lanza `NotImplementedException` sin ninguna rama (stub mínimo, tal
    cual pide mi rol).
  - Los tres records del contrato QUERY (`FiltroListarFichasColaborador`,
    `FiltroEtiqueta`, `CursorFicha`) están **completos** (no son stubs con
    `throw`): son DTOs planos sin comportamiento, con la forma exacta que fija
    el issue -- mismo criterio que ya aplica el read model
    `FichaColaborador` (record pleno, sin lógica).
- No hice falta ningún stub de marker/seam (`IColaboradoresProjectionStore` y
  `ConfiguracionMartenProjectionsColaboradores.ConfigurarColaboradores` ya
  existen y están implementados desde #356/#360) ni ninguna `ProjectReference`
  nueva -- el worker ya referencia `Colaboradores.DomainEvents` desde ese
  mismo issue.

## Cobertura de criterios de aceptación (desde el lado read-side)

- CA-1 (vigencia), CA-2 (filtro AND + normalización), CA-3 (paginación
  keyset): sin cobertura unitaria en esta fase -- exigen `QuerySession` real
  contra Postgres (LINQ traducido a SQL), y quedan para el smoke test contra
  dev (CA-6, fuera de mi alcance: responsabilidad de `smoke-test-writer`/
  `projection-implementer`). Mi archivo `FunctionEndpointTests.cs` sólo cubre
  las ramas de validación que cortocircuitan **antes** de Marten.
- CA-4 (contrato QUERY: 415/400/422): cubierto íntegramente por
  `FunctionEndpointTests.cs`.
- CA-5 (índices declarados): cubierto por los tres facts nuevos en
  `ConfiguracionMartenProjectionsTests.cs`, con el oráculo tolerante descrito
  arriba.
- CA-6 (gates de ejecución, smoke test QUERY end-to-end, colación de la
  base): fuera de mi alcance (read-side unit/config-test únicamente).

## Verificación de build

- `dotnet build ControlAsistencias.slnx`: compilación correcta, 0 errores (los
  únicos warnings nuevos son `CS9113` sobre los parámetros `store`/
  `tenantResolver` del stub, esperados).
- `dotnet test --project tests/Bitakora.ControlAsistencia.Colaboradores.Tests/`:
  310 correctos, 8 en rojo (los nuevos de `FunctionEndpointTests.cs`) -- sin
  regresiones sobre los 309 tests preexistentes.
- `dotnet test --project tests/Bitakora.ControlAsistencia.Projections.Tests/`:
  74 correctos, 3 en rojo (los nuevos de CA-5) -- sin regresiones sobre los 74
  tests preexistentes.
- No corrí `dotnet test` sobre la solución completa (no hace falta: ya sé que
  el resto está en verde y los nuevos en rojo por diseño).

## Señal no-red

No aplica. El issue sí tiene comportamiento nuevo alcanzable en fase roja
(la Function QUERY completa); la señal de `agents/projection-test-writer.md`
sólo cubre el caso donde lo único posible son guardrails de wiring/config-test,
que no es este caso.

</details>

<details>
<summary>Projection Implementer (fase verde) — 16m 26s</summary>

# Resumen -- projection-implementer (issue #373)

## Enfoque

Hice pasar los tests read-side que dejó `projection-test-writer` (4 archivos, ninguno modificado):
`FunctionEndpoint.cs` (stub -> implementación), `ComposicionServiciosTests.cs`,
`FunctionEndpointTests.cs` y `ConfiguracionMartenProjectionsTests.cs`. El issue es la segunda mitad
del desglose de #356: ninguna proyección ni read model nuevos, solo:

1. La Function QUERY `ListarFichasColaborador` (RFC 10008 / MEF-ADR-0042) sobre la vista ya
   materializada `FichaColaborador`.
2. Tres índices en el seam del worker (`ConfiguracionMartenProjectionsColaboradores`, CA-5).

Antes de escribir el endpoint verifiqué contra un Postgres 16 real (contenedor Docker efímero,
eliminado al terminar) y Marten 9.12.0 cuál es el mecanismo que **realmente** traduce a SQL correcto
y cuál usa el índice GIN declarado, porque el ejemplo canónico de `read-apis.md` deja
explícitamente "NO VERIFICADO" tanto el filtro por campos JSONB anidados como la traducción
`CompareTo` de un cursor keyset sobre `string`.

## Hallazgos del spike (no documentados en el Skill, quedan registrados aquí y en comentarios del código)

- **Filtro AND por etiquetas sobre `Dictionary<string,string>`**: probé tres mecanismos con datos
  reales insertados vía Marten y `EXPLAIN` con `enable_seqscan=off`:
  - `f.EtiquetasNormalizadas[cat] == val` (indexer LINQ, encadenado con múltiples `.Where()`): SÍ
    traduce correctamente y da resultados correctos, pero genera `data -> 'X' ->> 'clave' = valor`
    (lookup por clave) -- **nunca** usa un índice GIN, ni forzando `enable_seqscan=off` (siempre
    Seq Scan).
  - `f.EtiquetasNormalizadas.Contains(new KeyValuePair<string,string>(cat, val))`: SÍ genera
    containment (`data @> :p0`), pero el JSON que arma Marten para el containment tiene shape
    `{"EtiquetasNormalizadas":[{"Key":"area","Value":"tecnologia"}]}` (array de KVP), que **jamás**
    calza con la representación real de un `Dictionary<string,string>` serializado por STJ
    (`{"area":"tecnologia"}`, un objeto). Devuelve **0 resultados siempre**, exista o no el par --
    antipatrón silencioso, ningún test unitario lo habría atrapado.
  - `f.MatchesSql("(data->>'EtiquetasNormalizadas')::jsonb @> ?::jsonb", json)`: reproduce
    EXACTAMENTE el mismo shape de expresión que genera
    `Schema.For<FichaColaborador>().Index(x => x.EtiquetasNormalizadas, gin)` (verificado leyendo
    el DDL real: `USING gin (((data ->> 'EtiquetasNormalizadas')::jsonb))`). Confirmado con
    `EXPLAIN`: `Bitmap Index Scan` sobre ese índice. Esta es la forma que implementé.
- **Cursor keyset sobre campos `string`**: `f.Campo.CompareTo(valor) > 0` SÍ traduce a SQL
  (`data ->> 'Campo' > :p0`, o `id > :p0` para el `Id`, que es columna dedicada del documento).
  `string.Compare(a, b, StringComparison.Ordinal) > 0` **no** -- Marten lanza
  `BadLinqExpressionException` ("cannot reduce... to a constant"). Usé `CompareTo`.

Documenté ambos hallazgos en comentarios inline del endpoint y del seam, para que el próximo que
toque este archivo no repita el spike.

## Decisiones de diseño

- **Reutilicé `FichaColaboradorRespuesta.DesdeVista`** (de `ObtenerFichaColaborador`, #356) para
  traducir el centinela `VigenteHasta` a `null` en cada item de la lista, en vez de duplicar la
  misma traducción en un DTO propio de este endpoint (MEF-ADR-0018: es la misma excepción de DTO de
  respuesta bajo MEF-ADR-0041 decisión 4, ahora con un segundo consumidor del mismo read model). Sin
  envelope (propuesta del issue): la respuesta es `OkObjectResult` con la lista plana; el cliente
  deriva el cursor de `NombreCompleto`/`Id` de la última fila.
- **Cursor "incompleto"**: interpreté "un solo campo presente" de forma inclusiva -- si CUALQUIERA
  de los dos campos del cursor es `null` (uno o ambos), es 422. Un cliente que no quiere paginar
  debe omitir `cursor` por completo (`null`), no enviar un objeto vacío.
- **422 por `FechaReferencia` ausente**: chequeo explícito `filtro.FechaReferencia == default`
  (mismo mecanismo que el comentario de `FunctionEndpointTests.cs` sugiere). Trade-off aceptado: un
  caller que explícitamente enviara `"0001-01-01"` sería rechazado como si estuviera ausente --
  edge case fuera de alcance real.
- Los tres índices (CA-5) se agregan **aditivamente** dentro del mismo `AddMartenStore` que ya
  registra `FichaColaboradorProjection` (#356) -- no se tocó nada de lo ya registrado.

## ADRs / recursos consultados

- MEF-ADR-0042 (frontera GET/QUERY, contrato, códigos 400/415/422, paginación keyset) y su ejemplo
  canónico en `skills/projections/read-apis.md`.
- MEF-ADR-0034 (worker de proyecciones, índices en el seam) / MEF-ADR-0035 (vía de consulta (a')).
- MEF-ADR-0028 (`QuerySession` acotada al tenant del resolver).
- MEF-ADR-0012 (Tell-don't-Ask: `Etiqueta.Crear` normaliza, el endpoint no reimplementa).
- MEF-ADR-0041 decisión 4 (DTO de respuesta como excepción) y decisión 3 (naming sin sufijo).
- MEF-ADR-0018 (Rule of Three: reutilización de `FichaColaboradorRespuesta` en vez de duplicar).
- `skills/projections/modelos-marten.md` y `naming.md` para confirmar que este issue no toca ni
  read model ni clase de proyección (ya existen desde #356).

## Desviaciones

Ninguna desviación consciente de un ADR o del Skill. La única extensión sobre lo documentado es el
mecanismo verificado por spike (arriba) para dos superficies que `read-apis.md` marca explícitamente
como "NO VERIFICADO" -- no contradice el Skill, lo completa con evidencia de ejecución real para
este dominio.

## Resultado

- `dotnet build` de toda la solución: sin errores, sin warnings nuevos.
- Tests dejados por `projection-test-writer`: 8/8 (`FunctionEndpointTests`), 15/15
  (`ComposicionServiciosTests` de Colaboradores.Tests, incluida la guarda del nuevo endpoint), 34/34
  (`ConfiguracionMartenProjectionsTests`, incluidas las 3 guardas de índices de CA-5).
- Resto de la suite (Colaboradores.Tests, Programacion.Tests, ControlHoras.Tests,
  Projections.Tests, Public/PrivateEvents.Tests) en verde: 318 + 227 + 442 + 77 + 13 + 50 tests, sin
  regresiones sobre el write-side existente.
- Sin tests de smoke tocados (fuera de mi alcance -- corresponde a `smoke-test-writer`/gate de
  ejecución de CA-6).

</details>
<details>
<summary>Smoke Test Writer — 12m 53s</summary>

_(El agente no generó resumen)_

</details>
<details>
<summary>Reviewer (fase refactor) — 23m 43s</summary>

# ES Reviewer - Revision (issue #373)

### Evaluacion general
- Calidad: **buena** — diseño correcto, ADRs cumplidos, un defecto de robustez de borde corregido.
- Cambios realizados: **si** (commit `81dfebc`).

Estado de la suite tras la revision: **1226 correctos, 12 en rojo, 46 omitidos**. Los 12 rojos son
*exclusivamente* `ListarFichasColaboradorSmokeTests`, todos con `404` porque el endpoint todavia no
esta desplegado en dev (convencion documentada del repo; el CI del PR solo corre `*.Tests`). Al
inicio de la revision habia **14** rojos: los 2 adicionales eran un oraculo obsoleto heredado de
`main`, corregido aqui (ver Hallazgos).

---

### Cumplimiento de ADRs aplicables

| ADR | Cumplimiento | Observacion |
|---|---|---|
| MEF-ADR-0042: frontera GET/QUERY, DTO tipado, 400/415/422, keyset, clamp | ok | Verbo `"query"` sobre el mismo recurso; `HasJsonContentType()` **antes** de `ReadFromJsonAsync` (el punto exacto que el ADR marca como trampa del `500`); `ObjectResult` con mensaje en los tres codigos, ninguno pelado; keyset con `Take` acotado en servidor (`Math.Clamp(take,1,200)`), sin `Skip`. Gate NO VERIFICADO #4 (traduccion LINQ del cursor) cerrado, ver Hallazgo 4. |
| MEF-ADR-0035: read-side sobre `QuerySession`, via (a') | ok | `session.Query<FichaColaborador>()` con LINQ; ninguna proyeccion ni read model nuevos, como manda el issue. |
| MEF-ADR-0034: indices en el seam del worker; compatibilidad write/read | ok | Los tres indices se suman **aditivamente** dentro del mismo `AddMartenStore` que ya registra `FichaColaboradorProjection`, sin tocar nada de lo registrado. Ver fila de compatibilidad en el checklist. |
| MEF-ADR-0006 (+ enmienda de MEF-ADR-0042 §5): naming | ok | `ListarFichasColaborador`, feature folder sin sufijo `Function`, `Route` identica a la del GET puntual — solo cambia el verbo, exactamente lo que fija la enmienda. |
| MEF-ADR-0028 / CA-ADR-0027: tenancy | ok | `store.QuerySession(tenantResolver.TenantId)`; ningun tenant id sale del body. **Verificado a nivel de SQL generado**, no solo por lectura — ver Hallazgo 4. |
| MEF-ADR-0012: Tell-don't-Ask en la normalizacion | ok | El endpoint llama `Etiqueta.Crear(categoria, valor)` y consume `CategoriaNormalizada`/`ValorNormalizado`, propiedades preexistentes que el propio VO documenta como *"identidad observable, no dato intermedio de calculo"*. No reimplementa el algoritmo, no agrega propiedad nueva al VO, no introduce clase estatica sobre datos crudos. |
| MEF-ADR-0041: sin DTO de respuesta nuevo | ok | Reutiliza `FichaColaboradorRespuesta.DesdeVista` de `ObtenerFichaColaborador` (excepcion ya vigente por decision 4, ahora con segundo consumidor) en vez de crear un DTO gemelo ni duplicar la traduccion del centinela. |
| MEF-ADR-0018: sin campo de orden, sin envelope, sin offset | ok | Nada de eso aparece. La reutilizacion del DTO de respuesta es justamente lo contrario a duplicar. |

Recorrido explicito del checklist de antipatrones de MEF-ADR-0012: **ninguno de los 7 aplica**
(no hay propiedad nueva de VO para consumidor externo, ni clase estatica sobre datos crudos, ni
getter solo-para-test, ni `InternalsVisibleTo` desde ensamblados de eventos, ni `[JsonConstructor]`,
ni `record` con `IReadOnlyList` de igualdad nuevo, ni evento con marker de bus — este issue no
declara ningun evento).

---

### Desviaciones de ADRs

**Declaradas por el implementer**: ninguna (`stage-2-projection-implementer.md`: *"Ninguna desviacion
consciente de un ADR o del Skill"*).

**Detectadas por el reviewer (NO declaradas por el implementer)**:

#### Desviacion 1: MEF-ADR-0016 (convencion de naming de tests)
- **Regla del ADR**: `<Sujeto>_<LoQuePasa>[_Cuando<Condicion>]`, donde el sujeto es el verbo de
  negocio, nunca el punto de entrada tecnico (`HandleAsync`). Su tabla fija para endpoint HTTP
  `CrearTurno_Retorna202_CuandoPayloadEsValido`.
- **Desviacion encontrada**: los 8 tests de `ListarFichasColaborador/FunctionEndpointTests.cs`
  usaban `Run_Retorna415_...` — `Run` es el equivalente exacto de `HandleAsync`. El precedente del
  propio repo (`ListarTurnosVigentes/FunctionEndpointTests.cs`) ya usa `ListarTurnosVigentes_...`.
- **Accion tomada**: **corregida** — renombrados a `ListarFichasColaborador_Retorna4xx_...`.
- **Status**: resuelta, sin pendientes.

#### Desviacion 2 (menor, no de ADR sino de la nota tecnica del issue): `AuthorizationLevel`
- **Regla**: la nota tecnica del issue escribe `HttpTrigger(AuthorizationLevel.Function, "query", ...)`.
- **Desviacion encontrada**: el endpoint declara `AuthorizationLevel.Anonymous`.
- **Evaluacion del reviewer**: **aceptable, no se corrige**. Las 21 declaraciones de
  `AuthorizationLevel` del repo son `Anonymous` sin excepcion; alinearse al precedente es lo
  correcto y cambiarlo solo en este endpoint lo dejaria inconsistente. El nivel de autorizacion es
  materia de MEF-ADR-0032 (borde APIM/WorkOS), no de este issue.
- **Status**: pendiente de evaluacion del usuario (informativo).

---

### Precedentes consultados por el implementer

| Precedente | ADR aplicable | Veredicto |
|---|---|---|
| `ObtenerFichaColaborador/FunctionEndpoint.cs` (#356) — `FichaColaboradorRespuesta.DesdeVista` | MEF-ADR-0041 dec. 4 | alineado (el DTO existe por evidencia real: ocultar el centinela; reutilizarlo evita el segundo tipo gemelo) |
| `ListarTurnosVigentes` (#329/#337) — tres capas de test, logica pura en el feature folder | MEF-ADR-0035 / MEF-ADR-0016 | alineado (y ademas *contradice* el naming `Run_*` que el implementer uso — ver Desviacion 1) |
| `RangoConsulta.cs` — determinismo de fechas, nunca "hoy" | MEF-ADR-0018 | alineado |
| `skills/projections/read-apis.md` — ejemplo canonico QUERY | MEF-ADR-0042 §4 | alineado |
| `ObtenerFichaColaboradorSmokeTests.cs` (#356/#382) | — | **VIOLA su propio contrato**: reconstruia la llave con `:` cuando #381 la movio a `-`. Bug del precedente, reportado y corregido (Hallazgo 1). |

---

### Convenciones del pipeline (no ADRs)

| Convencion | Estado | Observacion |
|---|---|---|
| Cada test con `Then()` + `And<>()` | n/a | No hay tests de command handler en el diff (issue read-side puro). |
| Overloads correctos para stream IDs compuestos | n/a | Idem. |
| Fakes manuales (no NSubstitute) | ok | `store`/`tenantResolver` nulos a proposito (patron del precedente #329): cortocircuito verificado antes de tocar Marten. Cero NSubstitute. |
| Feature folders (produccion y tests) | ok | `ListarFichasColaborador/` en produccion, tests y smoke tests — espejo exacto, un archivo por responsabilidad. |
| Smoke tests: SkipWhen, secrets, cobertura | ok | Solo usan `ApiFixture` (obligatorio, no opcional) — `SkipWhen` no aplica, igual que el precedente. Sin secrets. **Aislamiento ejemplar**: cada assert filtra por `f.Id == streamId` derivado de un Guid unico, nunca por posicion; ver nota en "Elegancia". |
| Proyecciones read-side: partial, inmutabilidad, read APIs, naming sin sufijo, cuarta isla | ok | Ninguna proyeccion ni read model nuevos. `ReadModels.csproj` intacto (cero `ProjectReference` sigue en pie). |
| Antipatrones de habilitacion (MEF-ADR-0039) | n/a | `git diff` de la rama no toca **ningun** `.csproj` ni declara tipo de evento nuevo. |
| Compatibilidad Marten write-side/read-side (MEF-ADR-0034 §6) | **falla (no verificada)** | El gate **si aplica** (el diff toca `ConfiguracionMartenProjectionsColaboradores.cs`), pero `ilspycmd` no esta instalado y no lo instalo por cuenta propia. Requiere `dotnet tool install -g ilspycmd`. **Evidencia mitigante**: (1) el diff no modifica **ningun** atributo de la columna "debe coincidir" — solo suma DDL de indices, propiedad del worker (MEF-ADR-0034 §11, cambio aditivo aplicado al arrancar); (2) la version de `Cosmos.EventSourcing.*` no cambia (2.3.1 en ambos lados); (3) las guardas de par 1 y par 2 ya existentes en ambos lados (`ConfiguracionMartenProjectionsTests` + `ComposicionServiciosTests`) siguen verdes, incluida la de tenancy/tabla/`IdMember` de `FichaColaborador` — es decir, el `Schema.For<FichaColaborador>()` agregado **no** desplazo la politica `AllDocumentsAreMultiTenanted`. |
| Identidad de stream (MEF-ADR-0037) | ok | Sin `ToString("N"/"B"/...)`, sin `ToUpper`/`ToLower`, sin construccion manual de llave en produccion. El `Id` del cursor es un **string opaco de comparacion**, no una identidad que se resuelva contra el store (el endpoint nunca hace `LoadAsync(id)`) — fuera del sujeto del ADR. El unico `ComputarStreamId` local vive en los smoke tests, que no pueden referenciar el Function App (isla, MEF-ADR-0034 §5) y actuan como oraculo independiente (MEF-ADR-0002). |
| Control de volumen de telemetria (MEF-ADR-0038) | n/a | El diff no toca `ComposicionServicios*`, `ConfiguracionObservabilidad*`, `AddOpenTelemetry`, `SetSampler` ni el callback de Wolverine. |
| Tests via ToString/comportamiento | ok | Todo se verifica por el `IActionResult` y por la respuesta HTTP; ningun getter expuesto para test. |
| Sin numeros magicos | ok | `TakeMaximo = 200` y `Take = 50` con nombre; el centinela de vigencia se lee de `FichaColaborador.CentinelaVigenciaAbierta`, nunca reescrito. |
| Condiciones en positivo | ok | Las negaciones que quedan son guard clauses de salida temprana (`if (!req.HasJsonContentType()) return 415`), que el propio criterio exceptua. |

---

### Elegancia del codigo

Puntos fuertes que vale la pena registrar:

- **Aislamiento de los smoke tests contra un entorno acumulativo**: el archivo no asume una base
  limpia — cada test se aisla con un `NombreCompleto` unico (Guid en el apellido) + cursor
  posicionado, o con un par de etiqueta discriminador con Guid en el valor. Y el mecanismo de
  aislamiento **es** la superficie publica bajo prueba (el cursor keyset real), no un atajo. Es la
  mejor solucion que he visto en este repo al problema de "el listado sin filtro nunca es oraculo".
- **El comentario que evita repetir el spike**: los tres mecanismos de filtrado JSONB probados y
  descartados quedan documentados con su modo de falla exacto (`Contains(KeyValuePair)` devolviendo
  0 resultados *siempre*, en silencio). Eso es conocimiento caro que normalmente se pierde.
- **CA-1 verificado sin polling en el segundo assert**: el test de vigencia primero confirma que la
  proyeccion aplico `VinculacionTerminada` y solo entonces consulta el dia siguiente de forma
  deterministica. Evita el falso verde clasico de "no aparece porque la proyeccion aun no corrio".

Correcciones de elegancia aplicadas (ver Refactorings): `Run` bajo de ~120 a ~75 lineas de codigo
eliminando la triple repeticion del inicializador de `ObjectResult` y extrayendo la normalizacion de
etiquetas a una funcion pura; el `System.Text.Json.JsonSerializerOptions` calificado del smoke test
paso a `using`.

---

### Criticas y hallazgos

#### Hallazgo 1 — **mayor, corregido**: oraculo obsoleto heredado de `main` (2 smoke tests en rojo falso)
`ObtenerFichaColaboradorSmokeTests.ComputarStreamId` seguia reconstruyendo la llave como
`"CC:{numero}"`, cuando el issue #381 / PR #382 movio el separador a `"-"`. El refactor de #382
alcanzo los otros 8 archivos de smoke test del dominio y se salto este. Consecuencia: 2 tests en
rojo permanente contra dev, con el codigo de produccion **correcto** (la API devolvia `CC-...`, el
test esperaba `CC:...`). No estaba en el diff de esta HU, pero es un rojo falso que contamina la
señal del pipeline y es una correccion de un caracter, sin cambio de intencion del test. Corregido,
mas el comentario obsoleto que lo acompañaba. Ambos tests ahora en verde.

#### Hallazgo 2 — **mayor, corregido**: `500` donde RFC 10008 pide `422` (elemento nulo en `etiquetas`)
El body es entrada del cliente y STJ acepta `"etiquetas":[null]` pese a la anotacion no-nullable de
`FiltroEtiqueta`. El acceso a `par.Categoria` producia una `NullReferenceException` que **no** cae en
el `catch (ArgumentException)` y escapaba como `500`. Es exactamente la misma clase de trampa que
MEF-ADR-0042 §3 documenta para el media type (el error de `ReadFromJsonAsync` que no es
`JsonException`), en otra rama. Corregido con guard explicito y test nuevo
(`ListarFichasColaborador_Retorna422_CuandoUnaEtiquetaDelFiltroEsNula`).

#### Hallazgo 3 — **menor, corregido**: literal del nombre de campo en el SQL crudo
`MatchesSql("(data->>'EtiquetasNormalizadas')::jsonb @> ?::jsonb", ...)` era el unico punto del
sistema donde el nombre de una propiedad de la vista viajaba como texto suelto. Un rename de
`FichaColaborador.EtiquetasNormalizadas` (herramienta de refactor incluida) compilaria, pasaria
todos los tests unitarios y dejaria el filtro devolviendo **0 resultados siempre** — el mismo modo de
falla silencioso que el spike del implementer encontro en `Contains(KeyValuePair)`. Corregido
interpolando `nameof(...)` en una `const string`.

#### Hallazgo 4 — verificacion añadida (no era defecto): el SQL generado, inspeccionado sin Postgres
`MatchesSql` inyecta un fragmento crudo en una query de un store con tenancy conjoined; que Marten
siga aplicando el filtro de tenant sobre esa query no se sigue de leer el codigo. Lo verifique con un
spike desechable (`ToCommand(FetchType.FetchMany)`, sin conexion a Postgres, `AutoCreate.None`),
ya eliminado. SQL real generado:

```
select d.data from colaboradores.mt_doc_fichacolaborador as d
where (d.tenant_id = :p0
   and (d.data ->> 'NombreCompleto' > :p1 or (d.data ->> 'NombreCompleto' = :p2 and d.id > :p3))
   and (data->>'EtiquetasNormalizadas')::jsonb @> :p4::jsonb
   and colaboradores.mt_immutable_date(d.data ->> 'VigenteHasta') >= :p5)
order by d.data ->> 'NombreCompleto', d.id LIMIT :p6;
```

Cuatro cosas quedan verificadas de una vez: (a) **`d.tenant_id = :p0` sobrevive** al lado del
fragmento crudo — MEF-ADR-0028 se sostiene, `MatchesSql` no evade la mitigacion BOLA/IDOR; (b) el
JSON del containment viaja **parametrizado** (`:p4::jsonb`), no concatenado; (c) el predicado keyset
`CompareTo` **si traduce** (`> :p1` / `d.id > :p3`), lo que cierra a nivel de generacion de SQL el
gate NO VERIFICADO #4 de MEF-ADR-0042 §6 (el cierre end-to-end sigue siendo el smoke test, CA-6); y
(d) el `ORDER BY` usa **exactamente las mismas expresiones** que el predicado, sin las cuales el
keyset saltaria o repetiria filas. Documente (a) y (b) como comentario en el endpoint.

#### Hallazgo 5 — **menor, no corregido (observacion de contrato)**: categoria repetida en el filtro
Si el cliente envia dos pares con la misma categoria y distinto valor (`area:tecnologia` +
`area:ventas`), el diccionario hace que **gane el ultimo**. Bajo AND estricto la respuesta "correcta"
seria vacia (la ficha tiene un solo valor por categoria), no el resultado de la segunda. Esta
documentado en el codigo como decision consciente, espejo de la invariante del aggregate (#355), y
el containment JSONB no puede expresar dos valores para la misma clave. No lo cambio: el issue no
fija ese caso y alterarlo sin especificacion seria inventar contrato. **Queda registrado para que el
planner decida** si merece 422 o lista vacia explicita.

#### Hallazgo 6 — **menor, no corregido**: cota superior del `Take` sin cobertura automatizada
`Math.Clamp(filtro.Take, 1, 200)`: la cota inferior la cubre el smoke test (`Take: 0`), la superior
no la cubre nada (sembrar 200+ fichas en dev no es razonable, y probarla unitariamente exigiria
extraer el clamp solo para el test). Aplica el carve-out del endpoint de consulta. El riesgo residual
es minimo (`Math.Clamp` de la BCL con constante nombrada) y quedo verificado por lectura + por el
`LIMIT :p6` del Hallazgo 4.

**No hubo hallazgos** sobre: manejo de errores, tenancy, naming de la Function/ruta, forma de la
vista, composicion de ensamblados, telemetria ni caracteres prohibidos.

---

### Refactorings aplicados

Todos con `dotnet test` despues de cada paso; ninguno revertido.

1. **Guard de elemento nulo en `etiquetas`** (`FunctionEndpoint.cs`) — Hallazgo 2. Robustez de borde.
2. **`nameof` en el SQL de containment** (`FunctionEndpoint.cs`) — Hallazgo 3. Convierte un fallo
   silencioso en error de compilacion.
3. **Extraccion de `NormalizarEtiquetas(...)`** (funcion pura, privada) — el bucle con su `try/catch`
   y su `return` de tres niveles de anidamiento salia del cuerpo de `Run`. Efecto colateral util: la
   rama de fallo pasa a ser un unico `return null` que el llamador traduce, en vez de un
   `ObjectResult` construido dentro de un `foreach` dentro de un `if`.
4. **Extraccion de `NoProcesable(mensaje)`** — el inicializador de `ObjectResult` con
   `Status422UnprocessableEntity` estaba repetido tres veces (18 lineas). Ahora una linea por uso,
   con la forma del ADR (status + mensaje) en un solo lugar.
5. **Llaves innecesarias** en la guarda del cursor, para igualar el estilo de las guardas vecinas.
6. **Renombre de los 8 tests `Run_*` → `ListarFichasColaborador_*`** — Desviacion 1 (MEF-ADR-0016).
7. **`using System.Text.Json`** en el smoke test, eliminando el tipo calificado a mano.
8. **Separador `:` → `-`** en `ObtenerFichaColaboradorSmokeTests` — Hallazgo 1.

---

### Cobertura de criterios de aceptacion

| Criterio | Estado | Test(s) |
|---|---|---|
| CA-1: vigencia inclusive; el preaviso desaparece al dia siguiente sin evento nuevo | cubierto (smoke, pendiente de deploy) | `ListarFichasColaborador_IncluyeElDiaEfectivoDeTerminacionYLoExcluyeAlDiaSiguiente_CuandoLaVigenciaEsInclusive` |
| CA-2: AND + normalizacion simetrica; sin filtro retorna todos los vigentes | cubierto (smoke, pendiente de deploy) | `ListarFichasColaborador_AplicaAndDeEtiquetasConNormalizacionSimetrica_...` (incluye el caso negativo del AND estricto), `ListarFichasColaborador_IncluyeAlVigenteConVigenteHastaVacio_CuandoElFiltroNoTraeEtiquetas` |
| CA-3: keyset por `NombreCompleto`+`Id`; clamp del `Take` | cubierto (smoke + SQL verificado) | `ListarFichasColaborador_PaginaSinSaltarNiRepetir_CuandoSeUsaElCursorDeLaUltimaFila`, `ListarFichasColaborador_ClampeaTakeAMinimoUno_CuandoTakeLlegaEnCero`; cota superior por lectura + Hallazgo 4 (Hallazgo 6) |
| CA-4: 415 / 400 / 422 con mensaje; 200 lista vacia; `VigenteHasta` vacio | **cubierto integramente en unit tests** | `ListarFichasColaborador_Retorna415_CuandoElContentTypeNoEsJson`, `..._CuandoElContentTypeEstaAusente`, `..._Retorna400_CuandoElBodyEstaAusente`, `..._CuandoElBodyNoEsJsonValido`, `..._CuandoElBodyEsElLiteralJsonNull`, `..._Retorna422_CuandoFaltaFechaReferencia`, `..._CuandoUnaEtiquetaDelFiltroEsInvalida`, **`..._CuandoUnaEtiquetaDelFiltroEsNula` (nuevo)**, `..._CuandoElCursorTraeUnSoloCampo`; + smoke `..._Retorna200ConListaVacia_...` |
| CA-5: tres indices en el seam del worker | cubierto | `ConfigurarColaboradores_DeclaraIndiceGinSobreEtiquetasNormalizadasDeFichaColaborador`, `..._DeclaraUnIndiceSobreVigenteHastaDeFichaColaborador`, `..._DeclaraUnIndiceSobreNombreCompletoDeFichaColaborador` |
| CA-6: gates de ejecucion (smoke QUERY end-to-end + colacion de dev) | **pendiente de ejecucion** | Ver "Gates pendientes" abajo |
| — composicion del endpoint | cubierto | `AgregarServiciosColaboradores_ResuelveElEndpointDeListarFichasColaborador_CuandoElContenedorEstaCompuesto` |

#### Gates pendientes de CA-6 (MEF-ADR-0042 §6, bloqueantes del primer despliegue)

1. **Front-end de App Service reenviando el verbo QUERY**: NO VERIFICADO. Se resuelve solo, y
   automaticamente, cuando los 12 smoke tests pasen de `404` a verde tras el deploy a dev. **No
   marcar el issue como cerrado antes de leer ese veredicto.**
2. **Traduccion LINQ del cursor keyset**: verificado a nivel de SQL generado en esta revision
   (Hallazgo 4); el cierre end-to-end contra Postgres real llega con el mismo deploy.
3. **Colacion de la base de dev (`en_US.utf8` vs `C`)**: **NO VERIFICADA — no la pude obtener**. No
   es observable por HTTP y `Postgres__ConnectionString` no esta configurada en este entorno (los
   tests que dependen de `PostgresFixture` salen `omitido`). Requiere ejecutar `SHOW LC_COLLATE;`
   (o `SELECT datcollate FROM pg_database WHERE datname = current_database();`) contra el Postgres de
   dev y registrarlo. Con colacion `C` el orden visible por `NombreCompleto` pondria tildes y "ñ" al
   final — el listado seguiria siendo correcto y la paginacion consistente (predicado y `ORDER BY`
   usan la misma colacion, Hallazgo 4), pero el orden no seria el natural del castellano.
4. **APIM/CORS**: no aplica — no hay APIM en `infra/environments/dev/` (confirmado en la
   investigacion del planner).

---

### Tests agregados

- `ListarFichasColaborador_Retorna422_CuandoUnaEtiquetaDelFiltroEsNula` — caso borde del Hallazgo 2
  (`"etiquetas":[null]` producia `500`). Verde tras el guard.
- Tests de contrato de igualdad/serializacion: **no aplican** — el diff no introduce ningun
  `IEquatable<T>` ni ningun `ConfigurarSerializacion`. Los tres records del filtro
  (`FiltroListarFichasColaborador`, `FiltroEtiqueta`, `CursorFicha`) son DTOs de **request** planos,
  deserializados por STJ por defecto, sin resolver custom.
- No se agregaron tests de proyeccion: el issue no crea ni modifica ninguna.

</details>

## Cobertura

| Archivo | Cobertura | Umbral | Estado |
|---|---|---|---|
| FunctionEndpoint.cs | - | excluido | - |
| ConfiguracionMartenProjectionsColaboradores.cs | - | sin clasificar | ⚠ revisar |

> **Archivos sin clasificar** (`⚠ revisar`): ninguna regla de clasificacion los reconocio — el gate **no los midio**. No es una exclusion deliberada (a diferencia de `excluido`, donde si se decidio que no requieren cobertura): requieren revision humana para confirmar si necesitan tests.
## Commits

81dfebc refactor(hu-373): robustez del borde QUERY, naming de tests y oraculo obsoleto del smoke
1fa5cdf Agregar smoke tests de ListarFichasColaborador (issue #373)
54fb99f feat(hu-373): endpoint QUERY ListarFichasColaborador e indices read-side (fase verde)
2087d82 test(hu-373): tests read-side para ListarFichasColaborador (fase roja)

Closes #373