### PR TITLE
docs(bitacora): entradas hasta el 2026-08-14

### DIFF
--- a/docs/bitacora/2026-08-04.md
+++ b/docs/bitacora/2026-08-04.md
@@ -1,0 +1,55 @@
+# 2026-08-04 - OIDC, el Sampler Fantasma y el Robo de Mensajes
+
+> Un día de tres actos completamente distintos: primero la fundación de infraestructura (backend keyless, OIDC, Terraform v5) migró de golpe seis issues encadenados; después una investigación de telemetría encontró que la Capa 2 de control de costos llevaba mes y medio sin filtrar una sola traza; y de noche dos suites de smoke tests resultaron robándose mutuamente los mensajes de Service Bus.
+
+## Lo que se logró
+
+**La cadena de infraestructura completa, seis issues seguidos vía `/infra`.** En el orden en que se mergearon: #298 (backend de Terraform a autenticación keyless por AAD, PR #299), #297 (los cinco workflows de CI/CD migrados a OIDC, PR #300), #301 (lock file de Terraform versionado con hashes multiplataforma, PR #302), #305 (eliminado el diff perpetuo que reescribía `app_settings` de los dos Function Apps en cada apply, PR #306), #303 (versión de Terraform CLI pinneada en los workflows, PR #307) y #304 (provider `azurerm` migrado a v5, PR #310). Los seis compartían una dependencia real: el CI ya no depende de un `AZURE_CLIENT_SECRET` que expiraba cada año, y el `plan` de cada PR volvió a mostrar solo lo que cambiaba de verdad.
+
+**El sampler de OpenTelemetry, restaurado (#308, PR #311).** Investigado y refinado esa misma tarde (field note 17:29) y ejecutado esa misma noche: `UseAzureMonitorExporter()` llamaba internamente a `SetSampler` **después** del `SetSampler` del proyecto, así que lo pisaba con un `RateLimitedSampler(5/s)` en vez del `ParentBasedSampler` con ratio 0.2 que CA-ADR-0009 documentaba desde el 2026-06-18. La corrección fue de **orden**, no de contenido: encadenar un segundo `.WithTracing(...)` después de `UseAzureMonitorExporter()`. De paso se agregó `SamplerQueDescartaPollingDelDaemon`, que elimina por nombre el span `marten.daemon.highwatermark` del worker de proyecciones sin tocar el ratio del resto de la fuente Marten.
+
+**Las métricas de durabilidad de Wolverine, apagadas (#309, PR #312).** `DurabilitySettings.DurabilityMetricsEnabled = false` corta el polling de `PersistenceMetrics.StartPolling` en origen, sin el `ConfigureCommandFilter` por texto SQL que el borrador proponía y calificaba de frágil.
+
+**La carrera de smoke tests, cerrada por los dos costados (#313 → PR #315, #314 → PR #316).** Se agregó `concurrency` al reusable de smoke tests (mismo patrón que ya protegía el Terraform state de dev) y se sumó la suite de ControlHoras al deploy del worker de proyecciones, que hasta ese momento era el único de los tres deploys sin verificación funcional después de desplegar.
+
+## Problemas encontrados
+
+**El sampler nunca estuvo activo, y nadie lo notó porque el código visible era correcto.** Verificado en runtime replicando el wiring exacto: el sampler efectivo era `Azure.Monitor.OpenTelemetry.Exporter.Internals.RateLimitedSampler`, no el `ParentBasedSampler` que el proyecto creía haber instalado. Desde el 2026-06-18 (adopción de OpenTelemetry con sampler configurable) hasta este día — mes y medio — el sistema exportó prácticamente el 100% del tráfico de trazas en vez del 20% que CA-ADR-0009 ordenaba, porque el tráfico real (~1,4-1,6 trazas/s) siempre estuvo muy por debajo del techo accidental de 5/s. La ironía quedó registrada en el propio ADR: el sistema hacía por accidente lo que la decisión *original* del proyecto (un límite clásico de 5 items/seg) quería, no lo que la decisión *vigente* (un ratio de muestreo) ordenaba.
+
+**El hueco de cobertura estaba declarado como límite conocido, y no era superable con la técnica que el propio texto proponía.** `ConfiguracionObservabilidadProjectionsTests` documentaba explícitamente que verificar el sampler efectivo "queda cubierto por revisión de código" — y la revisión de código no podía atrapar esto, porque el defecto vivía dentro de una llamada de librería. La técnica que sí funcionó fue leer el sampler efectivo del `TracerProvider` resuelto y comparar tipos: determinista, sin necesidad de muestrear actividades contra un ratio fraccionario.
+
+**Dos suites de smoke tests se robaron los mensajes mutuamente.** El `workflow_run` de `Infra CD` dispara `Deploy ControlHoras` y `Deploy Programacion` al mismo tiempo, y las dos consumen de la misma suscripción `smoke-tests` del Service Bus de dev. En el run `30961302452` (ambos arrancaron a las 23:49:56Z), la suite de ControlHoras recibió y destruyó (`CompleteMessageAsync`) el mensaje que esperaba Programación (empleado `555666777`), y viceversa (`777666555`). Correlación sobre 40 runs: cuando las dos suites corrieron a la vez, fallaron 3 de 3; cuando corrió solo una, 0 de 9 fallaron. No era cold start — el gate de `/api/version` y el warm-up ya lo descartaban — era un fallo de contenido, no de latencia.
+
+## Lo que descartamos
+
+**Configurar `AzureMonitorExporterOptions.SamplingRatio` en vez de reordenar `SetSampler`.** Es la vía idiomática del exporter y tiene una ventaja real (`ApplicationInsightsSampler` estampa `sampleRate` para que Application Insights extrapole conteos), pero esa clase es `internal` y no se puede componer con un filtro por nombre de span. Se asumió la subcuenta de métricas como consecuencia conocida.
+
+**Apagar el `ActivitySource` del daemon de Marten.** Parecía la solución limpia para matar el span de polling, pero `JasperFx.Events.Daemon.SubscriptionMetrics` desreferencia ese mismo objeto sin null-check — `NullReferenceException` en cuanto una proyección real procesara eventos.
+
+**Apagar `EnableFirstResponseEvent` de Npgsql.** Resultó redundante: verificado que al dropear el span padre, el hijo Npgsql ni siquiera se instancia.
+
+**Filtrar con `BaseProcessor<Activity>` o subir `UpdateMetricsPeriod` a 5 minutos.** El primero solo suprime el span ya creado (obligaría a filtrar también el hijo Npgsql); el segundo no tiene sentido porque nadie consume esos contadores.
+
+**Recalibrar `TELEMETRY_SAMPLING_RATIO` ya.** No tiene sentido mientras la variable sea inerte, y una vez conectada hace falta medir tráfico real antes de elegir un valor nuevo.
+
+## Aprendizajes
+
+1. **Un guardrail declarado "cubierto por revisión de código" merece reexaminarse periódicamente, no darse por cerrado.** El defecto vivía dentro de una llamada de librería; el código propio, visible en la revisión, era correcto. La lección no fue "confiar menos en la revisión de código" sino identificar cuándo una limitación declarada es en realidad superable con otra técnica.
+2. **El orden de composición de un pipeline de telemetría es frágil por naturaleza y debe protegerse con guardrail, no con convención.** Cualquier reordenamiento futuro — o una versión del exporter que cambie cuándo registra su sampler — volvería a dejar el sampler del proyecto sin instalar, compilando y en verde.
+3. **Un `plan` de Terraform "sin cambios" es la prueba de éxito, no de fracaso, cuando el objetivo es cambiar el mecanismo de autenticación sin tocar recursos.** El backend keyless por AAD se validó exactamente así.
+4. **Un `0 added, 2 changed` que se repite en dos PRs de contenido totalmente distinto es la señal inequívoca de un diff perpetuo, no de drift puntual.** Así se detectó que el módulo de Function App gestionaba dos claves de `app_settings` que el provider ya gestionaba por argumento propio.
+5. **La superficie de impacto real de un salto de versión mayor puede ser mucho menor que lo que el número sugiere, si se audita contra lo que el proyecto realmente declara.** De 22 recursos y data sources propios, cero cayeron en las remociones de azurerm v5 — las remociones apuntaban a la generación legacy que este repo nunca adoptó.
+6. **Serializar el acceso a un recurso compartido en CI es el mismo patrón sin importar cuál sea el recurso.** El `concurrency` group que ya protegía el Terraform state de dev resolvió también la carrera del Service Bus de dev entre smoke tests.
+
+## Números del día
+
+| Métrica | Valor |
+|---|---|
+| Field notes | 1 (planner) |
+| Commits | 20 |
+| PRs mergeados | 11 |
+| Issues cerrados | 10 (#297, #298, #301, #303, #304, #305, #308, #309, #313, #314) |
+| ADRs actualizados | 1 (CA-ADR-0009, dos enmiendas el mismo día) |
+| Archivos cambiados | 56 |
+| Líneas agregadas | ~1210 |
+| Líneas eliminadas | 206 |

--- a/docs/bitacora/2026-08-05.md
+++ b/docs/bitacora/2026-08-05.md
@@ -1,0 +1,45 @@
+# 2026-08-05 - Nacen las Tres Islas
+
+> Un día corto en commits y enorme en doctrina: CA-ADR-0029 se enmendó para exigir cero referencias entre los tres ensamblados de eventos, adoptando el canon MEF-ADR-0039 del harness antes incluso de que ese ADR llegara al plugin instalado. Y a mitad del refinamiento apareció una cuarta fuga que la enmienda todavía no sabía nombrar.
+
+## Lo que se logró
+
+**CA-ADR-0029 enmendada a "tres islas" (#317, PR #321, mergeado el mismo día).** La regla pasa de "un ensamblado no debe depender del otro" a **cero referencias de proyecto** entre `PublicEvents`, `PrivateEvents` y `{Dominio}.DomainEvents` — cada uno posee sus propios payloads, sin heredar tipos del ensamblado vecino. MEF-ADR-0039 existía en `main` del harness pero no en el plugin instalado (0.20.0); se citó por identificador estable y se leyó vía `gh api` mientras tanto.
+
+**Convención de naming de payloads, agregada a CA-2.** Nombres puros del lenguaje ubicuo para el event store; el rol marcado (bus) lo cargan los DTOs (`Detalle*`); se proscribió el sufijo `*Persistido` por invadir el dominio con vocabulario de infraestructura — precedente directo del issue #270, donde ya se había decidido que el dominio conserva el nombre puro.
+
+**El plan de ejecución completo quedó armado para el día siguiente.** Se reescribieron/crearon #318 (retirar la referencia `PrivateEvents -> PublicEvents`, payload nuevo `DetalleEmpleado`), #319 (lado Programación de la migración) y #322 (lado ControlHoras, partido de #319 por ejes ortogonales sin archivos compartidos).
+
+## Problemas encontrados
+
+**Una fuga transitiva nueva, que el enforcement planeado no iba a detectar.** `ReadModels` referencia ambos buses porque `TurnoDiarioView` embebe `InformacionEmpleado` y `DetalleTurno` directamente — así que el worker de proyecciones arrastra los dos ensamblados de todas formas, de forma transitiva. El enforcement propuesto en #320 (tests de arquitectura) solo iba a comparar referencias **directas** de ensamblado, y este gap vive un nivel más abajo: en la forma de los tipos que `ReadModels` reutiliza. Quedó documentado como gap doctrinal de MEF-ADR-0039, sin resolver todavía.
+
+## Lo que descartamos
+
+**Sufijo `*Persistido` para los records del event store.** Es vocabulario de infraestructura colándose en el dominio; el usuario tenía razón al rechazarlo, con el precedente de #270 de por medio.
+
+**Mantener #319 unificado.** Cubría dos ejes (Programación y ControlHoras) que no pasaban la regla de 30 minutos de revisión; se partió en #319 y #322, verificados como paralelo-seguros entre sí porque no comparten un solo archivo.
+
+**Combinar #322 con la corrección de ReadModels en un solo issue.** Habría tocado la proyección una sola vez, a cambio de mezclar tres ejes en un PR — se prefirió dejar #323 (ReadModels) como un issue propio, todavía en borrador.
+
+**Abrir ya un draft en Mefisto sobre el gap de ReadModels.** Se diferió a propósito: primero se resuelve #323 internamente, y con esa evidencia se propone la corrección al marco — no al revés.
+
+## Aprendizajes
+
+1. **Una enmienda doctrinal puede fusionar naming y arquitectura cuando ambos ejes son la misma decisión de fondo.** La convención de payloads y la regla de cero referencias no son dos temas — son la misma pregunta ("¿de quién es este tipo?") vista desde dos ángulos.
+2. **Un enforcement automatizado que solo compara referencias directas de ensamblado no detecta fugas transitivas.** Hay que perseguir la cadena completa hasta el proceso que finalmente las arrastra — en este caso, el worker de proyecciones.
+3. **Partir un issue en dos ejes ortogonales que no comparten ni un archivo es más barato que forzar la revisión de un cambio grande**, incluso cuando la motivación de fondo (la enmienda del ADR) es una sola.
+4. **Diferir la propuesta al marco hasta tener evidencia de la solución interna evita proponer una corrección doctrinal a ciegas.** Resolver primero, generalizar después.
+
+## Números del día
+
+| Métrica | Valor |
+|---|---|
+| Field notes | 1 (planner) |
+| Commits | 2 |
+| PRs mergeados | 1 |
+| Issues cerrados | 1 (#317) |
+| ADRs actualizados | 1 (CA-ADR-0029, enmendado a tres islas) |
+| Archivos cambiados | 3 |
+| Líneas agregadas | ~202 |
+| Líneas eliminadas | 32 |

--- a/docs/bitacora/2026-08-06.md
+++ b/docs/bitacora/2026-08-06.md
@@ -1,0 +1,55 @@
+# 2026-08-06 - La Retractación: TurnoVigente Nace del Actor, no del Evento
+
+> El día más denso del proyecto hasta ahora, y el que más se corrigió a sí mismo en tiempo real: por la mañana el planner adoptó una política de diseño ("el read model deriva del event store"), por la tarde el usuario la retractó por completo ("no me interesan las solicitudes, me interesa la programación vigente" ya había dicho el 31 de julio — hoy tocaba diseñar la vista de verdad), y por la noche una entrevista de necesidad del actor rediseñó `TurnoVigente` desde cero. Entremedio, la cadena de las tres islas se cerró completa y el read model que llevaba tres días de vida se eliminó sin dejar rastro.
+
+## Lo que se logró
+
+**La cadena de las tres islas, cerrada.** #318 (PrivateEvents posee `DetalleEmpleado`, PR #324, 08:45), #319 (Programación.DomainEvents posee sus payloads, PR #325, 09:49) y #322 (ControlHoras.DomainEvents posee sus payloads, PR #326, 17:10) se mergearon uno tras otro. #320 (tests de arquitectura que congelaran las tres islas) se cerró **not planned**: el enforcement se va a construir desde el harness, no como tests locales — decisión tomada en la sesión de la mañana (10:19) tras verificar que MEF-ADR-0039 solo prohíbe `ProjectReference` **en** los tres ensamblados de eventos, y que `ReadModels` no es uno de ellos.
+
+**`TurnoDiario.Segmentar`, la aritmética de calendario que vive donde debe (#327, PR #332, 18:25).** El turno asignado se parte en bloques absolutos de tiempo como comportamiento del payload persistido — Tell-don't-Ask, no una utilidad suelta — porque `DomainEvents` es el único ensamblado que write-side y worker comparten.
+
+**`TurnoVigente` nace (#328, PR #333, 19:19) y su panorama multi-empleado (#329, PR #334, 20:07).** El nuevo read model no hereda la forma del evento: nace de una entrevista de necesidad con tres actores (Programador, Trabajador, Aprobador) que llevó a una forma mínima — `Id`, `EmpleadoId`, `NombreCompleto`, `Fecha`, `NombreTurno`, `HorarioResumido`, `Bloques[{Tipo,Inicio,Fin}]` — excluyendo identificación completa y `UltimaSolicitudId`, que nadie pedía.
+
+**`TurnoDiarioView` eliminado y la cuarta isla consumada (#323, PR #342, 22:05).** El read model construido apenas el 3 de agosto — walking skeleton del read-side — se retiró por completo. `ReadModels` queda con cero referencias de proyecto, ni a los buses ni a `DomainEvents`: sus records son propios y la proyección del worker es el único punto de mapeo.
+
+**Arranca la saga de la sede, con dos eslabones mergeados la misma noche.** #331 (registrar la sede en la solicitud de programación, PR #343, 22:49) y #335 (prearmar la sede por franja en los turnos del catálogo, PR #344, 23:34) — los dos últimos merges del día, ya entrada la madrugada del 7. La cadena completa se extendió con #341 (cascada al copiar), #336 (sede en ControlHoras) y #337 (filtro del panorama), que siguieron ejecutándose en las horas siguientes fuera del alcance de esta entrada.
+
+## Problemas encontrados
+
+**La política de la mañana se retractó por completo en la tarde, y el motivo fue de fondo, no de gusto.** A las 10:19 se adoptó "el read model deriva del event store": `ReadModels` referenciaría únicamente `{Dominio}.DomainEvents`, embebiendo sus payloads por defecto. A las 17:17 el usuario la frenó al pedir una entrevista de necesidad del actor para `TurnoVigente`, y la sesión reveló la falla de la política: **evento persistido y vista NO son independientes** — la proyección los sincroniza en lockstep — así que la motivación original de las tres islas (velocidades de evolución independientes) no aplica entre evento y vista. Duplicar payloads entre ellos habría sido ceremonia sin protección. La política quedó retractada, y un draft cross-repo ya escrito con la premisa invertida (harness#581) se marcó explícitamente para reescritura.
+
+**El facilismo original de `TurnoDiarioView`.** Se había diseñado desde la forma del evento disponible — identificación completa, `UltimaSolicitudId`, jerarquía de franjas con offsets — y ningún actor necesitaba esa forma. Vivió tres días antes de ser retirado por completo el mismo ciclo semanal en que nació.
+
+## Lo que descartamos
+
+**La política "el read model deriva del event store"** (adoptada en la mañana, retractada en la tarde). Quedó registrado el aprendizaje de por qué fallaba, no solo que fallaba.
+
+**Renombrar `TurnoDiario` (el payload del evento, en un PR ya en vuelo) a `TurnoAsignado`.** El usuario prefirió no tocar el PR #326 en curso; el nombre se conserva por opción 3 (no re-litigar un PR abierto).
+
+**Nombres descartados para el read model nuevo**: `DiaProgramado` (promete más de lo que trae), `JornadaProgramada` (Jornada reservada al concepto jurídico), `PanoramaTurnos` (nombra una presentación, no el concepto).
+
+**Duplicar payloads en `ReadModels` con nombres puros + alias de using**, marcador de rol `*View` en todo el ensamblado (colisión raíz/anidado), y nested records (`TurnoDiarioView.Empleado`, sin precedente, CA1034). Los tres se probaron insuficientes antes de llegar a la cuarta isla.
+
+**Paginación de día uno en el panorama** y **dos proyecciones separadas (resumida + detallada)** — el resumen es un recorte del mismo grano, se prefirió una sola proyección con recortes por Rule of Three cuando duela.
+
+## Aprendizajes
+
+1. **Diseñar un read model desde la forma del evento disponible, en vez de desde la necesidad del actor, produce una vista que nadie pidió.** `TurnoDiarioView` es el ejemplo medido: nació completo, funcional, con tests — y no sobrevivió una semana porque nadie lo necesitaba con esa forma.
+2. **Toda proyección ve, por construcción, las dos islas que sincroniza.** Duplicar payloads entre evento y vista no protege velocidades de evolución independientes porque no lo son — la proyección las ata en lockstep. Es la razón de fondo, no una preferencia de estilo, detrás de la retractación de la política de la mañana.
+3. **Cuando el usuario retracta una decisión de la misma sesión, corregir el rastro (un draft ya escrito, un ADR ya citado) de inmediato es más barato que dejar la premisa invertida circulando.**
+4. **Una cadena expand-contract de cinco eslabones secuenciales se puede diseñar, refinar y mergear completa en un solo día** cuando el pipeline TDD ya está afinado — de la entrevista de necesidad (17:17) al último merge de la noche (23:34) pasaron menos de siete horas.
+5. **"Vigente" ya era lenguaje del sistema antes de que existiera el read model.** El glosario, la documentación de la proyección anterior y los smoke tests ya usaban esa palabra para describir exactamente el concepto del "último gana". El nombre correcto a veces ya está escrito en otro lugar del proyecto, solo falta encontrarlo.
+
+## Números del día
+
+| Métrica | Valor |
+|---|---|
+| Field notes | 3 (planner: 10:19, 17:17, 20:55) |
+| Commits | 33 |
+| PRs mergeados | 9 |
+| Issues cerrados | 10 (#318, #319, #320 *not planned*, #322, #323, #327, #328, #329, #331, #335) |
+| Issues creados | 12 (#331, #335-#341 y continuaciones de la saga de sede) |
+| ADRs creados o tocados | 0 (la doctrina de la cuarta isla queda registrada en issues; el draft doctrinal se difiere al cierre de la saga) |
+| Archivos cambiados | 231 |
+| Líneas agregadas | ~6200 |
+| Líneas eliminadas | 2130 |

--- a/docs/bitacora/2026-08-10.md
+++ b/docs/bitacora/2026-08-10.md
@@ -1,0 +1,59 @@
+# 2026-08-10 - El Nacimiento del Dominio Colaboradores
+
+> Cuatro días sin un solo commit de código, cerrando la sesión de knowledge crunching más larga del proyecto: lo que empezó como "falta una plantilla maestra de empleados" (el gap descubierto el 6 de agosto durante la entrevista del turno diario) terminó redefiniendo el lenguaje ubicuo completo de un dominio nuevo — Colaboradores reemplaza a Empleados — y se desglosó en diez issues de implementación más dos estratégicos.
+
+## Contexto de continuidad
+
+Esta entrada cierra una sesión que el propio field note describe como multi-día (2026-08-07 al 2026-08-10): no hay commits de código ni entradas de bitácora propias para el 7, 8 y 9 porque no quedaron field notes pendientes de esos días puntuales — todo el razonamiento se consolidó en la nota del día 10. El hilo que la dispara viene directo del 6 de agosto: la entrevista de necesidad del turno diario reveló que el bounded context no tiene plantilla maestra de empleados, bloqueando la vista de ausencias (#359) y quedando registrado como #330.
+
+## Lo que se logró
+
+**Colaborador reemplaza a Empleado como concepto rico.** Independiente del tipo de vinculación, abre la puerta a contratistas sin costo de modelo — el dominio se renombra de Empleados a Colaboradores, un cambio que ya estaba anticipado y salió gratis.
+
+**Identidad doble, resuelta.** La `Identificacion` (`{Tipo}:{Numero}`) identifica a la persona y ES el streamId; el `CodigoColaborador` (antes `EmpleadoId`) es el id transaccional de la vinculación. Tenerlos embarrados en un solo campo (`EmpleadoId`) era el problema de fondo. La prueba de voz mató a "VinculacionId" — nadie lo diría en la vida real; la gente dice "el código" — y esa misma prueba fijó el naming por posición: `Codigo` anidado, `CodigoColaborador` aplanado en la frontera.
+
+**StreamId = identificación disuelve una invariante cross-stream en una invariante local.** "Identificación no repetida en estado activo por tenant" se vuelve "máximo una vinculación vigente por stream" — mucho más barato de garantizar. La corrección de una identificación errada se resuelve cerrando el stream viejo y abriendo el correcto: basura tolerable, con el stream reutilizable por su dueño legítimo.
+
+**Doctrina bitemporal completa para el bounded context.** El tiempo de los hechos viene de afuera (fechas siempre requeridas, sin default del servidor); el sistema solo registra cuándo se enteró. Preaviso y carga tardía son el mismo fenómeno visto desde ese único principio. Vigencia sin booleano: el preaviso voltea sin evento nuevo — se materializan hechos (`VigenteDesde`/`VigenteHasta`, centinela `9999-12-31`) y la consulta evalúa contra la fecha del lector.
+
+**Etiquetas dinámicas de la vinculación, no de la persona.** Pares categoría:valor libres, un valor por categoría, con doble forma (original/normalizada) como invariante del VO y filtrado por contención JSONB + GIN. Van en la vinculación — no en la persona — porque un reingreso nace limpio: los huecos visibles son preferibles a las mentiras silenciosas de un cargo viejo heredado.
+
+**Desglose completo en 12 issues.** Diez de implementación (#348 VOs de identidad, #330 registrar re-titulado, #349 terminar, #350 reingresar, #351 corregir nombres, #352 corregir fecha de inicio, #353 VO Etiqueta, #354 corregir fecha de terminación, #355 etiquetar, #356/#357 proyecciones N1/N2) y dos estratégicos en borrador (#358 impacto de vinculaciones sobre marcaciones y días calculados, #359 vista de ausencias — la motivación original). Glosario (7 términos), context map y catálogo EDA (8 eventos, 8 comandos, 1 aggregate, 4 VOs) actualizados.
+
+## Problemas encontrados
+
+No hubo bugs de código — es un día puramente de diseño — pero sí un cuello de botella de proceso: los diez issues de implementación quedaron atascados en `estado:borrador` porque la Definition of Ready (MEF-ADR-0011) exige rutas que todavía no existen. Nada se podía refinar a `estado:listo` hasta correr `/scaffold Colaboradores`, dejando el desglose completo a la espera de un paso de tooling antes de poder arrancar el pipeline TDD.
+
+## Lo que descartamos
+
+**Nombres para el dominio/concepto**: Plantilla (España/fútbol), Planta de personal ("de planta" excluye contratistas), Nómina (ocupado por otro concepto), Maestro de X (canon reservado a maestros), Contrato (el promovido conserva su contrato laboral — se prefirió "Vinculación"), VinculacionId, IdExterno, DatosActualizados (genérico, sin semántica), sufijo View (acuerdo previo del 2026-08-06).
+
+**Enum de C# para `TipoIdentificacion`.** La trampa del enum: valores 0, 1, 2 persistidos por accidente. Se prefirió una lista cerrada estilo PILA como VO sin sombra numérica.
+
+**Booleano `Activo` materializado y `ShouldDelete` de no-vigentes.** Ambos necesitan un reloj que la doctrina bitemporal del BC no otorga al servidor.
+
+**Etiquetas de la persona en vez de la vinculación.** Habría heredado el cargo viejo al reingreso — la mentira silenciosa que la sesión quiso evitar desde el principio.
+
+**Fusionar registro y reingreso en un solo comando.** La ambigüedad se esconde, no desaparece.
+
+**Fechas de vinculación con default del servidor.** El usuario se desdijo a mitad de sesión: son requeridas, sin excepción — nace de la angustia explícita "hoy no es hoy".
+
+## Aprendizajes
+
+1. **Nombrar por prueba de voz ("¿alguien lo diría así en la vida real?") descarta candidatos técnicamente correctos pero ajenos al lenguaje del negocio.** "VinculacionId" era preciso y nadie lo iba a decir jamás.
+2. **Colapsar identidad de persona e identidad transaccional en un solo campo obliga, tarde o temprano, a separar dos invariantes distintas.** `EmpleadoId` cumplía dos roles incompatibles — identidad estable de la persona y ciclo de vida transaccional de la vinculación — y la separación resultó ser también la que simplificó la invariante cross-stream.
+3. **Modelar el tiempo como "lo que el sistema se enteró" en vez de "lo que pasó" resuelve preaviso y carga tardía como el mismo fenómeno**, sin necesitar dos mecanismos distintos ni un reloj de servidor.
+4. **Diferir una pieza del modelo (la sede natural del colaborador) hasta que exista su dominio propio es más honesto que forzarla dentro de Colaboradores solo porque el gap apareció ahí.** Quedó anotada, sin issue, esperando un futuro dominio Sedes.
+
+## Números del día
+
+| Métrica | Valor |
+|---|---|
+| Field notes | 1 (planner, cierre de una sesión multi-día 2026-08-07 a 2026-08-10) |
+| Commits | 0 |
+| PRs mergeados | 0 |
+| Issues cerrados | 0 |
+| Issues creados | 12 (#348-#357, #358, #359) |
+| ADRs creados | 0 |
+| Archivos de código cambiados | 0 |
+| Artefactos de dominio actualizados | context-map.yaml, ubiquitous-language.yaml, catalog.yaml |

--- a/docs/bitacora/2026-08-11.md
+++ b/docs/bitacora/2026-08-11.md
@@ -1,0 +1,56 @@
+# 2026-08-11 - Nueve Comandos en un Día, y un ADR que Nació de una Pregunta Incómoda
+
+> El día de mayor throughput del proyecto: el scaffold de Colaboradores se generó a media mañana y, sobre esa base, nueve comandos del ciclo de vida de la vinculación se refinaron, implementaron y mergearon uno detrás de otro — cada uno con su ciclo TDD completo. A media tarde, una pregunta del usuario ("¿por qué aceptamos un evento que no es posible recibir?") hizo que el planner corrigiera su propia recomendación en tiempo real, y de ahí nació CA-ADR-0030.
+
+## Lo que se logró
+
+**El scaffold del dominio Colaboradores (#360, PR #361, 11:33).** Function App, tests, Terraform y workflow de deploy — la base sobre la que corrió todo el resto del día. Un fix de carrera aparte (#362, sin issue numerado, 12:31) hizo que los smoke tests esperaran los deploys ajenos antes de correr, extendiendo al dominio nuevo el mismo problema de concurrencia resuelto para ControlHoras/Programación el día 4.
+
+**La cadena completa write-side de Colaboradores, nueve comandos mergeados el mismo día:** #348 VOs de identidad (PR #363, 13:27), #353 VO Etiqueta con normalización (PR #364, 13:48), #330 Registrar colaboradores (PR #365, 14:48), #349 Terminar vinculación (PR #366, 15:32), #350 Reingresar (PR #367, 16:04), #351 Corregir nombres (PR #368, 17:05), #352 Corregir fecha de inicio (PR #369, 19:18), #354 Anular terminación (PR #370, 20:00) y #355 Asignar/retirar etiquetas (PR #372, 22:57). Nueve ciclos rojo → verde → refactor, uno detrás de otro, sobre el mismo aggregate.
+
+**CA-ADR-0030 nace: "fallos síncronos en comandos HTTP sin consumidores downstream".** La doctrina fija que una violación de regla de negocio en un comando HTTP de modificación sin consumidores que reaccionen se traduce a un status code síncrono (409/404 + mensaje `.resx`), no a un evento de fallo persistido — esos se reservan para flujos con un consumidor real. Gobernó, sin re-discutir, los cuatro refinamientos siguientes de la cadena.
+
+**Un insight de composición eliminó un comando completo.** Al refinar #354, el usuario propuso: "si creamos `AnularTerminacion`, corregir la fecha de terminación es Anular + Terminar". El comando de corrección de fecha y sus tres reglas de negocio desaparecieron — `AnularTerminacion` quedó con una sola regla, sin fechas en el payload, y `TerminarVinculacion` revalida todo gratis al volver a aplicarse. El "caso delicado" del desglose original se convirtió en el comando más simple de la cadena.
+
+## Problemas encontrados
+
+**El planner recomendó, primero, seguir la lectura literal de la Capa 3 de MEF-ADR-0004** para #349: un evento `TerminacionVinculacionFallida` persistido. El usuario detectó la incoherencia — "¿por qué aceptamos un evento que no es posible recibir?" — y una relectura completa del ADR (no solo la capa citada) le dio la razón: la razón de ser de los eventos de fallo son los consumidores downstream que reaccionan, y un comando HTTP de modificación sin consumidores dejaría ciego al caller (202 por un rechazo) y contaminaría el stream del colaborador legítimo con hechos ajenos. El planner tuvo que corregir su propia recomendación en la misma sesión, con el precedente interno de `ControlDiarioAggregateRoot.AdicionarMarcacion` (declinar sin emitir) como prueba de que el patrón ya existía en el código.
+
+**El método de la sesión se corrigió a mitad del refinamiento de #355.** El usuario exigió resolver "pregunta por pregunta, SIEMPRE" — no agrupar decisiones de negocio aunque parezcan livianas — después de que el planner intentara resolver dos preguntas juntas. Quedó anotado como método para futuras sesiones del planner.
+
+**El planner recomendó "solo existencia" para la regla de apertura de asignar/retirar etiquetas** (simetría con #351), y el usuario eligió la regla estricta: vinculación sin terminación registrada. Consecuencia asumida explícitamente — las etiquetas quedan congeladas durante un preaviso, y corregirlas en ese estado no es posible hasta que aparezca un caso real que lo justifique.
+
+## Lo que descartamos
+
+**Los eventos de fallo persistidos de los cuatro borradores** (`TerminacionVinculacionFallida`, `RegistroColaboradorFallido` y sus equivalentes) — ninguno llegó a entrar al catálogo EDA.
+
+**Idempotencia por comparación de payload completo** para el registro (7 campos) — el patrón de `RegistroDeMarcacion` no se transfiere; se prefirió el 409 uniforme para todo POST con identificación existente.
+
+**El campo `Motivo` en `TerminarVinculacion`, eliminado por completo, no solo hecho opcional.** Ninguna regla, consulta o vista del bounded context lo usa — la fuente autoritativa de "por qué salió" es RRHH/nómina, y este BC no es su espejo. Agregarlo después sería aditivo y barato; cargarlo desde el principio habría sido ruido persistido para siempre.
+
+**Exigir vigencia para corregir nombres.** Impondría un orden artificial y bloquearía la reutilización del stream tras una corrección de identificación errada.
+
+**El comando `CorregirFechaTerminacionVinculacion` completo**, absorbido por composición de `AnularTerminacion` + `TerminarVinculacion`.
+
+**Silencio al retirar una etiqueta de categoría inexistente.** Con categorías libres, un typo debe aflorar al instante (409) — el silencio idempotente habría sido la misma mentira silenciosa que la sesión del día 10 ya había descartado para el reingreso.
+
+## Aprendizajes
+
+1. **Releer una doctrina completa, no solo la sección citada, puede invertir una recomendación ya dada.** La Capa 3 de MEF-ADR-0004 leída aislada decía una cosa; su razón de ser (consumidores downstream) decía la contraria.
+2. **Una pregunta de arquitectura bien hecha por el usuario vale más que cualquier checklist.** De "¿por qué aceptamos un evento que no es posible recibir?" nació un ADR nuevo que gobernó, sin fricción, los cuatro refinamientos siguientes.
+3. **Componer dos comandos existentes puede eliminar un tercero completo, con todas sus reglas.** `AnularTerminacion` + `TerminarVinculacion` reemplazó a `CorregirFechaTerminacionVinculacion`, que era el "caso delicado" del desglose original.
+4. **Un dato sin ningún lector es ruido persistido para siempre.** `Motivo` de terminación no tenía consulta, regla ni vista que lo usara — la asimetría de reversa (agregarlo después es barato, cargarlo siempre no lo es) decidió eliminarlo del todo.
+5. **Nueve slices verticales del mismo aggregate en un solo día es posible cuando cada uno resuelve una sola pregunta de negocio** y el patrón arquitectónico de fondo (CA-ADR-0030) ya quedó fijado desde el segundo comando de la cadena.
+
+## Números del día
+
+| Métrica | Valor |
+|---|---|
+| Field notes | 4 (planner: 12:35, 13:34, 14:12, 14:42) |
+| Commits | 35 |
+| PRs mergeados | 11 |
+| Issues cerrados | 10 (#330, #348, #349, #350, #351, #352, #353, #354, #355, #360) |
+| ADRs creados | 1 (CA-ADR-0030) |
+| Archivos cambiados | 296 |
+| Líneas agregadas | ~13764 |
+| Líneas eliminadas | 665 |

--- a/docs/bitacora/2026-08-12.md
+++ b/docs/bitacora/2026-08-12.md
@@ -1,0 +1,46 @@
+# 2026-08-12 - El Verbo QUERY se Desbloquea
+
+> Un día más tranquilo tras el maratón del 11: el usuario pidió refinar un issue que ya estaba listo, y el issue que de verdad esperaba turno resultó ser otro — bloqueado, hasta hoy, por un verbo HTTP que Mefisto todavía no tenía.
+
+## Lo que se logró
+
+**Se verificó que #356 (FichaColaborador) ya estaba `estado:listo` y completo**, re-verificando cada una de sus afirmaciones contra el código. El refinamiento pendiente real era #373 (listado de fichas con filtro por etiquetas), que llevaba días en borrador esperando el verbo HTTP `QUERY` del marco.
+
+**#373 refinado a `estado:listo`.** El bloqueo se había levantado con el plugin Mefisto 0.22.0, que trajo MEF-ADR-0042 (doctrina GET vs QUERY, paginación keyset, filtros tipados, RFC 10008). La doctrina completa: `FechaReferencia` obligatoria en el body — el back jamás resuelve "hoy", lo resuelve el consumidor en su zona horaria (relevante para Colombia, UTC-5 desde ~19:00 UTC) —, orden por `NombreCompleto` con desempate por `Id` vía un cursor compuesto (`CursorFicha`), `Take` con default 50 y tope 200 como clamp del servidor, y respuesta sin envelope porque el cursor es derivable de la última fila.
+
+**#371 implementado y mergeado el mismo día (PR #374).** La normalización del código de tipo de identificación se mueve al VO `TipoIdentificacion.Desde`, cerrando un hueco de invariante que quedaba fuera del VO.
+
+**#356 avanzó su ciclo TDD completo** (test/feat/refactor, commits `hu-356`) pero su PR (#375) quedó abierto — se mergeó recién el 14 de agosto, arrastrado por el orden de revisión, no por ningún bloqueo técnico.
+
+## Problemas encontrados
+
+No hubo bugs de código nuevos. El único costo del día fue de proceso: la petición inicial del usuario apuntaba a #356, y hubo que verificar el estado real del backlog completo (incluida su dependencia satisfecha) antes de identificar que el trabajo pendiente de verdad era #373.
+
+## Lo que descartamos
+
+**Resolver "hoy" en el back**, sea con UTC fijo o con una zona horaria por tenant — la segunda es un concepto que ni siquiera existe en el modelo (Rule of Three); la primera es sencillamente incorrecta para Colombia buena parte del día.
+
+**Tope de página ilimitado.** Violaría el clamp doctrinal de MEF-ADR-0042 — el tope acota la página, nunca el listado completo: la completitud la da el cursor, no el tamaño de la página.
+
+**Orden por `Id` puro.** Sería irregular para quien consulta la lista — el orden visible tiene que ser el nombre.
+
+**Construir ya un campo normalizado de orden** para resolver cómo la colación de Postgres trata tildes y eñes. Se registró el comportamiento en el reporte del gate, sin tocar la vista — sería una enmienda con issue propio si algún día hace falta.
+
+## Aprendizajes
+
+1. **Verificar el estado real de un issue antes de refinarlo puede revelar que la petición del usuario, sin quererlo, apunta a un issue distinto del mencionado.** #356 no necesitaba trabajo; #373 sí.
+2. **Un bloqueo doctrinal externo se resuelve actualizando el marco, no inventando un workaround local.** Esperar el verbo `QUERY` de Mefisto fue más barato que improvisar una convención propia que luego habría que migrar.
+3. **Un nombre mutable en el criterio de orden de una paginación keyset (`NombreCompleto`, que puede cambiar por `NombresCorregidos`) puede saltar o repetir una fila entre páginas.** Se aceptó conscientemente como anomalía conocida, no como bug latente sin registrar — la alternativa (orden por Id) sacrificaba la experiencia por una garantía que casi nunca se necesita.
+
+## Números del día
+
+| Métrica | Valor |
+|---|---|
+| Field notes | 1 (planner) |
+| Commits | 8 |
+| PRs mergeados | 1 |
+| Issues cerrados | 1 (#371) |
+| ADRs creados | 0 |
+| Archivos cambiados | 60 |
+| Líneas agregadas | ~1552 |
+| Líneas eliminadas | 148 |

--- a/docs/bitacora/2026-08-13.md
+++ b/docs/bitacora/2026-08-13.md
@@ -1,0 +1,55 @@
+# 2026-08-13 - Trece Rutas Bajo la Lupa: la Doctrina HTTP que Faltaba
+
+> Un día sin un solo commit de código y con el hallazgo doctrinal más profundo de la semana: al discutir la ruta de un endpoint nuevo, el experto detectó que las trece rutas HTTP del sistema se venían justificando por precedente interno, sin una doctrina escrita detrás — y la sesión se convirtió en una investigación de fuentes primarias que terminó destilando un test de precedencia completo.
+
+## Lo que se logró
+
+**#357 (CategoriaDeEtiquetas) refinado a `estado:listo`.** Vista N2 — la primera `MultiStream` del bounded context —, catálogo acumulativo de categorías (nada sale nunca; Rule of Three para una futura depuración), display "la última gana", y un solo endpoint `ListarCategoriasDeEtiquetas` (GET `colaboradores/etiquetas/categorias`).
+
+**Una doctrina HTTP completa, destilada evaluando las trece rutas del sistema una a una.** Fuentes primarias verificadas: RFC 9110 (semántica de POST/PUT/DELETE, 409 por constraints en PUT, sin body en DELETE), RFC 5789/7386 (PATCH), RFC 3986 (el `:` es legal en path y query), Fielding *"It is okay to use POST"* (2009), Zalando REST API Guidelines (evitar acciones y buzones sustantivos), Google AIP-136 (métodos personalizados `:verbo`), Microsoft Azure REST API Guidelines (`:action`, `:` proscrito en ids), Greg Young (UI orientada a tareas) y Dudycz (comandos vía REST, eventos vía colas).
+
+**Un test de precedencia de ocho reglas**, para decidir el verbo HTTP correcto sin re-litigar caso por caso: (1) ids URL-safe, `:` reservado para acciones; (2) un create — incluso disfrazado — siempre va POST a colección; (3) el reemplazo completo de un VO atómico va PUT (409 sancionado por RFC 9110); (4) un remove veraz sin payload va DELETE; (5) el resto son acciones `POST {recurso}:{verbo}`; (6) PATCH queda proscrito con VOs atómicos; (7) kebab-case; (8) queda marcado explícitamente como NO VERIFICADO si el literal `:` funciona en route templates del worker aislado.
+
+**Draft #621 abierto en el harness**, con mandato explícito: el planner propone el test de precedencia al crear un endpoint nuevo; el reviewer recibe un checklist de evaluación para cualquier PR que cree o modifique endpoints HTTP.
+
+**Cinco issues de migración del consumidor creados**, todos en borrador y bloqueados por #621: #376 (verbos canónicos en etiquetas), #377 (corrección de nombres como PUT), #378 (reingreso absorbido como creación canónica de vinculación), #379 (acciones de la vinculación con verbo explícito, con la verificación empírica del `:` pendiente) y #380 (renombrar la ruta de solicitudes de programación).
+
+## Problemas encontrados
+
+**El disparador fue una pregunta incómoda sobre un patrón que nadie había cuestionado.** Al discutir las rutas de #357, se cuestionó la justificación del POST-a-buzón frente a DELETE, y quedó expuesto que las trece rutas HTTP del sistema se venían decidiendo por precedente interno — "así se hizo antes" — sin una doctrina escrita que las respaldara.
+
+**Una corrección honesta a mitad de la propia sesión.** Se había argumentado que "el `:` es hostil en URLs" como razón para proscribirlo de los ids — un argumento débil, porque RFC 3986 lo permite explícitamente en path y en query. Lo que en realidad lo prohíbe en ids no es el RFC sino la guía de Microsoft Azure REST API Guidelines. El experto se corrigió a sí mismo antes de dejar la doctrina escrita con un argumento incorrecto en su base.
+
+## Lo que descartamos
+
+**Reingresar como comando distinto de iniciar la vinculación.** El dominio ya emite el mismo evento (`VinculacionIniciada`) para ambos casos — "Reingreso" nombra el escenario de negocio, no un comando distinto del servidor. Principio destilado: el cliente no declara lo que el servidor deriva de la historia del stream.
+
+**PATCH como verbo del bounded context.** Con VOs atómicos se vuelve un embudo de intenciones — varios comandos distintos colapsando en el mismo recurso, distinguibles solo por el contenido del body, lo que rompe el principio de una-Function-por-comando.
+
+**Un command bus HTTP genérico (`POST /comandos`).** Pierde routing por endpoint, autorización por ruta y observabilidad por endpoint — todo lo que el diseño actual (una Function por comando) da gratis.
+
+**Un buzón sustantivo `correcciones-de-fecha-inicio`.** Invade el espacio nominal de los eventos, que hablan en pasado; la forma `:verbo` (imperativo, como los comandos) es la que respeta la simetría CQRS entre API y event store.
+
+**Contar usos para depurar el catálogo de etiquetas.** `EtiquetaRetirada` no trae el valor retirado; hacerlo exigiría estado adicional por colaborador — una tercera proyección (N3) sin beneficio claro.
+
+**Un endpoint `ObtenerCategoriaDeEtiquetas` por id.** Sin caso de uso real que lo justifique (Rule of Three).
+
+## Aprendizajes
+
+1. **El vocabulario del dominio a veces ya unificó dos "comandos" en un solo hecho.** Cuando el cliente cree que declara algo distinto al reingresar, en realidad el servidor deriva el mismo evento de la historia del stream — el hecho ya estaba unificado, solo el comando quedó partido.
+2. **La granularidad de los recursos REST la dictan los value objects del dominio, no la conveniencia del endpoint.** Un campo suelto (`fecha-inicio`) no es PUT-able porque no es un VO atómico; un value object propio sí lo es — la frontera de la API refleja la frontera del modelo.
+3. **Cuestionar el propio argumento en tiempo real vale más que dejarlo pasar porque suena convincente.** Una doctrina construida sobre un argumento débil ("el `:` es hostil") es doctrina débil, aunque la conclusión final sea correcta por otras razones.
+4. **Verificar empíricamente antes de comprometerse a una forma de URI.** El soporte del literal `:` pegado a un parámetro en el route template del worker aislado quedó marcado explícitamente como no verificado, con la verificación diferida a un issue concreto (#379) en vez de asumirse.
+
+## Números del día
+
+| Métrica | Valor |
+|---|---|
+| Field notes | 1 (planner) |
+| Commits | 0 |
+| PRs mergeados | 0 |
+| Issues cerrados | 0 |
+| Issues creados en este repo | 6 (#376, #377, #378, #379, #380; #357 se refinó, no se creó) |
+| Issues creados en el harness | 1 (draft #621, doctrina HTTP) |
+| ADRs creados en este repo | 0 (la doctrina HTTP queda como draft en el harness) |
+| Archivos cambiados | 0 |

--- a/docs/bitacora/2026-08-14.md
+++ b/docs/bitacora/2026-08-14.md
@@ -1,0 +1,46 @@
+# 2026-08-14 - El Guion que Cambia (y Arregla) la Identidad de Colaborador
+
+> El día que un solo cambio de carácter — el separador de la llave de stream de Colaborador, de `:` a `-` — obligó a limpiar el número de identificación a alfanumérico para que ese guion siguiera siendo inequívoco. Se implementó y mergeó el mismo día, y de paso terminaron de aterrizar tres PRs que llevaban días en cola.
+
+## Lo que se logró
+
+**#381 implementado y mergeado el mismo día (PR #382).** El separador de la llave del stream de Colaborador cambia de `{Tipo}:{Numero}` a `{Tipo}-{Numero}`, y el número de identificación se limpia a alfanumérico como invariante del VO: letras a mayúsculas, todo carácter no alfanumérico se elimina sin lanzar error — no es una validación de borde, es limpieza incondicional, con precedente directo en `Etiqueta` (MEF-ADR-0012).
+
+**Tres PRs en cola de días anteriores, finalmente mergeados**: #375 (FichaColaborador, issue #356, abierto desde el 12 de agosto), #383 (ListarFichasColaborador, issue #373) y #384 (CategoriaDeEtiquetas, issue #357) — el cierre del write-side y read-side completo de la cadena de Colaboradores que venía construyéndose desde el 10.
+
+**Revisión post-merge del backlog completo por divergencias.** Con #381 ya en `main`, se repasaron los issues que dependían de la forma vieja de la llave: #373 (su dependencia de #356 quedó satisfecha, y el `Id` de `FichaColaborador` ya nació con el contrato nuevo — el cursor keyset resultó agnóstico al formato del separador); #376 (la pregunta abierta desde el 13 de agosto sobre la forma URL-safe de `Identificacion` quedó resuelta por el propio #381: el `{id}` de ruta ES `Identificacion.ToString()`, vía el punto único de conversión de MEF-ADR-0037); #377-#379 heredan la resolución sin necesitar edición propia.
+
+## Problemas encontrados
+
+**Dos peticiones que parecían independientes eran, en realidad, un solo contrato de identidad.** Cambiar el separador sin limpiar el número habría dejado la llave ambigua: hoy `"AB-123"` es un número de documento legal (pasaporte), así que `"CC-AB-123"` sería indistinguible de una identificación con separador propio dentro del número. Tratarlas como dos issues separados habría entregado una mitad rota — el guion solo es un separador inequívoco *porque* la limpieza garantiza que el número nunca contiene uno.
+
+**El separador viejo (`:`) era, hasta este día, el mismo carácter que la sesión del día anterior había identificado como el que hay que reservar exclusivamente para acciones HTTP (`:verbo`).** El cambio de separador de la llave de stream resulta, en la práctica, un prerequisito silencioso de la migración de rutas que #378/#379 venían proponiendo — sin que ninguna de las dos sesiones lo hubiera anticipado como dependencia explícita.
+
+## Lo que descartamos
+
+**Cambiar solo el separador sin limpieza alfanumérica.** Dejaría la llave ambigua, como se explicó arriba.
+
+**Limpiar en el handler en vez de en el VO.** Dejaría caminos del código sin la invariante aplicada — la limpieza tiene que vivir donde vive la identidad, no en cada punto de entrada que la use.
+
+**Tocar `Etiqueta.ToString()`.** También usa `:`, pero es una representación de display/debug sin consumidores externos — verificado en código, quedó explícitamente fuera de alcance.
+
+**Purgar los streams huérfanos que deja el cambio de separador en dev.** Se toleran sin protocolo de migración: no hay producción todavía, y los datos existentes son de smoke tests, no de negocio real.
+
+## Aprendizajes
+
+1. **Dos peticiones que suenan a features distintas pueden ser, en el fondo, un único contrato de identidad.** Separar "cambiar el separador" de "limpiar el número" en dos issues habría entregado una mitad inconsistente — la unidad del cambio solo se ve al preguntar qué hace al guion inequívoco.
+2. **Un cambio de invariante en un VO de identidad exige revisar de inmediato todo el backlog que depende de su forma anterior.** La revisión post-merge encontró que una pregunta abierta desde el día anterior (la forma URL-safe de `Identificacion`) ya había quedado resuelta como efecto colateral del propio cambio, sin que nadie lo hubiera planeado así.
+3. **Tolerar streams huérfanos en un ambiente sin producción es una decisión legítima y explícita, no negligencia.** La condición que la hace válida — sin usuarios reales, datos de smoke tests — es la que hay que verificar antes de aplicar el mismo criterio en cualquier otro ambiente.
+
+## Números del día
+
+| Métrica | Valor |
+|---|---|
+| Field notes | 1 (planner) |
+| Commits | 12 |
+| PRs mergeados | 4 (#375, #382, #383, #384) |
+| Issues cerrados | 4 (#356, #357, #373, #381) |
+| ADRs creados | 0 |
+| Archivos cambiados | 68 |
+| Líneas agregadas | ~2286 |
+| Líneas eliminadas | 221 |

--- a/docs/bitacora/field-notes/procesadas/2026-08-04-1729-planner.md
+++ b/docs/bitacora/field-notes/procesadas/2026-08-04-1729-planner.md
@@ -1,0 +1,149 @@
+---
+fecha: 2026-08-04
+hora: 17:29
+sesion: planner
+tema: Refinamiento de los issues de recorte de telemetria (#308, #309)
+---
+
+## Contexto
+
+Se venia de una pregunta operativa ("¿puedo implementar los issues restantes con sequential?") que se
+respondio negativa: los dos issues abiertos en ese momento (#304, #305) son `tipo:infra` y
+`batch-pipeline.sh` los saltea. La via es `/infra` uno a uno, en orden #305 -> #304.
+
+Luego se paso a refinar #308 y #309, los dos borradores de recorte de telemetria de Application
+Insights capturados esa misma manana. Ambos declaraban explicitamente preguntas abiertas "a validar
+en el refinamiento". Se resolvieron las tres con verificacion en codigo descompilado, ejecucion en
+runtime y consultas KQL contra dev.
+
+## Descubrimientos
+
+### El sampler de OpenTelemetry nunca estuvo activo
+
+El hallazgo mayor de la sesion, y no estaba en ninguno de los dos borradores. `UseAzureMonitorExporter()`
+llama internamente a `SetSampler`, y como se invoca despues del `SetSampler` del proyecto, lo pisa.
+`AzureMonitorExporterOptions.TracesPerSecond` tiene default `5.0`, asi que siempre instala
+`RateLimitedSampler(5/s)`.
+
+Verificado replicando el wiring exacto de los seams en runtime:
+
+```
+Sampler efectivo: Azure.Monitor.OpenTelemetry.Exporter.Internals.RateLimitedSampler
+Esperado:         OpenTelemetry.Trace.ParentBasedSampler (ratio 0.2)
+```
+
+Consecuencias: `TELEMETRY_SAMPLING_RATIO` es una variable inerte, `ResolverRatioDeSampling` calcula
+un valor que se descarta, y la Capa 2 de CA-ADR-0009 no es la que el ADR describe desde su
+actualizacion de 2026-06-18. Lo que corre es un techo de 5 traces/s, muy por encima del trafico real
+(~1,4-1,6/s), o sea que **hoy no se recorta nada**.
+
+Ironia registrada: el ADR *original* (Capa 2 clasica, `maxTelemetryItemsPerSecond = 5`) describia
+justo un limite de 5 items/seg. El sistema hace por accidente lo que la decision original queria, y
+no lo que la decision vigente dice.
+
+### El hueco de cobertura estaba declarado como limitacion conocida
+
+`ConfiguracionObservabilidadProjectionsTests` documenta: *"Que el ratio resuelto llegue efectivamente
+al ParentBasedSampler/TraceIdRatioBasedSampler no se verifica... Queda cubierto por revision de
+codigo."* La revision de codigo no podia atraparlo: el codigo visible es correcto; el defecto vive
+dentro de una llamada de libreria. Y el mismo archivo apoya otra decision de diseno en la premisa
+falsa ("ese lleva el sampler de ratio 0.2").
+
+Ademas, la limitacion resulto ser superable: leer el sampler efectivo del `TracerProvider` resuelto
+y comparar su tipo es determinista, sin muestreo probabilistico. Leccion transferible: **un limite de
+testing declarado como "cubierto por revision de codigo" merece ser reexaminado periodicamente**, no
+tratarse como cerrado.
+
+### Trampa evitada: apagar el ActivitySource del daemon
+
+`DaemonSettings.ActivitySource` es settable y `HighWaterAgent` lo invoca con `?.`, asi que ponerlo en
+`null` parece la solucion limpia para matar el span de polling. Rompe el worker:
+`JasperFx.Events.Daemon.SubscriptionMetrics` toma el mismo objeto y lo desreferencia **sin** null-check,
+o sea `NullReferenceException` justo cuando una proyeccion procese eventos reales. Y aunque no lanzara,
+borraria `TrackExecution`/`TrackGrouping`, que son los spans con valor diagnostico.
+
+### Un cambio del borrador resulto redundante
+
+`received-first-response` tiene correlacion 1:1 exacta con los spans `postgresql` (123.276 vs 123.050
+en ControlHoras; 72.361 vs 72.242 en el worker): es un `ActivityEvent` dentro del span de Npgsql.
+Como se verifico que al dropear el span padre el hijo Npgsql devuelve `Activity NULL` -- ni se
+instancia --, apagar `EnableFirstResponseEvent` no aporta nada una vez filtrado el polling. Se elimino
+del alcance.
+
+Queda registrado igual el hallazgo util por si se necesita despues: Marten 9.12 expone
+`ConfigureNpgsqlDataSourceBuilder`, y el callback se aplica aunque se siga usando
+`opts.Connection(string)` -- no hay que cambiar la forma de construir la conexion.
+
+### Las metricas de Wolverine se apagan en origen, pero solo son el 56%
+
+`DurabilitySettings.DurabilityMetricsEnabled = false` corta `PersistenceMetrics.StartPolling` en
+`DurabilityAgent.StartAsync`. Elimina el span y la carga sobre Postgres, sin el
+`ConfigureCommandFilter` por texto SQL que el borrador proponia y calificaba de fragil.
+
+Pero el desglose por SQL mostro siete consultas a 4.320 spans/6h cada una, y solo cuatro son metricas.
+Las otras tres (advisory lock, scheduled jobs, batch de recovery) son durabilidad real y no se tocan.
+El borrador asumia que apagaba el 100% del polling; apaga el 56%.
+
+### Gotcha de wiring en Cosmos.EventSourcing.CritterStack
+
+`AgregarWolverineParaComandosServerless` invoca `configureOptions?.Invoke(options)` **antes** de fijar
+`options.Durability.Mode`. `DurabilityMetricsEnabled` puesto en el callback sobrevive; cualquier
+intento de tocar `Mode` desde ahi se descarta en silencio.
+
+## Decisiones
+
+- **#308 absorbe la causa raiz y el filtro, fusionados** (decision del usuario). Sin arreglar el orden
+  del wiring, el sampler filtrante quedaria igual de inerte que el actual: compilaria, pasaria tests
+  unitarios en aislamiento, se desplegaria y no haria nada, sin ninguna senal. Los CA-1/CA-2 son
+  precondicion de los CA-3/CA-4. Se registro en el issue que la fusion queda al limite de la Revision
+  de complejidad y por que se acepto igual.
+- **La via de correccion es `SetSampler` despues de `UseAzureMonitorExporter`**, no configurar
+  `AzureMonitorExporterOptions`. Razon: `ApplicationInsightsSampler` es `internal` y no se puede
+  componer con un sampler que filtre por nombre. Costo asumido y anotado: se pierde el `sampleRate`
+  que permite a Application Insights extrapolar conteos.
+- **#309 se aplica a los dos Function Apps** (decision del usuario). En Programacion el beneficio hoy
+  es solo carga sobre Postgres, porque ese dominio no exporta telemetria.
+- **#309 depende de #308 por conflicto de merge**, no por logica: ambos modifican
+  `ControlHoras/Infraestructura/ComposicionServicios.cs`. Van secuenciales.
+- **El nombre del span se ancla a la API de Marten con un guardrail** en vez de hardcodearse:
+  `HighWaterAgent` lo construye como `OtelPrefix + ".daemon.highwatermark"` y no existe como literal
+  en ningun ensamblado.
+
+## Descartado
+
+- **Apagar `EnableFirstResponseEvent` de Npgsql**: redundante (ver arriba).
+- **Recalibrar `TELEMETRY_SAMPLING_RATIO`**: no tiene sentido mientras la variable sea inerte, y una
+  vez conectada hay que medir antes de elegir valor. Sale del alcance de esta tanda.
+- **Apagar el `ActivitySource` del daemon**: rompe el worker.
+- **Filtrar con `BaseProcessor<Activity>`**: solo suprime el span ya creado; obligaria a filtrar
+  tambien el hijo Npgsql por texto de comando SQL.
+- **`UpdateMetricsPeriod = 5 min` en vez de apagar las metricas**: nadie consume esos contadores.
+- **Instrumentar Programacion con exporter**: fuera de alcance, trabajo aparte.
+- **Afirmacion del borrador de #309 de que el sampler descarta ~11 de 14 marcaciones**: falsa. No se
+  descarta ninguna. El argumento valido es el volumen absoluto contra el daily cap.
+
+## Preguntas abiertas
+
+- El worker muestra ~48 spans/min de `marten.daemon.highwatermark`, contra 60/min teoricos si el
+  `HighWaterAgent` corriera siempre en `SlowPollingTime` (1s). La diferencia no quedo explicada. No
+  bloquea nada: el filtro los elimina a todos.
+- El worker registra dos named stores con `AddAsyncDaemon(HotCold)` y `DaemonLockId` comparte default
+  (4444). No se determino si eso hace que solo un daemon obtenga el lock. Relevante solo si alguna vez
+  una proyeccion parece no avanzar.
+- Instrumentar Programacion con `UseAzureMonitorExporter` sigue pendiente desde CA-ADR-0009. Cuando se
+  haga, debe nacer con el orden correcto del sampler y con el guardrail de #308.
+- `TELEMETRY_SAMPLING_RATIO` no esta en Terraform para ningun recurso. Definir si se declara y con que
+  valor por ambiente, una vez #308 la vuelva efectiva.
+
+## Referencias
+
+Issues refinados a `estado:listo`:
+- #308 -- Restaurar el sampler de OpenTelemetry y descartar el span de polling del daemon de Marten
+  (`tipo:refactor`, `bug`, `dom:tooling`)
+- #309 -- Apagar la recoleccion de metricas de durabilidad de Wolverine
+  (`tipo:refactor`, `dom:control-horas`, `dom:programacion`, `bloqueado` por #308)
+
+Issues previos sin cambios: #305 y #304 (`tipo:infra`, siguen en su orden #305 -> #304 via `/infra`).
+
+Consultas KQL usadas: workspace `controlasistencias-dev-logs`
+(`99f46a07-f2e7-47e2-a3dd-d085c78f2247`), tablas `AppTraces` y `AppDependencies`, ventanas de 6h y 24h.

--- a/docs/bitacora/field-notes/procesadas/2026-08-05-2125-planner.md
+++ b/docs/bitacora/field-notes/procesadas/2026-08-05-2125-planner.md
@@ -1,0 +1,75 @@
+---
+fecha: 2026-08-05
+hora: 21:25
+sesion: planner
+tema: refinamiento de la familia tres-islas (#317-#320) y split de #319
+---
+
+## Contexto
+
+Refinar los borradores de la adopcion de MEF-ADR-0039 (tres islas, cero referencias entre
+ensamblados de eventos), creados desde la sesion de planning en Mefisto del 2026-08-05.
+
+## Descubrimientos
+
+- MEF-ADR-0039 existe en `main` del harness pero no en el plugin instalado (0.20.0); se cita por
+  identificador estable y se lee via `gh api` mientras tanto.
+- `Programacion.DomainEvents` no tiene el `PackageReference` de markers (solo ControlHoras); en
+  ControlHoras solo aparece en comentarios -> removible, canon "DomainEvents nace sin paquetes".
+- El evento `ProgramacionTurnoDiarioSolicitada` NO se persiste (confirmado en el comentario de
+  `IdentidadEventosControlHoras.cs`) -- la nota de seguridad de #318 es correcta.
+- Los tests de portabilidad/deserializacion del evento privado viven en `ControlHoras.Tests`
+  (consumidor), no en `PrivateEvents.Tests` como decia el borrador de #318.
+- El payload a duplicar no es un record sino una familia anidada de 4 (`DetalleTurno` ->
+  `DetalleFranjaOrdinaria` -> `DetalleSubFranja`, dos con Equals custom) + empleado.
+- **Fuga transitiva nueva**: `ReadModels` referencia ambos buses (`TurnoDiarioView` embebe
+  `InformacionEmpleado` y `DetalleTurno`) -> el worker arrastra los buses transitivamente; el
+  enforcement de #320 no lo detectaria (solo referencias directas). Gap doctrinal de MEF-ADR-0039.
+- `TurnoDiarioProjection` hoy es pass-through (evento y vista comparten tipos de bus): al poseer
+  el evento sus records, la proyeccion gana un mapeo.
+
+## Decisiones
+
+- **#317** (`estado:listo`, tipo:tooling): enmienda doctrinal de CA-ADR-0029. Se agrego la
+  **convencion de naming de payloads** a CA-2: nombres puros del lenguaje ubicuo para el event
+  store; el rol marcado lo cargan los DTOs de bus (`Detalle*`); proscrito `*Persistido`; cuando el
+  nombre puro lo ocupa un VO rico del mismo ensamblado, el calificador es de dominio
+  (`TurnoProgramado`, `FranjaProgramada`).
+- **#318** (`estado:listo`, refactor, dom ambos): payload nuevo `DetalleEmpleado` (familia
+  `Detalle*` de PrivateEvents), no `InformacionEmpleadoInterna`.
+- **#319 partido en dos** por ejes ortogonales (cero archivos compartidos): #319 = lado
+  Programacion, #322 = lado ControlHoras. Ambos `estado:listo`, paralelo-seguros entre si,
+  secuenciales con #318 (comparten un handler cada uno).
+- **Opcion (b) para `ToDetalle()`**: los VOs ricos retornan los records propios del mismo
+  ensamblado (Tell-don't-Ask preservado, campos privados intactos); el FA mapea dominio -> bus.
+- **Nombres acordados**: Programacion: `TurnoProgramado`, `FranjaProgramada`,
+  `SubFranjaProgramada`, `Empleado`. ControlHoras: `TurnoDiario` (termino exacto del glosario),
+  `FranjaProgramada`, `SubFranjaProgramada`, `Empleado`. Se descarto homonimia con los VOs ricos.
+- **Paridad JSON como guardrail**: los nombres de PROPIEDADES de los eventos no cambian (son las
+  claves de `mt_events`); round-trip contra `CrearOpcionesMarten()` con la forma persistida hoy.
+- **#322 es tipo:refactor aunque toca el worker**: la regla de MEF-ADR-0011 es operativa contra
+  la allowlist de tooling; el toque a la proyeccion es mapeo dirigido por compilador. Desviacion
+  documentada en el issue.
+- **#323** (borrador): ReadModels posee sus payloads, bloqueado por #322.
+
+## Descartado
+
+- Sufijo `*Persistido` para los records del event store (vocabulario de infraestructura en el
+  dominio; el usuario tenia razon -- precedente #270: el dominio conserva el nombre puro).
+- Mantener #319 unificado (2 ejes, no pasaba la regla de 30 minutos).
+- Combinar #322 + ReadModels en un issue (3 ejes, a cambio de tocar la proyeccion una sola vez).
+- **Draft en Mefisto sobre el gap de ReadModels: diferido a proposito.** Primero se resuelve #323
+  internamente; con esa evidencia se propone la correccion al marco. Registrado en #323.
+
+## Preguntas abiertas
+
+- Naming de los records de la vista en #323 (homonimia solo en la proyeccion, que importa ambos
+  ensamblados): calificador, alias de using, o aplanar. Se decide en su refinamiento.
+- #320 sigue en borrador y su texto referencia "los dos drafts" (ahora son tres: #318, #319,
+  #322); corregir al refinarlo. Evaluar si el enforcement de ReadModels entra ahi o en #323.
+
+## Referencias
+
+Issues refinados: #317, #318, #319 (reescrito como lado Programacion).
+Issues creados: #322 (lado ControlHoras, listo), #323 (ReadModels, borrador).
+Pendiente de refinar: #320 (tests de arquitectura).

--- a/docs/bitacora/field-notes/procesadas/2026-08-06-1019-planner.md
+++ b/docs/bitacora/field-notes/procesadas/2026-08-06-1019-planner.md
@@ -1,0 +1,61 @@
+---
+fecha: 2026-08-06
+hora: 10:19
+sesion: planner
+tema: refinamiento de #323 y politica "el read model deriva del event store"
+---
+
+## Contexto
+
+Refinamiento de #323 (ReadModels con referencias a buses, ultima fuga de la familia tres-islas).
+Antes de refinar se verifico el estado real post-merges: #318 y #319 cerrados (PRs #324/#325
+mergeados), #322 listo pero sin ejecutar, #320 cerrado hoy como not planned.
+
+## Descubrimientos
+
+- La pregunta correcta para el naming de los tipos de la vista no era "que nombres" sino "que
+  archivos ven dos islas a la vez": toda proyeccion ve event store + read models POR
+  CONSTRUCCION (`Create(evento) -> vista`). Cualquier politica de duplicacion paga alias o
+  marcadores en 2N archivos frontera, para siempre.
+- La motivacion de las tres islas (MEF-ADR-0039 d2) es velocidades de evolucion independientes.
+  Evento persistido y vista NO son independientes: la proyeccion los sincroniza en lockstep.
+  Duplicar payloads entre ellos es ceremonia sin proteccion.
+- Legalidad verificada: MEF-ADR-0039 solo prohibe ProjectReference EN los tres ensamblados de
+  eventos (ReadModels no lo es); MEF-ADR-0034 s5 solo exige "sin Marten ni transitivamente"
+  (DomainEvents post-#322 queda con cero refs y cero paquetes).
+
+## Decisiones
+
+- **Politica** (propuesta del usuario, adoptada): el read model deriva del event store.
+  ReadModels referencia unicamente `{Dominio}.DomainEvents`. La vista embebe los payloads del
+  evento cuando su forma coincide (default); declara DTOs propios cuando diverge (calculos,
+  agregaciones, multi-dominio). Frontera HTTP = DTO de respuesta del FA, Rule of Three.
+- #323 refinado con esa politica y marcado `estado:listo` + `bloqueado` (por #322). Cero
+  archivos nuevos; la homonimia desaparece por construccion.
+- El enforcement (tests de arquitectura) se montara desde Mefisto -- por eso #320 se cerro como
+  not planned. NO se crea draft en Mefisto todavia.
+- El planner es el responsable de escudrinar cada `tipo:projection` con las preguntas
+  discriminantes embebe-vs-DTOs-propios (1:1 -> embebe; calculado/agregado -> propio;
+  multi-dominio -> propio; forma HTTP -> DTO del FA). Mejora futura al agente planner del marco.
+
+## Descartado
+
+- Duplicar payloads en ReadModels con nombres puros + alias de using (costo lineal perpetuo).
+- Duplicar con marcador de rol `*View` en todo el ensamblado (colision raiz/anidado
+  `TurnoDiarioView`; paridad que no protege nada).
+- Nested records (`TurnoDiarioView.Empleado`): sin precedente, CA1034.
+- Crear ya el draft doctrinal en Mefisto (se evalua al cerrar #323, con la evidencia completa:
+  politica + enforcement + receta del planner).
+
+## Preguntas abiertas
+
+- Cuando llegue la primera vista multi-dominio (N2), validar que la excepcion "DTOs propios"
+  funciona sin fricciones.
+- Momento de crear el draft doctrinal en Mefisto (politica + enforcement + preguntas del
+  planner): al cierre de #323.
+
+## Referencias
+
+Issues editados: #323 (refinado, estado:listo + bloqueado, titulo nuevo: "Retirar las
+referencias de ReadModels a los buses y derivar las vistas de los DomainEvents").
+Issues verificados sin cambios: #322 (su estado intermedio sigue siendo el plan correcto).

--- a/docs/bitacora/field-notes/procesadas/2026-08-06-1717-planner.md
+++ b/docs/bitacora/field-notes/procesadas/2026-08-06-1717-planner.md
@@ -1,0 +1,77 @@
+---
+fecha: 2026-08-06
+hora: 17:17
+sesion: planner
+tema: retractacion de la politica read-side, entrevista del turno diario y rediseno TurnoVigente
+---
+
+## Contexto
+
+Continuacion de la sesion de la manana (field notes 2026-08-06-1019). El usuario retracto la
+politica "el read model deriva del event store" y pidio entrevista de necesidad de lectura para
+redisenar el read model del turno diario desde el actor, no desde el evento.
+
+## Descubrimientos
+
+- **El facilismo original**: `TurnoDiarioView` (#289) se diseno desde el evento disponible --
+  identificacion completa, `UltimaSolicitudId`, jerarquia de franjas con offsets. Ningun actor
+  necesitaba esa forma.
+- **Actores y preguntas** (entrevista): Programador (principal) -- panorama multi-empleado x
+  rango para rebalancear ante novedades, y ausencias de turnos (quien NO tiene); Trabajador --
+  su turno por rango; Aprobador -- consulta puntual ante vacios del calculo.
+- **Dos gaps write-side**: no existe plantilla maestra de empleados (bloquea ausencias, #330) y
+  la asignacion no lleva lugar/sede (bloquea filtro del panorama, #331).
+- **Contrato para calendarios**: los controles consumen bloques planos con instantes absolutos.
+  Se decidio segmentar sin solape y romper en medianoche. La aritmetica es semantica de dominio:
+  vive como comportamiento del payload del evento en DomainEvents (unico ensamblado que write
+  side y worker comparten, MEF-ADR-0039 d2/d4), invocable por la proyeccion (Tell-don't-Ask).
+- **Dimensionamiento**: pantalla tipica 50-150 empleados x 1-2 semanas; sin paginacion de dia
+  uno -- tope de rango con recorte + envelope con seam (precedente #290).
+- **"Vigente" ya era lenguaje del sistema**: glosario, doc de la proyeccion y smoke tests lo
+  usaban para describir exactamente este concepto (resultado del "ultimo gana").
+- El PR #326 (ejecucion de #322) ya estaba en vuelo con `TurnoDiario` creado como payload del
+  evento -- verificar contra main no basta, hay que mirar PRs abiertos.
+
+## Decisiones
+
+- **ReadModels es cuarta isla**: cero referencias de proyecto (ni buses ni DomainEvents). Sus
+  records son propios; la proyeccion en el worker es el punto de mapeo evento -> vista.
+- **El read model se disena desde la necesidad del actor**, no desde la forma del evento.
+- **Sin sufijos arquitectonicos** (View, DTO) en los objetos: extension de #317 CA-2 al
+  read-side. Divergencia frente a `{Concepto}View` del marco -- insumo para el draft doctrinal.
+- **Nombres**: el payload del evento conserva `TurnoDiario` (opcion 3, no tocar el PR #326); el
+  read model nuevo se llama `TurnoVigente` (respaldado por glosario y semantica del ultimo gana).
+- **Forma de `TurnoVigente`**: Id (stream key, ancla para comandos de la UI), EmpleadoId,
+  NombreCompleto (un campo), Fecha, NombreTurno, HorarioResumido, Bloques[{Tipo,Inicio,Fin}].
+  Excluidos: identificacion, UltimaSolicitudId.
+- **Una sola proyeccion** para todas las presentaciones (comparten grano); recortes en DTOs de
+  respuesta cuando duela (Rule of Three).
+- **Cadena expand-contract**: #327 (Segmentar en DomainEvents) -> #328 (TurnoVigente +
+  ObtenerTurnoVigente) -> #329 (ListarTurnosVigentes, panorama) -> #323 reformulado
+  (eliminar lo viejo y consumar la cuarta isla). Todos secuenciales.
+- Sin clientes actuales de los endpoints viejos: eliminacion directa, sin convivencia.
+
+## Descartado
+
+- Politica "el read model deriva del event store" (creada en la manana, retractada): harness#581
+  quedo con la premisa invertida -- corregirlo/reemplazarlo desde el repo de Mefisto.
+- Renombrar el payload del evento a `TurnoAsignado` via fix-review del PR #326 (opcion 1):
+  el usuario prefirio no tocar el PR.
+- Nombres para el read model: DiaProgramado (promete mas de lo que trae), JornadaProgramada
+  (Jornada reservada al concepto juridico), PanoramaTurnos (nombra una presentacion).
+- Paginacion del panorama de dia uno.
+- Dos proyecciones (resumida + detallada): el resumen es recorte del mismo grano.
+
+## Preguntas abiertas
+
+- Reescribir harness#581 desde Mefisto con la doctrina final (cuarta isla + read models desde la
+  necesidad + preguntas discriminantes del planner + enforcement).
+- Los documentos mt_doc_turnodiarioview huerfanos en dev: drop manual o dejarlos (#323, nota).
+- Registrar "Turno Vigente" en el glosario (sesion de event-stormer o al ejecutar #328).
+
+## Referencias
+
+Issues creados: #327 (Segmentar, listo+bloqueado por #322/PR#326), #328 (TurnoVigente,
+listo+bloqueado por #327), #329 (panorama, listo+bloqueado por #328), #330 (plantilla maestra de
+empleados, borrador), #331 (lugar en la programacion, borrador dom:programacion).
+Issues editados: #323 (reformulado como contraccion, listo+bloqueado por #328/#329).

--- a/docs/bitacora/field-notes/procesadas/2026-08-06-2055-planner.md
+++ b/docs/bitacora/field-notes/procesadas/2026-08-06-2055-planner.md
@@ -1,0 +1,111 @@
+---
+fecha: 2026-08-06
+hora: 20:55
+sesion: planner
+tema: knowledge crunching de la sede en la programacion de turnos (refinamiento de #331)
+---
+
+## Contexto
+
+Refinamiento de #331 (la asignacion de turnos no lleva la sede), gap descubierto en la entrevista
+del turno diario (field notes 2026-08-06-1717) que bloqueaba el filtro del panorama (#329).
+
+## Descubrimientos
+
+- **Modelo hibrido**: la sede natural del empleado vive en el maestro (#330); la asignacion lleva
+  la sede efectiva. "Que necesita el jefe de sede al filtrar" discrimino entre ambos modelos.
+- **Cascada de defaults delegados** (diseño del usuario): `sede de la franja del catalogo ??
+  sede de la solicitud ?? sede natural del empleado`. El catalogo (intencion explicita de diseño)
+  le gana a la solicitud; razon letal: el default silencioso del cliente (sede natural puesta sin
+  preguntar) aplastaria el prearmado multi-sede en cada asignacion.
+- **El tercer nivel vive en el cliente**: el comando llega con la sede resuelta (patron
+  InformacionEmpleado). El servidor nunca consulta el maestro -> #331 no depende de #330.
+- **Asimetria intra-dia**: "lunes en A, martes en B" sale gratis (dos solicitudes, ultimo gana);
+  "mañana en Suba, tarde en Chapinero" requiere sede por franja -- el turno prearmado del
+  catalogo la resuelve sin friccion de asignacion (#335).
+- **Squatting de nombres**: la referencia parcial en eventos no puede ocupar el nombre del
+  concepto rico. `Sede` queda reservado al futuro maestro (direccion, ciudad, dispositivos);
+  en eventos viaja `SedeProgramada`/`DetalleSede`. `Empleado` en las islas DomainEvents ya sufre
+  ese squatting -> #340.
+- **Guia de naming por intencion e isla**: cada isla tiene dialecto (Programado/a en DomainEvents,
+  Detalle* en PrivateEvents, campos planos sin sufijos en ReadModels); la sede lo respeta en cada
+  eslabon. Tabla cara a cara validada contra origin/main (post #322/#327/#328).
+- La asociacion dispositivo->sede es el puente entre lo externo (DispositivoId opaco) y lo
+  interno (Sede rica): habilita control de cumplimiento de lugar y cobertura en vivo (#338).
+- El rechazo de "sede" en el glosario (DispositivoId) no aplica aqui: protegia al id de
+  dispositivo de disfrazarse de concepto geografico, y anticipaba que la geografia existe aparte.
+
+## Decisiones
+
+- Sede: objeto nullable `{ Id: string opaco del cliente, Nombre: string }`; propiedades
+  obligatorias cuando el objeto viene. Snapshot al solicitar; retrocompat con eventos sin campo.
+- Nombres: `SedeProgramada` (Programacion.DomainEvents y ControlHoras.DomainEvents, cada isla su
+  tipo), `DetalleSede` (PrivateEvents), `SedeId` + `NombreSede` (TurnoVigente -- el id SI va: el
+  filtro por nombre se parte cuando renombran la sede).
+- Termino del glosario: **Sede** (definir con nota: puede ser instalacion propia o sitio de
+  terceros; sinonimos rechazados: sitio de trabajo, lugar de trabajo, centro de trabajo).
+- Corte: #331 (solicitud, eslabones 1-3, listo) -> #335 (catalogo por franja) -> #336
+  (ControlHoras) -> #337 (vista + filtro, depende de #336 y #329).
+- Validacion de sede invalida en el validator del request (400), no invariantes en los records
+  (paridad con Empleado/DetalleEmpleado) -- propuesta revisable por el pipeline.
+
+## Descartado
+
+- "Sede" como nombre del record de eventos (squatting), `InformacionSede` (nombra la forma, no
+  la intencion), solo `NombreSede` en la vista (filtro fragil ante renombres).
+- Lugar por fecha dentro del comando (dos solicitudes lo cubren) y sede por franja en la
+  solicitud (la versatilidad va en el catalogo, #335).
+- Resolver la sede natural en el servidor (requeriria el maestro #330; el cliente la resuelve).
+- Bloquear #331 con #330.
+
+## Preguntas abiertas
+
+- Registrar "Sede" en el glosario y ajustar la prosa del actor Programador (event-stormer).
+- Actualizar catalog.yaml con los payloads nuevos de ProgramacionTurnoSolicitada y
+  ProgramacionTurnoDiarioSolicitada (eda-modeler o al ejecutar #331).
+- Donde vive la resolucion de la cascada al copiar (handler vs Tell-don't-Ask) -- refinamiento
+  de #335.
+- Maestro de sedes: aun sin issue; #338 depende conceptualmente de el.
+
+## Referencias
+
+Issues refinados: #331 (estado:listo, tipo:feature, titulo nuevo "Registrar la sede en la
+solicitud de programacion de turnos").
+Issues creados: #335 (sede por franja en catalogo, borrador bloqueado), #336 (sede en
+ControlHoras, borrador bloqueado), #337 (filtro del panorama, borrador bloqueado,
+tipo:projection), #338 (dispositivos->sedes, borrador), #339 (modificacion unitaria de franja,
+borrador), #340 (renombrar Empleado en eventos, borrador).
+Housekeeping: #329 desbloqueado (su dependencia #328 se mergeo en PR #333).
+
+---
+
+## Continuacion de la sesion (refinamiento de la saga completa)
+
+### Decisiones adicionales
+
+- **Split de #335 por complejidad** (dos ejes): #335 = guardar sede por franja en el catalogo;
+  #341 (nuevo) = aplicar la cascada al copiar. Bonus verificado: ObtenerDetalle() -> ToDetalle()
+  hace fluir la sede prearmada sin tocar el flujo de solicitud.
+- **La sede entra a la igualdad** de FranjaOrdinaria/FranjaProgramada/DetalleFranjaOrdinaria
+  (dato de identidad del diseno), a diferencia de Descripcion (derivado, excluido).
+- **Validacion por frontera natural**: #331 en el RequestValidator (la solicitud no tiene factory
+  de dominio); #335 en las invariantes acumuladas del factory de FranjaOrdinaria.
+- **Cascada como comportamiento del payload**: TurnoProgramado.ConSedePorDefecto() (Tell-don't-Ask,
+  precedente Segmentar #327); con null es identidad. Un solo punto de resolucion, antes de
+  construir el evento persistido. Descartado: que los consumidores coalescieran.
+- **ControlHoras guarda la sede SOLO por franja, sin campo de dia**: el nivel dia del bus es "lo
+  solicitado" y puede ser null con franjas con sede (turno prearmado asignado sin sede) -- un
+  campo de dia seria fuente incorrecta para el filtro. Trazabilidad via SolicitudId.
+- **Segmentar estampa la sede de la franja madre en cada BloqueTurno**; descansos/extras heredan.
+- **La sede va POR BLOQUE en TurnoVigente** (SedeId/NombreSede planos y anulables en Bloque),
+  SUPERANDO la decision inicial de campos de dia. Filtro = "dias donde algun bloque rige en esa
+  sede" (Bloques.Any); dia multi-sede aparece bajo cualquiera de sus sedes. Sin resumen de dia
+  en la vista (Rule of Three: recorte al DTO cuando duela).
+- DiaCalculado (nomina) NO se toca: si nomina necesita sede/centro de trabajo, issue propio.
+
+### Referencias (actualizadas)
+
+Issues refinados a listo: #331, #335 (eje 1 del split), #341 (eje 2, nuevo), #336, #337.
+Cadena secuencial completa: #331 -> #335 -> #341 -> #336 -> #337 (con #329 requerido por #337).
+Borradores de descubrimiento: #338 (dispositivos->sedes), #339 (modificacion unitaria de franja),
+#340 (renombrar Empleado).

--- a/docs/bitacora/field-notes/procesadas/2026-08-10-1947-planner.md
+++ b/docs/bitacora/field-notes/procesadas/2026-08-10-1947-planner.md
@@ -1,0 +1,92 @@
+---
+fecha: 2026-08-10
+hora: 19:47
+sesion: planner
+tema: Dominio Colaboradores — knowledge crunching completo y desglose (refinamiento de #330)
+---
+
+## Contexto
+
+Sesion multi-dia (2026-08-07 al 2026-08-10) para refinar #330 ("plantilla maestra de empleados").
+Termino redefiniendo el lenguaje ubicuo del dominio y produciendo el desglose completo en 10 issues.
+
+## Descubrimientos
+
+- **Colaborador reemplaza a Empleado** como concepto rico: independiente del tipo de vinculacion,
+  abre la puerta a contratistas. El dominio se renombra Empleados -> Colaboradores (era planificado,
+  costo cero).
+- **Identidad doble**: la `Identificacion` ({Tipo}:{Numero}) identifica a la persona y ES el
+  streamId; el `CodigoColaborador` (antes EmpleadoId) es el id TRANSACCIONAL de la vinculacion.
+  EmpleadoId embarraba ambas. Prueba de voz mato a "VinculacionId" ("nadie lo diria en la vida");
+  la gente dice "el codigo". Naming por posicion: Codigo anidado, CodigoColaborador aplanado.
+- **StreamId = identificacion** disuelve la invariante cross-stream ("identificacion no repetida
+  en estado activo por tenant") en invariante local: max una vinculacion vigente por stream.
+  Correccion de identificacion errada: cerrar stream y abrir el correcto (basura tolerable;
+  stream reutilizable por el dueno legitimo).
+- **Vinculacion** (no "Contrato": el promovido conserva su contrato laboral) es vocabulario
+  interno del aggregate; no cruza la frontera. Invariante nueva: las vinculaciones no se solapan.
+- **Etiquetas dinamicas** (pares categoria:valor libres): de la VINCULACION, no de la persona
+  (priman las laborales; reingreso nace limpio: huecos visibles > mentiras silenciosas). Un valor
+  por categoria. Doble forma original/normalizada (tildes/mayusculas) como invariante del VO;
+  filtrado por contencion JSONB + GIN (AND multi-etiqueta en una operacion). Se descarto la
+  taxonomia personal/laboral (incompatible con categorias dinamicas).
+- **Doctrina bitemporal del BC**: el tiempo de los hechos viene de afuera (fechas REQUERIDAS,
+  sin default del servidor); el sistema solo registra cuando se entero. Preaviso y carga tardia
+  son el mismo fenomeno. Nacio de la angustia "hoy no es hoy" del usuario.
+- **Vigencia sin booleano**: el preaviso voltea sin evento -> se materializan hechos
+  (VigenteDesde/VigenteHasta, centinela 9999-12-31) y la consulta evalua contra la fecha del
+  lector. Degradacion por retirados historicos: despreciable (numeros: ~40k docs/20 anos).
+- **Nombres**: 4 campos colombianos SOLO dentro de Colaboradores (captura granular, irreversible
+  perderla); NombreCompleto plano cruza fronteras (CA-ADR-0025 aplicado). Minimo legal: primer
+  nombre + primer apellido.
+- **TipoIdentificacion**: lista cerrada estilo PILA (CC, CE, TI, PA, PT) como VO sin sombra
+  numerica (la trampa del enum: 0,1,2 persistidos por accidente). Numero alfanumerico
+  (pasaportes), trim+mayusculas (compone clave de stream).
+- **Comandos intencionales + adaptadores**: RegistrarColaborador falla SIEMPRE si existe;
+  ReingresarColaborador (sin nombres) opera contra el stream. El "upsert" vive en los
+  adaptadores de fuentes automaticas (ACL), no en el dominio. El fallo es informativo
+  (MEF-ADR-0004).
+
+## Decisiones
+
+- Desglose en 10 issues: #348 (VOs identidad), #330 re-titulado (registrar), #349 (terminar),
+  #350 (reingresar), #351 (nombres), #352 (fecha inicio), #353 (VO Etiqueta), #354 (fecha
+  terminacion), #355 (etiquetar), #356 (ficha, projection N1), #357 (etiquetas en uso,
+  projection N2). Todos borradores (DoR exige rutas que no existen hasta /scaffold).
+- Borradores estrategicos: #358 (analisis impacto vinculaciones x marcaciones/dias calculados —
+  3 arquitecturas) y #359 (vista de ausencias, la motivacion original).
+- #340 re-alcanzado via comentario: EmpleadoId -> CodigoColaborador.
+- Sede natural del colaborador: DIFERIDA hasta que exista el dominio Sedes (probablemente
+  dominio propio pequeno — neutral entre Programacion/ControlHoras/Colaboradores).
+- Ingesta inicial: POST HTTP (interfaz minima convergente); webhook/UI/archivo despues.
+- Fichas: listado solo vigentes; puntual incluye no-vigentes (reingreso, adaptadores).
+- Label dom:colaboradores creado. Context map, glosario (7 terminos) y catalogo (8 eventos,
+  8 comandos, 1 aggregate, 4 VOs) actualizados.
+
+## Descartado
+
+- Nombres: Plantilla (Espana/futbol), Planta de personal ("de planta" excluye contratistas),
+  Nomina (ocupado), Maestro de X (canon de maestros), Contrato, VinculacionId, IdExterno,
+  DatosActualizados (generico sin semantica), sufijo View (acuerdo previo 2026-08-06).
+- Enum C# para TipoIdentificacion (sombra numerica).
+- Booleano Activo materializado y ShouldDelete de no-vigentes (necesitan reloj).
+- Etiquetas de la persona (mentira silenciosa del cargo viejo en reingreso).
+- Fusionar registro y reingreso en un comando (la ambiguedad se esconde, no desaparece).
+- Fechas de vinculacion con default del servidor (el usuario se desdijo: requeridas).
+
+## Preguntas abiertas
+
+- AnularTerminacion (arrepentimiento del preaviso): alcance de #354 o comando propio.
+- Etiquetas sin uso: salen de las recomendaciones? (refinamiento #357).
+- Ficha puntual de no-vigente: que muestra (refinamiento #356).
+- CorregirNombres exige vigencia? (el caso "reutilizo el stream" sugiere que no — refinamiento #351).
+- Unicidad de CodigoColaborador vigente por tenant (hoy la controla el sistema externo).
+- Dominio Sedes: sin issue; #338 y la sede natural lo esperan.
+- Etiquetado multi-dominio de #359 (dom:colaboradores + dom:control-horas).
+
+## Referencias
+
+Issues creados: #348-#357 (desglose), #358, #359 (borradores estrategicos).
+Issues editados: #330 (re-titulo + cuerpo completo), #340 (comentario de re-alcance).
+Artefactos: context-map.yaml, ubiquitous-language.yaml, catalog.yaml actualizados.
+Pendiente del usuario: correr /scaffold Colaboradores antes de refinar #348/#353 a listo.

--- a/docs/bitacora/field-notes/procesadas/2026-08-11-1235-planner.md
+++ b/docs/bitacora/field-notes/procesadas/2026-08-11-1235-planner.md
@@ -1,0 +1,43 @@
+---
+fecha: 2026-08-11
+hora: 12:35
+sesion: planner
+tema: Refinamiento de #330 (Registrar colaboradores) a estado:listo
+---
+
+## Contexto
+Refinar el borrador #330, corte del comando `RegistrarColaborador` del desglose del dominio
+Colaboradores (#348-#357). Su dependencia #348 (VOs de identidad) sigue abierta, asi que el
+label `bloqueado` se conserva.
+
+## Descubrimientos
+- El borrador proponia `RegistroColaboradorFallido` citando MEF-ADR-0004, pero el ADR (capa 2)
+  y el precedente `CrearTurnoCommandHandler` prescriben lo contrario para creacion HTTP con
+  stream existente: `InvalidOperationException` + mensaje `.resx` -> 409 Conflict. No existe
+  ningun evento `*Fallido` en el codebase; ademas el evento habria contaminado el stream del
+  colaborador legitimo. El evento nunca habia entrado al catalogo EDA.
+- El patron de idempotencia de RegistroDeMarcacion no se transfiere: alla el streamId codifica
+  la clave completa de deduplicacion; aca exigiria rehidratar y comparar 7 campos.
+- MEF-ADR-0037 conciliado con el contrato de #348: `ComputarStreamId(Identificacion)` del
+  aggregate delega en `Identificacion.ToString()` — punto unico de conversion.
+- `ConfiguracionSerializacionColaboradores` llega en este issue (primeros eventos persistidos
+  del dominio), invocada dentro del `ConfigureMarten` existente del scaffold.
+- Ruta HTTP: dominio y recurso homonimos -> `Route = "Colaboradores"` (evita
+  `Colaboradores/Colaboradores` y deja limpio el GET de #356). Propuesta revisable.
+
+## Decisiones
+- Usuario confirmo: 409 sin evento de fallo, y sin CA de idempotencia por duplicado exacto
+  (todo POST con identificacion existente -> 409; el cargador de migracion lo trata como
+  "ya registrado").
+- #330 pasa a estado:listo con 6 CAs de un solo eje (slice vertical del comando, dimensionado
+  como #105); `bloqueado` se mantiene hasta que cierre #348.
+
+## Descartado
+- Evento persistido `RegistroColaboradorFallido` (contradice MEF-ADR-0004 capa 2).
+- Idempotencia por payload exacto (costo de rehidratacion sin consumidor).
+
+## Preguntas abiertas
+- Ninguna nueva para #330. Las del desglose siguen en las field notes 2026-08-10.
+
+## Referencias
+Issues editados: #330 (cuerpo completo + estado:listo).

--- a/docs/bitacora/field-notes/procesadas/2026-08-11-1334-planner.md
+++ b/docs/bitacora/field-notes/procesadas/2026-08-11-1334-planner.md
@@ -1,0 +1,57 @@
+---
+fecha: 2026-08-11
+hora: 13:34
+sesion: planner
+tema: Refinamiento de #349 (Terminar vinculacion) — relectura de MEF-ADR-0004 y eliminacion del motivo
+---
+
+## Contexto
+Refinar #349, segundo comando del ciclo de vida de ColaboradorAggregateRoot. La conversacion
+derivo en una relectura profunda de MEF-ADR-0004 disparada por el usuario ("por que aceptamos
+un evento que no es posible recibir?").
+
+## Descubrimientos
+- **Relectura de MEF-ADR-0004**: la razon de ser de los eventos de fallo son los consumidores
+  downstream que reaccionan ("alguien downstream espera respuesta"); su principio general es
+  "el tipo de trigger determina el mecanismo". Para comandos HTTP de modificacion SIN
+  consumidores, persistir un evento de fallo deja ciego al caller (202 por un rechazo),
+  contamina el stream con hechos ajenos al colaborador, y estrena un patron sin lector.
+  El planner habia propuesto la lectura literal de la capa 3; el usuario detecto la
+  incoherencia y la doctrina completa le dio la razon.
+- Precedente interno de declinar-sin-emitir: ControlDiarioAggregateRoot.AdicionarMarcacion
+  (duplicados se ignoran sin evento de fallo).
+- Mecanismo compatible con no-throw + Tell-don't-Ask: el aggregate declina con resultado
+  (enum/VO), el handler traduce a InvalidOperationException/.resx, el endpoint responde 409
+  (molde SolicitarProgramacionTurno para 404/409).
+- **"Ya terminada" sin reloj**: la regla es "la ultima vinculacion tiene terminacion
+  registrada" — un preaviso futuro no vencido bloquea una segunda terminacion.
+- **Regla nueva**: FechaEfectiva < FechaInicio -> rechazo; == permitido (vinculacion de un
+  dia); futura sin limite.
+- **Motivo eliminado por completo** (no solo opcional): ninguna regla/consulta/vista del BC
+  lo usa; la fuente autoritativa del "por que salio" es RRHH/nomina — este BC no es su espejo.
+  Asimetria de reversa: agregarlo despues es aditivo barato; cargarlo siempre es ruido
+  persistido. Catalogo EDA actualizado (evento y comando sin Motivo).
+
+## Decisiones
+- #349 a estado:listo (bloqueado por #330). 7 CAs (6 del comando + 1 documental).
+- **CA-ADR-0030 entra al alcance de #349**: "violaciones de regla de negocio en comandos HTTP
+  sin consumidores downstream -> status code sincrono (409 + .resx); eventos de fallo solo
+  con un consumidor que reaccione". Gobierna #350/#351/#352/#355 sin re-discutir.
+- TerminacionVinculacionFallida DESCARTADO (nunca entro al catalogo).
+- Ruta: POST Colaboradores/Terminaciones (identificacion en el body — la clave contiene ':').
+- AnularTerminacion (arrepentimiento del preaviso): se decide al refinar #354.
+
+## Descartado
+- Evento de fallo persistido + 202 (lectura literal de capa 3 sin su razon de ser).
+- Motivo opcional (dato ajeno sin lector).
+- Vigencia evaluada contra el reloj del servidor.
+
+## Preguntas abiertas
+- Los borradores #350/#351/#352/#355 aun proponen eventos de fallo (*Fallido): al refinarlos,
+  aplicar CA-ADR-0030 y limpiar sus modelos de eventos.
+- AnularTerminacion: alcance de #354 o comando propio (pendiente de ese refinamiento).
+
+## Referencias
+Issues editados: #349 (cuerpo completo + estado:listo).
+Artefactos: docs/eda/catalog.yaml (VinculacionTerminada y TerminarVinculacion sin Motivo,
+notas de refinamiento).

--- a/docs/bitacora/field-notes/procesadas/2026-08-11-1412-planner.md
+++ b/docs/bitacora/field-notes/procesadas/2026-08-11-1412-planner.md
@@ -1,0 +1,62 @@
+---
+fecha: 2026-08-11
+hora: 14:12
+sesion: planner
+tema: Refinamiento en cadena de #350, #351, #352 y #354 (dominio Colaboradores)
+---
+
+## Contexto
+Continuacion de la sesion que refino #330 y #349. Con el patron CA-ADR-0030 fijado
+(409/404 sincronos, declinar-con-resultado, sin eventos de fallo), los siguientes
+refinamientos fueron rapidos: una pregunta de negocio por issue.
+
+## Descubrimientos
+- **#350 (Reingresar)**: la frontera del no-solape es estricta — el dia de la fecha
+  efectiva pertenece a la vinculacion que termina, asi que el reingreso debe iniciar
+  estrictamente despues. El preaviso se resuelve componiendo las reglas existentes,
+  sin regla nueva y sin reloj. Cero tipos de evento nuevos (reutiliza VinculacionIniciada).
+- **#351 (Corregir nombres)**: solo exige existencia, no vigencia — los nombres son de la
+  PERSONA (viven en ColaboradorRegistrado), y exigir vigencia bloquearia la reutilizacion
+  del stream y la limpieza de historicos. Resuelve pregunta abierta de las field notes
+  2026-08-10. Idempotencia silenciosa por igualdad de valor (patron AdicionarMarcacion).
+- **#352 (Corregir fecha inicio)**: "vigente" no existe en el modelo sin reloj — el alcance
+  se preciso a "la ULTIMA vinculacion, con o sin terminacion registrada", cerrando el gap
+  del preaviso con dos reglas de coherencia (no-solape hacia atras estricto; fecha <= 
+  terminacion propia si existe).
+- **#354 — insight del usuario que elimino un comando**: "si creamos AnularTerminacion,
+  corregir fecha es Anular + Terminar". El comando de correccion de fecha de terminacion
+  y sus tres reglas desaparecen por composicion: AnularTerminacion (una sola regla, sin
+  fechas en el payload) + TerminarVinculacion re-valida todo gratis. El "caso delicado"
+  del desglose se volvio el comando mas simple de la cadena. Consecuencia aprobada
+  explicitamente: tras un reingreso, la terminacion anterior queda congelada (anularla
+  crearia dos vinculaciones abiertas).
+
+## Decisiones
+- #350, #351, #352, #354 a estado:listo (todos bloqueados por su antecesor en la cadena).
+- Cadena secuencial completa: #348 -> #330 -> #349 -> #350 -> #351/#352/#354 (todos tocan
+  ColaboradorAggregateRoot; #351 depende de #349, #352 y #354 de #350).
+- #354 re-titulado: "Anular la terminacion de una vinculacion" (comando AnularTerminacion,
+  evento TerminacionAnulada sin payload). Resuelve la pregunta abierta del arrepentimiento
+  del preaviso.
+- Rutas fijadas (revisables): Colaboradores/Reingresos, Colaboradores/Nombres,
+  Colaboradores/FechasInicio, Colaboradores/Terminaciones/Anulaciones.
+- Catalogo EDA actualizado en cada paso: ReingresarColaborador y CorregirFechaInicio
+  con sus refinamientos; CorregirFechaTerminacionVinculacion/FechaTerminacionVinculacionCorregida
+  REEMPLAZADOS por AnularTerminacion/TerminacionAnulada.
+
+## Descartado
+- Eventos *Fallido de los cuatro borradores (CA-ADR-0030).
+- Reingreso el mismo dia de la terminacion (el dia efectivo pertenece a la vinculacion vieja).
+- Exigir vigencia para corregir nombres (impone orden artificial).
+- Alcance "solo la abierta" en #352 (gap del preaviso).
+- Comando CorregirFechaTerminacionVinculacion completo (composicion anular+terminar).
+- DELETE como verbo de AnularTerminacion (identidad en body; consistencia POST).
+
+## Preguntas abiertas
+- #355 (etiquetas): pendiente de refinar — ultima pieza write-side de la cadena.
+- #356/#357 (projections): esperan la cadena; el filtrado JSONB+GIN se discute alli.
+- Anular terminaciones anteriores a la ultima: sin caso real, diferido (comando nuevo si aparece).
+
+## Referencias
+Issues editados: #350, #351, #352, #354 (cuerpos completos + estado:listo; #354 re-titulado).
+Artefactos: docs/eda/catalog.yaml (4 actualizaciones).

--- a/docs/bitacora/field-notes/procesadas/2026-08-11-1442-planner.md
+++ b/docs/bitacora/field-notes/procesadas/2026-08-11-1442-planner.md
@@ -1,0 +1,48 @@
+---
+fecha: 2026-08-11
+hora: 14:42
+sesion: planner
+tema: Refinamiento de #355 (etiquetas) — cierre del write-side de Colaboradores
+---
+
+## Contexto
+Ultimo refinamiento del write-side del desglose Colaboradores. Dos preguntas de negocio,
+resueltas una a una (correccion de metodo a mitad de sesion: el usuario exigio pregunta
+por pregunta, SIEMPRE — no agrupar decisiones aunque parezcan livianas).
+
+## Descubrimientos
+- **Regla estricta de apertura (usuario eligio A contra la recomendacion del planner)**:
+  asignar y retirar etiquetas exigen vinculacion sin terminacion registrada. Durante un
+  preaviso las etiquetas quedan CONGELADAS (409) — las etiquetas describen la relacion
+  laboral activa. El planner recomendaba "solo existencia" (simetria con #351, caso del
+  preaviso); el usuario prefirio la estricta. Consecuencia asumida: correcciones de
+  etiquetas durante el preaviso no son posibles.
+- **Retirar categoria inexistente -> 409**: con categorias libres, el typo ("aera" por
+  "area") debe aflorar al instante; el silencio idempotente seria la mentira silenciosa
+  que la sesion original quiso evitar.
+- Asignar etiqueta identica por valor -> 202 sin evento (idempotencia silenciosa, patron #351).
+- El reset de etiquetas en el reingreso ("nace limpio") entra al alcance de #355:
+  extiende Apply(VinculacionIniciada).
+
+## Decisiones
+- #355 a estado:listo (depende de #350 + #353). 7 CAs homogeneos; dos comandos gemelos
+  en un issue (partir seria corte cosmetico — Given acoplados).
+- Rutas: POST Colaboradores/Etiquetas y Colaboradores/Etiquetas/Retiros.
+- Catalogo EDA alineado (regla estricta, 409 retirar inexistente, triggers POST).
+
+## Descartado
+- "Solo existencia" para la regla de apertura (el usuario eligio la estricta).
+- Silencio al retirar inexistente.
+- Partir asignar/retirar en dos issues.
+
+## Preguntas abiertas
+- #356/#357 (projections): siguientes a refinar — tipo:projection con su propio template
+  (via de consulta, receta N1/N2, endpoints GET). #356 ademas trae la pregunta "que muestra
+  la ficha puntual de un no-vigente".
+- Si la regla estricta de etiquetas resulta incomoda en el preaviso real, el cambio es
+  barato (relajar la regla del aggregate) — dejar madurar con uso.
+
+## Referencias
+Issues editados: #355 (cuerpo completo + estado:listo).
+Artefactos: docs/eda/catalog.yaml (3 entradas de etiquetas actualizadas).
+Metodo: pregunta por pregunta, siempre — anotado para futuras sesiones del planner.

--- a/docs/bitacora/field-notes/procesadas/2026-08-12-1139-planner.md
+++ b/docs/bitacora/field-notes/procesadas/2026-08-12-1139-planner.md
@@ -1,0 +1,46 @@
+---
+fecha: 2026-08-12
+hora: "11:39"
+sesion: planner
+tema: Refinamiento de #373 (listado de fichas con verbo QUERY) tras verificar #356
+---
+
+## Contexto
+El usuario pidio refinar #356; se verifico que ya estaba `estado:listo` y completo (refinado antes,
+todas sus afirmaciones re-verificadas contra el codigo). El refinamiento pendiente era en realidad
+el #373 (listado con filtros), que estaba en borrador esperando el verbo HTTP QUERY de Mefisto.
+
+## Descubrimientos
+- El bloqueo de Mefisto se levanto: plugin activo 0.22.0 con MEF-ADR-0042 (doctrina GET vs QUERY,
+  paginacion keyset, filtros tipados, RFC 10008). Issues #587/#608/#609 de Mefisto cerrados.
+- Sin APIM en infra dev: los gates APIM/CORS del ADR no aplican; el gate del front-end de App
+  Service SI (este sera el primer endpoint QUERY real del consumidor).
+- El precedente `RangoConsulta.cs` ya documenta el determinismo de las queries ("nunca relativo a
+  la fecha de hoy") — coherente con el termino existente "Tiempo del hecho / tiempo de registro".
+
+## Decisiones
+1. **FechaReferencia obligatoria en el body; el back jamas resuelve "hoy"** — lo resuelve el
+   consumidor en su zona horaria. Descarta default UTC (incorrecto para Colombia UTC-5 desde
+   ~19:00) y descarta zona horaria por tenant (concepto inexistente, Rule of Three).
+2. **Orden por NombreCompleto con desempate por Id** (cursor compuesto `CursorFicha`): ideal para
+   el usuario aunque amplia el gate NO VERIFICADO de Marten (CompareTo sobre strings). Anomalia
+   aceptada: nombre mutable por `NombresCorregidos` puede saltar/repetir una ficha en paginacion.
+3. **Take default 50, tope 200** (clamp servidor). Se aclaro que el tope acota la pagina, no el
+   listado: ningun empleado queda excluido, la completitud la da el cursor.
+4. Respuesta sin envelope (cursor derivable de la ultima fila) — propuesta revisable.
+5. Indice btree sobre NombreCompleto se suma a los dos ya previstos en el seam.
+6. Colacion de Postgres decide el orden visible de tildes/ñ: se registra en el reporte del gate;
+   NO se construye campo normalizado de orden (seria enmienda a la vista con issue propio).
+
+## Descartado
+- Default de "hoy" resuelto en el back (UTC o zona por tenant).
+- Tope de pagina ilimitado ("sin tope"): viola el clamp doctrinal de MEF-ADR-0042.
+- Orden por Id puro (irregular para el usuario).
+
+## Preguntas abiertas
+- Ninguna para #373. El #357 (etiquetas en uso) sigue en borrador sin refinar.
+
+## Referencias
+Issues editados: #373 (refinado completo, `estado:borrador` -> `estado:listo`, conserva `bloqueado`
+por #356 abierto). Glosario: agregado "Fecha de referencia" (docs/eda/ubiquitous-language.yaml —
+pendiente el `git mv` a docs/ddd/).

--- a/docs/bitacora/field-notes/procesadas/2026-08-13-0738-planner.md
+++ b/docs/bitacora/field-notes/procesadas/2026-08-13-0738-planner.md
@@ -1,0 +1,78 @@
+---
+fecha: 2026-08-13
+hora: 07:38
+sesion: planner
+tema: refinamiento #357 (CategoriaDeEtiquetas) + investigacion y doctrina HTTP REST para comandos event-sourced
+---
+
+## Contexto
+La sesion arranco como refinamiento del borrador #357 (autocompletado de etiquetas). Al discutir las rutas
+de los endpoints, el experto cuestiono la justificacion del POST-a-buzon vs DELETE y detecto que las URIs
+del sistema se venian justificando por precedente interno sin doctrina escrita. La sesion derivo en una
+investigacion profunda de fuentes primarias y en la destilacion de una doctrina HTTP, evaluando las 13
+rutas del sistema una a una con el experto.
+
+## Descubrimientos
+- **Reingresar = iniciar vinculacion**: `Reingresar` emite el MISMO evento que el registro
+  (`VinculacionIniciada`) -- el dominio ya habia unificado el hecho; solo el comando quedo partido.
+  Principio destilado: el cliente no declara lo que el servidor deriva de la historia del stream.
+  "Reingreso" nombra el escenario, no un comando.
+- **La granularidad de los recursos REST la dictan los VOs del dominio**: `nombres` es PUT-able porque
+  `NombreColaborador` es un VO atomico; `fecha-inicio` no lo es porque es un DateOnly suelto. Ni PUT
+  de pseudo-recurso ni PATCH (embudo de intenciones: varios comandos colapsando en un PATCH del mismo
+  recurso, distinguibles solo por el body -- rompe una-Function-por-comando).
+- **Simetria CQRS de la forma `:verbo`**: la API habla en imperativo (comandos = intenciones), el event
+  store en pasado (eventos = hechos). El buzon sustantivo invade el espacio gramatical de los eventos.
+- **La vinculacion tiene identidad direccionable**: el codigo. Ponerlo en la ruta agrega salvaguarda
+  tipo concurrencia optimista (rechazar si el codigo no es el de la vinculacion actual).
+- **La solicitud de programacion es un create genuino**: tiene Guid propio generado por el cliente.
+- Fuentes verificadas: RFC 9110 (POST/PUT/DELETE, 409 por constraints en PUT, sin body en DELETE),
+  Fielding "It is okay to use POST" (2009), Zalando (avoid actions/letter box, PATCH), Google AIP-136
+  (custom methods `:verbo`, prefer standard), Microsoft Azure Guidelines (`:action`, `:` proscrito en
+  ids), Greg Young (task-based UI), Dudycz (comandos via REST, eventos via colas), RFC 5789/7386.
+- Correccion honesta durante la sesion: el argumento "el `:` es hostil en URLs" es debil por RFC 3986
+  (legal en path y query); lo que lo proscribe en ids es la guia de Microsoft, no el RFC.
+
+## Decisiones
+- **#357 refinado y en estado:listo**: vista `CategoriaDeEtiquetas` (N2, la primera MultiStream del BC),
+  catalogo acumulativo (nada sale; Rule of Three para depuracion futura), display "la ultima gana",
+  un solo endpoint `ListarCategoriasDeEtiquetas` GET `colaboradores/etiquetas/categorias` (opcion B;
+  el Obtener por id se agrega si un caso real lo pide).
+- **Doctrina HTTP destilada** (test de precedencia): (1) ids URL-safe, `:` reservado para acciones;
+  (2) create -- incluso disfrazado -- va POST a coleccion; (3) replace completo de VO atomico va PUT
+  (409 sancionado por RFC 9110); (4) remove veraz sin payload va DELETE; (5) el resto son acciones
+  `POST {recurso}:{verbo}`; (6) PATCH proscrito con VOs atomicos; (7) kebab-case; (8) NO VERIFICADO:
+  literal `:` en route templates del worker aislado.
+- **Draft #621 en el harness** con mandato explicito: el planner propone el test al crear endpoints;
+  el reviewer recibe checklist de evaluacion para PRs que crean/modifican endpoints HTTP.
+- **Issues de migracion del consumidor** (borrador + bloqueado por #621): #376 etiquetas PUT/DELETE +
+  representacion URL-safe de Identificacion; #377 nombres PUT; #378 reingreso como POST vinculaciones
+  + rename IniciarVinculacion; #379 acciones `:terminar`/`:anular-terminacion`/`:corregir-fecha-inicio`
+  + verificacion empirica del `:`; #380 ruta solicitudes-de-turno.
+- Glosario actualizado: termino CategoriaDeEtiquetas; nota en Vinculacion sobre reingreso.
+
+## Descartado
+- Contar usos para depurar el catalogo de etiquetas (EtiquetaRetirada no trae el valor; retiros
+  implicitos exigirian estado por colaborador -- N3 sin beneficio).
+- Nombres de vista: Etiqueta (homonimia con el VO), EtiquetasEnUso, SugerenciaDeEtiquetas.
+- DELETE para TerminarVinculacion (miente + payload bitemporal sin body posible).
+- PATCH como verbo del BC (VOs atomicos, trampa del null, embudo de intenciones).
+- Command bus HTTP (`POST /comandos`): pierde routing, auth por ruta, observabilidad por endpoint.
+- Buzon `correcciones-de-fecha-inicio` (invade el espacio nominal de los eventos; gana `:verbo`).
+- Comando ReingresarColaborador como concepto distinto (es IniciarVinculacion).
+- Issue endpoint `ObtenerCategoriaDeEtiquetas` por id (Rule of Three).
+
+## Preguntas abiertas
+- ¿El route template del worker aislado soporta el literal `:` pegado a un parametro
+  (`{codigo}:terminar`)? Verificacion empirica en #379; resultado se reporta a #621.
+- Representacion URL-safe exacta de la Identificacion (`CC-79543210` vs dos segmentos): se fija en
+  el refinamiento de #376.
+- ¿Google camelCase (`:corregirFechaInicio`) o kebab (`:corregir-fecha-inicio`) en el verbo de accion?
+  Decision del ADR en el harness.
+
+## Referencias
+Issues creados: harness #621 (draft doctrina HTTP); consumidor #376, #377, #378, #379, #380
+(migracion, borrador+bloqueado). Issue refinado: #357 (estado:listo). Pendiente de sesiones previas:
+#356 sigue listo; #357 y #356 se serializan al implementar (/sequential, dos tipo:projection).
+Sugerencia vigente: `git mv docs/eda/ubiquitous-language.yaml docs/ddd/ubiquitous-language.yaml`
+(el glosario sigue en la ruta vieja).

--- a/docs/bitacora/field-notes/procesadas/2026-08-14-1506-planner.md
+++ b/docs/bitacora/field-notes/procesadas/2026-08-14-1506-planner.md
@@ -1,0 +1,55 @@
+---
+fecha: 2026-08-14
+hora: 15:06
+sesion: planner
+tema: Llave de Colaborador con guion y limpieza alfanumerica del numero de identificacion
+---
+
+## Contexto
+El usuario necesita cambiar la llave del stream de Colaborador de "{Tipo}:{Numero}" a
+"{Tipo}-{Numero}" (el ":" es problematico como segmento de URI, pensando en las rutas
+orientadas a recurso de #378) y restringir el numero de documento a alfanumerico.
+
+## Descubrimientos
+- Las dos peticiones son UN solo contrato de identidad: la limpieza (solo [A-Z0-9]) es lo
+  que hace del guion un separador inequivoco — hoy "AB-123" es numero legal (pasaportes) y
+  "CC-AB-123" seria ambiguo sin limpieza. Un solo issue, no dos.
+- La limpieza es invariante del VO (precedente Etiqueta, MEF-ADR-0012): letras a MAYUSCULAS,
+  todo caracter no alfanumerico se ELIMINA sin error. No es validacion de borde — el
+  validador HTTP sigue solo con NotEmpty.
+- Etiqueta.ToString() tambien usa ":" pero es display/debug sin consumidores externos, no es
+  llave de stream ni viaja en URI — verificado en codigo, fuera del alcance.
+- MEF-ADR-0036 no aplica: cubre identidad de TIPOS de evento, no llaves de stream. La
+  consecuencia analoga (streams huerfanos en dev) se decidio como tolerable.
+
+## Decisiones
+- Vacio tras la limpieza ("---") ES error: se reusa Mensajes.NumeroVacio, evaluado despues
+  de limpiar.
+- Se toleran los streams huerfanos en dev (no hay produccion; datos de smoke tests). Sin
+  purga ni protocolo de dos despliegues.
+- Alcance de "letras": ASCII [A-Z0-9]; enies y acentuadas son caracteres invalidos y se
+  eliminan (propuesta revisable en el issue).
+- Glosario actualizado: definicion de Identificacion (separador + limpieza).
+
+## Descartado
+- Cambiar solo el separador sin limpieza (llave ambigua).
+- Limpiar en el handler en vez del VO (dejaria caminos sin la invariante).
+- Tocar Etiqueta.ToString().
+
+## Preguntas abiertas
+- Ninguna nueva.
+
+## Revision post-merge (misma sesion)
+#381 se implemento y mergeo el mismo dia (PR #382). Revision del backlog por divergencias:
+- #373 (listo): dependencia de #356 marcada SATISFECHA (cerrado via PR #375); el Id de
+  FichaColaborador ya nacio con el contrato nuevo "{Tipo}-{Numero}" — el cursor keyset es
+  agnostico al formato, nada mas cambia.
+- #376 (borrador): la "decision de forma URL-safe de la Identificacion" que dejaba pendiente
+  quedo tomada por #381 — el {id} de ruta ES Identificacion.ToString() (MEF-ADR-0037, punto
+  unico de conversion); en su alcance queda solo el parseo inverso ruta->Identificacion.
+- #377-#379 heredan via #376 (sin edicion); #357 agrupa por categoria (sin impacto);
+  #359 correlaciona por campos separados Tipo+Numero (sin impacto).
+
+## Referencias
+Issues creados: #381 (Cambiar el separador de la llave de Colaborador a guion y limpiar el
+numero de identificacion a alfanumerico — tipo:feature, dom:colaboradores, estado:listo).


### PR DESCRIPTION
Pone al dia la bitacora: 8 entradas nuevas (2026-08-04 a 2026-08-14). 13 field notes movidas a `procesadas/`.

## Entradas

- **2026-08-04** — OIDC, el Sampler Fantasma y el Robo de Mensajes
- **2026-08-05** — Nacen las Tres Islas
- **2026-08-06** — La Retractación: TurnoVigente Nace del Actor, no del Evento
- **2026-08-10** — El Nacimiento del Dominio Colaboradores
- **2026-08-11** — Nueve Comandos en un Día, y un ADR que Nació de una Pregunta Incómoda
- **2026-08-12** — El Verbo QUERY se Desbloquea
- **2026-08-13** — Trece Rutas Bajo la Lupa: la Doctrina HTTP que Faltaba
- **2026-08-14** — El Guion que Cambia (y Arregla) la Identidad de Colaborador

Nota: los días 2026-08-07 a 09 tuvieron actividad de commits pero no dejaron field notes propias en el backlog (su razonamiento quedó consolidado en la nota del día 10), así que no generan entrada propia en esta corrida.

🤖 Generado con [Claude Code](https://claude.com/claude-code)