### PR TITLE
Restringir el codigo de la vinculacion a caracteres URL-safe

### DIFF
--- a/src/Bitakora.ControlAsistencia.Colaboradores/Infraestructura/ValidacionesCompartidas.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/Infraestructura/ValidacionesCompartidas.cs
@@ -1,0 +1,24 @@
+using System.Text.RegularExpressions;
+using FluentValidation;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Infraestructura;
+
+// Issue #387: CodigoColaborador debe ser URL-safe porque viajara como segmento de ruta
+// (vinculaciones/{codigo}:terminar, issue #379). Set permitido: unreserved characters de RFC 3986
+// seccion 2.3 (A-Z a-z 0-9 - . _ ~) -- el mismo set que las Microsoft Azure REST API Guidelines
+// fijan para path segments (MEF-ADR-0043 seccion 1). El ":" queda explicitamente fuera (reservado
+// como separador de accion). Se RECHAZA (400), nunca se limpia ni normaliza en silencio -- a
+// diferencia de Identificacion (#381), el codigo lo asigna la empresa y alterarlo cambiaria un dato
+// ajeno.
+//
+// La regla aparece en dos validators (RegistrarColaboradorValidator, ReingresarColaboradorValidator)
+// -- MEF-ADR-0018 (Rule of Three): compartir la definicion unica evita que diverjan.
+public static partial class ValidacionesCompartidas
+{
+    [GeneratedRegex("^[A-Za-z0-9._~-]+$")]
+    private static partial Regex CodigoColaboradorUrlSafeRegex();
+
+    public static IRuleBuilderOptions<T, string> DebeSerCodigoColaboradorUrlSafe<T>(
+        this IRuleBuilder<T, string> ruleBuilder) =>
+        ruleBuilder.Matches(CodigoColaboradorUrlSafeRegex());
+}

--- a/src/Bitakora.ControlAsistencia.Colaboradores/Infraestructura/ValidacionesCompartidas.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/Infraestructura/ValidacionesCompartidas.cs
@@ -12,13 +12,27 @@ namespace Bitakora.ControlAsistencia.Colaboradores.Infraestructura;
 // ajeno.
 //
 // La regla aparece en dos validators (RegistrarColaboradorValidator, ReingresarColaboradorValidator)
-// -- MEF-ADR-0018 (Rule of Three): compartir la definicion unica evita que diverjan.
+// y se define en un solo lugar por exigencia del CA-4 del issue. Con dos sitios, la Rule of Three de
+// MEF-ADR-0018 toleraria la duplicacion, pero esa heuristica regula reglas del DOMINIO que pueden
+// divergir: aqui el set de caracteres es mecanica neutral (una precondicion de la URL, identica para
+// cualquier comando que reciba el codigo), que ese mismo ADR deja fuera de su alcance.
 public static partial class ValidacionesCompartidas
 {
-    [GeneratedRegex("^[A-Za-z0-9._~-]+$")]
+    // Anclas \A y \z (no ^ y $): en .NET el ancla "$" hace match tambien ANTES de un "\n" final,
+    // asi que "^...$" aceptaria "COL-001\n" -- un valor que rompe la URL igual que un espacio y que
+    // ademas habilita CRLF injection en cualquier consumidor que lo reenvie en un header o lo
+    // escriba en un log. "\z" ancla al fin real de la cadena, sin esa excepcion.
+    [GeneratedRegex(@"\A[A-Za-z0-9._~-]+\z")]
     private static partial Regex CodigoColaboradorUrlSafeRegex();
 
+    // Mensaje explicito en vez del default de FluentValidation ("is not in the correct format"):
+    // este texto viaja al cliente dentro del ValidationProblemDetails del 400 (RequestValidator), y
+    // el default no le dice al integrador cual es el formato esperado. Mismo criterio que la regla
+    // de TipoIdentificacion en estos dos validators.
     public static IRuleBuilderOptions<T, string> DebeSerCodigoColaboradorUrlSafe<T>(
         this IRuleBuilder<T, string> ruleBuilder) =>
-        ruleBuilder.Matches(CodigoColaboradorUrlSafeRegex());
+        ruleBuilder
+            .Matches(CodigoColaboradorUrlSafeRegex())
+            .WithMessage(
+                "El codigo del colaborador solo admite letras sin tilde, digitos y los caracteres - . _ ~");
 }

--- a/src/Bitakora.ControlAsistencia.Colaboradores/RegistrarColaboradorFunction/CommandHandler/RegistrarColaboradorValidator.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/RegistrarColaboradorFunction/CommandHandler/RegistrarColaboradorValidator.cs
@@ -1,4 +1,5 @@
 using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+using Bitakora.ControlAsistencia.Colaboradores.Infraestructura;
 using FluentValidation;
 
 namespace Bitakora.ControlAsistencia.Colaboradores.RegistrarColaboradorFunction.CommandHandler;
@@ -9,6 +10,10 @@ namespace Bitakora.ControlAsistencia.Colaboradores.RegistrarColaboradorFunction.
 // SegundoNombre/SegundoApellido son opcionales (NombreColaborador.Crear ya los normaliza).
 // Se descubre solo via el AddValidatorsFromAssemblyContaining que ComposicionServicios ya configura:
 // no requiere tocar el wiring de DI.
+//
+// Issue #387: CodigoColaborador ademas debe ser URL-safe (Cascade(Stop): NotEmpty primero, la regla
+// de caracteres solo evalua un valor no vacio) -- ver ValidacionesCompartidas para el detalle del
+// set permitido.
 public class RegistrarColaboradorValidator : AbstractValidator<RegistrarColaborador>
 {
     public RegistrarColaboradorValidator()
@@ -26,7 +31,11 @@ public class RegistrarColaboradorValidator : AbstractValidator<RegistrarColabora
         RuleFor(x => x.NumeroIdentificacion).NotEmpty();
         RuleFor(x => x.PrimerNombre).NotEmpty();
         RuleFor(x => x.PrimerApellido).NotEmpty();
-        RuleFor(x => x.CodigoColaborador).NotEmpty();
+
+        RuleFor(x => x.CodigoColaborador)
+            .Cascade(CascadeMode.Stop)
+            .NotEmpty()
+            .DebeSerCodigoColaboradorUrlSafe();
 
         // FechaInicio es REQUERIDA -- el default de DateOnly (0001-01-01) equivale a "no llego"
         // (doctrina bitemporal del BC: el tiempo de los hechos viene del cliente).

--- a/src/Bitakora.ControlAsistencia.Colaboradores/ReingresarColaboradorFunction/CommandHandler/ReingresarColaboradorValidator.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/ReingresarColaboradorFunction/CommandHandler/ReingresarColaboradorValidator.cs
@@ -1,4 +1,5 @@
 using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+using Bitakora.ControlAsistencia.Colaboradores.Infraestructura;
 using FluentValidation;
 
 namespace Bitakora.ControlAsistencia.Colaboradores.ReingresarColaboradorFunction.CommandHandler;
@@ -10,6 +11,10 @@ namespace Bitakora.ControlAsistencia.Colaboradores.ReingresarColaboradorFunction
 // FechaInicio requeridos.
 // Se descubre via el AddValidatorsFromAssemblyContaining que ComposicionServicios ya configura: no
 // requiere tocar el wiring de DI.
+//
+// Issue #387: CodigoColaborador ademas debe ser URL-safe (Cascade(Stop): NotEmpty primero, la regla
+// de caracteres solo evalua un valor no vacio) -- ver ValidacionesCompartidas para el detalle del
+// set permitido.
 public class ReingresarColaboradorValidator : AbstractValidator<ReingresarColaborador>
 {
     public ReingresarColaboradorValidator()
@@ -24,7 +29,10 @@ public class ReingresarColaboradorValidator : AbstractValidator<ReingresarColabo
 
         RuleFor(x => x.NumeroIdentificacion).NotEmpty();
 
-        RuleFor(x => x.CodigoColaborador).NotEmpty();
+        RuleFor(x => x.CodigoColaborador)
+            .Cascade(CascadeMode.Stop)
+            .NotEmpty()
+            .DebeSerCodigoColaboradorUrlSafe();
 
         // FechaInicio es REQUERIDA -- el default de DateOnly (0001-01-01) equivale a "no llego"
         // (doctrina bitemporal del BC: el tiempo de los hechos viene del cliente).

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/AnularTerminacionFunction/AnularTerminacionSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/AnularTerminacionFunction/AnularTerminacionSmokeTests.cs
@@ -35,6 +35,7 @@ using System.Net;
 using System.Net.Http.Json;
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.Colaboradores.SmokeTests.Fixtures;
+using static Bitakora.ControlAsistencia.Colaboradores.SmokeTests.Fixtures.DatosDePrueba;
 
 namespace Bitakora.ControlAsistencia.Colaboradores.SmokeTests.AnularTerminacionFunction;
 
@@ -59,10 +60,6 @@ public class AnularTerminacionSmokeTests(ApiFixture api, PostgresFixture postgre
     // sobrevive intacto a la limpieza del numero (#381) y la llave esperada de abajo coincide con
     // la que arma el backend.
     private static string NuevoNumeroIdentificacion() => Guid.CreateVersion7().ToString("N").ToUpperInvariant();
-
-    // Issue #387: codigo URL-safe (unreserved RFC 3986) -- corregido de "[TEST]-" (corchetes
-    // fuera del set permitido) a "TEST-" para que el arrange no falle con 400.
-    private static string NuevoCodigoColaborador() => $"TEST-{Guid.CreateVersion7()}";
 
     // Oraculo independiente de la clave de stream (MEF-ADR-0002): se recompone aqui a mano, no se
     // deriva de Identificacion.ToString(), para que un cambio de formato en el VO no se auto-valide.

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/AnularTerminacionFunction/AnularTerminacionSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/AnularTerminacionFunction/AnularTerminacionSmokeTests.cs
@@ -60,7 +60,9 @@ public class AnularTerminacionSmokeTests(ApiFixture api, PostgresFixture postgre
     // la que arma el backend.
     private static string NuevoNumeroIdentificacion() => Guid.CreateVersion7().ToString("N").ToUpperInvariant();
 
-    private static string NuevoCodigoColaborador() => $"[TEST]-{Guid.CreateVersion7()}";
+    // Issue #387: codigo URL-safe (unreserved RFC 3986) -- corregido de "[TEST]-" (corchetes
+    // fuera del set permitido) a "TEST-" para que el arrange no falle con 400.
+    private static string NuevoCodigoColaborador() => $"TEST-{Guid.CreateVersion7()}";
 
     // Oraculo independiente de la clave de stream (MEF-ADR-0002): se recompone aqui a mano, no se
     // deriva de Identificacion.ToString(), para que un cambio de formato en el VO no se auto-valide.

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/AsignarEtiquetaFunction/AsignarEtiquetaSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/AsignarEtiquetaFunction/AsignarEtiquetaSmokeTests.cs
@@ -73,7 +73,9 @@ public class AsignarEtiquetaSmokeTests(ApiFixture api, PostgresFixture postgres)
     // la que arma el backend.
     private static string NuevoNumeroIdentificacion() => Guid.CreateVersion7().ToString("N").ToUpperInvariant();
 
-    private static string NuevoCodigoColaborador() => $"[TEST]-{Guid.CreateVersion7()}";
+    // Issue #387: codigo URL-safe (unreserved RFC 3986) -- corregido de "[TEST]-" (corchetes
+    // fuera del set permitido) a "TEST-" para que el arrange no falle con 400.
+    private static string NuevoCodigoColaborador() => $"TEST-{Guid.CreateVersion7()}";
 
     // Oraculo independiente de la clave de stream (MEF-ADR-0002): se recompone aqui a mano, no se
     // deriva de Identificacion.ToString(), para que un cambio de formato en el VO no se auto-valide.

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/AsignarEtiquetaFunction/AsignarEtiquetaSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/AsignarEtiquetaFunction/AsignarEtiquetaSmokeTests.cs
@@ -42,6 +42,7 @@ using System.Text.Json;
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
 using Bitakora.ControlAsistencia.Colaboradores.SmokeTests.Fixtures;
+using static Bitakora.ControlAsistencia.Colaboradores.SmokeTests.Fixtures.DatosDePrueba;
 
 namespace Bitakora.ControlAsistencia.Colaboradores.SmokeTests.AsignarEtiquetaFunction;
 
@@ -72,10 +73,6 @@ public class AsignarEtiquetaSmokeTests(ApiFixture api, PostgresFixture postgres)
     // sobrevive intacto a la limpieza del numero (#381) y la llave esperada de abajo coincide con
     // la que arma el backend.
     private static string NuevoNumeroIdentificacion() => Guid.CreateVersion7().ToString("N").ToUpperInvariant();
-
-    // Issue #387: codigo URL-safe (unreserved RFC 3986) -- corregido de "[TEST]-" (corchetes
-    // fuera del set permitido) a "TEST-" para que el arrange no falle con 400.
-    private static string NuevoCodigoColaborador() => $"TEST-{Guid.CreateVersion7()}";
 
     // Oraculo independiente de la clave de stream (MEF-ADR-0002): se recompone aqui a mano, no se
     // deriva de Identificacion.ToString(), para que un cambio de formato en el VO no se auto-valide.

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/CorregirFechaInicioVinculacionFunction/CorregirFechaInicioVinculacionSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/CorregirFechaInicioVinculacionFunction/CorregirFechaInicioVinculacionSmokeTests.cs
@@ -55,7 +55,9 @@ public class CorregirFechaInicioVinculacionSmokeTests(ApiFixture api, PostgresFi
     // la que arma el backend.
     private static string NuevoNumeroIdentificacion() => Guid.CreateVersion7().ToString("N").ToUpperInvariant();
 
-    private static string NuevoCodigoColaborador() => $"[TEST]-{Guid.CreateVersion7()}";
+    // Issue #387: codigo URL-safe (unreserved RFC 3986) -- corregido de "[TEST]-" (corchetes
+    // fuera del set permitido) a "TEST-" para que el arrange no falle con 400.
+    private static string NuevoCodigoColaborador() => $"TEST-{Guid.CreateVersion7()}";
 
     // Oraculo independiente de la clave de stream (MEF-ADR-0002): se recompone aqui a mano, no se
     // deriva de Identificacion.ToString(), para que un cambio de formato en el VO no se auto-valide.

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/CorregirFechaInicioVinculacionFunction/CorregirFechaInicioVinculacionSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/CorregirFechaInicioVinculacionFunction/CorregirFechaInicioVinculacionSmokeTests.cs
@@ -27,6 +27,7 @@ using System.Net;
 using System.Net.Http.Json;
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.Colaboradores.SmokeTests.Fixtures;
+using static Bitakora.ControlAsistencia.Colaboradores.SmokeTests.Fixtures.DatosDePrueba;
 
 namespace Bitakora.ControlAsistencia.Colaboradores.SmokeTests.CorregirFechaInicioVinculacionFunction;
 
@@ -54,10 +55,6 @@ public class CorregirFechaInicioVinculacionSmokeTests(ApiFixture api, PostgresFi
     // sobrevive intacto a la limpieza del numero (#381) y la llave esperada de abajo coincide con
     // la que arma el backend.
     private static string NuevoNumeroIdentificacion() => Guid.CreateVersion7().ToString("N").ToUpperInvariant();
-
-    // Issue #387: codigo URL-safe (unreserved RFC 3986) -- corregido de "[TEST]-" (corchetes
-    // fuera del set permitido) a "TEST-" para que el arrange no falle con 400.
-    private static string NuevoCodigoColaborador() => $"TEST-{Guid.CreateVersion7()}";
 
     // Oraculo independiente de la clave de stream (MEF-ADR-0002): se recompone aqui a mano, no se
     // deriva de Identificacion.ToString(), para que un cambio de formato en el VO no se auto-valide.

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/CorregirNombresFunction/CorregirNombresSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/CorregirNombresFunction/CorregirNombresSmokeTests.cs
@@ -74,7 +74,9 @@ public class CorregirNombresSmokeTests(ApiFixture api, PostgresFixture postgres)
     // la que arma el backend.
     private static string NuevoNumeroIdentificacion() => Guid.CreateVersion7().ToString("N").ToUpperInvariant();
 
-    private static string NuevoCodigoColaborador() => $"[TEST]-{Guid.CreateVersion7()}";
+    // Issue #387: codigo URL-safe (unreserved RFC 3986) -- corregido de "[TEST]-" (corchetes
+    // fuera del set permitido) a "TEST-" para que el arrange no falle con 400.
+    private static string NuevoCodigoColaborador() => $"TEST-{Guid.CreateVersion7()}";
 
     // Oraculo independiente de la clave de stream (MEF-ADR-0002): se recompone aqui a mano, no se
     // deriva de Identificacion.ToString(), para que un cambio de formato en el VO no se auto-valide.

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/CorregirNombresFunction/CorregirNombresSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/CorregirNombresFunction/CorregirNombresSmokeTests.cs
@@ -40,6 +40,7 @@ using System.Text.Json;
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
 using Bitakora.ControlAsistencia.Colaboradores.SmokeTests.Fixtures;
+using static Bitakora.ControlAsistencia.Colaboradores.SmokeTests.Fixtures.DatosDePrueba;
 
 namespace Bitakora.ControlAsistencia.Colaboradores.SmokeTests.CorregirNombresFunction;
 
@@ -73,10 +74,6 @@ public class CorregirNombresSmokeTests(ApiFixture api, PostgresFixture postgres)
     // sobrevive intacto a la limpieza del numero (#381) y la llave esperada de abajo coincide con
     // la que arma el backend.
     private static string NuevoNumeroIdentificacion() => Guid.CreateVersion7().ToString("N").ToUpperInvariant();
-
-    // Issue #387: codigo URL-safe (unreserved RFC 3986) -- corregido de "[TEST]-" (corchetes
-    // fuera del set permitido) a "TEST-" para que el arrange no falle con 400.
-    private static string NuevoCodigoColaborador() => $"TEST-{Guid.CreateVersion7()}";
 
     // Oraculo independiente de la clave de stream (MEF-ADR-0002): se recompone aqui a mano, no se
     // deriva de Identificacion.ToString(), para que un cambio de formato en el VO no se auto-valide.

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/Fixtures/DatosDePrueba.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/Fixtures/DatosDePrueba.cs
@@ -1,0 +1,17 @@
+namespace Bitakora.ControlAsistencia.Colaboradores.SmokeTests.Fixtures;
+
+// Generadores de datos de ARRANGE compartidos por los smoke tests del dominio. No son oraculos:
+// lo que cada test verifica (clave de stream, contenido del evento) se sigue recomponiendo a mano
+// en su propia clase, para que un cambio de formato en un VO no se auto-valide (MEF-ADR-0002).
+//
+// Issue #387: el codigo de la vinculacion ahora es URL-safe (unreserved RFC 3986: A-Z a-z 0-9 - . _ ~,
+// MEF-ADR-0043 seccion 1), lo que obligo a corregir a mano el mismo helper copiado en 11 clases
+// (venia con prefijo "[TEST]-", con corchetes fuera del set permitido). Ese cambio simultaneo, que
+// dejo los 11 sitios identicos, es el momento natural de la extraccion segun MEF-ADR-0018: la
+// proxima invariante del codigo se tocara en un solo lugar.
+internal static class DatosDePrueba
+{
+    // Prefijo "TEST-" (no "[TEST]-"): los corchetes no son unreserved characters y el borde los
+    // rechaza con 400 desde el issue #387.
+    internal static string NuevoCodigoColaborador() => $"TEST-{Guid.CreateVersion7()}";
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/ListarCategoriasDeEtiquetas/ListarCategoriasDeEtiquetasSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/ListarCategoriasDeEtiquetas/ListarCategoriasDeEtiquetasSmokeTests.cs
@@ -88,7 +88,9 @@ public class ListarCategoriasDeEtiquetasSmokeTests(ApiFixture api)
 
     private static string NuevoNumeroIdentificacion() => Guid.CreateVersion7().ToString("N").ToUpperInvariant();
 
-    private static string NuevoCodigoColaborador() => $"[TEST]-{Guid.CreateVersion7()}";
+    // Issue #387: codigo URL-safe (unreserved RFC 3986) -- corregido de "[TEST]-" (corchetes
+    // fuera del set permitido) a "TEST-" para que el arrange no falle con 400.
+    private static string NuevoCodigoColaborador() => $"TEST-{Guid.CreateVersion7()}";
 
     // Formato "N": hexadecimal en minusculas -- sobrevive intacto a la normalizacion del VO Etiqueta
     // (minusculas + sin tildes + trim). Lo unico que varia entre "formas" de una misma categoria

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/ListarCategoriasDeEtiquetas/ListarCategoriasDeEtiquetasSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/ListarCategoriasDeEtiquetas/ListarCategoriasDeEtiquetasSmokeTests.cs
@@ -54,6 +54,7 @@ using System.Net.Http.Json;
 using System.Text.Json;
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.Colaboradores.SmokeTests.Fixtures;
+using static Bitakora.ControlAsistencia.Colaboradores.SmokeTests.Fixtures.DatosDePrueba;
 
 namespace Bitakora.ControlAsistencia.Colaboradores.SmokeTests.ListarCategoriasDeEtiquetas;
 
@@ -87,10 +88,6 @@ public class ListarCategoriasDeEtiquetasSmokeTests(ApiFixture api)
         string Id, string Categoria, IReadOnlyList<ValorCategoriaSmoke> Valores);
 
     private static string NuevoNumeroIdentificacion() => Guid.CreateVersion7().ToString("N").ToUpperInvariant();
-
-    // Issue #387: codigo URL-safe (unreserved RFC 3986) -- corregido de "[TEST]-" (corchetes
-    // fuera del set permitido) a "TEST-" para que el arrange no falle con 400.
-    private static string NuevoCodigoColaborador() => $"TEST-{Guid.CreateVersion7()}";
 
     // Formato "N": hexadecimal en minusculas -- sobrevive intacto a la normalizacion del VO Etiqueta
     // (minusculas + sin tildes + trim). Lo unico que varia entre "formas" de una misma categoria

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/ListarFichasColaborador/ListarFichasColaboradorSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/ListarFichasColaborador/ListarFichasColaboradorSmokeTests.cs
@@ -38,6 +38,7 @@ using System.Text;
 using System.Text.Json;
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.Colaboradores.SmokeTests.Fixtures;
+using static Bitakora.ControlAsistencia.Colaboradores.SmokeTests.Fixtures.DatosDePrueba;
 
 namespace Bitakora.ControlAsistencia.Colaboradores.SmokeTests.ListarFichasColaborador;
 
@@ -76,10 +77,6 @@ public class ListarFichasColaboradorSmokeTests(ApiFixture api)
         IReadOnlyDictionary<string, string> EtiquetasNormalizadas);
 
     private static string NuevoNumeroIdentificacion() => Guid.CreateVersion7().ToString("N").ToUpperInvariant();
-
-    // Issue #387: codigo URL-safe (unreserved RFC 3986) -- corregido de "[TEST]-" (corchetes
-    // fuera del set permitido) a "TEST-" para que el arrange no falle con 400.
-    private static string NuevoCodigoColaborador() => $"TEST-{Guid.CreateVersion7()}";
 
     // Apellido con un Guid embebido -- garantiza que el NombreCompleto resultante ("[TEST]
     // {apellido}") es unico frente a cualquier ficha creada en cualquier corrida, pasada o futura,

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/ListarFichasColaborador/ListarFichasColaboradorSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/ListarFichasColaborador/ListarFichasColaboradorSmokeTests.cs
@@ -77,7 +77,9 @@ public class ListarFichasColaboradorSmokeTests(ApiFixture api)
 
     private static string NuevoNumeroIdentificacion() => Guid.CreateVersion7().ToString("N").ToUpperInvariant();
 
-    private static string NuevoCodigoColaborador() => $"[TEST]-{Guid.CreateVersion7()}";
+    // Issue #387: codigo URL-safe (unreserved RFC 3986) -- corregido de "[TEST]-" (corchetes
+    // fuera del set permitido) a "TEST-" para que el arrange no falle con 400.
+    private static string NuevoCodigoColaborador() => $"TEST-{Guid.CreateVersion7()}";
 
     // Apellido con un Guid embebido -- garantiza que el NombreCompleto resultante ("[TEST]
     // {apellido}") es unico frente a cualquier ficha creada en cualquier corrida, pasada o futura,

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/ObtenerFichaColaborador/ObtenerFichaColaboradorSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/ObtenerFichaColaborador/ObtenerFichaColaboradorSmokeTests.cs
@@ -38,6 +38,7 @@ using System.Net.Http.Json;
 using System.Text.Json;
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.Colaboradores.SmokeTests.Fixtures;
+using static Bitakora.ControlAsistencia.Colaboradores.SmokeTests.Fixtures.DatosDePrueba;
 
 namespace Bitakora.ControlAsistencia.Colaboradores.SmokeTests.ObtenerFichaColaborador;
 
@@ -73,10 +74,6 @@ public class ObtenerFichaColaboradorSmokeTests(ApiFixture api)
     // identidad del stream (y por lo tanto el Id de la ficha) es Identificacion.ToString()
     // ("CC-<numero>"), no un Guid nuevo por llamada.
     private static string NuevoNumeroIdentificacion() => Guid.CreateVersion7().ToString("N").ToUpperInvariant();
-
-    // Issue #387: codigo URL-safe (unreserved RFC 3986) -- corregido de "[TEST]-" (corchetes
-    // fuera del set permitido) a "TEST-" para que el arrange no falle con 400.
-    private static string NuevoCodigoColaborador() => $"TEST-{Guid.CreateVersion7()}";
 
     // Mismo formato que ColaboradorAggregateRoot.ComputarStreamId (separador "-" desde #381),
     // reconstruido localmente: el smoke test no referencia el Function App (Colaboradores.Entities).

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/ObtenerFichaColaborador/ObtenerFichaColaboradorSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/ObtenerFichaColaborador/ObtenerFichaColaboradorSmokeTests.cs
@@ -74,7 +74,9 @@ public class ObtenerFichaColaboradorSmokeTests(ApiFixture api)
     // ("CC-<numero>"), no un Guid nuevo por llamada.
     private static string NuevoNumeroIdentificacion() => Guid.CreateVersion7().ToString("N").ToUpperInvariant();
 
-    private static string NuevoCodigoColaborador() => $"[TEST]-{Guid.CreateVersion7()}";
+    // Issue #387: codigo URL-safe (unreserved RFC 3986) -- corregido de "[TEST]-" (corchetes
+    // fuera del set permitido) a "TEST-" para que el arrange no falle con 400.
+    private static string NuevoCodigoColaborador() => $"TEST-{Guid.CreateVersion7()}";
 
     // Mismo formato que ColaboradorAggregateRoot.ComputarStreamId (separador "-" desde #381),
     // reconstruido localmente: el smoke test no referencia el Function App (Colaboradores.Entities).

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/RegistrarColaboradorFunction/RegistrarColaboradorSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/RegistrarColaboradorFunction/RegistrarColaboradorSmokeTests.cs
@@ -28,6 +28,10 @@
 // casing exacto.
 // CA-3: request invalida (NumeroIdentificacion/CodigoColaborador vacios, FechaInicio vacia, tipo
 // fuera de la lista cerrada) -> 400, sin tocar el event store.
+//
+// Issue #387 (CodigoColaborador URL-safe): CA-1 con caracteres unreserved no alfanumericos (. _ ~)
+// -> 202 (el set permitido no se limita a alfanumerico+guion); CA-2/CA-3 con ":" (separador de
+// accion reservado, MEF-ADR-0043) y espacio (fuera del set unreserved RFC 3986) -> 400.
 using System.Net;
 using System.Net.Http.Json;
 using AwesomeAssertions;
@@ -283,6 +287,70 @@ public class RegistrarColaboradorSmokeTests(ApiFixture api, PostgresFixture post
         var ct = TestContext.Current.CancellationToken;
         var payload = PayloadRegistro(
             NuevoNumeroIdentificacion(), new DateOnly(2026, 1, 1), tipoIdentificacion: "XX");
+
+        var response = await _client.PostAsJsonAsync(RutaRegistrar, payload, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    // CA-1 (#387): codigo con caracteres unreserved no alfanumericos (. _ ~) tambien produce 202 --
+    // el set permitido no se limita a alfanumerico+guion, que es lo unico que ejercita el helper
+    // NuevoCodigoColaborador de este archivo ("TEST-<guid>"). Verificacion end-to-end de que el
+    // regex desplegado en dev no es mas restrictivo que el unreserved de RFC 3986 seccion 2.3.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task RegistrarColaborador_Retorna202_CuandoCodigoColaboradorTieneCaracteresUnreservedNoAlfanumericos()
+    {
+        Assert.SkipWhen(!postgres.IsConfigured, postgres.SkipReason ?? "Postgres no disponible.");
+
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion();
+        var codigoColaborador = $"a.b_{Guid.CreateVersion7()}~2";
+
+        var response = await _client.PostAsJsonAsync(
+            RutaRegistrar,
+            PayloadRegistro(numeroIdentificacion, new DateOnly(2026, 4, 1), codigoColaborador: codigoColaborador),
+            ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+
+        var streamId = ComputarStreamId(numeroIdentificacion);
+
+        var existe = await postgres.ExisteEventoAsync(
+            SchemaColaboradores, streamId, TipoEventoColaboradorRegistrado, Timeout);
+
+        existe.Should().BeTrue(
+            $"el codigo con caracteres unreserved no alfanumericos deberia haberse aceptado y persistido en {streamId}");
+    }
+
+    // CA-2 (#387): ":" esta explicitamente fuera del set permitido -- MEF-ADR-0043 seccion 1 lo
+    // reserva como separador de accion (vinculaciones/{codigo}:terminar, #379). Un codigo con ":"
+    // haria inparseable esa ruta -- caso destacado del issue.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task RegistrarColaborador_Retorna400_CuandoCodigoColaboradorContieneDosPuntos()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var codigoColaborador = $"COL:{Guid.CreateVersion7()}";
+        var payload = PayloadRegistro(
+            NuevoNumeroIdentificacion(), new DateOnly(2026, 4, 1), codigoColaborador: codigoColaborador);
+
+        var response = await _client.PostAsJsonAsync(RutaRegistrar, payload, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    // CA-3 (#387): cualquier otro caracter fuera del set (espacio, aqui) -> 400. La exhaustividad
+    // del regex (acento, "/") ya la cubre RegistrarColaboradorValidatorTests; este smoke test solo
+    // confirma que la regla llega desplegada end-to-end en dev.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task RegistrarColaborador_Retorna400_CuandoCodigoColaboradorContieneEspacio()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var codigoColaborador = $"COL {Guid.CreateVersion7()}";
+        var payload = PayloadRegistro(
+            NuevoNumeroIdentificacion(), new DateOnly(2026, 4, 1), codigoColaborador: codigoColaborador);
 
         var response = await _client.PostAsJsonAsync(RutaRegistrar, payload, ct);
 

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/RegistrarColaboradorFunction/RegistrarColaboradorSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/RegistrarColaboradorFunction/RegistrarColaboradorSmokeTests.cs
@@ -54,7 +54,11 @@ public class RegistrarColaboradorSmokeTests(ApiFixture api, PostgresFixture post
     // arma el backend.
     private static string NuevoNumeroIdentificacion() => Guid.CreateVersion7().ToString("N").ToUpperInvariant();
 
-    private static string NuevoCodigoColaborador() => $"[TEST]-{Guid.CreateVersion7()}";
+    // Issue #387: el codigo debe ser URL-safe (unreserved RFC 3986: A-Z a-z 0-9 - . _ ~) -- antes
+    // de este issue el prefijo era "[TEST]-", con corchetes fuera del set permitido. Se corrige aqui
+    // (y en el resto de smoke tests del dominio que comparten este helper) para que el arrange no
+    // empiece a fallar con 400 en cuanto la nueva regla se implemente.
+    private static string NuevoCodigoColaborador() => $"TEST-{Guid.CreateVersion7()}";
 
     // Siempre canonico ("CC-<numero>", separador "-" desde el issue #381): TipoIdentificacion.Desde
     // nunca almacena el input crudo, solo retorna la instancia canonica de la lista cerrada (issue

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/RegistrarColaboradorFunction/RegistrarColaboradorSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/RegistrarColaboradorFunction/RegistrarColaboradorSmokeTests.cs
@@ -36,6 +36,7 @@ using System.Net;
 using System.Net.Http.Json;
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.Colaboradores.SmokeTests.Fixtures;
+using static Bitakora.ControlAsistencia.Colaboradores.SmokeTests.Fixtures.DatosDePrueba;
 
 namespace Bitakora.ControlAsistencia.Colaboradores.SmokeTests.RegistrarColaboradorFunction;
 
@@ -57,12 +58,6 @@ public class RegistrarColaboradorSmokeTests(ApiFixture api, PostgresFixture post
     // intacto a la limpieza del numero (#381) y la llave esperada de abajo coincide con la que
     // arma el backend.
     private static string NuevoNumeroIdentificacion() => Guid.CreateVersion7().ToString("N").ToUpperInvariant();
-
-    // Issue #387: el codigo debe ser URL-safe (unreserved RFC 3986: A-Z a-z 0-9 - . _ ~) -- antes
-    // de este issue el prefijo era "[TEST]-", con corchetes fuera del set permitido. Se corrige aqui
-    // (y en el resto de smoke tests del dominio que comparten este helper) para que el arrange no
-    // empiece a fallar con 400 en cuanto la nueva regla se implemente.
-    private static string NuevoCodigoColaborador() => $"TEST-{Guid.CreateVersion7()}";
 
     // Siempre canonico ("CC-<numero>", separador "-" desde el issue #381): TipoIdentificacion.Desde
     // nunca almacena el input crudo, solo retorna la instancia canonica de la lista cerrada (issue
@@ -295,8 +290,8 @@ public class RegistrarColaboradorSmokeTests(ApiFixture api, PostgresFixture post
 
     // CA-1 (#387): codigo con caracteres unreserved no alfanumericos (. _ ~) tambien produce 202 --
     // el set permitido no se limita a alfanumerico+guion, que es lo unico que ejercita el helper
-    // NuevoCodigoColaborador de este archivo ("TEST-<guid>"). Verificacion end-to-end de que el
-    // regex desplegado en dev no es mas restrictivo que el unreserved de RFC 3986 seccion 2.3.
+    // compartido NuevoCodigoColaborador ("TEST-<guid>"). Verificacion end-to-end de que el regex
+    // desplegado en dev no es mas restrictivo que el unreserved de RFC 3986 seccion 2.3.
     [Fact]
     [Trait("Category", "Smoke")]
     public async Task RegistrarColaborador_Retorna202_CuandoCodigoColaboradorTieneCaracteresUnreservedNoAlfanumericos()

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/ReingresarColaboradorFunction/ReingresarColaboradorSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/ReingresarColaboradorFunction/ReingresarColaboradorSmokeTests.cs
@@ -32,6 +32,7 @@ using System.Net.Http.Json;
 using System.Text.Json;
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.Colaboradores.SmokeTests.Fixtures;
+using static Bitakora.ControlAsistencia.Colaboradores.SmokeTests.Fixtures.DatosDePrueba;
 
 namespace Bitakora.ControlAsistencia.Colaboradores.SmokeTests.ReingresarColaboradorFunction;
 
@@ -54,12 +55,6 @@ public class ReingresarColaboradorSmokeTests(ApiFixture api, PostgresFixture pos
     // sobrevive intacto a la limpieza del numero (#381) y la llave esperada de abajo coincide con
     // la que arma el backend.
     private static string NuevoNumeroIdentificacion() => Guid.CreateVersion7().ToString("N").ToUpperInvariant();
-
-    // Issue #387: el codigo debe ser URL-safe (unreserved RFC 3986: A-Z a-z 0-9 - . _ ~) -- antes
-    // de este issue el prefijo era "[TEST]-", con corchetes fuera del set permitido. Se corrige aqui
-    // (y en el resto de smoke tests del dominio que comparten este helper) para que el arrange no
-    // empiece a fallar con 400 en cuanto la nueva regla se implemente.
-    private static string NuevoCodigoColaborador() => $"TEST-{Guid.CreateVersion7()}";
 
     // Oraculo independiente de la clave de stream (MEF-ADR-0002): se recompone aqui a mano, no se
     // deriva de Identificacion.ToString(), para que un cambio de formato en el VO no se auto-valide.
@@ -410,9 +405,9 @@ public class ReingresarColaboradorSmokeTests(ApiFixture api, PostgresFixture pos
 
     // CA-1 (#387): codigo de reingreso con caracteres unreserved no alfanumericos (. _ ~) tambien
     // produce 202 -- el set permitido no se limita a alfanumerico+guion, que es lo unico que
-    // ejercita el helper NuevoCodigoColaborador de este archivo ("TEST-<guid>"). Verificacion
-    // end-to-end de que el regex desplegado en dev no es mas restrictivo que el unreserved de RFC
-    // 3986 seccion 2.3.
+    // ejercita el helper compartido NuevoCodigoColaborador ("TEST-<guid>"). Verificacion end-to-end
+    // de que el regex desplegado en dev no es mas restrictivo que el unreserved de RFC 3986
+    // seccion 2.3.
     [Fact]
     [Trait("Category", "Smoke")]
     public async Task ReingresarColaborador_Retorna202_CuandoCodigoColaboradorTieneCaracteresUnreservedNoAlfanumericos()

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/ReingresarColaboradorFunction/ReingresarColaboradorSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/ReingresarColaboradorFunction/ReingresarColaboradorSmokeTests.cs
@@ -22,6 +22,10 @@
 // igual o anterior a la FechaEfectiva de la ultima terminacion, incluido un preaviso no vencido).
 // CA-5: colaborador inexistente -> 404.
 // CA-6: request invalida -> 400, sin tocar el event store.
+//
+// Issue #387 (CodigoColaborador URL-safe): CA-1 con caracteres unreserved no alfanumericos (. _ ~)
+// -> 202 (el set permitido no se limita a alfanumerico+guion); CA-2/CA-3 con ":" (separador de
+// accion reservado, MEF-ADR-0043) y espacio (fuera del set unreserved RFC 3986) -> 400.
 using System.Globalization;
 using System.Net;
 using System.Net.Http.Json;
@@ -398,6 +402,75 @@ public class ReingresarColaboradorSmokeTests(ApiFixture api, PostgresFixture pos
         var payload = PayloadReingreso(
             NuevoNumeroIdentificacion(), NuevoCodigoColaborador(), new DateOnly(2025, 3, 1),
             tipoIdentificacion: "XX");
+
+        var response = await _client.PostAsJsonAsync(RutaReingresos, payload, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    // CA-1 (#387): codigo de reingreso con caracteres unreserved no alfanumericos (. _ ~) tambien
+    // produce 202 -- el set permitido no se limita a alfanumerico+guion, que es lo unico que
+    // ejercita el helper NuevoCodigoColaborador de este archivo ("TEST-<guid>"). Verificacion
+    // end-to-end de que el regex desplegado en dev no es mas restrictivo que el unreserved de RFC
+    // 3986 seccion 2.3.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ReingresarColaborador_Retorna202_CuandoCodigoColaboradorTieneCaracteresUnreservedNoAlfanumericos()
+    {
+        Assert.SkipWhen(!postgres.IsConfigured, postgres.SkipReason ?? "Postgres no disponible.");
+
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion();
+        var fechaEfectivaTerminacion = new DateOnly(2025, 6, 30);
+        var fechaReingreso = new DateOnly(2025, 7, 1);
+        var codigoReingreso = $"a.b_{Guid.CreateVersion7()}~2";
+
+        await RegistrarColaboradorAsync(numeroIdentificacion, new DateOnly(2025, 1, 15), ct);
+        await TerminarVinculacionAsync(numeroIdentificacion, fechaEfectivaTerminacion, ct);
+
+        var response = await _client.PostAsJsonAsync(
+            RutaReingresos, PayloadReingreso(numeroIdentificacion, codigoReingreso, fechaReingreso), ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+
+        var streamId = ComputarStreamId(numeroIdentificacion);
+
+        var existe = await postgres.ExisteEventoAsync(
+            SchemaColaboradores, streamId, TipoEventoVinculacionIniciada, Timeout,
+            campoJson: "Codigo", valorJson: codigoReingreso);
+
+        existe.Should().BeTrue(
+            $"el codigo de reingreso con caracteres unreserved no alfanumericos deberia haberse aceptado y persistido en {streamId}");
+    }
+
+    // CA-2 (#387): ":" esta explicitamente fuera del set permitido -- MEF-ADR-0043 seccion 1 lo
+    // reserva como separador de accion (vinculaciones/{codigo}:terminar, #379). Un codigo con ":"
+    // haria inparseable esa ruta -- caso destacado del issue.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ReingresarColaborador_Retorna400_CuandoCodigoColaboradorContieneDosPuntos()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var codigoColaborador = $"COL:{Guid.CreateVersion7()}";
+        var payload = PayloadReingreso(
+            NuevoNumeroIdentificacion(), codigoColaborador, new DateOnly(2025, 3, 1));
+
+        var response = await _client.PostAsJsonAsync(RutaReingresos, payload, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    // CA-3 (#387): cualquier otro caracter fuera del set (espacio, aqui) -> 400. La exhaustividad
+    // del regex (acento, "/") ya la cubre ReingresarColaboradorValidatorTests; este smoke test solo
+    // confirma que la regla llega desplegada end-to-end en dev.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ReingresarColaborador_Retorna400_CuandoCodigoColaboradorContieneEspacio()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var codigoColaborador = $"COL {Guid.CreateVersion7()}";
+        var payload = PayloadReingreso(
+            NuevoNumeroIdentificacion(), codigoColaborador, new DateOnly(2025, 3, 1));
 
         var response = await _client.PostAsJsonAsync(RutaReingresos, payload, ct);
 

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/ReingresarColaboradorFunction/ReingresarColaboradorSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/ReingresarColaboradorFunction/ReingresarColaboradorSmokeTests.cs
@@ -51,7 +51,11 @@ public class ReingresarColaboradorSmokeTests(ApiFixture api, PostgresFixture pos
     // la que arma el backend.
     private static string NuevoNumeroIdentificacion() => Guid.CreateVersion7().ToString("N").ToUpperInvariant();
 
-    private static string NuevoCodigoColaborador() => $"[TEST]-{Guid.CreateVersion7()}";
+    // Issue #387: el codigo debe ser URL-safe (unreserved RFC 3986: A-Z a-z 0-9 - . _ ~) -- antes
+    // de este issue el prefijo era "[TEST]-", con corchetes fuera del set permitido. Se corrige aqui
+    // (y en el resto de smoke tests del dominio que comparten este helper) para que el arrange no
+    // empiece a fallar con 400 en cuanto la nueva regla se implemente.
+    private static string NuevoCodigoColaborador() => $"TEST-{Guid.CreateVersion7()}";
 
     // Oraculo independiente de la clave de stream (MEF-ADR-0002): se recompone aqui a mano, no se
     // deriva de Identificacion.ToString(), para que un cambio de formato en el VO no se auto-valide.

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/RetirarEtiquetaFunction/RetirarEtiquetaSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/RetirarEtiquetaFunction/RetirarEtiquetaSmokeTests.cs
@@ -63,7 +63,9 @@ public class RetirarEtiquetaSmokeTests(ApiFixture api, PostgresFixture postgres)
     // la que arma el backend.
     private static string NuevoNumeroIdentificacion() => Guid.CreateVersion7().ToString("N").ToUpperInvariant();
 
-    private static string NuevoCodigoColaborador() => $"[TEST]-{Guid.CreateVersion7()}";
+    // Issue #387: codigo URL-safe (unreserved RFC 3986) -- corregido de "[TEST]-" (corchetes
+    // fuera del set permitido) a "TEST-" para que el arrange no falle con 400.
+    private static string NuevoCodigoColaborador() => $"TEST-{Guid.CreateVersion7()}";
 
     // Oraculo independiente de la clave de stream (MEF-ADR-0002): se recompone aqui a mano, no se
     // deriva de Identificacion.ToString(), para que un cambio de formato en el VO no se auto-valide.

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/RetirarEtiquetaFunction/RetirarEtiquetaSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/RetirarEtiquetaFunction/RetirarEtiquetaSmokeTests.cs
@@ -32,6 +32,7 @@ using System.Net;
 using System.Net.Http.Json;
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.Colaboradores.SmokeTests.Fixtures;
+using static Bitakora.ControlAsistencia.Colaboradores.SmokeTests.Fixtures.DatosDePrueba;
 
 namespace Bitakora.ControlAsistencia.Colaboradores.SmokeTests.RetirarEtiquetaFunction;
 
@@ -62,10 +63,6 @@ public class RetirarEtiquetaSmokeTests(ApiFixture api, PostgresFixture postgres)
     // sobrevive intacto a la limpieza del numero (#381) y la llave esperada de abajo coincide con
     // la que arma el backend.
     private static string NuevoNumeroIdentificacion() => Guid.CreateVersion7().ToString("N").ToUpperInvariant();
-
-    // Issue #387: codigo URL-safe (unreserved RFC 3986) -- corregido de "[TEST]-" (corchetes
-    // fuera del set permitido) a "TEST-" para que el arrange no falle con 400.
-    private static string NuevoCodigoColaborador() => $"TEST-{Guid.CreateVersion7()}";
 
     // Oraculo independiente de la clave de stream (MEF-ADR-0002): se recompone aqui a mano, no se
     // deriva de Identificacion.ToString(), para que un cambio de formato en el VO no se auto-valide.

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/TerminarVinculacionFunction/TerminarVinculacionSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/TerminarVinculacionFunction/TerminarVinculacionSmokeTests.cs
@@ -22,6 +22,7 @@ using System.Net.Http.Json;
 using System.Text.Json;
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.Colaboradores.SmokeTests.Fixtures;
+using static Bitakora.ControlAsistencia.Colaboradores.SmokeTests.Fixtures.DatosDePrueba;
 
 namespace Bitakora.ControlAsistencia.Colaboradores.SmokeTests.TerminarVinculacionFunction;
 
@@ -53,8 +54,6 @@ public class TerminarVinculacionSmokeTests(ApiFixture api, PostgresFixture postg
     private static string FormatearFecha(DateOnly fecha) =>
         fecha.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
 
-    // Issue #387: codigo URL-safe (unreserved RFC 3986) -- corregido de "[TEST]-" (corchetes fuera
-    // del set permitido) a "TEST-" para que el arrange no falle con 400.
     private static object PayloadRegistro(string numeroIdentificacion, DateOnly fechaInicio) => new
     {
         tipoIdentificacion = TipoIdentificacionCc,
@@ -63,7 +62,7 @@ public class TerminarVinculacionSmokeTests(ApiFixture api, PostgresFixture postg
         segundoNombre = (string?)null,
         primerApellido = "Smoke",
         segundoApellido = (string?)null,
-        codigoColaborador = $"TEST-{Guid.CreateVersion7()}",
+        codigoColaborador = NuevoCodigoColaborador(),
         fechaInicio
     };
 

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/TerminarVinculacionFunction/TerminarVinculacionSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/TerminarVinculacionFunction/TerminarVinculacionSmokeTests.cs
@@ -53,6 +53,8 @@ public class TerminarVinculacionSmokeTests(ApiFixture api, PostgresFixture postg
     private static string FormatearFecha(DateOnly fecha) =>
         fecha.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
 
+    // Issue #387: codigo URL-safe (unreserved RFC 3986) -- corregido de "[TEST]-" (corchetes fuera
+    // del set permitido) a "TEST-" para que el arrange no falle con 400.
     private static object PayloadRegistro(string numeroIdentificacion, DateOnly fechaInicio) => new
     {
         tipoIdentificacion = TipoIdentificacionCc,
@@ -61,7 +63,7 @@ public class TerminarVinculacionSmokeTests(ApiFixture api, PostgresFixture postg
         segundoNombre = (string?)null,
         primerApellido = "Smoke",
         segundoApellido = (string?)null,
-        codigoColaborador = $"[TEST]-{Guid.CreateVersion7()}",
+        codigoColaborador = $"TEST-{Guid.CreateVersion7()}",
         fechaInicio
     };
 

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/RegistrarColaboradorFunction/RegistrarColaboradorValidatorTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/RegistrarColaboradorFunction/RegistrarColaboradorValidatorTests.cs
@@ -1,6 +1,13 @@
 // Issue #330: validacion de forma del comando RegistrarColaborador en el borde (CA-3).
 // Patron de referencia: RegistrarMarcacionValidatorTests (ValidateAsync + verificacion de
 // PropertyName en resultado.Errors).
+//
+// Issue #387: CodigoColaborador debe ser URL-safe -- set permitido: unreserved characters de
+// RFC 3986 seccion 2.3 (A-Z a-z 0-9 - . _ ~), el mismo set que las Microsoft Azure REST API
+// Guidelines fijan para path segments (MEF-ADR-0043 seccion 1). El ":" queda explicitamente fuera
+// (reservado como separador de accion). Se RECHAZA (400), nunca se limpia ni normaliza en
+// silencio -- a diferencia de Identificacion (#381), el codigo lo asigna la empresa y alterarlo
+// cambiaria un dato ajeno.
 
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.Colaboradores.RegistrarColaboradorFunction.CommandHandler;
@@ -141,5 +148,70 @@ public class RegistrarColaboradorValidatorTests
         var resultado = await Validar(ComandoValido() with { SegundoApellido = null });
 
         resultado.IsValid.Should().BeTrue();
+    }
+
+    // CA-1 (#387): codigo con caracteres unreserved no alfanumericos (. _ ~ -) sigue siendo valido --
+    // el set permitido no se limita a alfanumericos.
+    [Fact]
+    public async Task Validar_Aprueba_CuandoCodigoColaboradorTieneCaracteresUnreservedNoAlfanumericos()
+    {
+        var resultado = await Validar(ComandoValido() with { CodigoColaborador = "a.b_c~2" });
+
+        resultado.IsValid.Should().BeTrue();
+    }
+
+    // CA-1 (#387): ejemplo explicito del issue -- guion es unreserved.
+    [Fact]
+    public async Task Validar_Aprueba_CuandoCodigoColaboradorEsAlfanumericoConGuion()
+    {
+        var resultado = await Validar(ComandoValido() with { CodigoColaborador = "EMP-001" });
+
+        resultado.IsValid.Should().BeTrue();
+    }
+
+    // CA-2 (#387): ":" esta explicitamente fuera del set permitido -- MEF-ADR-0043 seccion 1 lo
+    // reserva como separador de accion (vinculaciones/{codigo}:terminar, #379). Un codigo con ":"
+    // haria inparseable esa ruta.
+    [Fact]
+    public async Task Validar_RechazaCodigoColaborador_CuandoContieneDosPuntos()
+    {
+        var resultado = await Validar(ComandoValido() with { CodigoColaborador = "COL:001" });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e =>
+            e.PropertyName == nameof(RegistrarColaborador.CodigoColaborador));
+    }
+
+    // CA-3 (#387): espacio no es unreserved -> 400.
+    [Fact]
+    public async Task Validar_RechazaCodigoColaborador_CuandoContieneEspacio()
+    {
+        var resultado = await Validar(ComandoValido() with { CodigoColaborador = "COL 001" });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e =>
+            e.PropertyName == nameof(RegistrarColaborador.CodigoColaborador));
+    }
+
+    // CA-3 (#387): caracter acentuado no es unreserved -> 400.
+    [Fact]
+    public async Task Validar_RechazaCodigoColaborador_CuandoContieneCaracterAcentuado()
+    {
+        var resultado = await Validar(ComandoValido() with { CodigoColaborador = "CÓDIGO1" });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e =>
+            e.PropertyName == nameof(RegistrarColaborador.CodigoColaborador));
+    }
+
+    // CA-3 (#387): "/" no es unreserved -> 400.
+    [Fact]
+    public async Task Validar_RechazaCodigoColaborador_CuandoContieneBarra()
+    {
+        var resultado = await Validar(ComandoValido() with { CodigoColaborador = "COL/001" });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e =>
+            e.PropertyName == nameof(RegistrarColaborador.CodigoColaborador));
     }
 }

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/RegistrarColaboradorFunction/RegistrarColaboradorValidatorTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/RegistrarColaboradorFunction/RegistrarColaboradorValidatorTests.cs
@@ -214,4 +214,19 @@ public class RegistrarColaboradorValidatorTests
         resultado.Errors.Should().Contain(e =>
             e.PropertyName == nameof(RegistrarColaborador.CodigoColaborador));
     }
+
+    // CA-3 (#387), caso borde del ancla de fin de linea: un salto de linea final tampoco es
+    // unreserved -> 400. En .NET el ancla "$" hace match tambien ANTES de un "\n" final
+    // (a diferencia de "\z"), asi que un patron anclado con "$" aceptaria "COL-001\n" en silencio
+    // -- un valor que rompe la URL igual que un espacio, y ademas habilita CRLF injection en
+    // cualquier consumidor que lo reenvie en un header o lo escriba en un log.
+    [Fact]
+    public async Task Validar_RechazaCodigoColaborador_CuandoTerminaEnSaltoDeLinea()
+    {
+        var resultado = await Validar(ComandoValido() with { CodigoColaborador = "COL-001\n" });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e =>
+            e.PropertyName == nameof(RegistrarColaborador.CodigoColaborador));
+    }
 }

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ReingresarColaboradorFunction/ReingresarColaboradorValidatorTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ReingresarColaboradorFunction/ReingresarColaboradorValidatorTests.cs
@@ -1,6 +1,13 @@
 // Issue #350: validacion de forma del comando ReingresarColaborador en el borde (CA-6).
 // Patron de referencia: TerminarVinculacionValidatorTests (ValidateAsync + verificacion de
 // PropertyName en resultado.Errors).
+//
+// Issue #387: CodigoColaborador debe ser URL-safe -- set permitido: unreserved characters de
+// RFC 3986 seccion 2.3 (A-Z a-z 0-9 - . _ ~), el mismo set que las Microsoft Azure REST API
+// Guidelines fijan para path segments (MEF-ADR-0043 seccion 1). El ":" queda explicitamente fuera
+// (reservado como separador de accion). Se RECHAZA (400), nunca se limpia ni normaliza en
+// silencio -- a diferencia de Identificacion (#381), el codigo lo asigna la empresa y alterarlo
+// cambiaria un dato ajeno.
 
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.Colaboradores.ReingresarColaboradorFunction;
@@ -107,5 +114,70 @@ public class ReingresarColaboradorValidatorTests
         var resultado = await Validar(ComandoValido() with { FechaInicio = new DateOnly(2030, 1, 1) });
 
         resultado.IsValid.Should().BeTrue();
+    }
+
+    // CA-1 (#387): codigo con caracteres unreserved no alfanumericos (. _ ~ -) sigue siendo valido --
+    // el set permitido no se limita a alfanumericos.
+    [Fact]
+    public async Task Validar_Aprueba_CuandoCodigoColaboradorTieneCaracteresUnreservedNoAlfanumericos()
+    {
+        var resultado = await Validar(ComandoValido() with { CodigoColaborador = "a.b_c~2" });
+
+        resultado.IsValid.Should().BeTrue();
+    }
+
+    // CA-1 (#387): ejemplo explicito del issue -- guion es unreserved.
+    [Fact]
+    public async Task Validar_Aprueba_CuandoCodigoColaboradorEsAlfanumericoConGuion()
+    {
+        var resultado = await Validar(ComandoValido() with { CodigoColaborador = "EMP-001" });
+
+        resultado.IsValid.Should().BeTrue();
+    }
+
+    // CA-2 (#387): ":" esta explicitamente fuera del set permitido -- MEF-ADR-0043 seccion 1 lo
+    // reserva como separador de accion (vinculaciones/{codigo}:terminar, #379). Un codigo con ":"
+    // haria inparseable esa ruta.
+    [Fact]
+    public async Task Validar_RechazaCodigoColaborador_CuandoContieneDosPuntos()
+    {
+        var resultado = await Validar(ComandoValido() with { CodigoColaborador = "COL:002" });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e =>
+            e.PropertyName == nameof(ReingresarColaborador.CodigoColaborador));
+    }
+
+    // CA-3 (#387): espacio no es unreserved -> 400.
+    [Fact]
+    public async Task Validar_RechazaCodigoColaborador_CuandoContieneEspacio()
+    {
+        var resultado = await Validar(ComandoValido() with { CodigoColaborador = "COL 002" });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e =>
+            e.PropertyName == nameof(ReingresarColaborador.CodigoColaborador));
+    }
+
+    // CA-3 (#387): caracter acentuado no es unreserved -> 400.
+    [Fact]
+    public async Task Validar_RechazaCodigoColaborador_CuandoContieneCaracterAcentuado()
+    {
+        var resultado = await Validar(ComandoValido() with { CodigoColaborador = "CÓDIGO2" });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e =>
+            e.PropertyName == nameof(ReingresarColaborador.CodigoColaborador));
+    }
+
+    // CA-3 (#387): "/" no es unreserved -> 400.
+    [Fact]
+    public async Task Validar_RechazaCodigoColaborador_CuandoContieneBarra()
+    {
+        var resultado = await Validar(ComandoValido() with { CodigoColaborador = "COL/002" });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e =>
+            e.PropertyName == nameof(ReingresarColaborador.CodigoColaborador));
     }
 }

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ReingresarColaboradorFunction/ReingresarColaboradorValidatorTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ReingresarColaboradorFunction/ReingresarColaboradorValidatorTests.cs
@@ -180,4 +180,19 @@ public class ReingresarColaboradorValidatorTests
         resultado.Errors.Should().Contain(e =>
             e.PropertyName == nameof(ReingresarColaborador.CodigoColaborador));
     }
+
+    // CA-3 (#387), caso borde del ancla de fin de linea: un salto de linea final tampoco es
+    // unreserved -> 400. En .NET el ancla "$" hace match tambien ANTES de un "\n" final
+    // (a diferencia de "\z"), asi que un patron anclado con "$" aceptaria "COL-002\n" en silencio
+    // -- un valor que rompe la URL igual que un espacio, y ademas habilita CRLF injection en
+    // cualquier consumidor que lo reenvie en un header o lo escriba en un log.
+    [Fact]
+    public async Task Validar_RechazaCodigoColaborador_CuandoTerminaEnSaltoDeLinea()
+    {
+        var resultado = await Validar(ComandoValido() with { CodigoColaborador = "COL-002\n" });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e =>
+            e.PropertyName == nameof(ReingresarColaborador.CodigoColaborador));
+    }
 }


### PR DESCRIPTION
## Resumen

Pipeline TDD completado:
- Fase roja: tests escritos con stubs
- Fase verde: implementación completa
- Smoke tests: escritos para endpoints detectados
- Fase refactor: revisión de calidad

## Decisiones del pipeline

<details>
<summary>Test Writer (fase roja) — 7m 41s</summary>

## ES Test Writer - Decisiones (Issue #387)

### Tests creados

- `RegistrarColaboradorValidatorTests.cs`: +6 tests nuevos
  - `Validar_Aprueba_CuandoCodigoColaboradorTieneCaracteresUnreservedNoAlfanumericos` - CA-1 (`.`, `_`, `~`, `-` permitidos)
  - `Validar_Aprueba_CuandoCodigoColaboradorEsAlfanumericoConGuion` - CA-1 (ejemplo explicito `EMP-001`)
  - `Validar_RechazaCodigoColaborador_CuandoContieneDosPuntos` - CA-2 (`:` reservado, MEF-ADR-0043)
  - `Validar_RechazaCodigoColaborador_CuandoContieneEspacio` - CA-3
  - `Validar_RechazaCodigoColaborador_CuandoContieneCaracterAcentuado` - CA-3
  - `Validar_RechazaCodigoColaborador_CuandoContieneBarra` - CA-3

- `ReingresarColaboradorValidatorTests.cs`: +6 tests nuevos (mismo set, sobre `ReingresarColaborador`)

### Estructura elegida

- No se crearon clases nuevas ni stubs de producción: `RegistrarColaborador`, `ReingresarColaborador` y
  ambos validators ya existían y compilaban. La regla nueva (regex URL-safe) todavía no existe en
  ninguno de los dos validators -- por eso los 8 tests de rechazo fallan (fase roja) y los de
  aprobación (positivos) pasan sin cambios de producción.
- No se creó ninguna clase compartida (constante/regex) para CA-4 (DRY entre los dos validators):
  crear esa clase con el patrón real habría sido escribir la implementación de la funcionalidad
  (la regla en sí), lo cual viola la regla 1 de este agente. La forma exacta de compartir la
  definición (extension method de FluentValidation, constante estática, etc.) queda a criterio del
  implementer, tal como el propio issue lo permite ("forma exacta a juicio del pipeline",
  MEF-ADR-0018).
- Los tests no usan `.resx`/`Mensajes.Clave`: siguiendo el precedente ya establecido en los 8
  validators existentes del dominio (todos usan `.WithMessage("...")` con string literal para la
  única regla con mensaje custom, `TipoIdentificacion`), y los tests solo verifican `PropertyName`
  en `resultado.Errors`, nunca el texto del mensaje -- no había necesidad de crear infraestructura
  de mensajes nueva.

### Stubs creados

Ninguno. Todos los tipos referenciados (`RegistrarColaborador`, `ReingresarColaborador`,
`RegistrarColaboradorValidator`, `ReingresarColaboradorValidator`) ya existían y compilaban antes de
este issue.

### Decisiones de diseño

- Casos de rechazo elegidos para CA-3 (espacio, acento, `/`): son exactamente los ejemplos que el
  propio issue cita ("espacio, acento, `/`, etc."), suficientes para acotar el comportamiento sin
  caer en combinatoria innecesaria (recordar: solo `[Fact]`, nunca `[Theory]`/`[InlineData]`).
- Casos de aprobación (CA-1): uno con los caracteres unreserved no alfanuméricos (`.`, `_`, `~`, `-`)
  y otro con el ejemplo textual del issue (`EMP-001`) para dejar registrado el criterio de
  aceptación de forma literal.

### Cobertura de criterios

| Criterio de aceptación | Test(s) |
|---|---|
| CA-1: código con caracteres permitidos -> comportamiento actual intacto | `Validar_Aprueba_CuandoCodigoColaboradorTieneCaracteresUnreservedNoAlfanumericos`, `Validar_Aprueba_CuandoCodigoColaboradorEsAlfanumericoConGuion` (en ambos validators) |
| CA-2: código con `:` -> 400 en ambos comandos | `Validar_RechazaCodigoColaborador_CuandoContieneDosPuntos` (en ambos validators) |
| CA-3: código con espacio/acento/`/` -> 400 en ambos comandos | `Validar_RechazaCodigoColaborador_CuandoContieneEspacio`, `Validar_RechazaCodigoColaborador_CuandoContieneCaracterAcentuado`, `Validar_RechazaCodigoColaborador_CuandoContieneBarra` (en ambos validators) |
| CA-4: definición del set permitido en UN solo lugar | No verificable por test unitario (constraint estructural/DRY) -- queda como decisión de diseño del implementer, documentada arriba. Se sugiere una clase estática compartida o extension method de FluentValidation referenciado desde ambos validators. |

### Hallazgo crítico: 11 smoke tests del dominio usaban un código NO conforme (corregido en este commit)

La investigación del planner afirmaba: *"los existentes de registrar/reingresar usan códigos
conformes"*. Al verificar (grep sobre todo `Colaboradores.SmokeTests/`), esto resultó **falso**: el
helper `NuevoCodigoColaborador() => $"[TEST]-{Guid.CreateVersion7()}"` se repite en **11 archivos**
de smoke tests de todo el dominio (no solo Registrar/Reingresar), y su prefijo `[TEST]-` contiene
corchetes `[` `]`, que **no** son unreserved characters de RFC 3986 -- quedarían rechazados por la
regla que este issue introduce.

Sin corregirlo, en cuanto el implementer agregue la regla real a los validators, **todo el arrange**
de los smoke tests del dominio Colaboradores (que siempre empieza registrando un colaborador vía
`POST Colaboradores` con este código) habría empezado a fallar con 400 en vez de 202/409/404 —
rompiendo el suite completo de smoke tests contra dev (MEF-ADR-0013), no solo los dos archivos que el
issue anticipaba tocar.

**Resolución aplicada** (autoridad de la regla 19 -- decisión de test-writer sin reportar bloqueo,
por ser un fix mecánico de dato de prueba, no de lógica de producción): se reemplazó el prefijo
`[TEST]-` por `TEST-` (sin corchetes, mismo significado, URL-safe) en los 11 archivos:

- `RegistrarColaboradorSmokeTests.cs`, `ReingresarColaboradorSmokeTests.cs`,
  `TerminarVinculacionSmokeTests.cs`, `CorregirNombresSmokeTests.cs`,
  `AsignarEtiquetaSmokeTests.cs`, `AnularTerminacionSmokeTests.cs`,
  `CorregirFechaInicioVinculacionSmokeTests.cs`, `ListarCategoriasDeEtiquetasSmokeTests.cs`,
  `ListarFichasColaboradorSmokeTests.cs`, `RetirarEtiquetaSmokeTests.cs`,
  `ObtenerFichaColaboradorSmokeTests.cs`.

No se tocó `primerNombre = "[TEST]"` (ese campo no tiene la restricción URL-safe de este issue).
Cada archivo quedó con un comentario de una línea referenciando el issue #387 y la razón del cambio.

### Desviaciones del plan del planner

| Sugerencia del issue | Desviación aplicada | Razón técnica | Consecuencia |
|---|---|---|---|
| "los existentes de registrar/reingresar usan códigos conformes" (investigación del planner, sección "MEF-ADR-0013") | Se corrigió el dato: **11** smoke tests del dominio (no solo registrar/reingresar) usaban `[TEST]-` (no conforme); se reemplazó por `TEST-` en los 11 archivos | Verificado con grep: el prefijo `[TEST]-` contiene `[`/`]`, fuera del set unreserved RFC 3986; el helper es compartido por arrange de todo el dominio, no exclusivo de los dos comandos que el issue anticipaba | Sin esta corrección, el implementer habría roto silenciosamente el smoke suite completo de Colaboradores al implementar la regla real; con la corrección, los smoke tests seguirán verdes cuando se despliegue el cambio |
| "Impacto esperado en archivos" no lista los smoke tests como archivos a modificar | Se modificaron igualmente (11 archivos fuera de la lista) | Consecuencia directa y necesaria del cambio de invariante que este mismo issue introduce (mismo criterio que MEF-ADR-0018 aplica a nivel de código: un cambio de invariante obliga a revisar sus dependientes) | Los smoke tests no requieren cambios adicionales cuando el implementer agregue la regla real |

</details>

<details>
<summary>Implementer (fase verde) — 5m 27s</summary>

## ES Implementer - Decisiones

### Enfoque de implementacion
Se agrego, a `RegistrarColaboradorValidator` y `ReingresarColaboradorValidator`, una regla
`Matches` sobre `CodigoColaborador` que exige el set de unreserved characters de RFC 3986
seccion 2.3 (`A-Z a-z 0-9 - . _ ~`). La regla es capa 1 (forma del dato en el borde HTTP,
MEF-ADR-0004): se agrego encadenada con `Cascade(CascadeMode.Stop)` despues de `NotEmpty()` para
que un codigo vacio no dispare ademas el error de formato (mismo patron ya usado en el proyecto
para `TipoIdentificacion`). No se toco el aggregate ni `VinculacionIniciada` -- el issue es
explicito en que la invariante vive en el validator, no en el estado del stream.

### Decisiones de diseno
- La definicion del set permitido (CA-4: debe existir en un solo lugar) se extrajo a
  `Infraestructura/ValidacionesCompartidas.cs`, una clase estatica con un `[GeneratedRegex]`
  privado y un metodo de extension `DebeSerCodigoColaboradorUrlSafe<T>()` sobre
  `IRuleBuilder<T, string>`, consumido por ambos validators. Se eligio el folder `Infraestructura/`
  (ya existente en el proyecto, alberga `RequestValidator`, `ComposicionServicios`,
  `TenantResolverFijo`) por ser el unico lugar de este Function App para codigo transversal a mas
  de un feature folder -- no hay precedente de un folder `Compartido/` o similar en el proyecto,
  y crear uno nuevo para una sola clase de 20 lineas no se justifico (MEF-ADR-0018).
  Se documento esta eleccion aqui porque el issue delega la "forma exacta" al pipeline (CA-4).
- Se prefirio `[GeneratedRegex]` (source generator, .NET 7+) sobre `new Regex(...)` estatico por
  ser el patron recomendado para regex fijos en tiempo de compilacion en .NET moderno; no cambia
  el comportamiento observable, solo el mecanismo de compilacion de la expresion.
- No se agrego mensaje custom de FluentValidation para la regla `Matches` (el mensaje default de
  FluentValidation es suficiente para 400 BadRequest) -- ningun test verifica el texto del mensaje,
  solo `PropertyName`. Consistente con el precedente del proyecto (la regla `NotEmpty()` de los
  mismos campos tampoco trae mensaje custom).

### ADRs consultados
- MEF-ADR-0043 seccion 1 (precondicion ids URL-safe, `:` reservado a acciones) -- fuente directa
  del set de caracteres permitido y de la exclusion explicita de `:`.
- MEF-ADR-0004 / capa 1 (validacion de forma en el borde) -- confirma que la regla va en el
  validator FluentValidation, no en el aggregate ni como evento de fallo.
- MEF-ADR-0018 (Rule of Three) -- fundamenta compartir la definicion del regex entre los dos
  validators en un solo punto en vez de duplicarla.
- MEF-ADR-0036 -- verificado cero impacto: `VinculacionIniciada` no se toco.

### Desviaciones de ADRs
Ninguna desviacion -- todos los ADRs aplicados al pie de la letra.

### Desviaciones del plan del planner
Ninguna desviacion relevante. El planner sugirio "constante/regla compartida entre los dos
validators (forma exacta a juicio del pipeline)" sin fijar un archivo concreto; se eligio
`Infraestructura/ValidacionesCompartidas.cs` como se explica arriba en "Decisiones de diseno".

### Precedentes consultados
- `TipoIdentificacion` (`RegistrarColaboradorValidator`/`ReingresarColaboradorValidator` ya
  existentes): patron `Cascade(CascadeMode.Stop)` + `Must(...)` -- replicado para `CodigoColaborador`
  con `Matches` en vez de `Must`. Alineado con MEF-ADR-0004 (capa 1), sin desviacion.
- `Identificacion.Crear` (#381, `Colaboradores.DomainEvents`): normaliza (limpia) el numero en vez
  de rechazarlo. Se evaluo replicar ese patron para `CodigoColaborador` y se descarto explicitamente
  -- el propio issue #387 (seccion "Decision de la sesion") aclara que el codigo se rechaza, nunca
  se limpia, porque a diferencia del numero de identificacion lo asigna una fuente externa
  (la empresa) y alterarlo en silencio cambiaria un dato ajeno.

### Infraestructura modificada
Ninguna. Este issue no introduce ni modifica ningun evento, topic o subscription -- es una regla
de validacion de forma pura en el borde HTTP. `infra/environments/dev/main.tf` no se toco.

### Complejidad encontrada
- `dotnet test` con el runner Microsoft.Testing.Platform (xUnit v3) de este repo no acepta
  `--filter` de la forma clasica de VSTest al pasar la ruta del proyecto como argumento posicional
  ("La especificacion de un directorio... deberia ser via --project"); se resolvio invocando con
  `--project <csproj>` explicito. No afecto el resultado, solo el comando de verificacion.
- Los smoke tests (`tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/`) ya venian
  actualizados por el test-writer para usar codigos `TEST-{Guid}` (URL-safe) en vez del formato
  previo `[TEST]-...` (con corchetes, invalido bajo la nueva regla) -- se verifico por grep que no
  quedaba ningun codigo con corchetes u otro caracter fuera del set permitido antes de dar por
  cerrado el issue; no se toco ningun smoke test.

### Resultado
- Tests pasando: 1270/1316 (46 omitidos por falta de Postgres/ServiceBus local, esperado fuera de
  CI/dev desplegado -- no relacionado con este cambio).
- Tests del proyecto `Colaboradores.Tests` (incluye los dos validators de este issue): 334/334.

</details>
<details>
<summary>Smoke Test Writer — 3m 5s</summary>

_(El agente no generó resumen)_

</details>
<details>
<summary>Reviewer (fase refactor) — 13m 27s</summary>

## ES Reviewer - Revision (Issue #387)

### Evaluacion general
- Calidad: **buena** (con un defecto funcional real corregido en esta fase)
- Cambios realizados: **si** — commit `33275d5`

### Estado de la suite

| Conjunto | Resultado |
|---|---|
| Todos los proyectos `*.Tests` (unitarios) | **1272 correctos, 0 errores, 48 omitidos** |
| `Colaboradores.Tests` (los dos validators del issue) | **336/336** (334 heredados + 2 agregados en esta fase) |
| `Colaboradores.SmokeTests` | 4 rojos **por diseno**: dev todavia no tiene desplegada la regla (ver abajo) |

**Los 4 smoke tests rojos NO son un bloqueo.** Son `RegistrarColaborador_Retorna400_Cuando{ContieneDosPuntos,ContieneEspacio}` y sus gemelos de reingreso: dev responde hoy `202` (registro) y `404` (reingreso) porque el validator con la regla nueva aun no esta desplegado. Es el comportamiento esperado de MEF-ADR-0013 (smoke tests contra el entorno dev desplegado) y el `smoke-test-writer` lo declaro explicitamente ("Ejecucion contra dev: NO EJECUTADA"). Verificado ademas que `ci.yml` (el workflow del PR) itera `tests/Bitakora.ControlAsistencia.*.Tests/` — glob que **no** alcanza `*.SmokeTests` —, asi que el PR no se bloquea; los smoke corren en `smoke-tests-dominio.yml` despues del deploy. No se toco ningun test para "ponerlo verde".

### Cumplimiento de ADRs aplicables

| ADR | Cumplimiento | Observacion |
|---|---|---|
| MEF-ADR-0043 seccion 1 (ids URL-safe, `:` reservado a acciones) | **desviacion NO declarada, corregida** | El set implementado (`A-Za-z0-9 - . _ ~`) es exactamente el de la guia citada, pero el ancla `$` del regex dejaba pasar `"COL-001\n"` — un valor fuera del set permitido. Corregido a `\A...\z`. |
| MEF-ADR-0004 (capa 1: validacion de forma en el borde -> 400) | ok | La regla vive en los dos validators FluentValidation; el aggregate y `VinculacionIniciada` intactos. Sin evento de fallo ni 409 nuevos, coherente con la frontera capa 1 vs capa 3 (CA-ADR-0030). |
| MEF-ADR-0018 (Rule of Three) | ok | Ver "Precedentes / lecturas del ADR" abajo: la definicion unica esta justificada, pero el comentario que la justificaba citaba mal el ADR y se corrigio. |
| MEF-ADR-0036 (identidad del evento persistido) | ok | Cero impacto verificado: `VinculacionIniciada.cs` no aparece en `git diff main...HEAD`; ningun tipo de `IdentidadEventosColaboradores.TiposPersistidos` fue renombrado ni movido. |
| MEF-ADR-0013 (smoke tests contra dev) | ok | Cobertura CA-1/CA-2/CA-3 end-to-end en los dos comandos; camino feliz verifica el efecto secundario real (persistencia via `PostgresFixture.ExisteEventoAsync`, con `campoJson: "Codigo"` en reingreso). Sin Service Bus en estos comandos (CA-ADR-0030) -> no aplica suscripcion `smoke-tests`. |
| MEF-ADR-0016 (naming de tests) | ok | `Validar_RechazaCodigoColaborador_CuandoContieneDosPuntos`, etc. Sujeto + lo que pasa + condicion; solo `[Fact]`. |

### Desviaciones de ADRs

**Desviaciones declaradas por el implementer**: ninguna (su resumen declara "todos los ADRs aplicados al pie de la letra").

**Desviaciones detectadas por el reviewer (NO declaradas por el implementer)**:

#### Desviacion: MEF-ADR-0043 seccion 1 — el ancla `$` admitia un salto de linea final
- **Regla del ADR**: *"DO restrict the characters in service-defined path segments to `0-9 A-Z a-z - . _ ~`"* — el set es cerrado; `\n` no pertenece a el.
- **Desviacion encontrada en el diff**: `ValidacionesCompartidas.cs:18`, patron `^[A-Za-z0-9._~-]+$`. En .NET el ancla `$` (sin `Multiline`) hace match **al final de la cadena o antes de un `\n` final**, de modo que `"COL-001\n"` pasaba la validacion. Confirmado empiricamente antes de corregir: los dos tests nuevos fallaron en rojo con el patron original y pasaron tras el cambio.
- **Impacto**: un codigo con salto de linea final habria quedado persistido en `VinculacionIniciada` y, cuando #379 lo promueva a segmento de ruta, romperia la URL igual que un espacio; ademas habilita CRLF injection en cualquier consumidor que lo reenvie en un header o lo escriba en un log.
- **Accion tomada**: **corregida en refactor** — patron a `@"\A[A-Za-z0-9._~-]+\z"`, con comentario que explica por que no se usan `^`/`$`, mas un test por validator (`Validar_RechazaCodigoColaborador_CuandoTerminaEnSaltoDeLinea`) que fija el contrato.
- **Status**: resuelta en este PR; no requiere evaluacion del usuario.

### Precedentes consultados por el implementer

| Precedente | ADR aplicable | Veredicto |
|---|---|---|
| `TipoIdentificacion` en ambos validators (`Cascade(Stop)` + regla + `WithMessage`) | MEF-ADR-0004 capa 1 | **alineado** — el `Cascade(CascadeMode.Stop)` replicado es correcto: `NotEmpty()` primero, la regla de caracteres solo evalua un valor no vacio. El precedente incluye ademas `WithMessage` explicito, que el implementer **no** replico (ver "Criticas"). |
| `Identificacion.Crear` (#381, normaliza en vez de rechazar) | — | **alineado con el issue**: descartarlo fue correcto; #387 decide explicitamente rechazar, no limpiar, porque el codigo lo asigna la empresa. |

**Lectura de MEF-ADR-0018 en el comentario del codigo**: el comentario del implementer decia *"MEF-ADR-0018 (Rule of Three): compartir la definicion unica evita que diverjan"* — el ADR dice lo contrario para dos sitios (*"con dos sitios, la duplicacion se mantiene"*). La decision de compartir **es correcta**, pero por dos razones distintas: (a) el CA-4 del issue lo exige explicitamente, y (b) el set de caracteres es mecanica neutral, que ese mismo ADR deja fuera de su alcance (*"reuso de utilidades sin riesgo de divergencia"*). Comentario reescrito para no dejar una cita invertida del ADR en el codigo.

### Convenciones del pipeline (no ADRs)

| Convencion | Estado | Observacion |
|---|---|---|
| Cada test con `Then()` + `And<>()` | n/a | El issue no toca command handlers ni aggregates: son tests de validator (`ValidateAsync` + `PropertyName`), sin DSL Given/When/Then. |
| Overloads correctos para stream IDs compuestos | n/a | Sin tests de handler en el diff. |
| Fakes manuales (no NSubstitute) | n/a | Sin dependencias fakeadas; `new Validator()` directo. |
| Feature folders (produccion y tests) | ok | Validators en `{Comando}Function/CommandHandler/`, tests espejo. La clase compartida va en `Infraestructura/` (transversal a dos feature folders), junto a `RequestValidator`/`ComposicionServicios`. |
| Smoke tests: SkipWhen, secrets, cobertura | ok | `Assert.SkipWhen(!postgres.IsConfigured, ...)` en los dos tests que verifican persistencia; los de 400 no usan `PostgresFixture` (mismo patron que los 400 preexistentes). `appsettings.json` no se toco. Sin archivos duplicados por comando. |
| Proyecciones read-side (MEF-ADR-0041, cuarta isla) | n/a | El diff no toca `ReadModels`/`Projections` ni ninguna Function GET. |
| Antipatrones de habilitacion (MEF-ADR-0039) | n/a | `git diff main...HEAD -- '**/*.csproj'` vacio; ningun tipo de evento nuevo. |
| Compatibilidad Marten write-side/read-side | n/a | Sin cambios de version del paquete ni de configuracion Marten (`ComposicionServicios`, `IdentidadEventos`, `ConfiguracionSerializacion` intactos). |
| Identidad de stream (MEF-ADR-0037) | n/a | El diff no toca `StartStream`/`ExistsAsync`/`ComputarStreamId`/`GroupId` ni ningun GET con id de ruta. **Nota anticipatoria**: este issue es precisamente la precondicion que habilita a #379 a mover el codigo a la ruta; ahi si aplicara el punto 3 (parseo tipado en el borde). |
| Contrato HTTP de comandos (MEF-ADR-0043 seccion 2-7) | n/a | `git diff main...HEAD --diff-filter=A -- '**/*Function/FunctionEndpoint.cs'` vacio: ningun endpoint nuevo ni migracion pactada. El issue declara "Contrato HTTP del comando: No aplica" de forma explicita, coherente con el diff. |
| Control de volumen de telemetria (MEF-ADR-0038) | n/a | Sin cambios en `ComposicionServicios`, wiring de OTel ni callback de Wolverine. |
| Tests via ToString/comportamiento | ok | Los tests verifican `IsValid` y `PropertyName`, sin getters expuestos para test. |
| Sin numeros magicos | ok | El unico literal con significado es el regex, con el set documentado contra RFC 3986 y MEF-ADR-0043. |
| Condiciones en positivo (guardas if/else afirmativas) | n/a | Sin bifurcaciones nuevas. |

### Elegancia del codigo
- **Compacto e idiomatico**: `[GeneratedRegex]` (source generator) sobre `new Regex(...)` es la eleccion correcta en .NET 10; el metodo de extension sobre `IRuleBuilder<T, string>` es el modo idiomatico de compartir una regla de FluentValidation y deja el call-site legible (`.DebeSerCodigoColaboradorUrlSafe()`).
- **Robustez**: era el punto flojo — el ancla `$` (corregido) y el mensaje default en ingles (corregido). Ambos silenciosos: compilaban, pasaban los tests existentes y solo se manifestarian en produccion.
- **Limpieza**: `dotnet build` con 0 errores; las 4 advertencias `NU1902` (OpenTelemetry.Api en Programacion) son preexistentes y ajenas al diff. `dotnet format --verify-no-changes` no reporta nada sobre ningun archivo de Colaboradores (los `IDE0005` que aparecen son preexistentes en `ControlHoras.Tests`, fuera del diff).
- **Observacion no bloqueante**: el nombre `ValidacionesCompartidas` describe el *mecanismo* (que se comparte) y no el *contenido* (que valida) — es un nombre "bucket" que invita a acumular reglas heterogeneas. No lo renombre: el issue delego explicitamente la forma al pipeline, el implementer documento la eleccion, y MEF-ADR-0018 ("el reviewer juzga la propuesta, no la origina") desaconseja imponer un rename cosmetico. Si #378/#379 suman una segunda regla de otro campo aqui, es el momento de partirla por campo.

### Criticas y hallazgos

1. **[MAYOR — corregido]** El regex aceptaba `"COL-001\n"` por el ancla `$` de .NET. Detalle completo en "Desviaciones detectadas por el reviewer". Corregido a `\A...\z` + 2 tests.
2. **[MENOR — corregido]** El 400 devolvia el mensaje default de FluentValidation (`"'Codigo Colaborador' is not in the correct format."`). Ese texto **viaja al cliente**: `RequestValidator` empaqueta `resultado.ToDictionary()` en un `ValidationProblemDetails` (`BadRequestObjectResult`). Un integrador externo recibia un mensaje en ingles que no dice cual es el formato esperado, mientras el precedente del mismo validator (`TipoIdentificacion`) si trae mensaje explicito en espanol. Agregado en el punto unico de definicion (respeta CA-4): *"El codigo del colaborador solo admite letras sin tilde, digitos y los caracteres - . _ ~"*. Ningun test verifica el texto, asi que no acopla la suite al literal.
3. **[MENOR — corregido]** `NuevoCodigoColaborador()` estaba copiado **11 veces** en los smoke tests del dominio, y este issue tuvo que editarlas una por una (el hallazgo mas valioso del test-writer: la investigacion del planner afirmaba que ya eran conformes, y no lo eran). MEF-ADR-0018 nombra exactamente este momento — *"cuando un cambio reciente toco simultaneamente los sitios y los dejo identicos, ese es el momento natural para proponer la extraccion en el mismo PR"* — y ademas excluye de su heuristica el reuso de utilidades sin riesgo de divergencia. Extraido a `Fixtures/DatosDePrueba.cs`. **No se toco `NuevoNumeroIdentificacion()`** (tambien duplicado, pero fuera del diff — regla de alcance).
4. **[COSMETICO — corregido]** El comentario de la clase citaba MEF-ADR-0018 diciendo lo contrario de lo que el ADR dice (ver "Precedentes"). Reescrito.
5. **[COSMETICO — corregido]** Dos comentarios de smoke test decian *"el helper NuevoCodigoColaborador de este archivo"*, afirmacion que la extraccion volvio falsa. Actualizados a "helper compartido".
6. **[SIN ACCION]** El smoke test `RegistrarColaborador_Retorna400_CuandoCodigoColaboradorContieneEspacio` dejo en dev, al correr hoy contra el codigo viejo, un colaborador con espacio en su codigo (dev respondio 202). Dev es desechable y el propio issue anota que esos streams no se migran ("la invariante rige hacia adelante"); no requiere accion. Se anota por trazabilidad: cuando #379 llegue, ese colaborador no sera direccionable por codigo.

### Refactorings aplicados

| Cambio | Justificacion | Verificacion |
|---|---|---|
| `^[A-Za-z0-9._~-]+$` -> `@"\A[A-Za-z0-9._~-]+\z"` en `ValidacionesCompartidas` | Defecto funcional contra MEF-ADR-0043 seccion 1 (hallazgo 1) | `Colaboradores.Tests` 336/336 |
| `.WithMessage(...)` explicito sobre la regla `Matches` | Contrato de error legible para el integrador; precedente de `TipoIdentificacion` (hallazgo 2) | idem |
| `NuevoCodigoColaborador()` extraido de 11 clases a `Fixtures/DatosDePrueba.cs` (via `using static`) | MEF-ADR-0018, momento natural de extraccion (hallazgo 3) | `dotnet build` 0 errores; los smoke tests que hoy corren mantienen exactamente el mismo resultado (4 rojos por deploy pendiente, ni uno mas) |
| Comentarios de la clase compartida y de dos smoke tests | Cita invertida de ADR y referencias obsoletas (hallazgos 4 y 5) | — |

Commit: `33275d5`. **No se modifico ningun test para hacerlo pasar**: los 2 tests agregados nacieron rojos contra la implementacion existente y pasaron al corregir el codigo de produccion.

### Cobertura de criterios de aceptacion

| Criterio | Estado | Test(s) |
|---|---|---|
| CA-1: codigo con caracteres permitidos (`EMP-001`, `a.b_c~2`) -> 202, comportamiento intacto | cubierto | `Validar_Aprueba_CuandoCodigoColaboradorEsAlfanumericoConGuion`, `Validar_Aprueba_CuandoCodigoColaboradorTieneCaracteresUnreservedNoAlfanumericos` (los dos validators) + smoke `{Registrar,Reingresar}Colaborador_Retorna202_CuandoCodigoColaboradorTieneCaracteresUnreservedNoAlfanumericos` (con verificacion de persistencia). Los 334 tests preexistentes de `Colaboradores.Tests` verdes confirman que el comportamiento actual queda intacto. |
| CA-2: codigo con `:` -> 400 en ambos comandos | cubierto | `Validar_RechazaCodigoColaborador_CuandoContieneDosPuntos` (x2) + smoke `{Registrar,Reingresar}Colaborador_Retorna400_CuandoCodigoColaboradorContieneDosPuntos` |
| CA-3: cualquier otro caracter fuera del set -> 400 en ambos comandos | cubierto | `..._CuandoContieneEspacio`, `..._CuandoContieneCaracterAcentuado`, `..._CuandoContieneBarra` y **`..._CuandoTerminaEnSaltoDeLinea` (agregado en esta fase)** (x2) + smoke con espacio |
| CA-4: la definicion del set existe en UN solo lugar | cubierto (estructural) | `ValidacionesCompartidas.CodigoColaboradorUrlSafeRegex()` es el unico literal del set en `src/`; verificado por grep — ningun otro sitio lo redefine. El mensaje de error tambien quedo en ese unico punto. |

### Tests agregados
- `RegistrarColaboradorValidatorTests.Validar_RechazaCodigoColaborador_CuandoTerminaEnSaltoDeLinea` (CA-3, caso borde del ancla).
- `ReingresarColaboradorValidatorTests.Validar_RechazaCodigoColaborador_CuandoTerminaEnSaltoDeLinea` (idem).
- Tests de contrato de value objects (igualdad / serializacion round-trip): **no aplican** — el diff no introduce ningun VO, `IEquatable<T>`, `ConfigurarSerializacion` ni evento con marker de bus.
- **No se agrego smoke test para el salto de linea**: la exhaustividad del set vive en los unit tests; el smoke solo confirma que la regla llega desplegada, con `:` (caso destacado) y un representante generico (espacio). Sumar casos ahi solo agrega latencia y basura en dev.

</details>

## Commits

33275d5 refactor(hu-387): ancla \z en el regex URL-safe, mensaje explicito y helper de codigo compartido
b0cae95 test(hu-387): smoke tests para CodigoColaborador URL-safe end-to-end
9b5317f feat(hu-387): restringe CodigoColaborador a caracteres URL-safe (fase verde)
c12dfd6 test(hu-387): tests para restringir CodigoColaborador a caracteres URL-safe (fase roja)

Closes #387