### PR TITLE
Exponer las etiquetas en uso para recomendaciones

### DIFF
--- a/src/Bitakora.ControlAsistencia.Colaboradores/Infraestructura/ComposicionServicios.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/Infraestructura/ComposicionServicios.cs
@@ -114,6 +114,15 @@ public static class ComposicionServicios
             // los mismos valores literales.
             options.Schema.For<FichaColaborador>().UseNumericRevisions(true);
 
+            // Issue #357: MISMA razon que la linea de arriba, para la segunda vista materializada
+            // del dominio -- el worker registra CategoriaDeEtiquetasProjection (N2) y crea
+            // mt_version como bigint; este Function App la consulta con session.Query en
+            // ListarCategoriasDeEtiquetas. Sin esta linea el GET responde 500 permanente en dev
+            // (42804 por request), no un 404: el mismo modo de falla que #294 dejo documentado
+            // arriba. Cada vista materializada que este store consulte necesita su propia
+            // declaracion -- el par de config-tests de ambos lados la congela.
+            options.Schema.For<CategoriaDeEtiquetas>().UseNumericRevisions(true);
+
             // Issue #330: registra la serializacion custom de los VOs con ctor privado que aparecen
             // como payload de eventos persistidos (Identificacion, NombreColaborador) -- AQUI
             // DENTRO junto a AddEventTypes -- nunca en un ConfigureMarten separado (issue #232 CA-5:

--- a/src/Bitakora.ControlAsistencia.Colaboradores/ListarCategoriasDeEtiquetas/FunctionEndpoint.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/ListarCategoriasDeEtiquetas/FunctionEndpoint.cs
@@ -35,7 +35,17 @@ public class FunctionEndpoint(IDocumentStore store, ITenantResolver tenantResolv
         // Opcion B (decision de refinamiento): catalogo entero de un tiro, sin filtros ni
         // paginacion. CA-6: sin ninguna etiqueta asignada, coleccion vacia con 200 (nunca 404 --
         // una lista vacia es una respuesta valida, no un recurso ausente).
-        var categorias = await session.Query<CategoriaDeEtiquetas>().ToListAsync(ct);
+        //
+        // OrderBy(Id) -- la categoria normalizada, que es la PK del documento: un SELECT sin ORDER
+        // BY devuelve las filas en el orden fisico del heap de Postgres, que cambia cuando el
+        // daemon reescribe una fila al aplicar un evento. Sin este orden dos consultas consecutivas
+        // pueden devolver el mismo catalogo permutado, y el consumidor (autocompletado que cachea
+        // el catalogo entre aperturas del control) veria un diff espurio. Mismo criterio que los
+        // otros dos listados del BC (ListarFichasColaborador, ListarTurnosVigentes), aqui sin
+        // cursor porque no hay paginacion.
+        var categorias = await session.Query<CategoriaDeEtiquetas>()
+            .OrderBy(categoria => categoria.Id)
+            .ToListAsync(ct);
 
         return new OkObjectResult(categorias);
     }

--- a/src/Bitakora.ControlAsistencia.Colaboradores/ListarCategoriasDeEtiquetas/FunctionEndpoint.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/ListarCategoriasDeEtiquetas/FunctionEndpoint.cs
@@ -1,3 +1,4 @@
+using Bitakora.ControlAsistencia.ReadModels.Colaboradores;
 using Cosmos.MultiTenancy;
 using Marten;
 using Microsoft.AspNetCore.Http;
@@ -14,20 +15,28 @@ namespace Bitakora.ControlAsistencia.Colaboradores.ListarCategoriasDeEtiquetas;
 // Sin filtros ni paginacion en esta primera version (opcion B, decision de refinamiento): la UI trae
 // el catalogo entero de un tiro y autocompleta en memoria -- el volumen es de decenas, no miles.
 //
-// Stub de fase roja (projection-test-writer, MEF-ADR-0033): el constructor fija la forma que el
-// test de composicion (Colaboradores.Tests/Infraestructura/ComposicionServiciosTests.cs,
-// AgregarServiciosColaboradores_ResuelveElEndpointDeListarCategoriasDeEtiquetas_...) resuelve del
-// contenedor DI real -- IDocumentStore y ITenantResolver, ya registrados por
-// ComposicionServicios.AgregarServiciosColaboradores. La apertura de la QuerySession acotada al
-// tenant del resolver, session.Query&lt;CategoriaDeEtiquetas&gt;() y el 200 con coleccion vacia
-// cuando no hay etiquetas asignadas (CA-6) son responsabilidad de projection-implementer -- Run solo
-// lanza NotImplementedException.
+// La vista se serializa tal cual (sin DTO de respuesta): a diferencia de FichaColaborador (#356),
+// CategoriaDeEtiquetas no tiene ningun campo interno de indexacion/filtrado que ocultar (ni
+// centinela ni equivalente) -- MEF-ADR-0041 decision 4, "el DTO de respuesta es excepcion".
 public class FunctionEndpoint(IDocumentStore store, ITenantResolver tenantResolver)
 {
     [Function("ListarCategoriasDeEtiquetas")]
-    public Task<IActionResult> Run(
+    public async Task<IActionResult> Run(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "colaboradores/etiquetas/categorias")]
         HttpRequest req,
-        CancellationToken ct) =>
-        throw new NotImplementedException();
+        CancellationToken ct)
+    {
+        // CA-6/MEF-ADR-0028: la QuerySession se abre SIEMPRE acotada al tenant que resuelve
+        // ITenantResolver -- nunca a un tenant id que llegara por ruta o query string (mitigacion
+        // estructural contra BOLA/IDOR, skills/projections/read-apis.md). Este GET no recibe ningun
+        // segmento de ruta que pudiera confundirse con un tenant.
+        await using var session = store.QuerySession(tenantResolver.TenantId);
+
+        // Opcion B (decision de refinamiento): catalogo entero de un tiro, sin filtros ni
+        // paginacion. CA-6: sin ninguna etiqueta asignada, coleccion vacia con 200 (nunca 404 --
+        // una lista vacia es una respuesta valida, no un recurso ausente).
+        var categorias = await session.Query<CategoriaDeEtiquetas>().ToListAsync(ct);
+
+        return new OkObjectResult(categorias);
+    }
 }

--- a/src/Bitakora.ControlAsistencia.Colaboradores/ListarCategoriasDeEtiquetas/FunctionEndpoint.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/ListarCategoriasDeEtiquetas/FunctionEndpoint.cs
@@ -1,0 +1,33 @@
+using Cosmos.MultiTenancy;
+using Marten;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.ListarCategoriasDeEtiquetas;
+
+// Issue #357: Function GET del catalogo CategoriaDeEtiquetas (via (a) proyeccion materializada,
+// skills/projections/naming.md, MEF-ADR-0006 enmienda #363). Feature folder sin sufijo Function, un
+// namespace por query (skills/projections/read-apis.md): esta clase FunctionEndpoint no colisiona
+// con ninguna otra del mismo ensamblado porque cada query vive en su propio namespace.
+//
+// Sin filtros ni paginacion en esta primera version (opcion B, decision de refinamiento): la UI trae
+// el catalogo entero de un tiro y autocompleta en memoria -- el volumen es de decenas, no miles.
+//
+// Stub de fase roja (projection-test-writer, MEF-ADR-0033): el constructor fija la forma que el
+// test de composicion (Colaboradores.Tests/Infraestructura/ComposicionServiciosTests.cs,
+// AgregarServiciosColaboradores_ResuelveElEndpointDeListarCategoriasDeEtiquetas_...) resuelve del
+// contenedor DI real -- IDocumentStore y ITenantResolver, ya registrados por
+// ComposicionServicios.AgregarServiciosColaboradores. La apertura de la QuerySession acotada al
+// tenant del resolver, session.Query&lt;CategoriaDeEtiquetas&gt;() y el 200 con coleccion vacia
+// cuando no hay etiquetas asignadas (CA-6) son responsabilidad de projection-implementer -- Run solo
+// lanza NotImplementedException.
+public class FunctionEndpoint(IDocumentStore store, ITenantResolver tenantResolver)
+{
+    [Function("ListarCategoriasDeEtiquetas")]
+    public Task<IActionResult> Run(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "colaboradores/etiquetas/categorias")]
+        HttpRequest req,
+        CancellationToken ct) =>
+        throw new NotImplementedException();
+}

--- a/src/Bitakora.ControlAsistencia.Projections/Colaboradores/CategoriaDeEtiquetasProjection.cs
+++ b/src/Bitakora.ControlAsistencia.Projections/Colaboradores/CategoriaDeEtiquetasProjection.cs
@@ -1,0 +1,56 @@
+using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+using Bitakora.ControlAsistencia.ReadModels.Colaboradores;
+using Marten.Events.Projections; // MultiStreamProjection<,> vive aqui, NO en Marten.Events.Aggregation
+
+namespace Bitakora.ControlAsistencia.Projections.Colaboradores;
+
+/// <summary>
+/// Clase de proyeccion companion de CategoriaDeEtiquetas (issue #357, receta N2 --
+/// MultiStreamProjection&lt;CategoriaDeEtiquetas, string&gt;: eventos EtiquetaAsignada de MUCHOS
+/// streams de ColaboradorAggregateRoot convergen en el MISMO documento cuando comparten categoria
+/// normalizada; MEF-ADR-0035, skills/projections/modelos-marten.md). Es la PRIMERA proyeccion N2 de
+/// este BC -- FichaColaboradorProjection (#356) y TurnoVigenteProjection (ControlHoras) son N1.
+///
+/// partial es obligatorio (mismo gotcha que FichaColaboradorProjection, #356): el source generator
+/// descubre Create/Apply por convencion y emite el dispatcher [GeneratedEvolver]. Sin partial el
+/// build queda limpio pero falla en RUNTIME al registrar la proyeccion (InvalidProjectionException),
+/// error que el config-test detecta al resolver el named store
+/// (ConfigurarColaboradores_RegistraCategoriaDeEtiquetasProjectionComoAsync).
+///
+/// Se registra en ConfiguracionMartenProjectionsColaboradores.ConfigurarColaboradores con
+/// opts.Projections.Add&lt;CategoriaDeEtiquetasProjection&gt;(ProjectionLifecycle.Async) -- lifecycle
+/// canonico del worker (MEF-ADR-0034 seccion 3).
+///
+/// CATALOGO ACUMULATIVO (CA-5, decision de refinamiento 2026-08-13): esta clase NO declara ningun
+/// metodo para EtiquetaRetirada -- ese evento no descuenta nada del catalogo (la sobrescritura y el
+/// reingreso-nace-limpio son retiros implicitos que exigirian estado por colaborador, territorio N3
+/// sin beneficio hoy para el proposito del autocompletado). Es una garantia ESTRUCTURAL (ausencia de
+/// metodo, no logica que testear): CategoriaDeEtiquetasProjectionTests documenta la regla en un
+/// comentario, no en un [Fact], porque un test que solo reflexionara sobre esa ausencia pasaria de
+/// una contra el stub -- nada que implementar lo pondria en rojo.
+/// </summary>
+public sealed partial class CategoriaDeEtiquetasProjection : MultiStreamProjection<CategoriaDeEtiquetas, string>
+{
+    public CategoriaDeEtiquetasProjection()
+    {
+        // Correlacion N2 (skills/projections/modelos-marten.md, "N2 -- correlacion entre streams"):
+        // la identidad del documento es la categoria NORMALIZADA del payload de EtiquetaAsignada --
+        // no el StreamKey de ningun stream de ColaboradorAggregateRoot. No es un stub: es codigo de
+        // configuracion real, sin logica de negocio que testear (por eso no hay unit test dedicado a
+        // esta linea; el test de correlacion de CategoriaDeEtiquetasProjectionTests verifica su
+        // EFECTO -- que dos streams distintos convergen en el mismo documento -- invocando Create/
+        // Apply directamente).
+        Identity<EtiquetaAsignada>(e => e.Etiqueta.CategoriaNormalizada);
+    }
+
+    // Stub -- fase roja read-side (issue #357). La implementacion real (nace el documento con la
+    // categoria y su primer valor) la escribe projection-implementer.
+    public static CategoriaDeEtiquetas Create(EtiquetaAsignada e) =>
+        throw new NotImplementedException();
+
+    // Stub -- fase roja read-side (issue #357). La implementacion real (agrupar por categoria,
+    // ultima-gana en Categoria y en cada Valor, acumulacion sin duplicados por ValorNormalizado) la
+    // escribe projection-implementer.
+    public static CategoriaDeEtiquetas Apply(EtiquetaAsignada e, CategoriaDeEtiquetas vista) =>
+        throw new NotImplementedException();
+}

--- a/src/Bitakora.ControlAsistencia.Projections/Colaboradores/CategoriaDeEtiquetasProjection.cs
+++ b/src/Bitakora.ControlAsistencia.Projections/Colaboradores/CategoriaDeEtiquetasProjection.cs
@@ -43,14 +43,27 @@ public sealed partial class CategoriaDeEtiquetasProjection : MultiStreamProjecti
         Identity<EtiquetaAsignada>(e => e.Etiqueta.CategoriaNormalizada);
     }
 
-    // Stub -- fase roja read-side (issue #357). La implementacion real (nace el documento con la
-    // categoria y su primer valor) la escribe projection-implementer.
+    // CA-1: el documento nace con la categoria NORMALIZADA como Id (misma identidad que fija el
+    // slicer de correlacion arriba), el display de esa PRIMERA asignacion y su primer valor
+    // (display + normalizado, ambos leidos del VO Etiqueta -- sin recalcular nada, MEF-ADR-0012).
     public static CategoriaDeEtiquetas Create(EtiquetaAsignada e) =>
-        throw new NotImplementedException();
+        new(
+            e.Etiqueta.CategoriaNormalizada,
+            e.Etiqueta.Categoria,
+            [new ValorCategoria(e.Etiqueta.Valor, e.Etiqueta.ValorNormalizado)]);
 
-    // Stub -- fase roja read-side (issue #357). La implementacion real (agrupar por categoria,
-    // ultima-gana en Categoria y en cada Valor, acumulacion sin duplicados por ValorNormalizado) la
-    // escribe projection-implementer.
-    public static CategoriaDeEtiquetas Apply(EtiquetaAsignada e, CategoriaDeEtiquetas vista) =>
-        throw new NotImplementedException();
+    // CA-2/CA-3/CA-4: "la ultima gana" en el display de la categoria (siempre se reemplaza,
+    // sin importar la forma original de esta asignacion) y upsert por ValorNormalizado en
+    // Valores -- se descarta el valor existente con el MISMO ValorNormalizado (si lo hay) y se
+    // agrega el nuevo, conservando el resto: acumulativo (CATALOGO ACUMULATIVO, decision de
+    // refinamiento 2026-08-13), nunca un reemplazo total de la lista.
+    public static CategoriaDeEtiquetas Apply(EtiquetaAsignada e, CategoriaDeEtiquetas vista)
+    {
+        var valores = vista.Valores
+            .Where(existente => existente.ValorNormalizado != e.Etiqueta.ValorNormalizado)
+            .Append(new ValorCategoria(e.Etiqueta.Valor, e.Etiqueta.ValorNormalizado))
+            .ToList();
+
+        return vista with { Categoria = e.Etiqueta.Categoria, Valores = valores };
+    }
 }

--- a/src/Bitakora.ControlAsistencia.Projections/Infraestructura/ConfiguracionMartenProjectionsColaboradores.cs
+++ b/src/Bitakora.ControlAsistencia.Projections/Infraestructura/ConfiguracionMartenProjectionsColaboradores.cs
@@ -114,6 +114,14 @@ public static class ConfiguracionMartenProjectionsColaboradores
                 // issue, ausente aqui.
                 opts.Projections.Add<FichaColaboradorProjection>(ProjectionLifecycle.Async);
 
+                // Issue #357: segunda proyeccion concreta del dominio -- la PRIMERA receta N2
+                // (MultiStreamProjection<CategoriaDeEtiquetas, string>) de este BC: eventos
+                // EtiquetaAsignada de MUCHOS streams de ColaboradorAggregateRoot convergen en el
+                // MISMO documento cuando comparten categoria normalizada
+                // (skills/projections/modelos-marten.md). Mismo lifecycle canonico del worker
+                // (MEF-ADR-0034 seccion 3), aditivo dentro del mismo AddMartenStore.
+                opts.Projections.Add<CategoriaDeEtiquetasProjection>(ProjectionLifecycle.Async);
+
                 // Issue #373 CA-5: indices para el listado QUERY ListarFichasColaborador
                 // (segunda mitad del desglose de #356) -- ninguna proyeccion ni read model
                 // nuevos, solo indices sobre la MISMA FichaColaborador ya registrada arriba.

--- a/src/Bitakora.ControlAsistencia.ReadModels/Colaboradores/CategoriaDeEtiquetas.cs
+++ b/src/Bitakora.ControlAsistencia.ReadModels/Colaboradores/CategoriaDeEtiquetas.cs
@@ -1,0 +1,50 @@
+namespace Bitakora.ControlAsistencia.ReadModels.Colaboradores;
+
+/// <summary>
+/// Valor en uso dentro de una categoria de etiquetas -- forma ORIGINAL (display) y NORMALIZADA
+/// (matcheo del autocompletado).
+/// </summary>
+/// <remarks>
+/// Issue #357: tipo propio de ReadModels, SIN relacion de tipo con el VO Etiqueta de
+/// Colaboradores.DomainEvents (islas, CA-ADR-0029; precedente EtiquetaFicha de #356). Record plano,
+/// sin comportamiento: el upsert por valor normalizado vive en CategoriaDeEtiquetasProjection
+/// (worker), nunca aqui.
+/// </remarks>
+public sealed record ValorCategoria(string Valor, string ValorNormalizado);
+
+/// <summary>
+/// Read model del catalogo de categorias de etiquetas en uso (issue #357) -- alimenta el
+/// autocompletado de la UI de etiquetado/filtrado: el usuario elige una categoria/valor existente
+/// en vez de teclear una variante que fragmentaria el reporte (complementa la normalizacion del VO
+/// Etiqueta, #353). Consumido por ListarCategoriasDeEtiquetas (GET, opcion B: catalogo entero de un
+/// tiro, sin filtros ni paginacion en esta primera version).
+/// </summary>
+/// <remarks>
+/// Record plano SIN partial (MEF-ADR-0035, skills/projections/modelos-marten.md): el comportamiento
+/// de proyeccion vive en la clase companion CategoriaDeEtiquetasProjection, en el worker
+/// (Bitakora.ControlAsistencia.Projections). Este tipo vive en ReadModels (MEF-ADR-0034 seccion 5),
+/// la cuarta isla del repo: cero referencias de proyecto.
+///
+/// Sin sufijo "View" (MEF-ADR-0041 decision 3).
+///
+/// Id es la categoria NORMALIZADA (Etiqueta.CategoriaNormalizada, #353) -- la identidad de
+/// correlacion N2 (MultiStreamProjection&lt;CategoriaDeEtiquetas, string&gt;,
+/// Identity&lt;EtiquetaAsignada&gt;(e =&gt; e.Etiqueta.CategoriaNormalizada)): eventos de MUCHOS
+/// streams de ColaboradorAggregateRoot convergen en el MISMO documento cuando comparten categoria
+/// normalizada, sin importar la forma original con la que cada colaborador la escribio.
+///
+/// Categoria y cada ValorCategoria.Valor reflejan la ULTIMA asignacion que toco esa categoria/valor
+/// (decision de refinamiento 2026-08-12) -- "la ultima gana", mismo espiritu que la sobrescritura de
+/// etiquetas en FichaColaborador (#356).
+///
+/// CATALOGO ACUMULATIVO (decision de refinamiento 2026-08-13): solo EtiquetaAsignada alimenta esta
+/// vista -- EtiquetaRetirada NO descuenta ningun valor (ver CategoriaDeEtiquetasProjection, que no
+/// declara ningun metodo para ese evento). Sobrescribir el valor de una categoria AGREGA el valor
+/// nuevo a Valores y conserva el anterior; no hay borrado implicito, ni por sobrescritura ni por
+/// reingreso-nace-limpio (ambos exigirian estado por colaborador, territorio N3 sin beneficio hoy
+/// para el proposito del autocompletado -- Rule of Three, MEF-ADR-0018).
+/// </remarks>
+public sealed record CategoriaDeEtiquetas(
+    string Id,
+    string Categoria,
+    IReadOnlyList<ValorCategoria> Valores);

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/ListarCategoriasDeEtiquetas/ListarCategoriasDeEtiquetasSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/ListarCategoriasDeEtiquetas/ListarCategoriasDeEtiquetasSmokeTests.cs
@@ -1,0 +1,382 @@
+// Issue #357: smoke tests de ListarCategoriasDeEtiquetas, GET colaboradores/etiquetas/categorias --
+// Function GET read-side (opcion B, decision de refinamiento: catalogo COMPLETO de un tiro, sin
+// filtros ni paginacion) sobre la proyeccion CategoriaDeEtiquetas (receta N2,
+// MultiStreamProjection<CategoriaDeEtiquetas, string>, MEF-ADR-0034/0035): la PRIMERA N2 de este BC
+// -- eventos EtiquetaAsignada de MUCHOS streams de ColaboradorAggregateRoot convergen en el MISMO
+// documento cuando comparten categoria normalizada.
+//
+// Arrange via API, nunca sembrando el event store por fuera de ella: cada colaborador se crea con
+// POST Colaboradores (#330) y se etiqueta/retira con POST Colaboradores/Etiquetas y
+// Colaboradores/Etiquetas/Retiros (#355) -- los mismos comandos que la proyeccion consume.
+//
+// Sin ObtenerCategoriaDeEtiquetas por id en este issue (el documento ya tiene id direccionable,
+// pero se agrega solo si un caso real lo pide -- Rule of Three, MEF-ADR-0018): por eso este archivo
+// SOLO cubre el caso "Listado" de la doctrina read-side (skills/projections/read-apis.md), nunca
+// "recurso existente"/"recurso no encontrado" via id de ruta -- este endpoint no toma ningun
+// segmento de ruta ni body, asi que tampoco hay casos de validacion 400/422 que probar.
+//
+// Lifecycle Async (MEF-ADR-0034 seccion 3): el worker materializa/actualiza CategoriaDeEtiquetas
+// DESPUES de que Colaboradores persiste sus eventos. Los casos de exito envuelven la consulta en
+// Polling.WaitUntilAsync (timeout estandar 30s) -- unica excepcion documentada al "no usar Polling
+// directo en tests".
+//
+// Aislamiento SIN cleanup, en un entorno que ACUMULA categorias de corridas anteriores (el catalogo
+// es GLOBAL y ACUMULATIVO por diseno, decision de refinamiento 2026-08-13: nada sale nunca): un
+// listado completo sin filtros nunca es un oraculo confiable por si solo. Cada test aisla SU propia
+// categoria embebiendo un Guid en el texto de la categoria misma (formato "N": hexadecimal en
+// minusculas, sobrevive intacto a la normalizacion) -- nadie mas, en ninguna corrida pasada o
+// futura, puede tener esa categoria normalizada exacta. Se filtra siempre por Id (la categoria
+// normalizada), nunca por posicion/indice.
+//
+// Patron "checkpoint"/evento centinela (CA-2/CA-3/CA-5): para verificar una condicion NEGATIVA
+// ("no duplica", "colapsa a un solo valor", "el retiro no descuenta") contra una proyeccion
+// asincrona, no basta con esperar a que aparezca el primer efecto -- hace falta certeza de que
+// TODOS los eventos previos de la corrida ya fueron aplicados. Como el async daemon de Marten
+// aplica los eventos en el orden de su secuencia global (mt_events), y este smoke test emite sus
+// comandos secuencialmente (await cada POST antes del siguiente), un evento "centinela" (una
+// asignacion en una categoria discriminadora final, unica para el checkpoint) que ya aparece en el
+// catalogo GARANTIZA que todos los eventos anteriores de esta corrida ya se aplicaron. Es la unica
+// forma deterministica de probar una ausencia bajo consistencia eventual, sin recurrir a un
+// Task.Delay arbitrario.
+//
+// Formas discriminadoras SIN tildes (mayusculas vs minusculas simples, no diacriticos): el detalle
+// Unicode de la normalizacion (NonSpacingMark, ver el comentario de Etiqueta.Normalizar) ya lo
+// prueban el unit test del VO y AsignarEtiquetaSmokeTests (CA-2, "Área"/"area"); repetirlo aqui solo
+// arriesgaria un bug de replicacion en el propio smoke test sin agregar cobertura nueva sobre el
+// EFECTO end-to-end que este archivo verifica.
+//
+// No se repite aqui el detalle exhaustivo de Create/Apply (agrupacion, upsert por
+// ValorNormalizado, ausencia de metodo para EtiquetaRetirada): eso ya lo cubre el unit test de
+// CategoriaDeEtiquetasProjection (projection-test-writer). Este smoke test es black-box: solo
+// verifica que el endpoint desplegado expone la vista materializada real, contra el entorno real.
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.SmokeTests.Fixtures;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.SmokeTests.ListarCategoriasDeEtiquetas;
+
+public class ListarCategoriasDeEtiquetasSmokeTests(ApiFixture api)
+{
+    private readonly HttpClient _client = api.Client;
+
+    private const string RutaCatalogo = "/api/colaboradores/etiquetas/categorias";
+    private const string RutaRegistrar = "/api/Colaboradores";
+    private const string RutaEtiquetas = "/api/Colaboradores/Etiquetas";
+    private const string RutaRetiros = "/api/Colaboradores/Etiquetas/Retiros";
+    private const string TipoIdentificacionCc = "CC";
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
+
+    // Case-insensitive: la respuesta viaja en camelCase (ComposicionServicios configura
+    // JsonNamingPolicy.CamelCase), mientras que las formas locales de este archivo son PascalCase.
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    // Formas locales DESACOPLADAS del read model de produccion
+    // (Bitakora.ControlAsistencia.ReadModels.Colaboradores.CategoriaDeEtiquetas/ValorCategoria): el
+    // smoke test no referencia ReadModels (isla, MEF-ADR-0034 seccion 5) ni el worker de
+    // proyecciones. Replican solo el shape JSON de la respuesta HTTP -- la vista se serializa tal
+    // cual, sin DTO de respuesta (ver el comentario del propio FunctionEndpoint, MEF-ADR-0041
+    // decision 4).
+    private sealed record ValorCategoriaSmoke(string Valor, string ValorNormalizado);
+
+    private sealed record CategoriaDeEtiquetasSmoke(
+        string Id, string Categoria, IReadOnlyList<ValorCategoriaSmoke> Valores);
+
+    private static string NuevoNumeroIdentificacion() => Guid.CreateVersion7().ToString("N").ToUpperInvariant();
+
+    private static string NuevoCodigoColaborador() => $"[TEST]-{Guid.CreateVersion7()}";
+
+    // Formato "N": hexadecimal en minusculas -- sobrevive intacto a la normalizacion del VO Etiqueta
+    // (minusculas + sin tildes + trim). Lo unico que varia entre "formas" de una misma categoria
+    // discriminadora es el prefijo alrededor de este sufijo unico.
+    private static string NuevoSufijoUnico() => Guid.CreateVersion7().ToString("N");
+
+    // Arrange comun: registra un colaborador con una vinculacion abierta -- via el comando que la
+    // origina (#330), nunca sembrando el event store por fuera del API.
+    private async Task RegistrarColaboradorAsync(
+        string numeroIdentificacion, DateOnly fechaInicio, CancellationToken ct)
+    {
+        var response = await _client.PostAsJsonAsync(RutaRegistrar, new
+        {
+            tipoIdentificacion = TipoIdentificacionCc,
+            numeroIdentificacion,
+            primerNombre = "[TEST]",
+            segundoNombre = (string?)null,
+            primerApellido = "Smoke",
+            segundoApellido = (string?)null,
+            codigoColaborador = NuevoCodigoColaborador(),
+            fechaInicio
+        }, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted,
+            "el arrange de este smoke test depende de que RegistrarColaborador funcione");
+    }
+
+    // Arrange comun: asigna una etiqueta dinamica -- via el comando que la origina (#355), la MISMA
+    // fuente de eventos que alimenta CategoriaDeEtiquetasProjection.
+    private async Task AsignarEtiquetaAsync(
+        string numeroIdentificacion, string categoria, string valor, CancellationToken ct)
+    {
+        var response = await _client.PostAsJsonAsync(RutaEtiquetas, new
+        {
+            tipoIdentificacion = TipoIdentificacionCc,
+            numeroIdentificacion,
+            categoria,
+            valor
+        }, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted,
+            "el arrange de este smoke test depende de que AsignarEtiqueta funcione");
+    }
+
+    // Arrange comun (CA-5): retira una etiqueta dinamica -- via el comando que la origina (#355).
+    private async Task RetirarEtiquetaAsync(
+        string numeroIdentificacion, string categoria, CancellationToken ct)
+    {
+        var response = await _client.PostAsJsonAsync(RutaRetiros, new
+        {
+            tipoIdentificacion = TipoIdentificacionCc,
+            numeroIdentificacion,
+            categoria
+        }, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted,
+            "el arrange de este smoke test depende de que RetirarEtiqueta funcione");
+    }
+
+    private async Task<List<CategoriaDeEtiquetasSmoke>> ObtenerCatalogoAsync(CancellationToken ct)
+    {
+        var response = await _client.GetAsync(RutaCatalogo, ct);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var catalogo = await response.Content.ReadFromJsonAsync<List<CategoriaDeEtiquetasSmoke>>(
+            JsonOptions, cancellationToken: ct);
+        return catalogo ?? [];
+    }
+
+    // Reintenta el GET hasta que la proyeccion asincrona satisfaga la condicion -- unica excepcion
+    // documentada al "no usar Polling directo en tests" (lifecycle Async, MEF-ADR-0034 seccion 3).
+    // Si el timeout se agota es un fallo real (worker no desplegado, proyeccion sin registrar en el
+    // named store, lifecycle equivocado), nunca un caso para Assert.Skip -- Polling.WaitUntilAsync
+    // lanza TimeoutException.
+    private Task<List<CategoriaDeEtiquetasSmoke>> EsperarCatalogoAsync(
+        Func<List<CategoriaDeEtiquetasSmoke>, bool> condicion, CancellationToken ct) =>
+        Polling.WaitUntilAsync(async () =>
+        {
+            var catalogo = await ObtenerCatalogoAsync(ct);
+            return condicion(catalogo) ? catalogo : null;
+        }, Timeout);
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task DebeEstarDisponible_CuandoSeConsultaHealthCheck()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var response = await _client.GetAsync("/api/health", ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    // CA-6 (mitad observable black-box): el GET siempre responde 200 con una coleccion, nunca 404
+    // -- una lista vacia es una respuesta valida, no un recurso ausente. El catalogo COMPLETAMENTE
+    // vacio (cero categorias en todo el tenant) solo es observable en un entorno recien
+    // provisionado; en dev, compartido y acumulativo por diseno, este smoke test no puede forzar esa
+    // condicion sin borrar datos de otras corridas (fuera de alcance de un smoke test). Ese caso
+    // exacto ("coleccion vacia") ya lo cubre el unit test de la proyeccion
+    // (CategoriaDeEtiquetasProjectionTests, contra un store en memoria realmente vacio).
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarCategoriasDeEtiquetas_Retorna200ConUnaColeccion_Siempre()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        var catalogo = await ObtenerCatalogoAsync(ct);
+
+        catalogo.Should().NotBeNull();
+    }
+
+    // CA-1: etiquetas asignadas en VARIOS colaboradores -> el GET devuelve las categorias
+    // DISTINTAS, cada una con sus valores DISTINTOS, en forma display. Dos categorias
+    // discriminadoras (Guid embebido) demuestran que la proyeccion agrupa por categoria
+    // NORMALIZADA a traves de streams distintos (receta N2, correlacion), sin mezclar los valores
+    // de una categoria con los de la otra.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarCategoriasDeEtiquetas_DevuelveCategoriasDistintasConSusValores_CuandoVariosColaboradoresAsignanEtiquetasDistintas()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var categoriaA = $"area357-{NuevoSufijoUnico()}";
+        var categoriaB = $"cargo357-{NuevoSufijoUnico()}";
+        var valorA = "tecnologia";
+        var valorB = "desarrollador";
+
+        var numeroA = NuevoNumeroIdentificacion();
+        var numeroB = NuevoNumeroIdentificacion();
+
+        await RegistrarColaboradorAsync(numeroA, new DateOnly(2026, 1, 1), ct);
+        await RegistrarColaboradorAsync(numeroB, new DateOnly(2026, 1, 1), ct);
+        await AsignarEtiquetaAsync(numeroA, categoriaA, valorA, ct);
+        await AsignarEtiquetaAsync(numeroB, categoriaB, valorB, ct);
+
+        var catalogo = await EsperarCatalogoAsync(
+            lista => lista.Any(c => c.Id == categoriaA) && lista.Any(c => c.Id == categoriaB), ct);
+
+        var vistaA = catalogo.Should().ContainSingle(c => c.Id == categoriaA).Subject;
+        vistaA.Categoria.Should().Be(categoriaA);
+        vistaA.Valores.Should().ContainSingle(v => v.ValorNormalizado == valorA)
+            .Which.Valor.Should().Be(valorA);
+
+        var vistaB = catalogo.Should().ContainSingle(c => c.Id == categoriaB).Subject;
+        vistaB.Categoria.Should().Be(categoriaB);
+        vistaB.Valores.Should().ContainSingle(v => v.ValorNormalizado == valorB)
+            .Which.Valor.Should().Be(valorB);
+    }
+
+    // CA-2: asignaciones repetidas del MISMO par (categoria, valor), en streams (colaboradores)
+    // distintos, no duplican ni la categoria ni el valor -- el checkpoint (categoria centinela,
+    // ver el comentario del encabezado) garantiza que ambas asignaciones ya fueron aplicadas antes
+    // de aseverar Count == 1.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarCategoriasDeEtiquetas_NoDuplicaCategoriaNiValor_CuandoSeAsignaElMismoParDosVeces()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var categoria = $"duplicado357-{NuevoSufijoUnico()}";
+        var valor = "mismovalor";
+        var categoriaCentinela = $"centinela357-{NuevoSufijoUnico()}";
+
+        var numero1 = NuevoNumeroIdentificacion();
+        var numero2 = NuevoNumeroIdentificacion();
+        var numeroCentinela = NuevoNumeroIdentificacion();
+
+        await RegistrarColaboradorAsync(numero1, new DateOnly(2026, 1, 1), ct);
+        await RegistrarColaboradorAsync(numero2, new DateOnly(2026, 1, 1), ct);
+        await RegistrarColaboradorAsync(numeroCentinela, new DateOnly(2026, 1, 1), ct);
+
+        await AsignarEtiquetaAsync(numero1, categoria, valor, ct);
+        await AsignarEtiquetaAsync(numero2, categoria, valor, ct); // mismo par, stream distinto
+        await AsignarEtiquetaAsync(numeroCentinela, categoriaCentinela, "checkpoint", ct);
+
+        // El checkpoint (orden global del daemon Async, ver el comentario del encabezado) garantiza
+        // que las DOS asignaciones anteriores ya se aplicaron cuando la categoria centinela aparece.
+        var catalogo = await EsperarCatalogoAsync(lista => lista.Any(c => c.Id == categoriaCentinela), ct);
+
+        var vista = catalogo.Should().ContainSingle(c => c.Id == categoria).Subject;
+        vista.Valores.Should().ContainSingle(v => v.ValorNormalizado == valor,
+            "el mismo par (categoria, valor) asignado dos veces no deberia duplicar ni la categoria ni el valor");
+    }
+
+    // CA-3: dos formas originales que normalizan igual (mayusculas vs minusculas) colapsan en UNA
+    // sola categoria -- el display de la categoria y el display del valor reflejan la ULTIMA
+    // asignacion que los toco (mismo espiritu que la sobrescritura de FichaColaborador, #356).
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarCategoriasDeEtiquetas_ColapsaEnUnaSolaCategoriaConDisplayDeLaUltima_CuandoDosFormasNormalizanIgual()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var sufijo = NuevoSufijoUnico();
+        var categoriaMayusculas = $"COLAPSO357-{sufijo}";
+        var categoriaMinusculas = categoriaMayusculas.ToLowerInvariant(); // misma categoria normalizada
+        var categoriaCentinela = $"centinela357-{NuevoSufijoUnico()}";
+
+        var numero1 = NuevoNumeroIdentificacion();
+        var numero2 = NuevoNumeroIdentificacion();
+        var numeroCentinela = NuevoNumeroIdentificacion();
+
+        await RegistrarColaboradorAsync(numero1, new DateOnly(2026, 1, 1), ct);
+        await RegistrarColaboradorAsync(numero2, new DateOnly(2026, 1, 1), ct);
+        await RegistrarColaboradorAsync(numeroCentinela, new DateOnly(2026, 1, 1), ct);
+
+        await AsignarEtiquetaAsync(numero1, categoriaMayusculas, "PRIMERVALOR", ct);
+        // Misma etiqueta por valor (categoria y valor normalizan igual), forma display distinta:
+        // "la ultima gana" debe reflejarse tanto en Categoria como en el Valor del ValorCategoria.
+        await AsignarEtiquetaAsync(numero2, categoriaMinusculas, "primervalor", ct);
+        await AsignarEtiquetaAsync(numeroCentinela, categoriaCentinela, "checkpoint", ct);
+
+        var catalogo = await EsperarCatalogoAsync(lista => lista.Any(c => c.Id == categoriaCentinela), ct);
+
+        var vista = catalogo.Should().ContainSingle(c => c.Id == categoriaMinusculas,
+            "dos formas originales que normalizan igual deberian colapsar en UNA sola categoria").Subject;
+
+        vista.Categoria.Should().Be(categoriaMinusculas,
+            "el display de la categoria deberia reflejar la ULTIMA asignacion que la toco");
+        vista.Valores.Should().ContainSingle(
+                "el mismo valor por forma distinta tambien deberia colapsar (upsert por ValorNormalizado)")
+            .Which.Valor.Should().Be("primervalor",
+                "el display del valor tambien refleja la ultima asignacion");
+    }
+
+    // CA-4: sobrescribir el valor de una categoria existente (mismo colaborador, mismo stream)
+    // AGREGA el valor nuevo al catalogo y CONSERVA el anterior -- catalogo acumulativo (decision de
+    // refinamiento 2026-08-13), nunca un reemplazo total de la lista de valores.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarCategoriasDeEtiquetas_AgregaElValorNuevoYConservaElAnterior_CuandoSeSobrescribeUnaCategoriaExistente()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var categoria = $"acumulativo357-{NuevoSufijoUnico()}";
+        var valorAnterior = "valoranterior";
+        var valorNuevo = "valornuevo";
+
+        var numero = NuevoNumeroIdentificacion();
+        await RegistrarColaboradorAsync(numero, new DateOnly(2026, 1, 1), ct);
+
+        await AsignarEtiquetaAsync(numero, categoria, valorAnterior, ct);
+        await AsignarEtiquetaAsync(numero, categoria, valorNuevo, ct); // sobrescribe la categoria
+
+        var catalogo = await EsperarCatalogoAsync(
+            lista => lista.Any(c => c.Id == categoria
+                && c.Valores.Any(v => v.ValorNormalizado == valorAnterior)
+                && c.Valores.Any(v => v.ValorNormalizado == valorNuevo)),
+            ct);
+
+        var vista = catalogo.Should().ContainSingle(c => c.Id == categoria).Subject;
+        vista.Valores.Should().Contain(v => v.ValorNormalizado == valorAnterior,
+            "el catalogo es ACUMULATIVO: sobrescribir no deberia borrar el valor anterior");
+        vista.Valores.Should().Contain(v => v.ValorNormalizado == valorNuevo,
+            "sobrescribir deberia agregar el valor nuevo al catalogo");
+    }
+
+    // CA-5: EtiquetaRetirada NO altera el catalogo -- la proyeccion no declara ningun metodo para
+    // ese evento (garantia estructural). El checkpoint (categoria centinela asignada DESPUES del
+    // retiro) garantiza que el retiro ya fue considerado por el daemon antes de aseverar que el
+    // catalogo no cambio.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarCategoriasDeEtiquetas_ConservaLaCategoriaYElValor_CuandoSeRetiraLaEtiqueta()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var categoria = $"retiro357-{NuevoSufijoUnico()}";
+        var valor = "valorretirado";
+        var categoriaCentinela = $"centinela357-{NuevoSufijoUnico()}";
+
+        var numero = NuevoNumeroIdentificacion();
+        var numeroCentinela = NuevoNumeroIdentificacion();
+
+        await RegistrarColaboradorAsync(numero, new DateOnly(2026, 1, 1), ct);
+        await RegistrarColaboradorAsync(numeroCentinela, new DateOnly(2026, 1, 1), ct);
+
+        await AsignarEtiquetaAsync(numero, categoria, valor, ct);
+
+        // Esperar a que la categoria aparezca ANTES de retirarla -- confirma que el arrange base ya
+        // esta materializado (mismo criterio que ObtenerFichaColaboradorSmokeTests: no encadenar mas
+        // eventos sobre una vista que todavia no reflejo el primero).
+        await EsperarCatalogoAsync(lista => lista.Any(c => c.Id == categoria), ct);
+
+        await RetirarEtiquetaAsync(numero, categoria, ct);
+        await AsignarEtiquetaAsync(numeroCentinela, categoriaCentinela, "checkpoint", ct);
+
+        // El checkpoint garantiza que el retiro (emitido antes) ya fue procesado por el daemon --
+        // CategoriaDeEtiquetasProjection no declara Apply para EtiquetaRetirada, asi que el catalogo
+        // NO deberia cambiar.
+        var catalogo = await EsperarCatalogoAsync(lista => lista.Any(c => c.Id == categoriaCentinela), ct);
+
+        var vista = catalogo.Should().ContainSingle(c => c.Id == categoria,
+            "EtiquetaRetirada no deberia alterar el catalogo (acumulativo, CA-5)").Subject;
+        vista.Valores.Should().ContainSingle(v => v.ValorNormalizado == valor);
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/ListarCategoriasDeEtiquetas/ListarCategoriasDeEtiquetasSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/ListarCategoriasDeEtiquetas/ListarCategoriasDeEtiquetasSmokeTests.cs
@@ -185,9 +185,15 @@ public class ListarCategoriasDeEtiquetasSmokeTests(ApiFixture api)
     // -- una lista vacia es una respuesta valida, no un recurso ausente. El catalogo COMPLETAMENTE
     // vacio (cero categorias en todo el tenant) solo es observable en un entorno recien
     // provisionado; en dev, compartido y acumulativo por diseno, este smoke test no puede forzar esa
-    // condicion sin borrar datos de otras corridas (fuera de alcance de un smoke test). Ese caso
-    // exacto ("coleccion vacia") ya lo cubre el unit test de la proyeccion
-    // (CategoriaDeEtiquetasProjectionTests, contra un store en memoria realmente vacio).
+    // condicion sin borrar datos de otras corridas (fuera de alcance de un smoke test).
+    //
+    // La otra mitad de CA-6 -- que la respuesta sea una coleccion VACIA y no un 404 cuando el
+    // tenant todavia no tiene ninguna categoria -- no tiene test propio en ningun nivel, y es
+    // deliberado: session.Query<T>() sobre una tabla sin filas devuelve lista vacia por
+    // construccion, y un unit test del endpoint solo verificaria ese comportamiento de Marten con
+    // un doble. Su guardrail real es el test de composicion del contenedor
+    // (ComposicionServiciosTests.AgregarServiciosColaboradores_ResuelveElEndpointDeListarCategorias
+    // DeEtiquetas...) mas este smoke test, que si afirma el 200 contra el entorno real.
     [Fact]
     [Trait("Category", "Smoke")]
     public async Task ListarCategoriasDeEtiquetas_Retorna200ConUnaColeccion_Siempre()

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/Infraestructura/ComposicionServiciosTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/Infraestructura/ComposicionServiciosTests.cs
@@ -437,4 +437,55 @@ public class ComposicionServiciosTests
 
         act.Should().NotThrow();
     }
+
+    // Issue #357, mitad write-side del par 2 de compatibilidad write-side/read-side (MEF-ADR-0034
+    // seccion 6) para la SEGUNDA vista materializada del dominio -- hermano exacto del guardrail
+    // que #356 dejo para FichaColaborador, cuyo comentario documenta el gotcha completo de
+    // "Numeric Revisioned Documents" y el incidente de dev del issue #294.
+    //
+    // Ninguna de las dos guardas de FichaColaborador cubre a CategoriaDeEtiquetas: cada documento
+    // lleva su propio mapping, asi que la declaracion explicita del lado LECTURA es por vista, no
+    // por store. Sin ella, este Function App esperaria mt_version uuid sobre la tabla que el worker
+    // crea como bigint y ListarCategoriasDeEtiquetas responderia 500 permanente (42804 por
+    // request), con el daemon funcionando.
+    //
+    // Oraculo literal, espejo del que ConfiguracionMartenProjectionsTests
+    // .ConfigurarColaboradores_MaterializaCategoriaDeEtiquetasConRevisionNumerica congela desde el
+    // worker, sin que ningun ensamblado referencie al otro (CA-ADR-0029).
+    [Fact]
+    public async Task AgregarServiciosColaboradores_EsperaLaMismaColumnaDeVersionQueMaterializaraElWorker_ParaCategoriaDeEtiquetas()
+    {
+        await using var provider = ComponerServiceProvider();
+        await using var scope = provider.CreateAsyncScope();
+
+        var mapping = scope.ServiceProvider.GetRequiredService<IDocumentStore>()
+            .Options.FindOrResolveDocumentType(typeof(CategoriaDeEtiquetas));
+
+        mapping.Metadata.Revision.Enabled.Should().BeTrue();
+        mapping.Metadata.Revision.Type.Should().Be("bigint");
+        mapping.Metadata.Version.Enabled.Should().BeFalse();
+    }
+
+    // Issue #357, segunda dimension del mismo par 2 sobre CategoriaDeEtiquetas (precedente #356
+    // sobre FichaColaborador): tabla, tenancy e IdMember tienen que converger entre el worker que
+    // materializa y este Function App que consulta, o el GET devuelve coleccion vacia para siempre
+    // con el daemon funcionando. Ningun compilador lo garantiza -- son dos configuraciones de
+    // Marten independientes sobre el mismo schema.
+    //
+    // Oraculo literal, espejo del que ConfiguracionMartenProjectionsTests
+    // .ConfigurarColaboradores_MaterializaCategoriaDeEtiquetasSobreLaTablaQueConsultaElWriteSide
+    // congela desde el worker.
+    [Fact]
+    public async Task AgregarServiciosColaboradores_ResuelveCategoriaDeEtiquetasSobreLaTablaQueMaterializaElWorker_CuandoElContenedorEstaCompuesto()
+    {
+        await using var provider = ComponerServiceProvider();
+        await using var scope = provider.CreateAsyncScope();
+
+        var mapping = scope.ServiceProvider.GetRequiredService<IDocumentStore>()
+            .Options.FindOrResolveDocumentType(typeof(CategoriaDeEtiquetas));
+
+        mapping.TableName.QualifiedName.Should().Be("colaboradores.mt_doc_categoriadeetiquetas");
+        mapping.TenancyStyle.Should().Be(TenancyStyle.Conjoined);
+        mapping.IdMember.Name.Should().Be(nameof(CategoriaDeEtiquetas.Id));
+    }
 }

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/Infraestructura/ComposicionServiciosTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/Infraestructura/ComposicionServiciosTests.cs
@@ -27,6 +27,7 @@ using OpenTelemetry.Trace;
 using Wolverine;
 using ObtenerFichaColaboradorEndpoint = Bitakora.ControlAsistencia.Colaboradores.ObtenerFichaColaborador.FunctionEndpoint;
 using ListarFichasColaboradorEndpoint = Bitakora.ControlAsistencia.Colaboradores.ListarFichasColaborador.FunctionEndpoint;
+using ListarCategoriasDeEtiquetasEndpoint = Bitakora.ControlAsistencia.Colaboradores.ListarCategoriasDeEtiquetas.FunctionEndpoint;
 
 namespace Bitakora.ControlAsistencia.Colaboradores.Tests.Infraestructura;
 
@@ -412,6 +413,27 @@ public class ComposicionServiciosTests
         await using var scope = provider.CreateAsyncScope();
 
         var act = () => ActivatorUtilities.CreateInstance<ListarFichasColaboradorEndpoint>(scope.ServiceProvider);
+
+        act.Should().NotThrow();
+    }
+
+    // Issue #357: test de composicion de la Function GET del catalogo CategoriaDeEtiquetas, mismo
+    // patron que #356 dejo para ObtenerFichaColaborador (MEF-ADR-0029: ActivatorUtilities
+    // .CreateInstance, sin host real -- no existe un WebApplicationFactory para Functions isolated
+    // worker). El endpoint recibe IDocumentStore/ITenantResolver por constructor, ya registrados por
+    // AgregarServiciosColaboradores desde el issue #360 -- no hace falta ningun registro nuevo para
+    // que este guardrail de wiring resuelva.
+    //
+    // Se prueba solo la RESOLUCION de dependencias por constructor -- no el comportamiento de Run
+    // (200 con la coleccion, incluso vacia -- CA-6), que es responsabilidad del endpoint y del smoke
+    // test contra dev.
+    [Fact]
+    public async Task AgregarServiciosColaboradores_ResuelveElEndpointDeListarCategoriasDeEtiquetas_CuandoElContenedorEstaCompuesto()
+    {
+        await using var provider = ComponerServiceProvider();
+        await using var scope = provider.CreateAsyncScope();
+
+        var act = () => ActivatorUtilities.CreateInstance<ListarCategoriasDeEtiquetasEndpoint>(scope.ServiceProvider);
 
         act.Should().NotThrow();
     }

--- a/tests/Bitakora.ControlAsistencia.Projections.Tests/Colaboradores/CategoriaDeEtiquetasProjectionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Projections.Tests/Colaboradores/CategoriaDeEtiquetasProjectionTests.cs
@@ -1,0 +1,164 @@
+// Issue #357: segunda proyeccion concreta del dominio Colaboradores, PRIMERA receta N2
+// (MultiStreamProjection<CategoriaDeEtiquetas, string>) de este BC. Invocacion DIRECTA de los
+// metodos estaticos de CategoriaDeEtiquetasProjection (skills/projections/modelos-marten.md) -- no
+// el DSL Given/When/Then de CommandHandlerTestBase (MEF-ADR-0002, testea command handlers contra el
+// event store): aqui se testean funciones puras evento -> vista, sin abrir ningun stream.
+//
+// Create toma EtiquetaAsignada a secas, no IEvent<EtiquetaAsignada>: a diferencia de N1
+// (FichaColaboradorProjectionTests, donde el Id del documento ES el StreamKey), aqui el Id lo fija
+// el slicer de correlacion N2 (Identity<EtiquetaAsignada>(e => e.Etiqueta.CategoriaNormalizada)) --
+// un campo del payload, no una propiedad de IEvent<T> (skills/projections/modelos-marten.md, "N2 --
+// correlacion entre streams", nota sobre no generalizar el fix de N1 a N2).
+//
+// Cada assert compara contra un oraculo armado a mano (MEF-ADR-0002, no-tautologia): nunca se reusa
+// la logica de Create/Apply bajo prueba para construir el valor esperado -- las formas normalizadas
+// esperadas ("area", "tecnologia", ...) se escriben como literales, replicando a mano el algoritmo de
+// Etiqueta.Normalizar (trim + remover diacriticos + minusculas), nunca invocando
+// Etiqueta.NormalizarCategoria/CategoriaNormalizada para construir el oraculo (precedente
+// FichaColaboradorProjectionTests).
+//
+// Dato de vistaPrevia en los tests de Apply: se construye a mano, simulando el documento que Marten
+// ya habria materializado -- nunca se obtiene invocando Create/Apply, para no encadenar el oraculo
+// de un test con la logica bajo prueba de otro.
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+using Bitakora.ControlAsistencia.Projections.Colaboradores;
+using Bitakora.ControlAsistencia.ReadModels.Colaboradores;
+
+namespace Bitakora.ControlAsistencia.Projections.Tests.Colaboradores;
+
+public class CategoriaDeEtiquetasProjectionTests
+{
+    // --- CA-1: Create nace el documento con la categoria (display) y el primer valor ---
+
+    [Fact]
+    public void Create_ProyectaCategoriaYPrimerValor_DesdeEtiquetaAsignada()
+    {
+        var evento = new EtiquetaAsignada(Etiqueta.Crear("Área", "Tecnología"));
+
+        var vista = CategoriaDeEtiquetasProjection.Create(evento);
+
+        vista.Id.Should().Be("area");
+        vista.Categoria.Should().Be("Área");
+        vista.Valores.Should().BeEquivalentTo([new ValorCategoria("Tecnología", "tecnologia")]);
+    }
+
+    // --- CA-1/CA-3: test de correlacion N2 (obligatorio para MultiStreamProjection) -- dos eventos
+    // que EN PRODUCCION vendrian de streams de DOS colaboradores distintos, con formas originales de
+    // categoria distintas que normalizan igual ("Área" / "area"), convergen en el MISMO documento
+    // (misma Id). No se abre ningun stream real: se invoca Create con el primero y Apply con el
+    // segundo sobre la vista que dejo el primero -- asi es exactamente como el daemon de Marten
+    // encadena eventos de streams distintos sobre un mismo documento N2 correlacionado. ---
+
+    [Fact]
+    public void Create_y_Apply_CorrelacionanPorCategoriaNormalizada_DesdeDosStreamsDeColaboradorDistintos()
+    {
+        var eventoDeColaboradorA = new EtiquetaAsignada(Etiqueta.Crear("Área", "Tecnología"));
+        var eventoDeColaboradorB = new EtiquetaAsignada(Etiqueta.Crear("area", "Sistemas"));
+
+        var vistaTrasColaboradorA = CategoriaDeEtiquetasProjection.Create(eventoDeColaboradorA);
+        var vistaTrasColaboradorB = CategoriaDeEtiquetasProjection.Apply(eventoDeColaboradorB, vistaTrasColaboradorA);
+
+        vistaTrasColaboradorA.Id.Should().Be("area");
+        vistaTrasColaboradorB.Id.Should().Be("area");
+    }
+
+    // --- CA-3 (segunda mitad): el display de la categoria refleja la ULTIMA asignacion, aunque la
+    // forma original de la nueva asignacion sea distinta de la que nombro el documento ---
+
+    [Fact]
+    public void Apply_ActualizaElDisplayDeLaCategoria_CuandoLaNuevaAsignacionUsaOtraFormaOriginal()
+    {
+        var vistaPrevia = new CategoriaDeEtiquetas(
+            "area", "Área", [new ValorCategoria("Tecnología", "tecnologia")]);
+        var evento = new EtiquetaAsignada(Etiqueta.Crear("area", "Tecnología"));
+
+        var vista = CategoriaDeEtiquetasProjection.Apply(evento, vistaPrevia);
+
+        vista.Id.Should().Be("area");
+        vista.Categoria.Should().Be("area");
+    }
+
+    // --- CA-2: reasignar el MISMO par (categoria, valor) no duplica ni la categoria (ya cubierto:
+    // Apply siempre opera sobre el documento existente, nunca crea uno nuevo) ni el valor -- oraculo
+    // mas fuerte que "un valor en la lista": descarta una implementacion que agregue sin upsert ---
+
+    [Fact]
+    public void Apply_NoDuplicaElValor_CuandoSeReasignaElMismoParCategoriaValor()
+    {
+        var vistaPrevia = new CategoriaDeEtiquetas(
+            "area", "Área", [new ValorCategoria("Tecnología", "tecnologia")]);
+        var evento = new EtiquetaAsignada(Etiqueta.Crear("Área", "Tecnología"));
+
+        var vista = CategoriaDeEtiquetasProjection.Apply(evento, vistaPrevia);
+
+        vista.Valores.Should().HaveCount(1);
+        vista.Valores.Should().BeEquivalentTo([new ValorCategoria("Tecnología", "tecnologia")]);
+    }
+
+    // --- CA-3 (valores): dos formas originales del MISMO valor normalizado son UN solo valor en el
+    // catalogo; el display de ese valor refleja la ultima asignacion ---
+
+    [Fact]
+    public void Apply_ActualizaElDisplayDelValor_CuandoDosFormasOriginalesDelValorNormalizanIgual()
+    {
+        var vistaPrevia = new CategoriaDeEtiquetas(
+            "area", "Área", [new ValorCategoria("Tecnología", "tecnologia")]);
+        var evento = new EtiquetaAsignada(Etiqueta.Crear("area", "tecnologia"));
+
+        var vista = CategoriaDeEtiquetasProjection.Apply(evento, vistaPrevia);
+
+        vista.Valores.Should().HaveCount(1);
+        vista.Valores.Should().BeEquivalentTo([new ValorCategoria("tecnologia", "tecnologia")]);
+    }
+
+    // --- CA-4: sobrescribir el valor de una categoria existente AGREGA el valor nuevo al catalogo y
+    // CONSERVA el anterior -- acumulativo (decision de refinamiento 2026-08-13), a diferencia de
+    // FichaColaborador (#356 CA-4), donde el mismo evento SI reemplaza el unico valor vigente de la
+    // categoria. Oraculo mas fuerte que "contiene el valor nuevo": tambien exige el anterior ---
+
+    [Fact]
+    public void Apply_AgregaElValorNuevoYConservaElAnterior_CuandoSeSobrescribeElValorDeLaCategoria()
+    {
+        var vistaPrevia = new CategoriaDeEtiquetas(
+            "area", "Área", [new ValorCategoria("Tecnología", "tecnologia")]);
+        var evento = new EtiquetaAsignada(Etiqueta.Crear("Área", "Sistemas"));
+
+        var vista = CategoriaDeEtiquetasProjection.Apply(evento, vistaPrevia);
+
+        vista.Valores.Should().BeEquivalentTo(
+        [
+            new ValorCategoria("Tecnología", "tecnologia"),
+            new ValorCategoria("Sistemas", "sistemas")
+        ]);
+    }
+
+    // --- CA-1: dos categorias DISTINTAS (normalizadas distintas) nunca comparten documento -- cada
+    // Create nace con Id propio, sin arrastrar los valores de otra categoria. Descarta una
+    // implementacion que comparta estado global entre documentos distintos ---
+
+    [Fact]
+    public void Create_NaceUnDocumentoIndependiente_ParaCadaCategoriaNormalizadaDistinta()
+    {
+        var eventoArea = new EtiquetaAsignada(Etiqueta.Crear("Área", "Tecnología"));
+        var eventoSede = new EtiquetaAsignada(Etiqueta.Crear("Sede", "Suba"));
+
+        var vistaArea = CategoriaDeEtiquetasProjection.Create(eventoArea);
+        var vistaSede = CategoriaDeEtiquetasProjection.Create(eventoSede);
+
+        vistaArea.Id.Should().Be("area");
+        vistaArea.Valores.Should().BeEquivalentTo([new ValorCategoria("Tecnología", "tecnologia")]);
+        vistaSede.Id.Should().Be("sede");
+        vistaSede.Valores.Should().BeEquivalentTo([new ValorCategoria("Suba", "suba")]);
+    }
+
+    // Nota CA-5 (catalogo ACUMULATIVO, decision de refinamiento 2026-08-13): EtiquetaRetirada NO
+    // descuenta nada del catalogo. No hay un test dedicado para esta regla -- la garantia es
+    // estructural, no de comportamiento: CategoriaDeEtiquetasProjection (worker) simplemente no
+    // declara ningun Apply/ShouldDelete para ese evento, asi que Marten no tiene que metodo
+    // despachar. Un test que solo reflexionara sobre esa ausencia pasaria de una contra el stub
+    // (nada que implementar lo pondria en rojo), violando el principio de la fase roja de este
+    // agente -- por eso queda fuera del archivo, documentado aqui en vez de en un [Fact] verde
+    // desde el commit inicial.
+}

--- a/tests/Bitakora.ControlAsistencia.Projections.Tests/ConfiguracionMartenProjectionsTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Projections.Tests/ConfiguracionMartenProjectionsTests.cs
@@ -504,6 +504,51 @@ public class ConfiguracionMartenProjectionsTests
             .AssertProyeccionAsyncRegistrada("CategoriaDeEtiquetas");
     }
 
+    // Issue #357, mismo gotcha de "Numeric Revisioned Documents" que #356 congelo para
+    // FichaColaborador (ver el comentario de ConfigurarColaboradores_MaterializaFichaColaboradorCon
+    // RevisionNumerica): ProjectionDocumentPolicy aplica POR DOCUMENTO target de una proyeccion
+    // registrada, asi que la vista nueva necesita su propia guarda -- la de FichaColaborador no la
+    // cubre. Este lado no declara nada: los valores los impone Marten al registrar
+    // CategoriaDeEtiquetasProjection arriba, y por eso es el lado que DEFINE la forma fisica que el
+    // Function App debe replicar.
+    //
+    // Espejo de ComposicionServiciosTests (Colaboradores.Tests)
+    // .AgregarServiciosColaboradores_EsperaLaMismaColumnaDeVersionQueMaterializaraElWorker_ParaCategoriaDeEtiquetas.
+    [Fact]
+    public void ConfigurarColaboradores_MaterializaCategoriaDeEtiquetasConRevisionNumerica()
+    {
+        using var provider = ProviderDeColaboradores();
+
+        var mapping = provider.GetRequiredService<IColaboradoresProjectionStore>()
+            .Options.FindOrResolveDocumentType(typeof(CategoriaDeEtiquetas));
+
+        mapping.Metadata.Revision.Enabled.Should().BeTrue();
+        mapping.Metadata.Revision.Type.Should().Be("bigint");
+        mapping.Metadata.Version.Enabled.Should().BeFalse();
+    }
+
+    // Issue #357, mitad worker del par 2 de compatibilidad write-side/read-side (MEF-ADR-0034
+    // seccion 6) para la vista nueva: el daemon materializa CategoriaDeEtiquetas desde este named
+    // store y el Function App de Colaboradores la lee, en otro proceso, con session.Query
+    // (ListarCategoriasDeEtiquetas). Que ambos lados converjan en la MISMA tabla fisica, la MISMA
+    // tenancy y el MISMO IdMember no lo garantiza ningun compilador.
+    //
+    // Espejo de ComposicionServiciosTests (Colaboradores.Tests)
+    // .AgregarServiciosColaboradores_ResuelveCategoriaDeEtiquetasSobreLaTablaQueMaterializaElWorker_...,
+    // sin que ningun ensamblado referencie al otro (CA-ADR-0029).
+    [Fact]
+    public void ConfigurarColaboradores_MaterializaCategoriaDeEtiquetasSobreLaTablaQueConsultaElWriteSide()
+    {
+        using var provider = ProviderDeColaboradores();
+
+        var mapping = provider.GetRequiredService<IColaboradoresProjectionStore>()
+            .Options.FindOrResolveDocumentType(typeof(CategoriaDeEtiquetas));
+
+        mapping.TableName.QualifiedName.Should().Be("colaboradores.mt_doc_categoriadeetiquetas");
+        mapping.TenancyStyle.Should().Be(TenancyStyle.Conjoined);
+        mapping.IdMember.Name.Should().Be(nameof(CategoriaDeEtiquetas.Id));
+    }
+
     // Issue #373 CA-5: indices declarados en el seam del worker para el listado QUERY de fichas
     // vigentes (ListarFichasColaborador, MEF-ADR-0042) -- rango sobre VigenteHasta, GIN sobre
     // EtiquetasNormalizadas (containment JSONB del filtro AND por etiquetas, precedente #337 sobre

--- a/tests/Bitakora.ControlAsistencia.Projections.Tests/ConfiguracionMartenProjectionsTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Projections.Tests/ConfiguracionMartenProjectionsTests.cs
@@ -484,6 +484,26 @@ public class ConfiguracionMartenProjectionsTests
         mapping.IdMember.Name.Should().Be(nameof(FichaColaborador.Id));
     }
 
+    // Issue #357: segunda proyeccion concreta de Colaboradores -- la PRIMERA receta N2
+    // (MultiStreamProjection<CategoriaDeEtiquetas, string>) de este BC: eventos EtiquetaAsignada de
+    // MUCHOS streams de ColaboradorAggregateRoot convergen en el MISMO documento cuando comparten
+    // categoria normalizada (skills/projections/modelos-marten.md). Mismo patron que #356 dejo para
+    // FichaColaboradorProjection (N1): complementa ConfigurarColaboradores_NoRegistraNingunaProyeccionInline
+    // -- aquella prueba que NADA quedo Inline, esta prueba que la proyeccion CONCRETA se registro con
+    // lifecycle Async, el canonico del worker (MEF-ADR-0034 seccion 3). El seam
+    // (ConfiguracionMartenProjectionsColaboradores.ConfigurarColaboradores) ya existe desde el issue
+    // #360 y ya registra FichaColaboradorProjection (#356); este issue le agrega la unica linea
+    // opts.Projections.Add<CategoriaDeEtiquetasProjection>(ProjectionLifecycle.Async) -- ausente hoy,
+    // por eso este test queda en rojo hasta que projection-implementer la sume.
+    [Fact]
+    public void ConfigurarColaboradores_RegistraCategoriaDeEtiquetasProjectionComoAsync()
+    {
+        using var provider = ProviderDeColaboradores();
+
+        provider.GetRequiredService<IColaboradoresProjectionStore>()
+            .AssertProyeccionAsyncRegistrada("CategoriaDeEtiquetas");
+    }
+
     // Issue #373 CA-5: indices declarados en el seam del worker para el listado QUERY de fichas
     // vigentes (ListarFichasColaborador, MEF-ADR-0042) -- rango sobre VigenteHasta, GIN sobre
     // EtiquetasNormalizadas (containment JSONB del filtro AND por etiquetas, precedente #337 sobre


### PR DESCRIPTION
## Resumen

Pipeline TDD completado:
- Fase roja: tests escritos con stubs
- Fase verde: implementación completa
- Smoke tests: escritos para endpoints detectados
- Fase refactor: revisión de calidad

## Decisiones del pipeline

<details>
<summary>Projection Test Writer (fase roja) — 11m 5s</summary>

# Stage 1 -- projection-test-writer (issue #357)

## Resumen

Fase roja read-side completa para "Exponer las etiquetas en uso para recomendaciones" (issue #357):
catalogo `CategoriaDeEtiquetas` materializado por la PRIMERA proyeccion N2
(`MultiStreamProjection<CategoriaDeEtiquetas, string>`) de este BC, alimentada por `EtiquetaAsignada`
de todos los streams de `ColaboradorAggregateRoot`, correlacionando por categoria normalizada.

## Tests creados

### 1. Unit tests de la proyeccion (`tests/Bitakora.ControlAsistencia.Projections.Tests/Colaboradores/CategoriaDeEtiquetasProjectionTests.cs`)

Invocacion directa de `CategoriaDeEtiquetasProjection.Create`/`.Apply` (sin DSL Given/When/Then,
sin abrir stream). Todos genuinamente rojos: los dos metodos de produccion son
`throw new NotImplementedException()`.

- `Create_ProyectaCategoriaYPrimerValor_DesdeEtiquetaAsignada` (CA-1)
- `Create_y_Apply_CorrelacionanPorCategoriaNormalizada_DesdeDosStreamsDeColaboradorDistintos` --
  test de correlacion N2 obligatorio (dos "streams" distintos, formas originales de categoria
  distintas que normalizan igual, convergen en el mismo `Id`)
- `Apply_ActualizaElDisplayDeLaCategoria_CuandoLaNuevaAsignacionUsaOtraFormaOriginal` (CA-3, mitad
  categoria)
- `Apply_NoDuplicaElValor_CuandoSeReasignaElMismoParCategoriaValor` (CA-2)
- `Apply_ActualizaElDisplayDelValor_CuandoDosFormasOriginalesDelValorNormalizanIgual` (CA-3, mitad
  valor)
- `Apply_AgregaElValorNuevoYConservaElAnterior_CuandoSeSobrescribeElValorDeLaCategoria` (CA-4,
  catalogo acumulativo -- oraculo exige AMBOS valores presentes)
- `Create_NaceUnDocumentoIndependiente_ParaCadaCategoriaNormalizadaDistinta` (CA-1, aislamiento
  entre documentos)

CA-5 (EtiquetaRetirada no descuenta) **no tiene un `[Fact]` dedicado**: la garantia es estructural
(la clase companion simplemente no declara ningun metodo para ese evento) y un test que solo
reflexionara sobre esa ausencia pasaria de una contra el stub, violando el principio de fase roja.
Documentado en comentario, tanto en el test file como en la clase de proyeccion.

### 2. Config-test del worker (`tests/Bitakora.ControlAsistencia.Projections.Tests/ConfiguracionMartenProjectionsTests.cs`)

Un test nuevo: `ConfigurarColaboradores_RegistraCategoriaDeEtiquetasProjectionComoAsync`, mismo
patron que la guarda que #356 dejo para `FichaColaboradorProjection`. Rojo hoy: el seam
`ConfiguracionMartenProjectionsColaboradores.ConfigurarColaboradores` (ya existente desde #360, ya
registra `FichaColaboradorProjection`) todavia no tiene la linea
`opts.Projections.Add<CategoriaDeEtiquetasProjection>(ProjectionLifecycle.Async)` -- responsabilidad
de `projection-implementer`.

No se agregaron las guardas adicionales de "numeric revision"/"tabla fisica" que #356 dejo para
`FichaColaborador`: esas verifican compatibilidad write-side/read-side completa y, segun el alcance
explicito de este agente, quedan bajo el gate del `reviewer` (MEF-ADR-0034 seccion 6), no de esta
fase.

### 3. Test de composicion de la Function GET (`tests/Bitakora.ControlAsistencia.Colaboradores.Tests/Infraestructura/ComposicionServiciosTests.cs`)

`AgregarServiciosColaboradores_ResuelveElEndpointDeListarCategoriasDeEtiquetas_CuandoElContenedorEstaCompuesto`,
mismo patron que la guarda de `ObtenerFichaColaborador` (#356): `ActivatorUtilities.CreateInstance`
sobre el `FunctionEndpoint` nuevo, verificando solo resolucion de `IDocumentStore`/`ITenantResolver`
por constructor (ya registrados desde #360) -- no el comportamiento de `Run`.

Nota: este test, igual que su precedente de #356, resuelve sin excepcion desde el commit inicial
(las dependencias del constructor ya estaban registradas) -- no es un rojo nuevo, pero es coherente
con el patron ya establecido en este repo para tests de composicion (guardrail de wiring, no driver
de TDD). La fase roja de este issue la aportan integramente los unit tests de la proyeccion (punto 1)
y el config-test de registro (punto 2).

## Stubs de compilacion creados

- **Read model** `src/Bitakora.ControlAsistencia.ReadModels/Colaboradores/CategoriaDeEtiquetas.cs`:
  record plano `CategoriaDeEtiquetas(string Id, string Categoria, IReadOnlyList<ValorCategoria> Valores)`
  + `ValorCategoria(string Valor, string ValorNormalizado)`. Sin `partial`, sin relacion de tipo con
  `Colaboradores.DomainEvents` (cuarta isla).
- **Clase de proyeccion companion**
  `src/Bitakora.ControlAsistencia.Projections/Colaboradores/CategoriaDeEtiquetasProjection.cs`:
  `sealed partial class CategoriaDeEtiquetasProjection : MultiStreamProjection<CategoriaDeEtiquetas, string>`.
  Constructor de correlacion (`Identity<EtiquetaAsignada>(e => e.Etiqueta.CategoriaNormalizada)`)
  **escrito real** (no stub, sin logica de negocio que testear). `Create`/`Apply` son stubs
  (`throw new NotImplementedException()`).
- **Seam de composicion**: ya existia (`ConfiguracionMartenProjectionsColaboradores`, issue #360),
  con modificadores de acceso y sin `partial` -- no se toco. La `ProjectReference` del worker hacia
  `Colaboradores.DomainEvents` tambien ya existia. Ninguna accion adicional requerida en este punto.
- **`FunctionEndpoint`** de la query:
  `src/Bitakora.ControlAsistencia.Colaboradores/ListarCategoriasDeEtiquetas/FunctionEndpoint.cs` --
  `[Function("ListarCategoriasDeEtiquetas")]`, GET, `Route = "colaboradores/etiquetas/categorias"`,
  constructor `(IDocumentStore store, ITenantResolver tenantResolver)`, `Run` lanza
  `NotImplementedException`.

## Cobertura de criterios de aceptacion

- CA-1: cubierto (Create con categoria/valor, y aislamiento entre documentos distintos)
- CA-2: cubierto (no-duplicado ante reasignacion identica)
- CA-3: cubierto (ultima-gana en categoria y en valor, correlacion entre formas que normalizan
  igual)
- CA-4: cubierto (acumulacion -- conserva el valor anterior al sobrescribir)
- CA-5: documentado como garantia estructural (ver arriba), sin `[Fact]` dedicado
- CA-6 (200 con coleccion vacia): fuera de alcance de este agente (comportamiento de `Run`,
  responsabilidad de `projection-implementer` + smoke test)

## Señal no-red

No aplica: el issue crea una proyeccion nueva con `Create`/`Apply` reales por implementar, asi que
la fase roja es alcanzable (layer 1, unit tests de la proyeccion). No se creo
`pipeline-state/no-red-signal.md`.

## Desviaciones del plan del planner

Ninguna. Estructura, nombres y ruta siguen exactamente lo propuesto en el issue
(`CategoriaDeEtiquetas`, `ValorCategoria` como tipo propio no mencionado explicitamente por el
planner pero derivado directamente del shape que el issue describe para `Valores`, ruta
`colaboradores/etiquetas/categorias`, receta N2).

## Verificacion

`dotnet build ControlAsistencias.slnx`: compilacion correcta, 0 errores (2 warnings `CS9113`
esperados en el stub del `FunctionEndpoint` por los parametros del constructor sin leer -- mismo
patron que el precedente de `ObtenerFichaColaborador` en #356). No se corrio `dotnet test` (sin
señal no-red, se espera rojo).

</details>

<details>
<summary>Projection Implementer (fase verde) — 4m 25s</summary>

# Stage 2 -- projection-implementer (issue #357)

## Enfoque

Implementación mínima que hace pasar los tests rojos dejados por `projection-test-writer`, sin tocar
ningún archivo de test. Tres piezas de producción:

1. **`CategoriaDeEtiquetasProjection`** (worker, `MultiStreamProjection<CategoriaDeEtiquetas, string>`,
   primera receta N2 del BC):
   - `Create(EtiquetaAsignada e)`: nace el documento con `Id = e.Etiqueta.CategoriaNormalizada`,
     `Categoria = e.Etiqueta.Categoria` (display de esa primera asignación) y `Valores` con un único
     `ValorCategoria(e.Etiqueta.Valor, e.Etiqueta.ValorNormalizado)`.
   - `Apply(EtiquetaAsignada e, CategoriaDeEtiquetas vista)`: "la última gana" incondicional sobre
     `Categoria` (siempre se reemplaza por el display de la asignación entrante) y upsert por
     `ValorNormalizado` sobre `Valores` -- se filtra el valor existente con el mismo
     `ValorNormalizado` (si lo hay) y se agrega el nuevo, conservando el resto de la lista intacta
     (catálogo acumulativo, CA-4).
   - Ningún método para `EtiquetaRetirada` (ya lo dejó así `projection-test-writer`; CA-5 es una
     garantía estructural, no de comportamiento).

2. **Registro en el seam del worker** (`ConfiguracionMartenProjectionsColaboradores.ConfigurarColaboradores`):
   el seam ya existía, implementado desde el issue #360, con `FichaColaboradorProjection` ya
   registrada (#356). Se sumó aditivamente
   `opts.Projections.Add<CategoriaDeEtiquetasProjection>(ProjectionLifecycle.Async)` dentro del mismo
   `AddMartenStore`, sin tocar el resto del método.

3. **`ListarCategoriasDeEtiquetas/FunctionEndpoint`**: `QuerySession` abierta con
   `store.QuerySession(tenantResolver.TenantId)` (nunca con un tenant de ruta/query string),
   `session.Query<CategoriaDeEtiquetas>().ToListAsync(ct)` sin filtros ni paginación (opción B del
   refinamiento) y `200 OK` con la colección (vacía si no hay etiquetas asignadas, CA-6). Sin DTO de
   respuesta propio: a diferencia de `FichaColaborador` (centinela de vigencia abierta),
   `CategoriaDeEtiquetas` no tiene ningún campo interno que ocultar, así que se serializa la vista tal
   cual.

## Decisiones de diseño

- **Firma de `Create`/`Apply` toma `EtiquetaAsignada` a secas**, no `IEvent<EtiquetaAsignada>`: la
  identidad del documento la fija el slicer de correlación N2
  (`Identity<EtiquetaAsignada>(e => e.Etiqueta.CategoriaNormalizada)`, ya escrito por
  `projection-test-writer`), no el `StreamKey` -- criterio documentado en
  `skills/projections/modelos-marten.md` para N2, distinto del caso N1
  (`FichaColaboradorProjection.Create(IEvent<ColaboradorRegistrado>)`).
- **Upsert por `ValorNormalizado`, no por índice ni por igualdad de `ValorCategoria` completo**: es
  el único criterio que hace que dos formas originales del mismo valor ("Tecnología"/"tecnologia")
  colapsen en una sola entrada con el display de la última asignación (CA-3), mientras que un valor
  normalizado distinto ("Sistemas") se agrega sin tocar el resto (CA-4).
- **Sin DTO de respuesta en el GET**: se evaluó replicar el patrón `FichaColaboradorRespuesta`
  (`ObtenerFichaColaborador`), pero `CategoriaDeEtiquetas` no tiene ningún campo de indexación/filtrado
  interno equivalente al centinela de vigencia -- introducir un DTO idéntico a la vista habría sido
  indirección sin propósito (MEF-ADR-0018, Rule of Three).

## ADRs / recursos consultados

- `skills/projections/modelos-marten.md`: árbol de decisión N1/N2, firma de `Create` según origen de
  identidad, gotcha del `partial`.
- `skills/projections/read-apis.md`: vía de consulta (a), `QuerySession` acotada al tenant de
  `ITenantResolver`, "el DTO de respuesta es excepción".
- MEF-ADR-0034 (secciones 2, 3, 6): named store, lifecycle `Async` canónico, guardas del config-test.
- MEF-ADR-0035: doctrina read-side, estilo canónico de proyección companion.
- MEF-ADR-0041 (decisiones 1, 3, 4): forma propia de la vista, nombre sin sufijo, DTO de respuesta
  como excepción.
- MEF-ADR-0028: tenancy conjoined, `QuerySession` nunca con un tenant de la petición.
- MEF-ADR-0012: lectura de `Etiqueta` vía sus propiedades públicas (`Categoria`, `CategoriaNormalizada`,
  `Valor`, `ValorNormalizado`), sin recalcular ni reimplementar la normalización.

## Desviaciones

Ninguna. La implementación siguió al pie de la letra los stubs y comentarios que dejó
`projection-test-writer` -- incluyendo la firma exacta de `Create`/`Apply`, el read model ya
declarado en `ReadModels` y el `FunctionEndpoint` ya con su `HttpTrigger` y dependencias fijadas por
constructor.

## Resultado

- `dotnet build`: compilación correcta, sin advertencias nuevas.
- `dotnet test` (suite completa): 1293 tests, 1247 correctos, 0 errores, 46 omitidos (smoke tests que
  requieren Postgres/Service Bus reales, sin relación con este issue).
- Tests específicos de este issue, todos en verde:
  - `Bitakora.ControlAsistencia.Projections.Tests` (incluye `CategoriaDeEtiquetasProjectionTests` y
    las guardas nuevas de `ConfiguracionMartenProjectionsTests`).
  - `Bitakora.ControlAsistencia.Colaboradores.Tests` (incluye
    `AgregarServiciosColaboradores_ResuelveElEndpointDeListarCategoriasDeEtiquetas_...`).
- Sin caracteres `─` (U+2500) introducidos; `dotnet format` no reportó cambios adicionales sobre los
  tres archivos tocados (ya estaban formateados).

## Commit

`6acd306` -- `feat(hu-357): proyeccion read-side CategoriaDeEtiquetas (fase verde)`

</details>
<details>
<summary>Smoke Test Writer — 7m 17s</summary>

_(El agente no generó resumen)_

</details>
<details>
<summary>Reviewer (fase refactor) — 26m 16s</summary>

## ES Reviewer - Revision

### Evaluacion general
- Calidad: **buena** (con un hallazgo bloqueante corregido)
- Cambios realizados: **si** (commit `f2e275f`)

La receta N2, el estilo canonico de la proyeccion, la forma propia de la vista y el naming son
correctos y bien fundamentados. El hallazgo bloqueante no esta en la logica de la proyeccion sino en
la **frontera de configuracion Marten entre el worker que materializa la vista y el Function App que
la consulta** -- exactamente el punto que ningun compilador ni test de comportamiento cubre y que el
gate del reviewer (MEF-ADR-0034 seccion 6, issue #447 del marco) existe para cazar.

### Cumplimiento de ADRs aplicables

| ADR | Cumplimiento | Observacion |
|---|---|---|
| MEF-ADR-0041: forma propia de la vista, cuarta isla, naming, DTO como excepcion | ok | La vista **no** es calco de `EtiquetaAsignada`/`Etiqueta`: agrupa por categoria normalizada, agrega la lista de valores en uso y aplica "la ultima gana" -- shape derivado de la necesidad de autocompletado (decision 1). `ReadModels.csproj` sigue con cero `ProjectReference` y `CategoriaDeEtiquetas.cs` no importa ningun tipo de `DomainEvents` (decision 2). Nombre sin sufijo de implementacion; companion `CategoriaDeEtiquetasProjection` con el mismo stem (decision 3). El GET serializa la vista sin DTO, con la ausencia de campo interno que ocultar documentada en el propio endpoint (decision 4) |
| MEF-ADR-0035: doctrina read-side (receta, estilo, superficie de consulta) | ok | N2 correctamente elegida: la correlacion es proyeccion directa de un campo del payload (`e.Etiqueta.CategoriaNormalizada`), no un `CustomGrouping`. Estilo canonico: record plano sin `partial` en `ReadModels`, companion `sealed partial` en el worker con `Create`/`Apply` **estaticos** que retornan `with { ... }` -- no calca el ejemplo oficial de Marten (clase mutable con metodos de instancia). `using Marten.Events.Projections` correcto para `MultiStreamProjection<,>` (no `Aggregation`). Via de consulta (a') con `session.Query<T>()` |
| MEF-ADR-0034: worker, named store, lifecycle, config-test | **desviacion NO declarada (corregida)** | Registro `Async` aditivo dentro del mismo `AddMartenStore` y config-test presente: ok. **Par 2 de compatibilidad write-side/read-side incumplido** -- ver "Desviaciones detectadas por el reviewer" |
| MEF-ADR-0006 (enmendado por #363/#0041): naming de Function y ruta | ok | `Listar{X}s` con plural correcto (`Categorias`), ruta REST por recurso reutilizando el segmento del comando (`colaboradores/etiquetas/...`), feature folder sin sufijo `Function`, clase `FunctionEndpoint` en namespace propio, `Route` y verbo explicitos |
| MEF-ADR-0012: encapsulamiento, Tell-don't-Ask, serializacion | ok | La proyeccion lee `Categoria`/`CategoriaNormalizada`/`Valor`/`ValorNormalizado` -- propiedades publicas **preexistentes** del VO, ya consumidas por el aggregate: ningun getter nuevo abierto para el read-side. Sin clase estatica operando sobre datos crudos, sin `InternalsVisibleTo` nuevo, sin `[JsonConstructor]`. El resolver de `Etiqueta` ya viaja por la fuente unica (`ConfiguracionSerializacionColaboradores.ConfigurarResolver`) que ambos procesos invocan, y `EtiquetaAsignada` esta en `IdentidadEventosColaboradores.TiposPersistidos` -- ambos verificados en codigo, no asumidos |
| CA-ADR-0027 / MEF-ADR-0028: tenancy conjoined | ok | `store.QuerySession(tenantResolver.TenantId)` -- nunca un tenant de ruta/query string/body (mitigacion BOLA/IDOR). El endpoint no recibe ningun segmento de ruta. `Policies.AllDocumentsAreMultiTenanted()` del worker ahora congelada tambien para esta vista por el guardrail nuevo (`TenancyStyle.Conjoined` en ambos lados) |

Sobre el antipatron 6 de MEF-ADR-0012 (`record` con `IReadOnlyList<T>` como propiedad de igualdad):
**no aplica aqui**. Esa proscripcion apunta a *value objects de dominio* cuya identidad depende de la
igualdad estructural; `CategoriaDeEtiquetas` es un read model plano, forma que MEF-ADR-0035 prescribe
explicitamente, sin ningun consumidor que dependa de `Equals` (los tests usan `BeEquivalentTo`, y
Marten identifica el documento por `Id`). Mismo criterio que el precedente `FichaColaborador` (#356).

### Desviaciones de ADRs

**Desviaciones declaradas por el implementer** (de `stage-2-projection-implementer.md`):

Ninguna. El implementer declaro "Ninguna" y la revision del diff lo confirma para todo lo que el
alcanzo a mirar.

**Desviaciones detectadas por el reviewer (NO declaradas por el implementer)**:

#### Desviacion: MEF-ADR-0034 seccion 6 -- par 2 de compatibilidad (read models: worker -> query-side)

- **Regla del ADR**: lo que determina como se interpreta lo ya persistido debe coincidir entre el
  proceso que materializa y el que consulta. La instancia conocida del par 2 es la forma del
  documento que `ProjectionDocumentPolicy` impone.
- **Desviacion encontrada en el diff**: `ConfiguracionMartenProjectionsColaboradores.cs:117` registra
  `CategoriaDeEtiquetasProjection`, con lo cual Marten aplica `ProjectionDocumentPolicy` a
  `CategoriaDeEtiquetas` en el worker (`UseNumericRevisions = true`, `Metadata.Revision` bigint
  habilitada, `Metadata.Version` uuid **deshabilitada**) y crea `mt_version` como `bigint`. El
  query-side (`Colaboradores/Infraestructura/ComposicionServicios.cs`) **no** declaraba la forma
  equivalente para la vista nueva, asi que resolvia el mapping al default y esperaria `mt_version`
  uuid sobre la **misma tabla fisica**.
- **Por que se escapo**: `ProjectionDocumentPolicy` aplica **por documento**, no por store. La
  declaracion que #356 dejo para `FichaColaborador` -- con su comentario de 25 lineas explicando el
  incidente -- no cubre a `CategoriaDeEtiquetas`, y nada en el build ni en los tests de
  comportamiento lo delata. Es el mismo defecto que el issue #294 peno en dev y que #328 y #356 ya
  cerraron, vista por vista.
- **Consecuencia si llegaba a dev**: con `AutoCreate` en su default `CreateOrUpdate`, Marten emite
  `alter column mt_version type uuid` en **cada** request, Postgres lo rechaza con `42804` (no hay
  cast automatico `bigint -> uuid`) y `ListarCategoriasDeEtiquetas` responde **500 permanente** con
  el daemon funcionando correctamente. No es un 404 ni un catalogo vacio: es el endpoint caido.
- **Accion tomada**: **corregida en refactor**.
  1. `options.Schema.For<CategoriaDeEtiquetas>().UseNumericRevisions(true)` en el query-side.
  2. Par de guardrails espejo, replicando el patron de #328/#356 sin que ningun ensamblado referencie
     al otro (CA-ADR-0029): `AgregarServiciosColaboradores_EsperaLaMismaColumnaDeVersionQueMaterializaraElWorker_ParaCategoriaDeEtiquetas`
     y `..._ResuelveCategoriaDeEtiquetasSobreLaTablaQueMaterializaElWorker_...` (write-side);
     `ConfigurarColaboradores_MaterializaCategoriaDeEtiquetasConRevisionNumerica` y
     `..._MaterializaCategoriaDeEtiquetasSobreLaTablaQueConsultaElWriteSide` (worker).
  3. **Guardrail verificado no vacuo**: comentando la linea nueva, `..._EsperaLaMismaColumnaDeVersion...`
     se pone rojo (1 de 2 falla; el de tabla/tenancy/IdMember pasa igual porque Marten resuelve esos
     tres por convencion -- coherente con lo que documenta el precedente de `FichaColaborador`).
- **Nota sobre la frontera del mandato**: la correccion toca el `ComposicionServicios` del Function
  App. Formalmente eso es "tocar el write-side", pero la linea agregada es **puramente query-side**
  (declara la forma de un documento que este proceso solo lee), con dos precedentes literales en el
  mismo archivo y el mismo dominio. Corregirla aqui evita que el PR llegue a dev con el endpoint
  caido; escalarla sin corregir habria sido el peor outcome.
- **Status**: pendiente de evaluacion del usuario

### Precedentes consultados por el implementer

| Precedente | ADR aplicable | Veredicto |
|---|---|---|
| `skills/projections/modelos-marten.md` (arbol N1/N2, firma de `Create` segun origen de identidad, gotcha del `partial`) | MEF-ADR-0035 | alineado -- la firma `Create(EtiquetaAsignada e)` **sin** `IEvent<T>` es la correcta para N2: el `TId` lo fija el slicer sobre un campo del payload, no el `StreamKey`. No generalizar el fix de N1 es exactamente lo que ese recurso advierte |
| `skills/projections/read-apis.md` (via (a), `QuerySession` acotada al tenant, DTO como excepcion) | MEF-ADR-0035 / 0041 / 0028 | alineado |
| `FichaColaboradorProjection` / `ObtenerFichaColaborador` (#356) como patron de la vista y del endpoint | MEF-ADR-0034 / 0035 | alineado **en lo que el implementer cito**, pero **incompleto como precedente**: #356 tambien dejo la declaracion de `UseNumericRevisions` y sus cuatro guardrails de compatibilidad, y esa mitad no se replico. Es la ilustracion exacta de "precedente != autoridad": copiar la forma visible del precedente sin leer el ADR que lo motiva deja fuera justo la parte que ningun test de comportamiento reclama |

### Convenciones del pipeline (no ADRs)

| Convencion | Estado | Observacion |
|---|---|---|
| Cada test con `Then()` + `And<>()` | n/a | No hay tests de command handler en este issue: la fase roja son unit tests de proyeccion (invocacion directa de `Create`/`Apply`), config-tests y tests de composicion |
| Overloads correctos para stream IDs compuestos | n/a | Idem -- sin DSL Given/When/Then en el diff |
| Fakes manuales (no NSubstitute) | n/a | Sin dobles: los unit tests de proyeccion son funciones puras y los config-tests construyen el contenedor real |
| Feature folders (produccion y tests) | ok | `ListarCategoriasDeEtiquetas/FunctionEndpoint.cs`; `Projections/Colaboradores/`; tests espejo en `Projections.Tests/Colaboradores/` y `SmokeTests/ListarCategoriasDeEtiquetas/` |
| Smoke tests: SkipWhen, secrets, cobertura | ok | `ApiFixture` es fixture obligatorio (falla el arranque si falta `Api:BaseUrl`), no opcional -- `Assert.SkipWhen` aplica a `Postgres`/`ServiceBusFixture`, que estos tests no usan. Aislamiento por Guid embebido en la categoria, filtrado siempre por `Id` y nunca por posicion. Sin archivo duplicado por comando. El patron centinela para condiciones negativas es solido: `ICommandRouter.InvokeAsync` se **await**ea dentro de la request, asi que el 202 implica evento persistido y el orden de los POST secuenciales fija el orden de secuencia global que el daemon respeta |
| Proyecciones read-side: `partial`, inmutabilidad, read APIs, naming, cuarta isla | ok | `partial` sobre la companion (nunca sobre el record); analizador via `PackageReference Include="Marten"` propio del worker; metodos estaticos que retornan copia; via (a'); naming sin sufijo; `ReadModels` sin `ProjectReference` |
| Antipatrones de habilitacion (MEF-ADR-0039) | n/a | El diff del issue (`429cf2f..HEAD`) no toca **ningun** `.csproj` ni declara tipo de evento nuevo |
| Compatibilidad Marten write-side/read-side | **falla (corregida)** | Gate disparado (el diff toca `ConfiguracionMartenProjectionsColaboradores.cs`). **Par 1 (eventos)**: sin cambios -- ni la version del paquete (`Cosmos.EventSourcing.CritterStack` 2.3.1, la misma contra la que #268/#447 ya decompilaron) ni ningun atributo de la columna "debe coincidir" se tocan; schema, `StreamIdentity`, `TenancyStyle`, `EventNamingStyle`, `MetadataConfig`, `AddEventTypes` y serializador siguen congelados por las guardas existentes. La re-decompilacion no se pudo correr: **`ilspycmd` no esta instalado** (`dotnet tool install -g ilspycmd`) -- declarado como *no verificado por falta de herramienta*, no como `n/a`. **Par 2 (read models)**: divergencia real encontrada y corregida (ver "Desviaciones detectadas") |
| Identidad de stream (MEF-ADR-0037) | n/a | El endpoint no recibe ningun segmento de ruta y no llama `LoadAsync`/`AggregateStreamAsync`/`FetchStreamAsync`. El `TId` de la vista es un campo de dominio del payload (categoria normalizada), no una clave de stream -- la frontera que el propio ADR excluye para N2. Sin `ToString()` con formato explicito en ningun punto del diff |
| Control de volumen de telemetria (MEF-ADR-0038) | ok | El diff del issue no toca los seams de observabilidad ni el callback de Wolverine. Verificado igual sobre `ComposicionServicios` de Colaboradores (que yo si toque, dentro de `ConfigureMarten`): `SetSampler` en un segundo `.WithTracing(...)` **despues** de `.UseAzureMonitorExporter()`, `Durability.DurabilityMetricsEnabled = false` presente y `Durability.Mode` sin asignar dentro del callback. Ver "Criticas y hallazgos" para un gap preexistente de guardrails |
| Tests via ToString/comportamiento | ok | Ningun getter abierto para tests; la proyeccion se verifica por su valor de retorno |
| Sin numeros magicos | ok | Sin literales con significado de dominio sin nombre |
| Condiciones en positivo (guardas if/else afirmativas) | n/a | Sin bifurcaciones en el codigo nuevo |

### Elegancia del codigo

El codigo de produccion ya era elegante y no requirio refactor de estilo:

- **Compacto**: `Create` es una expresion; `Apply` es `Where(...).Append(...).ToList()` mas un `with`
  -- la formulacion mas corta del upsert acumulativo. No hay indireccion ni helper prematuro (la
  unica "duplicacion", `new ValorCategoria(...)` en ambos metodos, es una expresion: extraerla seria
  abstraccion sin evidencia, MEF-ADR-0018).
- **Idiomatico**: LINQ para el upsert, `record` + `with` para la copia, colection expression para el
  primer valor, constructor primario en el endpoint. Sin `switch` ni `if` que pidieran lookup map.
- **Legible**: los nombres revelan intencion (`existente`, `vista`, `valores`); el comentario del
  `Apply` explica *por que* el upsert es por `ValorNormalizado` y no por igualdad completa, que es
  precisamente la decision no obvia.
- **Eficiente**: O(n) por evento sobre una lista de decenas de valores. La proyeccion compara
  `existente.ValorNormalizado` contra el del payload en vez de recalcular la normalizacion en cada
  iteracion -- mejor que el precedente `FichaColaboradorProjection`, que invoca
  `Etiqueta.NormalizarCategoria` dentro del `Where` porque su vista no persiste la forma normalizada
  de cada entrada.
- **Limpio**: cero warnings nuevos (`dotnet build`: los 4 `NU1902` son preexistentes de
  `Programacion`); `dotnet format --verify-no-changes` limpio sobre los archivos del diff; sin
  caracteres U+2500; sin debug cruft.

### Criticas y hallazgos

1. **[MAYOR - corregido]** Divergencia del par 2 de compatibilidad Marten (`mt_version` bigint vs
   uuid) entre worker y query-side para `CategoriaDeEtiquetas`. Detalle completo en "Desviaciones
   detectadas por el reviewer". Habria dejado el endpoint en **500 permanente** en dev.

2. **[MENOR - corregido]** `session.Query<CategoriaDeEtiquetas>()` sin `OrderBy`: un `SELECT` sin
   `ORDER BY` devuelve las filas en el orden fisico del heap, que cambia cuando el daemon reescribe
   una fila al aplicar un evento. Para un consumidor que **cachea el catalogo entre aperturas del
   control de etiquetado** (el caso de uso literal del issue), eso produce diffs espurios sin que
   nada haya cambiado. Agregado `OrderBy(categoria => categoria.Id)` sobre la PK del documento --
   consistente con los otros dos listados del BC (`ListarFichasColaborador`, `ListarTurnosVigentes`),
   aqui sin cursor porque no hay paginacion.

3. **[MENOR - corregido]** Comentario factualmente incorrecto en el smoke test: afirmaba que el caso
   "coleccion vacia" de CA-6 lo cubria `CategoriaDeEtiquetasProjectionTests` "contra un store en
   memoria realmente vacio". Ese test no existe y esos unit tests no usan ningun store. Reemplazado
   por la explicacion real de donde queda cubierto CA-6 y por que no lleva test propio. Un comentario
   que apunta a una cobertura inexistente es peor que su ausencia: le da al proximo lector una
   garantia falsa.

4. **[MENOR - no corregido, fuera de alcance]** MEF-ADR-0038 seccion 4 exige un test de composicion
   que resuelva el `TracerProvider` real y compare la `Description` del sampler efectivo
   (`..._ElSamplerEfectivoNoEsElDelExporterDeAzureMonitor`, `..._ElRatioDefaultLlegaAlSamplerEfectivo`).
   **Ningun dominio del repo los tiene** -- solo existe el de `DurabilityMetricsEnabled`. Es un gap
   **preexistente y transversal** (Colaboradores, ControlHoras, Programacion), y el diff de este issue
   no toca el wiring de OTel, asi que no lo trato como bloqueante de este PR. Merece issue propio:
   sin ese guardrail, un reorden accidental de `.WithTracing(...)`/`.UseAzureMonitorExporter()` pasa
   verde y solo se paga como volumen de ingesta semanas despues.

5. **[COSMETICO - no corregido]** `DebeEstarDisponible_CuandoSeConsultaHealthCheck` usa el patron
   `Debe...` que MEF-ADR-0016 retiro. Es copia literal del health check de **todos** los smoke tests
   del repo; renombrar solo este archivo empeoraria la consistencia. Renombrado masivo = issue propio.
   El resto de los nombres del diff sigue `<Sujeto>_<LoQuePasa>[_Cuando<Condicion>]`, incluida la
   variante `Create_Proyecta..._Desde<Evento>` que el propio ADR reivindica en su contexto (el error
   del reviewer humano del PR #148 fue justamente marcar esa variante como incorrecta).

### Refactorings aplicados

Commit `f2e275f`:

1. `ComposicionServicios.cs` (Colaboradores): `Schema.For<CategoriaDeEtiquetas>().UseNumericRevisions(true)`,
   con comentario que remite al bloque de #294/#356 en vez de duplicar sus 25 lineas de razonamiento.
2. `ListarCategoriasDeEtiquetas/FunctionEndpoint.cs`: `OrderBy(Id)` en la consulta.
3. `Colaboradores.Tests/Infraestructura/ComposicionServiciosTests.cs`: dos guardrails de compatibilidad.
4. `Projections.Tests/ConfiguracionMartenProjectionsTests.cs`: dos guardrails espejo.
5. `ListarCategoriasDeEtiquetasSmokeTests.cs`: correccion del comentario de CA-6.

Ningun cambio de API publica, ninguna firma tocada, ningun test existente modificado en su intent.

### Cobertura de criterios de aceptacion

| Criterio | Estado | Test(s) |
|---|---|---|
| CA-1: varios colaboradores -> categorias distintas con sus valores, en forma display | cubierto | `Create_ProyectaCategoriaYPrimerValor_DesdeEtiquetaAsignada`, `Create_NaceUnDocumentoIndependiente_ParaCadaCategoriaNormalizadaDistinta`, `Create_y_Apply_CorrelacionanPorCategoriaNormalizada_DesdeDosStreamsDeColaboradorDistintos` + smoke `..._DevuelveCategoriasDistintasConSusValores_...` |
| CA-2: asignaciones repetidas del mismo par no duplican | cubierto | `Apply_NoDuplicaElValor_CuandoSeReasignaElMismoParCategoriaValor` (oraculo `HaveCount(1)` + `BeEquivalentTo`, descarta un append sin upsert) + smoke `..._NoDuplicaCategoriaNiValor_...` con centinela |
| CA-3: dos formas que normalizan igual son UNA categoria; display de la ultima | cubierto | `Apply_ActualizaElDisplayDeLaCategoria_CuandoLaNuevaAsignacionUsaOtraFormaOriginal`, `Apply_ActualizaElDisplayDelValor_CuandoDosFormasOriginalesDelValorNormalizanIgual`, el test de correlacion + smoke `..._ColapsaEnUnaSolaCategoriaConDisplayDeLaUltima_...` |
| CA-4: sobrescribir AGREGA y conserva (acumulativo) | cubierto | `Apply_AgregaElValorNuevoYConservaElAnterior_CuandoSeSobrescribeElValorDeLaCategoria` (oraculo exige **ambos** valores) + smoke `..._AgregaElValorNuevoYConservaElAnterior_...` |
| CA-5: `EtiquetaRetirada` no altera el catalogo | cubierto (estructural + end-to-end) | Garantia estructural: la companion no declara ningun metodo para ese evento. **Verificada de verdad** por el smoke `..._ConservaLaCategoriaYElValor_CuandoSeRetiraLaEtiqueta`, que emite el retiro real contra dev y usa centinela para probar la ausencia bajo consistencia eventual. Comparto el criterio del test-writer de no escribir un `[Fact]` que solo reflexione sobre la ausencia del metodo: pasaria de una contra el stub |
| CA-6: sin etiquetas, 200 con coleccion vacia | cubierto parcialmente (aceptado) | `AgregarServiciosColaboradores_ResuelveElEndpointDeListarCategoriasDeEtiquetas_...` (wiring) + smoke `..._Retorna200ConUnaColeccion_Siempre` (200, nunca 404, contra el entorno real). La vacuidad exacta no es forzable en un dev compartido y acumulativo por diseno; el carve-out del endpoint GET frente al coverage gate cubre este caso. **Se corrigio el comentario que afirmaba falsamente que un unit test lo cubria** |

### Tests agregados

- `AgregarServiciosColaboradores_EsperaLaMismaColumnaDeVersionQueMaterializaraElWorker_ParaCategoriaDeEtiquetas`
- `AgregarServiciosColaboradores_ResuelveCategoriaDeEtiquetasSobreLaTablaQueMaterializaElWorker_CuandoElContenedorEstaCompuesto`
- `ConfigurarColaboradores_MaterializaCategoriaDeEtiquetasConRevisionNumerica`
- `ConfigurarColaboradores_MaterializaCategoriaDeEtiquetasSobreLaTablaQueConsultaElWriteSide`

Son tests de **contrato de configuracion**, no de comportamiento de negocio -- generarlos en fase
refactor no viola TDD, y MEF-ADR-0034 seccion 6 delega explicitamente esta verificacion al reviewer.
No se agregaron tests de igualdad ni de serializacion: el diff no introduce ningun `IEquatable<T>` ni
`ConfigurarSerializacion` nuevo (`ValorCategoria`/`CategoriaDeEtiquetas` son records planos de
`ReadModels`, categoria que MEF-ADR-0014 excluye del gate).

### Estado de la suite

```
total: 1304   correcto: 1252   error: 6   omitido: 46
```

- **Todos los proyectos `*.Tests` en verde** (1252 correctos; +4 respecto del baseline de la fase
  verde, que son los guardrails agregados aqui).
- Los **6 errores son los smoke tests nuevos de `ListarCategoriasDeEtiquetas` contra dev**, todos con
  `404` porque la revision desplegada todavia no publica la ruta. Es el comportamiento **esperado y
  precedente documentado** en el propio repo (`ObtenerFichaColaboradorSmokeTests`: *"Estos tests
  quedan ROJOS hasta que el deploy publique el endpoint en dev (...) su veredicto real se lee despues
  del deploy"*). El CI de PR solo corre `*.Tests`.
- Los 46 omitidos son smoke tests que exigen `Postgres__ConnectionString`, sin relacion con este issue.
- `dotnet format --verify-no-changes`: sin cambios pendientes en los archivos del diff.

</details>

## Commits

f2e275f refactor(hu-357): compatibilidad de mt_version del query-side y orden estable del catalogo
71e3d1c Agregar smoke tests de ListarCategoriasDeEtiquetas (issue #357)
6acd306 feat(hu-357): proyeccion read-side CategoriaDeEtiquetas (fase verde)
7875b4b test(hu-357): tests read-side para CategoriaDeEtiquetas y su proyeccion (fase roja)

Closes #357