### PR TITLE
Consultar la ficha del colaborador por su id unico

### DIFF
--- a/src/Bitakora.ControlAsistencia.Colaboradores/ObtenerFichaColaborador/FunctionEndpoint.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/ObtenerFichaColaborador/FunctionEndpoint.cs
@@ -28,8 +28,9 @@ namespace Bitakora.ControlAsistencia.Colaboradores.ObtenerFichaColaborador;
 // a diferencia del listado, que es responsabilidad del issue hermano). 404 sin body cuando la ficha
 // no existe.
 //
-// CA-3 (MEF-ADR-0037 seccion 2, precedente CorregirNombresFunction.FunctionEndpoint /
-// AsignarEtiquetaFunction.FunctionEndpoint): Identificacion.Parsear es el UNICO punto de conversion
+// CA-3 (MEF-ADR-0037 seccion 2, precedente CorregirNombresFunction.FunctionEndpoint -- el unico
+// endpoint que hoy parsea un {id} de ruta; AsignarEtiquetaFunction todavia recibe la identificacion
+// en el body): Identificacion.Parsear es el UNICO punto de conversion
 // string->Identificacion -- nunca se parte el {id} de ruta a mano. Un ArgumentException (sin guion,
 // tipo fuera de la lista cerrada PILA, numero vacio tras la limpieza) se traduce aqui, y solo aqui,
 // a 400 explicito, antes de tocar Marten.

--- a/src/Bitakora.ControlAsistencia.Colaboradores/ObtenerFichaColaborador/FunctionEndpoint.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/ObtenerFichaColaborador/FunctionEndpoint.cs
@@ -1,3 +1,5 @@
+using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+using Bitakora.ControlAsistencia.Colaboradores.Entities;
 using Bitakora.ControlAsistencia.ReadModels.Colaboradores;
 using Cosmos.MultiTenancy;
 using Marten;
@@ -26,10 +28,11 @@ namespace Bitakora.ControlAsistencia.Colaboradores.ObtenerFichaColaborador;
 // a diferencia del listado, que es responsabilidad del issue hermano). 404 sin body cuando la ficha
 // no existe.
 //
-// STUB de fase roja (test-writer): Run() solo lanza NotImplementedException. El comportamiento real
-// (parseo con Identificacion.Parsear -> 400 explicito, ComputarStreamId, session.LoadAsync, 200/404,
-// la traduccion centinela -> vacio de CA-6) es responsabilidad del implementer -- ver
-// FunctionEndpointTests.cs (CA-3) para el contrato exacto que debe cumplir.
+// CA-3 (MEF-ADR-0037 seccion 2, precedente CorregirNombresFunction.FunctionEndpoint /
+// AsignarEtiquetaFunction.FunctionEndpoint): Identificacion.Parsear es el UNICO punto de conversion
+// string->Identificacion -- nunca se parte el {id} de ruta a mano. Un ArgumentException (sin guion,
+// tipo fuera de la lista cerrada PILA, numero vacio tras la limpieza) se traduce aqui, y solo aqui,
+// a 400 explicito, antes de tocar Marten.
 public class FunctionEndpoint(IDocumentStore store, ITenantResolver tenantResolver)
 {
     [Function("ObtenerFichaColaborador")]
@@ -39,7 +42,30 @@ public class FunctionEndpoint(IDocumentStore store, ITenantResolver tenantResolv
         string id,
         CancellationToken ct)
     {
-        throw new NotImplementedException();
+        Identificacion identificacion;
+        try
+        {
+            identificacion = Identificacion.Parsear(id);
+        }
+        catch (ArgumentException)
+        {
+            return new BadRequestObjectResult(
+                "El id de la ruta es invalido -- debe tener la forma {Tipo}-{Numero}");
+        }
+
+        var streamKey = ColaboradorAggregateRoot.ComputarStreamId(identificacion);
+
+        // CA-6: la QuerySession se abre SIEMPRE acotada al tenant que resuelve ITenantResolver --
+        // nunca a un tenant id que llegara por ruta o query string (mitigacion estructural contra
+        // BOLA/IDOR, MEF-ADR-0028/skills/projections/read-apis.md). El {id} de ruta es el recurso,
+        // no el tenant.
+        await using var session = store.QuerySession(tenantResolver.TenantId);
+        var ficha = await session.LoadAsync<FichaColaborador>(streamKey, ct);
+
+        if (ficha is null)
+            return new NotFoundResult();
+
+        return new OkObjectResult(FichaColaboradorRespuesta.DesdeVista(ficha));
     }
 }
 

--- a/src/Bitakora.ControlAsistencia.Colaboradores/ObtenerFichaColaborador/FunctionEndpoint.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/ObtenerFichaColaborador/FunctionEndpoint.cs
@@ -1,5 +1,3 @@
-using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
-using Bitakora.ControlAsistencia.Colaboradores.Entities;
 using Bitakora.ControlAsistencia.ReadModels.Colaboradores;
 using Cosmos.MultiTenancy;
 using Marten;
@@ -9,55 +7,39 @@ using Microsoft.Azure.Functions.Worker;
 
 namespace Bitakora.ControlAsistencia.Colaboradores.ObtenerFichaColaborador;
 
-// Issue #356: Function GET del read model FichaColaborador (via (a) proyeccion materializada,
-// skills/projections/naming.md, MEF-ADR-0006 enmienda #363). Feature folder sin sufijo Function, un
-// namespace por query (skills/projections/read-apis.md): esta clase FunctionEndpoint no colisiona
-// con ninguna otra del mismo ensamblado porque cada query vive en su propio namespace.
+// Issue #356 (creacion): Function GET del read model FichaColaborador (via (a) proyeccion
+// materializada, skills/projections/naming.md, MEF-ADR-0006 enmienda #363). Feature folder sin
+// sufijo Function, un namespace por query (skills/projections/read-apis.md): esta clase
+// FunctionEndpoint no colisiona con ninguna otra del mismo ensamblado porque cada query vive en su
+// propio namespace.
 //
-// La ruta recibe tipoIdentificacion/numero como los componentes tipados de la clave natural
-// compuesta -- la clave se reconstruye con ColaboradorAggregateRoot.ComputarStreamId, nunca con una
-// concatenacion propia del endpoint (MEF-ADR-0037). tipoIdentificacion invalido (fuera de la lista
-// cerrada PILA) o numero vacio/whitespace -> 400 explicito (TipoIdentificacion.Desde/
-// Identificacion.Crear rechazan con ArgumentException, capturada aqui como unico punto de
-// traduccion a 400).
+// Issue #386 (esta revision): alinea el GET puntual a la forma unica de identidad en la ruta que ya
+// usan los comandos del ciclo de vida del colaborador (#376/#377): {id} = Identificacion.ToString()
+// ("CC-79543210"), la misma llave que devuelve FichaColaborador.Id -- cierra el round-trip completo
+// del cliente (consulta y comando comparten forma de id, MEF-ADR-0037: punto unico de conversion de
+// la identidad de stream via Identificacion.Parsear, nunca partiendo la llave por su cuenta).
+// Reemplaza la ruta de dos segmentos {tipoIdentificacion}/{numero} (issue #356): la ruta vieja deja
+// de existir (CA-5). Rename de un endpoint desplegado discutido con el humano (MEF-ADR-0043
+// seccion 7, por analogia).
 //
-// CA-6: consulta puntual, INCLUYE no-vigentes (sin filtro de vigencia -- a diferencia del listado,
-// que es responsabilidad del issue hermano). 404 sin body cuando la ficha no existe.
+// CA-6 (issue #356, sin cambios): consulta puntual, INCLUYE no-vigentes (sin filtro de vigencia --
+// a diferencia del listado, que es responsabilidad del issue hermano). 404 sin body cuando la ficha
+// no existe.
+//
+// STUB de fase roja (test-writer): Run() solo lanza NotImplementedException. El comportamiento real
+// (parseo con Identificacion.Parsear -> 400 explicito, ComputarStreamId, session.LoadAsync, 200/404,
+// la traduccion centinela -> vacio de CA-6) es responsabilidad del implementer -- ver
+// FunctionEndpointTests.cs (CA-3) para el contrato exacto que debe cumplir.
 public class FunctionEndpoint(IDocumentStore store, ITenantResolver tenantResolver)
 {
     [Function("ObtenerFichaColaborador")]
     public async Task<IActionResult> Run(
-        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "colaboradores/fichas/{tipoIdentificacion}/{numero}")]
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "colaboradores/fichas/{id}")]
         HttpRequest req,
-        string tipoIdentificacion,
-        string numero,
+        string id,
         CancellationToken ct)
     {
-        Identificacion identificacionTipada;
-        try
-        {
-            var tipo = TipoIdentificacion.Desde(tipoIdentificacion);
-            identificacionTipada = Identificacion.Crear(tipo, numero);
-        }
-        catch (ArgumentException)
-        {
-            return new BadRequestObjectResult(
-                "El tipoIdentificacion o el numero de la ruta son invalidos");
-        }
-
-        var streamKey = ColaboradorAggregateRoot.ComputarStreamId(identificacionTipada);
-
-        // CA-6: la QuerySession se abre SIEMPRE acotada al tenant que resuelve ITenantResolver --
-        // nunca a un tenant id que llegara por ruta o query string (mitigacion estructural contra
-        // BOLA/IDOR, MEF-ADR-0028/skills/projections/read-apis.md). tipoIdentificacion/numero SI
-        // vienen de la ruta: son el recurso, no el tenant.
-        await using var session = store.QuerySession(tenantResolver.TenantId);
-        var ficha = await session.LoadAsync<FichaColaborador>(streamKey, ct);
-
-        if (ficha is null)
-            return new NotFoundResult();
-
-        return new OkObjectResult(FichaColaboradorRespuesta.DesdeVista(ficha));
+        throw new NotImplementedException();
     }
 }
 

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/ObtenerFichaColaborador/ObtenerFichaColaboradorSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/ObtenerFichaColaborador/ObtenerFichaColaboradorSmokeTests.cs
@@ -1,8 +1,19 @@
-// Issue #356: smoke tests de ObtenerFichaColaborador, GET
-// colaboradores/fichas/{tipoIdentificacion}/{numero}. Function GET read-side sobre la proyeccion
+// Issue #356 (creacion) / issue #386 (esta revision): smoke tests de ObtenerFichaColaborador, GET
+// colaboradores/fichas/{id}. Function GET read-side sobre la proyeccion
 // FichaColaborador (receta N1, MEF-ADR-0034/0035): la primera vista materializada del dominio
 // Colaboradores, consultable puntualmente por identificacion y base del flujo de reingreso (por eso
 // la consulta puntual INCLUYE no-vigentes, a diferencia de un futuro listado).
+//
+// Issue #386: {id} = Identificacion.ToString() ("CC-79543210") -- un unico segmento, la misma llave
+// que devuelve FichaColaborador.Id y la misma forma de id que ya usan los comandos del ciclo de vida
+// (#376/#377). Cierra el round-trip del cliente: el Id que la API devuelve se reusa tal cual en
+// cualquier URL, sin que el cliente lo parta jamas. El endpoint lo parsea UNA sola vez con
+// Identificacion.Parsear (punto unico de conversion, MEF-ADR-0037 seccion 2) -- de ahi el 400 de
+// CA-3 y la normalizacion de CA-4. La ruta vieja de dos segmentos
+// ({tipoIdentificacion}/{numero}) deja de existir: CA-5 lo verifica AFIRMATIVAMENTE contra el
+// entorno real (404 del host), no solo por ausencia de referencias en este archivo -- misma
+// tecnica que CorregirNombresSmokeTests (#377), porque "no la llama nadie" no distingue una ruta
+// eliminada de una que sigue viva.
 //
 // Arrange via API, nunca sembrando el event store por fuera de ella: el colaborador se crea con
 // POST Colaboradores (#330) y, cuando aplica, se termina su vinculacion con POST
@@ -15,11 +26,12 @@
 // directo en tests": si el timeout se agota es un fallo real (worker no desplegado o proyeccion sin
 // registrar en el named store), nunca un skip.
 //
-// Estos tests quedan ROJOS hasta que el deploy publique ObtenerFichaColaborador en dev: mientras la
-// revision anterior siga corriendo, la ruta no existe y el host responde 404 a todo -- el caso 400
-// falla y el caso 404 pasa por la razon equivocada (mismo precedente que ObtenerTurnoVigenteSmokeTests
-// en ControlHoras). El CI de PR no los ejecuta (solo corre *.Tests); su veredicto real se lee
-// despues del deploy.
+// Estos tests quedan ROJOS hasta que el deploy publique la ruta nueva en dev: mientras la revision
+// anterior siga corriendo, solo existe la ruta vieja de dos segmentos y el host responde 404 a todo
+// lo demas -- los casos 400 fallan y los casos 404 pasan por la razon equivocada (mismo precedente
+// que ObtenerTurnoVigenteSmokeTests en ControlHoras y que CorregirNombresSmokeTests tras el rename
+// de #377). El CI de PR no los ejecuta (solo corre *.Tests); su veredicto real se lee despues del
+// deploy.
 //
 // Formas locales DESACOPLADAS del read model de produccion
 // (Bitakora.ControlAsistencia.ReadModels.Colaboradores.FichaColaborador/EtiquetaFicha): el smoke
@@ -75,12 +87,24 @@ public class ObtenerFichaColaboradorSmokeTests(ApiFixture api)
     // ("CC-<numero>"), no un Guid nuevo por llamada.
     private static string NuevoNumeroIdentificacion() => Guid.CreateVersion7().ToString("N").ToUpperInvariant();
 
-    // Mismo formato que ColaboradorAggregateRoot.ComputarStreamId (separador "-" desde #381),
-    // reconstruido localmente: el smoke test no referencia el Function App (Colaboradores.Entities).
+    // Oraculo independiente de la clave de stream (MEF-ADR-0002): mismo formato que
+    // ColaboradorAggregateRoot.ComputarStreamId (separador "-" desde #381), reconstruido localmente
+    // -- el smoke test no referencia el Function App (Colaboradores.Entities).
     private static string ComputarStreamId(string numeroIdentificacion) =>
         $"{TipoIdentificacionCc}-{numeroIdentificacion}";
 
-    private static string Ruta(string tipoIdentificacion, string numero) =>
+    // El {id} que un cliente real pone en la URL (issue #386). Deliberadamente separado de
+    // ComputarStreamId, mismo criterio que CorregirNombresSmokeTests (#377): uno es la ENTRADA de la
+    // request, el otro el ORACULO del Id que la respuesta debe traer -- que hoy coincidan
+    // textualmente es justamente lo que estos tests prueban (el round-trip del cliente), no algo que
+    // puedan asumir compartiendo el mismo metodo.
+    private static string IdDeRuta(string numeroIdentificacion) =>
+        $"{TipoIdentificacionCc}-{numeroIdentificacion}";
+
+    private static string Ruta(string id) => $"/api/colaboradores/fichas/{id}";
+
+    // Ruta vieja de dos segmentos (issue #356), eliminada por #386 -- solo la usa el test de CA-5.
+    private static string RutaVieja(string tipoIdentificacion, string numero) =>
         $"/api/colaboradores/fichas/{tipoIdentificacion}/{numero}";
 
     private static object PayloadRegistro(
@@ -127,6 +151,25 @@ public class ObtenerFichaColaboradorSmokeTests(ApiFixture api)
             "el arrange de este smoke test depende de que TerminarVinculacion funcione");
     }
 
+    // Act comun de los caminos felices: reintenta el GET hasta que la proyeccion asincrona
+    // materialice la ficha (404 = el worker todavia no la aplico) y, cuando se pasa "hasta", hasta
+    // que el body ademas cumpla esa condicion (el segundo evento del stream ya aplicado). Devuelve
+    // un valor no nulo o lanza TimeoutException -- por eso ningun caller afirma NotBeNull.
+    private Task<FichaColaboradorRespuestaSmoke> EsperarFichaAsync(
+        string id, CancellationToken ct, Func<FichaColaboradorRespuestaSmoke, bool>? hasta = null) =>
+        Polling.WaitUntilAsync(async () =>
+        {
+            var response = await _client.GetAsync(Ruta(id), ct);
+            if (response.StatusCode == HttpStatusCode.NotFound)
+                return null;
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            var body = await response.Content.ReadFromJsonAsync<FichaColaboradorRespuestaSmoke>(
+                JsonOptions, cancellationToken: ct);
+
+            return body is not null && (hasta is null || hasta(body)) ? body : null;
+        }, Timeout);
+
     [Fact]
     [Trait("Category", "Smoke")]
     public async Task DebeEstarDisponible_CuandoSeConsultaHealthCheck()
@@ -153,17 +196,7 @@ public class ObtenerFichaColaboradorSmokeTests(ApiFixture api)
         await RegistrarColaboradorAsync(numeroIdentificacion, fechaInicio, codigoColaborador, ct);
 
         // Act + Assert: reintentar el GET hasta que la proyeccion asincrona materialice la ficha.
-        var ruta = Ruta(TipoIdentificacionCc, numeroIdentificacion);
-        var respuesta = await Polling.WaitUntilAsync(async () =>
-        {
-            var response = await _client.GetAsync(ruta, ct);
-            if (response.StatusCode == HttpStatusCode.NotFound)
-                return null;
-
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
-            return await response.Content.ReadFromJsonAsync<FichaColaboradorRespuestaSmoke>(
-                JsonOptions, cancellationToken: ct);
-        }, Timeout);
+        var respuesta = await EsperarFichaAsync(IdDeRuta(numeroIdentificacion), ct);
 
         // Sin assert de NotBeNull: WaitUntilAsync devuelve un valor no nulo o lanza TimeoutException
         // ("el worker no materializo FichaColaborador dentro del timeout"), nunca null.
@@ -197,26 +230,50 @@ public class ObtenerFichaColaboradorSmokeTests(ApiFixture api)
         // Act + Assert: reintentar hasta que el worker aplique TAMBIEN VinculacionTerminada -- un
         // 200 con VigenteHasta todavia nulo solo significa que la proyeccion aun no proceso el
         // segundo evento del stream.
-        var ruta = Ruta(TipoIdentificacionCc, numeroIdentificacion);
-        var respuesta = await Polling.WaitUntilAsync(async () =>
-        {
-            var response = await _client.GetAsync(ruta, ct);
-            if (response.StatusCode == HttpStatusCode.NotFound)
-                return null;
-
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
-            var body = await response.Content.ReadFromJsonAsync<FichaColaboradorRespuestaSmoke>(
-                JsonOptions, cancellationToken: ct);
-
-            return body?.VigenteHasta is not null ? body : null;
-        }, Timeout);
+        var respuesta = await EsperarFichaAsync(
+            IdDeRuta(numeroIdentificacion), ct, hasta: ficha => ficha.VigenteHasta is not null);
 
         respuesta.Id.Should().Be(ComputarStreamId(numeroIdentificacion));
         respuesta.VigenteHasta.Should().Be(fechaEfectiva);
     }
 
-    // CA-6: ficha inexistente -> 404 sin body -- distingue el NotFoundResult() del endpoint de un
-    // 404 con payload de error, y de la pagina de error del host si la ruta no existiera.
+    // CA-4 (issue #386): el {id} en minusculas resuelve la MISMA ficha que su forma canonica --
+    // Identificacion.Parsear normaliza tipo (TipoIdentificacion.Desde: trim + MAYUSCULAS) y numero
+    // (Crear: limpieza + MAYUSCULAS) antes de componer la llave, asi que el cliente nunca tiene que
+    // preocuparse por el casing del id que la propia API le devolvio. Es la garantia que un route
+    // constraint NO daria (MEF-ADR-0037 seccion 2: los constraints no normalizan casing), y la
+    // razon por la que este endpoint parsea en vez de reenviar el segmento crudo a LoadAsync: sin
+    // el parseo, la comparacion de igualdad de texto de Postgres (collation deterministica) haria
+    // que "cc-..." simplemente no encuentre nada.
+    //
+    // Se espera primero con el id canonico (prueba que la ficha se materializo) y recien despues se
+    // consulta en minusculas con un unico GET: asi un fallo distingue "el worker no proyecto" de
+    // "la normalizacion se rompio", en vez de dar un timeout ambiguo.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ObtenerFichaColaborador_Retorna200ConLaMismaFicha_CuandoElIdDeRutaViajaEnMinusculas()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion();
+        var codigoColaborador = NuevoCodigoColaborador();
+
+        await RegistrarColaboradorAsync(numeroIdentificacion, new DateOnly(2026, 3, 10), codigoColaborador, ct);
+        await EsperarFichaAsync(IdDeRuta(numeroIdentificacion), ct);
+
+        var response = await _client.GetAsync(
+            Ruta(IdDeRuta(numeroIdentificacion).ToLowerInvariant()), ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var respuesta = await response.Content.ReadFromJsonAsync<FichaColaboradorRespuestaSmoke>(
+            JsonOptions, cancellationToken: ct);
+
+        respuesta!.Id.Should().Be(ComputarStreamId(numeroIdentificacion),
+            "el id se normaliza al canonico antes de tocar Marten, y la respuesta siempre trae esa forma");
+        respuesta.CodigoColaborador.Should().Be(codigoColaborador);
+    }
+
+    // CA-2/CA-6: ficha inexistente -> 404 sin body -- distingue el NotFoundResult() del endpoint de
+    // un 404 con payload de error, y de la pagina de error del host si la ruta no existiera.
     [Fact]
     [Trait("Category", "Smoke")]
     public async Task ObtenerFichaColaborador_Retorna404SinBody_CuandoLaFichaNoExiste()
@@ -226,24 +283,80 @@ public class ObtenerFichaColaboradorSmokeTests(ApiFixture api)
         // Numero nunca registrado por ningun test -- no puede tener ficha materializada.
         var numeroIdentificacion = NuevoNumeroIdentificacion();
 
-        var response = await _client.GetAsync(Ruta(TipoIdentificacionCc, numeroIdentificacion), ct);
+        var response = await _client.GetAsync(Ruta(IdDeRuta(numeroIdentificacion)), ct);
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
         (await response.Content.ReadAsStringAsync(ct)).Should().BeEmpty();
     }
 
-    // CA-6: tipoIdentificacion fuera de la lista cerrada (PILA: CC, CE, TI, PA, PT) -> 400 --
-    // TipoIdentificacion.Desde rechaza y el endpoint traduce a BadRequest (borde HTTP tipado,
-    // MEF-ADR-0037).
+    // CA-3: tipo de identificacion del {id} fuera de la lista cerrada (PILA: CC, CE, TI, PA, PT) ->
+    // 400 -- TipoIdentificacion.Desde rechaza dentro de Identificacion.Parsear y el endpoint lo
+    // traduce a BadRequest en su unico punto de traduccion (borde HTTP tipado, MEF-ADR-0037).
     [Fact]
     [Trait("Category", "Smoke")]
     public async Task ObtenerFichaColaborador_Retorna400_CuandoTipoIdentificacionNoEsReconocido()
     {
         var ct = TestContext.Current.CancellationToken;
-        var numeroIdentificacion = NuevoNumeroIdentificacion();
 
-        var response = await _client.GetAsync(Ruta("XX", numeroIdentificacion), ct);
+        var response = await _client.GetAsync(Ruta($"XX-{NuevoNumeroIdentificacion()}"), ct);
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    // CA-3: {id} sin guion -> 400. Contra el entorno real importa distinguirlo del 404 del host: el
+    // id llega a la Function (la ruta existe) y es el parseo quien lo rechaza.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ObtenerFichaColaborador_Retorna400_CuandoElIdDeRutaNoTraeGuion()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        var response = await _client.GetAsync(
+            Ruta($"{TipoIdentificacionCc}{NuevoNumeroIdentificacion()}"), ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    // CA-3: numero vacio tras el guion del {id} -> 400.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ObtenerFichaColaborador_Retorna400_CuandoElNumeroDelIdDeRutaQuedaVacio()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        var response = await _client.GetAsync(Ruta($"{TipoIdentificacionCc}-"), ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    // CA-5: la ruta vieja de dos segmentos deja de existir. Es la unica verificacion AFIRMATIVA de
+    // ese criterio -- el resto de la suite lo cubre solo por ausencia de referencias, que no
+    // distingue "la ruta se elimino" de "sigue viva y nadie la llama". El rename esta pactado en el
+    // issue (MEF-ADR-0043 seccion 7, por analogia): si alguien reintrodujera la ruta vieja "por
+    // compatibilidad", este test lo delata contra el entorno real, que es donde el breaking change
+    // se paga.
+    //
+    // El arrange (registrar + esperar la ficha) es lo que hace la verificacion NO vacua: se llama la
+    // ruta vieja con una identificacion que SI tiene ficha materializada, asi que un 404 solo puede
+    // significar que ninguna Function enruta esos cuatro segmentos. Sin el arrange, la ruta vieja
+    // seguiria respondiendo 404 aunque estuviera viva (ficha inexistente) y el test pasaria por la
+    // razon equivocada.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ObtenerFichaColaborador_Retorna404DelHost_CuandoSeLlamaLaRutaViejaDeDosSegmentos()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var numeroIdentificacion = NuevoNumeroIdentificacion();
+
+        await RegistrarColaboradorAsync(
+            numeroIdentificacion, new DateOnly(2026, 4, 5), NuevoCodigoColaborador(), ct);
+        await EsperarFichaAsync(IdDeRuta(numeroIdentificacion), ct);
+
+        var response = await _client.GetAsync(
+            RutaVieja(TipoIdentificacionCc, numeroIdentificacion), ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound,
+            "colaboradores/fichas/{tipoIdentificacion}/{numero} se reemplazo por colaboradores/fichas/{id} (issue #386), " +
+            "y esta identificacion SI tiene ficha materializada -- si la ruta vieja siguiera viva responderia 200");
     }
 }

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/Infraestructura/ComposicionServiciosTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/Infraestructura/ComposicionServiciosTests.cs
@@ -325,9 +325,10 @@ public class ComposicionServiciosTests
     // WebApplicationFactory para Functions isolated worker).
     //
     // Se prueba solo la RESOLUCION de IDocumentStore/ITenantResolver por constructor -- no el
-    // comportamiento de Run (parseo de tipoIdentificacion/numero con 400 explicito,
+    // comportamiento de Run (issue #386: parseo del {id} de ruta con 400 explicito,
     // session.LoadAsync y el 200/404, la traduccion centinela -> vacio de CA-6), que es
-    // responsabilidad del endpoint y del smoke test, no de este guardrail de wiring.
+    // responsabilidad del endpoint (parcialmente unit-testeado, ver ObtenerFichaColaborador/
+    // FunctionEndpointTests.cs) y del smoke test, no de este guardrail de wiring.
     [Fact]
     public async Task AgregarServiciosColaboradores_ResuelveElEndpointDeObtenerFichaColaborador_CuandoElContenedorEstaCompuesto()
     {

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ObtenerFichaColaborador/FichaColaboradorRespuestaTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ObtenerFichaColaborador/FichaColaboradorRespuestaTests.cs
@@ -7,7 +7,8 @@
 //
 // El test de composicion hermano (ComposicionServiciosTests
 // .AgregarServiciosColaboradores_ResuelveElEndpointDeObtenerFichaColaborador_...) cubre el wiring
-// del endpoint; el resto de Run (parseo con 400, LoadAsync, 200/404) es black-box del smoke test.
+// del endpoint; FunctionEndpointTests.cs cubre el parseo del {id} de ruta con 400 (issue #386,
+// CA-3); LoadAsync y el 200/404 (CA-1/CA-2/CA-4) siguen siendo black-box del smoke test.
 //
 // Oraculo independiente (MEF-ADR-0002, no-tautologia): el centinela se escribe como literal aqui,
 // nunca se importa de FichaColaborador.CentinelaVigenciaAbierta -- si alguien cambiara esa

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ObtenerFichaColaborador/FunctionEndpointTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ObtenerFichaColaborador/FunctionEndpointTests.cs
@@ -1,0 +1,71 @@
+// Issue #386: tests del endpoint HTTP GET colaboradores/fichas/{id} -- alinea la consulta puntual
+// a la forma unica de identidad en la ruta que ya usan los comandos del ciclo de vida del
+// colaborador (#376/#377): {id} = Identificacion.ToString() ("CC-79543210"), la misma llave que
+// devuelve FichaColaborador.Id (round-trip completo del cliente, MEF-ADR-0037). Reemplaza la ruta
+// de dos segmentos {tipoIdentificacion}/{numero} (issue #356): la ruta vieja deja de existir (CA-5,
+// verificado por la ausencia de esa firma en este archivo).
+//
+// CA-3: id de ruta invalido (sin guion, tipo fuera de la lista cerrada PILA, numero vacio tras el
+// guion) -> 400 -- parseo tipado unico (Identificacion.Parsear), mismo mecanismo que
+// CorregirNombresFunction.FunctionEndpoint (precedente post-#376/#377). Los tres casos se
+// cortocircuitan ANTES de tocar Marten -- store y tenantResolver se pasan nulos a proposito, mismo
+// patron que ListarFichasColaborador/FunctionEndpointTests.cs: si un cambio futuro moviera la
+// validacion DESPUES de abrir la QuerySession, estos tests se pondrian rojos por la razon correcta
+// (NullReferenceException en vez de 400), nunca en verde por accidente.
+//
+// CA-1/CA-2/CA-4 (200 con ficha existente, 404 sin ficha, normalizacion "cc-79543210" resuelve la
+// misma ficha que "CC-79543210") dependen de session.LoadAsync contra Marten real -- black-box del
+// smoke test, mismo precedente que el propio test-writer de #356 dejo documentado en
+// FichaColaboradorRespuestaTests.cs ("el resto de Run... es black-box del smoke test"): IDocumentStore/
+// IQuerySession de Marten no se fake-ean a mano (violaria "NUNCA NSubstitute" sin aportar cobertura
+// real) y este dominio no usa Testcontainers para unit tests (ADR de smoke tests del proyecto).
+//
+// Fase roja (test-writer): Run() hoy SOLO lanza NotImplementedException (stub minimo de
+// compilacion, ver FunctionEndpoint.cs) -- ninguno de estos tests puede pasar todavia.
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.ObtenerFichaColaborador;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Tests.ObtenerFichaColaborador;
+
+public class FunctionEndpointTests
+{
+    // store/tenantResolver nulos a proposito: los tres casos de este archivo deben resolverse
+    // ANTES de que el endpoint toque Marten (ver comentario de archivo).
+    private static FunctionEndpoint Endpoint() => new(store: null!, tenantResolver: null!);
+
+    private static HttpRequest FakeHttpRequest()
+    {
+        var context = new DefaultHttpContext();
+        return context.Request;
+    }
+
+    // CA-3: id de ruta sin guion -> 400, sin llegar a tocar Marten.
+    [Fact]
+    public async Task ObtenerFichaColaborador_Retorna400_CuandoIdDeRutaNoTraeGuion()
+    {
+        var result = await Endpoint().Run(FakeHttpRequest(), "CC79543210", CancellationToken.None);
+
+        result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    // CA-3: tipo de identificacion fuera de la lista cerrada PILA -> 400.
+    [Fact]
+    public async Task ObtenerFichaColaborador_Retorna400_CuandoElTipoDeLaIdentificacionNoEstaEnLaListaCerrada()
+    {
+        var result = await Endpoint().Run(FakeHttpRequest(), "XX-79543210", CancellationToken.None);
+
+        result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    // CA-3: numero vacio tras el guion del {id} de ruta -> 400.
+    [Fact]
+    public async Task ObtenerFichaColaborador_Retorna400_CuandoElNumeroDeLaIdentificacionQuedaVacio()
+    {
+        var result = await Endpoint().Run(FakeHttpRequest(), "CC-", CancellationToken.None);
+
+        result.Should().BeOfType<BadRequestObjectResult>();
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ObtenerFichaColaborador/FunctionEndpointTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ObtenerFichaColaborador/FunctionEndpointTests.cs
@@ -20,8 +20,11 @@
 // IQuerySession de Marten no se fake-ean a mano (violaria "NUNCA NSubstitute" sin aportar cobertura
 // real) y este dominio no usa Testcontainers para unit tests (ADR de smoke tests del proyecto).
 //
-// Fase roja (test-writer): Run() hoy SOLO lanza NotImplementedException (stub minimo de
-// compilacion, ver FunctionEndpoint.cs) -- ninguno de estos tests puede pasar todavia.
+// El 400 se verifica como BadRequestObjectResult CON MENSAJE, no solo por su status: MEF-ADR-0037
+// seccion 2 (y la documentacion oficial de ASP.NET Core que ese ADR cita, "Invalid input should
+// produce a 400 Bad Request with an appropriate error message") proscribe el BadRequestResult
+// pelado -- deja al cliente sin saber que componente de la ruta se rechazo. Sin esta asercion,
+// "simplificar" el endpoint a un BadRequestResult pasaria estos tests en verde.
 
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.Colaboradores.ObtenerFichaColaborador;
@@ -36,36 +39,41 @@ public class FunctionEndpointTests
     // ANTES de que el endpoint toque Marten (ver comentario de archivo).
     private static FunctionEndpoint Endpoint() => new(store: null!, tenantResolver: null!);
 
-    private static HttpRequest FakeHttpRequest()
-    {
-        var context = new DefaultHttpContext();
-        return context.Request;
-    }
+    private static HttpRequest FakeHttpRequest() => new DefaultHttpContext().Request;
+
+    private static Task<IActionResult> ObtenerAsync(string id) =>
+        Endpoint().Run(FakeHttpRequest(), id, CancellationToken.None);
+
+    // El 400 debe llevar mensaje (ver cabecera): se afirma el tipo Y que el cuerpo trae texto.
+    private static void DebeSer400ConMensaje(IActionResult resultado) =>
+        resultado.Should().BeOfType<BadRequestObjectResult>()
+            .Which.Value.Should().BeOfType<string>()
+            .Which.Should().NotBeNullOrWhiteSpace();
 
     // CA-3: id de ruta sin guion -> 400, sin llegar a tocar Marten.
     [Fact]
     public async Task ObtenerFichaColaborador_Retorna400_CuandoIdDeRutaNoTraeGuion()
     {
-        var result = await Endpoint().Run(FakeHttpRequest(), "CC79543210", CancellationToken.None);
+        var resultado = await ObtenerAsync("CC79543210");
 
-        result.Should().BeOfType<BadRequestObjectResult>();
+        DebeSer400ConMensaje(resultado);
     }
 
     // CA-3: tipo de identificacion fuera de la lista cerrada PILA -> 400.
     [Fact]
     public async Task ObtenerFichaColaborador_Retorna400_CuandoElTipoDeLaIdentificacionNoEstaEnLaListaCerrada()
     {
-        var result = await Endpoint().Run(FakeHttpRequest(), "XX-79543210", CancellationToken.None);
+        var resultado = await ObtenerAsync("XX-79543210");
 
-        result.Should().BeOfType<BadRequestObjectResult>();
+        DebeSer400ConMensaje(resultado);
     }
 
     // CA-3: numero vacio tras el guion del {id} de ruta -> 400.
     [Fact]
     public async Task ObtenerFichaColaborador_Retorna400_CuandoElNumeroDeLaIdentificacionQuedaVacio()
     {
-        var result = await Endpoint().Run(FakeHttpRequest(), "CC-", CancellationToken.None);
+        var resultado = await ObtenerAsync("CC-");
 
-        result.Should().BeOfType<BadRequestObjectResult>();
+        DebeSer400ConMensaje(resultado);
     }
 }


### PR DESCRIPTION
## Resumen

Pipeline TDD completado:
- Fase roja: tests escritos con stubs
- Fase verde: implementación completa
- Fase refactor: revisión de calidad

## Decisiones del pipeline

<details>
<summary>Test Writer (fase roja) — 8m 59s</summary>

## ES Test Writer - Decisiones (issue #386)

### Naturaleza de la tarea

Este issue **no involucra un command handler ni un aggregate**: es un endpoint HTTP
GET de query (`ObtenerFichaColaborador`) que alinea su ruta a la forma unica de
identidad (`{id}` = `Identificacion.ToString()`). No hay evento, no hay `Apply()`, no
hay harness `CommandHandlerAsyncTest`. Se trata como un cambio en el borde HTTP puro,
siguiendo el precedente ya establecido en este mismo repo para
`CorregirNombresFunction`/`AsignarEtiquetaFunction`/`ListarFichasColaborador`
(tests planos de `FunctionEndpoint` con fakes manuales, sin DSL Given/When/Then).

### Tests creados

- `ObtenerFichaColaborador/FunctionEndpointTests.cs` (nuevo, 3 tests):
  - `ObtenerFichaColaborador_Retorna400_CuandoIdDeRutaNoTraeGuion` - CA-3
  - `ObtenerFichaColaborador_Retorna400_CuandoElTipoDeLaIdentificacionNoEstaEnLaListaCerrada` - CA-3
  - `ObtenerFichaColaborador_Retorna400_CuandoElNumeroDeLaIdentificacionQuedaVacio` - CA-3

  Los tres pasan `store: null!, tenantResolver: null!` al endpoint (precedente
  `ListarFichasColaborador/FunctionEndpointTests.cs`): el parseo del `{id}` debe
  cortocircuitar ANTES de tocar Marten. Si una implementacion futura moviera la
  validacion despues de abrir la `QuerySession`, estos tests fallarian con
  `NullReferenceException` en vez de 400 -- rojo por la razon correcta.

### Stub creado

- `ObtenerFichaColaborador/FunctionEndpoint.cs`: `Run()` reescrito a
  `throw new NotImplementedException();`, con la firma/ruta ya migrada a
  `Route = "colaboradores/fichas/{id}"` y parametro `string id` (reemplaza
  `tipoIdentificacion`/`numero`). El constructor (`IDocumentStore store,
  ITenantResolver tenantResolver`) no cambia.

### Por que un stub completo y no la implementacion "real" del parseo

`Identificacion.Parsear` (la pieza que este issue reutiliza, dependencia #376) **ya
esta completamente implementada** en este worktree -- no es un stub bloqueado como
en el precedente de #377 (donde #376 aun no habia mergeado y el propio `Parsear` era
el stub que garantizaba rojo). Si hubiera escrito la logica real del endpoint
(parseo + `ComputarStreamId` + `LoadAsync`), los tests de CA-3 habrian pasado de
inmediato -- viola el principio fundamental ("los tests deben fallar"). Por eso el
stub cubre el `Run()` completo (regla 1: solo `throw new NotImplementedException()`
en metodos de produccion), y el mecanismo exacto (try/catch de `Identificacion
.Parsear`, `ComputarStreamId`, `LoadAsync`, traduccion del centinela) queda para el
implementer.

### Cobertura deliberadamente fuera de alcance de este agente

- **CA-1/CA-2** (200 con ficha existente / 404 sin ficha): requieren
  `session.LoadAsync` contra Marten real. Mismo precedente que el propio
  test-writer de #356 dejo documentado en `FichaColaboradorRespuestaTests.cs`
  ("el resto de Run... es black-box del smoke test"): `IDocumentStore`/
  `IQuerySession` de Marten no se fake-an a mano (violaria "NUNCA NSubstitute" sin
  aportar cobertura real de comportamiento), y este proyecto no usa Testcontainers
  para unit tests. Cobertura vive en el smoke test (`smoke-test-writer`, etapa
  separada del pipeline).
- **CA-4** (normalizacion `cc-79543210` resuelve la misma ficha que `CC-79543210`):
  el mecanismo que lo garantiza (`Identificacion.Parsear` + `TipoIdentificacion
  .Desde` normalizan a mayusculas) **ya existe y ya funciona** en este worktree (no
  es comportamiento nuevo de este issue) -- un test de esa propiedad a nivel de VO
  pasaria en verde de inmediato, lo cual no es aceptable en fase roja. Su
  verificacion end-to-end (que el HTTP GET realmente resuelva la misma ficha) queda
  para el smoke test.
- **CA-5** (ruta vieja deja de existir): se verifica por la ausencia de la firma de
  dos segmentos en este archivo y por los smoke tests apuntando a la ruta nueva
  (etapa `smoke-test-writer`, fuera de mi alcance).

### Documentacion actualizada (consecuencia directa del cambio de firma)

Dos comentarios que describian el comportamiento de `Run()` con los parametros
viejos (`tipoIdentificacion`/`numero`) quedaban factualmente incorrectos tras el
cambio de firma; se corrigieron quirurgicamente (sin tocar logica de test):

- `ComposicionServiciosTests.cs` (linea ~328): "parseo de tipoIdentificacion/numero"
  -> "parseo del {id} de ruta"; se agrega referencia al nuevo
  `FunctionEndpointTests.cs`.
- `FichaColaboradorRespuestaTests.cs` (cabecera): "el resto de Run (parseo con 400,
  LoadAsync, 200/404) es black-box del smoke test" -> se precisa que el parseo con
  400 ahora tiene cobertura unitaria (CA-3), y solo LoadAsync/200/404 siguen siendo
  black-box.

### Cobertura de criterios de aceptacion

| Criterio de aceptacion | Test(s) / mecanismo |
|---|---|
| CA-1: 200 con ficha existente | Fuera de alcance (smoke test) |
| CA-2: 404 sin body | Fuera de alcance (smoke test) |
| CA-3: id malformado -> 400 | `FunctionEndpointTests.cs` (3 tests) |
| CA-4: normalizacion minusculas | Mecanismo ya implementado (#376/#377); verificacion end-to-end fuera de alcance (smoke test) |
| CA-5: ruta vieja no existe | Firma de dos segmentos eliminada de `FunctionEndpoint.cs`; verificacion funcional en smoke tests (fuera de mi alcance) |

### Desviaciones del plan del planner

| Sugerencia del issue | Desviacion aplicada | Razon tecnica | Consecuencia |
|---|---|---|---|
| "Impacto/Modifica: ... `tests/.../Colaboradores.SmokeTests/ObtenerFichaColaborador/ObtenerFichaColaboradorSmokeTests.cs`" | No se toco el smoke test | Los smoke tests son responsabilidad de la etapa `smoke-test-writer` del pipeline, no de este agente (precedente: en #377 el smoke test se creo en un commit separado, etapa distinta) | El smoke test sigue apuntando a la ruta vieja hasta que corra esa etapa; es esperado, no un olvido |
| "Interfaz publica propuesta": ninguna declarada explicitamente (issue de query, no de VO) | N/A | El issue no trae seccion de interfaz publica; el cambio es puramente de borde HTTP | N/A |
| Ninguna otra desviacion | - | Las sugerencias de archivos a modificar (`FunctionEndpoint.cs`, `ComposicionServiciosTests.cs` si referencia la ruta) se aplicaron tal cual, mas la correccion adicional de `FichaColaboradorRespuestaTests.cs` (no listada por el planner, pero necesaria por consistencia documental) | - | - |

</details>

<details>
<summary>Implementer (fase verde) — 4m 24s</summary>

## ES Implementer - Decisiones

### Enfoque de implementacion
Se reemplazo el stub `throw new NotImplementedException()` de `ObtenerFichaColaborador/FunctionEndpoint.cs`
por el mismo patron ya vigente en `CorregirNombresFunction.FunctionEndpoint` (issue #377):

1. `Identificacion.Parsear(id)` como unico punto de conversion string->Identificacion (MEF-ADR-0037
   seccion 2) para el `{id}` de ruta. Un `ArgumentException` (sin guion, tipo fuera de la lista
   cerrada PILA, o numero vacio tras la limpieza) se traduce, y solo aqui, a `400 BadRequest` --
   antes de tocar Marten.
2. `ColaboradorAggregateRoot.ComputarStreamId(identificacion)` para computar la llave del documento
   (identica a la llave del stream, verificado por el planner).
3. `store.QuerySession(tenantResolver.TenantId)` + `session.LoadAsync<FichaColaborador>(streamKey, ct)`
   -- sin cambios respecto a la version anterior (issue #356): 200 con `FichaColaboradorRespuesta.DesdeVista`,
   404 sin body cuando la ficha no existe.

El resto del archivo (el DTO `FichaColaboradorRespuesta` y su traduccion del centinela de vigencia
abierta) no se toco: CA-6 (issue #356) queda intacto, solo cambio el origen del id (un segmento
parseado en vez de dos).

### Decisiones de diseno
- Se agregaron los `using` de `Bitakora.ControlAsistencia.Colaboradores.DomainEvents` (para
  `Identificacion`) y `Bitakora.ControlAsistencia.Colaboradores.Entities` (para
  `ColaboradorAggregateRoot`), removidos en el stub de fase roja.
- Mensaje de 400 alineado textualmente al de `CorregirNombresFunction.FunctionEndpoint`: "El id de
  la ruta es invalido -- debe tener la forma {Tipo}-{Numero}" (no se creo un mensaje nuevo porque el
  test-writer no dejo una clase `Mensajes` para este endpoint -- sigue el precedente de usar un
  string literal directamente, igual que el endpoint hermano).

### ADRs consultados
- MEF-ADR-0037 (punto unico de conversion de identidad de stream): `Identificacion.Parsear` +
  `ComputarStreamId`, sin partir la llave a mano.
- MEF-ADR-0012 (Tell-don't-Ask): el parseo/normalizacion vive en `Identificacion` (VO), el endpoint
  solo lo invoca.
- MEF-ADR-0006 (enmienda #363) / doctrina de queries: naming `ObtenerFichaColaborador` sin cambios.
- MEF-ADR-0043 seccion 7 (por analogia): rename de endpoint desplegado, discutido con el humano
  segun el propio issue -- no se aplico ninguna migracion adicional de compatibilidad (la ruta
  vieja simplemente deja de existir, CA-5).
- MEF-ADR-0028 / CA-ADR-0027: sin cambio, `QuerySession` sigue acotada a `tenantResolver.TenantId`.
- MEF-ADR-0013: ver nota en "Infraestructura modificada" -- el smoke test no se toco.

### Desviaciones de ADRs
Ninguna desviacion -- todos los ADRs aplicados al pie de la letra.

### Precedentes consultados
- `CorregirNombresFunction/FunctionEndpoint.cs` (issue #377): patron de parseo `Identificacion.Parsear`
  + traduccion `ArgumentException` -> 400. Alineado con MEF-ADR-0037/MEF-ADR-0012 -- replicado tal cual.
- Version anterior de `ObtenerFichaColaborador/FunctionEndpoint.cs` (issue #356, previa al stub de
  fase roja, recuperada via `git show`): confirma que el resto del comportamiento (QuerySession por
  tenant, LoadAsync, 200/404, DTO) no requeria cambios.

### Infraestructura modificada
Ninguna (no aplica: este issue no toca eventos ni Service Bus, es un endpoint HTTP de consulta).

**Nota para seguimiento administrativo**: el issue #386 lista
`tests/Bitakora.ControlAsistencia.Colaboradores.SmokeTests/ObtenerFichaColaborador/ObtenerFichaColaboradorSmokeTests.cs`
como archivo a modificar (CA-5: "smoke tests operan contra la ruta nueva"), pero el test-writer NO
lo incluyo en la lista de archivos creados/modificados para esta fase, y sigue apuntando a la ruta
vieja de dos segmentos (`/api/colaboradores/fichas/{tipoIdentificacion}/{numero}`). Como implementer
tengo prohibido modificar archivos de test que no fueron tocados por el test-writer en esta ronda
(regla del agente); dejo el archivo intacto y reporto el gap aqui para que el smoke-test-writer (o
el reviewer) lo actualice antes del deploy -- de lo contrario esos smoke tests fallaran contra dev
tras el rename (la ruta vieja ya no existe).

### Complejidad encontrada
Ninguna: el precedente de #377 resolvia identico problema (parseo tipado de `{id}` de ruta), asi
que la implementacion fue una adaptacion directa sin ambiguedad.

### Resultado
- Tests pasando: 341/341 (Bitakora.ControlAsistencia.Colaboradores.Tests)
- Suite completa del repo: 1283 correctos, 0 errores, 48 omitidos (smoke tests que requieren
  Postgres/ServiceBus reales, no configurados en este entorno local -- comportamiento esperado)

</details>
<details>
<summary>Reviewer (fase refactor) — 14m 36s</summary>

## ES Reviewer - Revision

### Evaluacion general
- Calidad: **buena** (implementacion de produccion impecable; el hueco estaba en la cobertura de CA-4/CA-5, fuera del alcance del test-writer y del implementer)
- Cambios realizados: **si** (commit `0060e68`)

### Baseline
- Antes de tocar nada: `dotnet test` completo -> 1331 tests, **0 errores**, 48 omitidos. Sin `blockage-report.md`.
- Despues de la revision: los 6 proyectos `*.Tests` (los que corre el gate del pipeline y el CI del PR) -> **1160 tests, 0 errores**.
- Los smoke tests quedan **rojos hasta el deploy**, por diseno y con precedente (ver "Hallazgo bloqueante" abajo).

### Cumplimiento de ADRs aplicables

| ADR | Cumplimiento | Observacion |
|---|---|---|
| MEF-ADR-0037: punto unico de conversion de la identidad de stream | ok, con una desviacion de la letra (ver abajo) | `Identificacion.Parsear` es el unico parseo string->VO; `ComputarStreamId` el unico punto de conversion inverso; ningun `ToString("N")`/`ToUpper()` ni concatenacion manual en el endpoint. `400` con `BadRequestObjectResult` **y mensaje** antes de tocar Marten. |
| MEF-ADR-0012: Tell-don't-Ask | ok | El parseo y la normalizacion viven en el VO (`Identificacion.Parsear` -> `TipoIdentificacion.Desde` + `Crear`); el endpoint solo invoca. Ninguno de los 7 antipatrones del checklist aparece en el diff (no hay propiedades nuevas de VO, ni clase estatica sobre datos crudos, ni getter para tests, ni `InternalsVisibleTo`, ni `[JsonConstructor]`, ni evento con marker de bus). |
| MEF-ADR-0006 (enmienda #363) + doctrina de queries del Skill `projections` | ok | `[Function("ObtenerFichaColaborador")]`, feature folder sin sufijo `Function`, un namespace por query, `Route` explicito y no vacio, verbo `get` declarado explicitamente. La Function hermana que comparte el segmento base (`ListarFichasColaborador`, `colaboradores/fichas`) tambien declara el suyo (`query`): ninguna captura a la otra. |
| MEF-ADR-0043 seccion 7 (por analogia): rename de endpoint desplegado | ok | El rename esta pactado en el issue (registro de la conversacion con el humano). No se dejo ninguna ruta de compatibilidad -- coherente con lo pactado; ahora **verificado afirmativamente** contra el entorno real (test de CA-5 agregado). |
| MEF-ADR-0028 / CA-ADR-0027: tenancy | ok | `store.QuerySession(tenantResolver.TenantId)` intacto. El `{id}` de ruta es el recurso, jamas el tenant -- sin superficie BOLA/IDOR nueva. |
| MEF-ADR-0013: smoke tests contra dev | **fallaba, corregido en esta fase** | Seguian apuntando a la ruta vieja de dos segmentos. Ver "Hallazgo bloqueante". |
| MEF-ADR-0002 (naming/estrategia de tests) + MEF-ADR-0016 | ok | Nombres `<Sujeto>_<LoQuePasa>_Cuando<Condicion>` con sujeto = `ObtenerFichaColaborador`; solo `[Fact]`; oraculo del stream id reconstruido localmente en el smoke test, no importado del VO. |
| MEF-ADR-0018 (Rule of Three) | ok | Los helpers que extraje (`ObtenerAsync`, `DebeSer400ConMensaje`, `EsperarFichaAsync`) tienen 3+ call sites. El literal del mensaje de 400 duplicado con `CorregirNombresFunction` son **2** ocurrencias: se deja duplicado a proposito. |

### Desviaciones de ADRs

**Desviaciones declaradas por el implementer**: ninguna (`stage-2-implementer.md`: "Ninguna desviacion -- todos los ADRs aplicados al pie de la letra").

**Desviaciones detectadas por el reviewer (NO declaradas por el implementer)**:

#### Desviacion: MEF-ADR-0037 seccion 2 (clave natural compuesta en un unico segmento de ruta)
- **Regla del ADR**: *"Clave compuesta: componentes tipados por separado en la ruta, cada uno parseado una sola vez, y la clave reconstruida con `ComputarStreamId(...)`"*. Y en `skills/projections/read-apis.md`: *"Proscrito: un parametro de ruta `string` cuyo valor -- simple o ya concatenado -- viaje **sin parsear** hasta el store... `LoadAsync`"*.
- **Desviacion encontrada en el diff**: `Identificacion` es una clave natural compuesta (tipo + numero) y este issue la mueve, deliberadamente, de dos segmentos (`{tipoIdentificacion}/{numero}`, la forma literal del ADR) a **uno solo** (`{id}` = `"CC-79543210"`). `src/.../ObtenerFichaColaborador/FunctionEndpoint.cs:40`.
- **Evaluacion del reviewer**: **aceptable**, y no la revierto. Tres razones:
  1. La proscripcion literal del ADR es sobre un string que viaja **sin parsear**. Aqui no ocurre: el segmento se parsea una unica vez con `Identificacion.Parsear` (que el VO posee como inverso exacto de su `ToString()`), y la unica salida a string es `ComputarStreamId`. Es exactamente el mecanismo "parsear una vez, reemitir por el punto unico" que el ADR prescribe para el caso `Guid`, aplicado a un tipo de identidad mas rico.
  2. La garantia que el ADR persigue -- **normalizacion** -- se cumple y ahora esta probada (CA-4): `cc-79543210` resuelve la misma ficha que `CC-79543210`. El separador y el orden de los componentes **no** quedan en manos del llamador: los posee el VO, y un orden invertido (`79543210-CC`) muere en `TipoIdentificacion.Desde` con 400.
  3. No es una invencion del implementer: es la forma pactada con el humano en el issue y ya mergeada en `main` para los comandos (#376/#377, `PUT colaboradores/{id}/nombres`). Revertirla aqui reintroduciria exactamente la divergencia de direccionamiento que este issue existe para cerrar.
- **Accion tomada**: no corregida (correcta por diseno). **Recomendacion al planner**: MEF-ADR-0037 seccion 2 contempla hoy dos clases de identidad (`Guid` / clave compuesta de componentes independientes). Este caso es una tercera: **identidad de dominio con VO que posee `ToString()`/`Parsear` canonicos y mutuamente inversos**, donde un unico segmento es seguro *porque* el VO es dueno de las dos direcciones. Vale un issue de enmienda del ADR para que la proxima revision no la lea como violacion.
- **Status**: pendiente de evaluacion del usuario.

### Precedentes consultados por el implementer

| Precedente | ADR aplicable | Veredicto |
|---|---|---|
| `CorregirNombresFunction/FunctionEndpoint.cs` (#377) | MEF-ADR-0037, MEF-ADR-0012 | **alineado** -- mismo parseo tipado unico, mismo `400` con mensaje, misma delegacion al VO. Replicado correctamente. |
| Version #356 del propio endpoint (via `git show`) | MEF-ADR-0028 | **alineado** -- confirmo que `QuerySession` por tenant, `LoadAsync`, 200/404 y el DTO no requerian cambios. |
| `AsignarEtiquetaFunction/FunctionEndpoint.cs` (citado en un comentario del codigo) | MEF-ADR-0037 | **precedente inexistente**: ese endpoint todavia recibe la identificacion en el body (`POST Colaboradores/Etiquetas`), no parsea ningun `{id}` de ruta. No propago ningun defecto (el codigo sigue el precedente bueno), pero el comentario mentia. **Corregido** en esta fase. |

### Convenciones del pipeline (no ADRs)

| Convencion | Estado | Observacion |
|---|---|---|
| Cada test con `Then()` + `And<>()` | n/a | No hay command handler ni aggregate en este issue: es borde HTTP puro. Precedente `ListarFichasColaborador/FunctionEndpointTests.cs`. |
| Overloads correctos para stream IDs compuestos | n/a | Sin tests de harness `CommandHandlerAsyncTest`. |
| Fakes manuales (no NSubstitute) | ok | `store`/`tenantResolver` se pasan **nulos a proposito** para que el cortocircuito antes de Marten sea verificable; cero NSubstitute. |
| Feature folders (produccion y tests) | ok | `ObtenerFichaColaborador/` sin sufijo `Function` (query), espejado en `*.Tests` y `*.SmokeTests`. Un archivo por responsabilidad. |
| Smoke tests: SkipWhen, secrets, cobertura | **fallaba, corregido** | Ver "Hallazgo bloqueante". `appsettings.json` sin secrets reales (connection strings vacios) ✓. Sin `Assert.SkipWhen` porque esta clase no depende de `PostgresFixture`/`ServiceBusFixture` (solo `ApiFixture`) -- correcto segun la convencion. Sin archivos duplicados por comando ✓. Sin topics involucrados (query pura), asi que no hay suscripcion `smoke-tests` que exigir en `infra/`. |
| Proyecciones read-side (partial, inmutabilidad, read APIs, naming, cuarta isla) | ok | El diff no toca `ReadModels` ni `Projections`. La via de lectura sigue siendo la (a) canonica (`LoadAsync<FichaColaborador>`), la `QuerySession` acotada al tenant del resolver, y `FichaColaborador` conserva su nombre sin sufijo de implementacion. Sin `ProjectReference` nueva en `ReadModels`. |
| Antipatrones de habilitacion (MEF-ADR-0039) | n/a | El diff no toca ningun `.csproj` de `PublicEvents`/`PrivateEvents`/`*.DomainEvents`/`Projections` ni declara ningun tipo de evento nuevo. |
| Compatibilidad Marten write-side/read-side | n/a | El diff no toca la version de `Cosmos.EventSourcing.*` ni configuracion de Marten (`ComposicionServicios*`, serializacion, `AddEventTypes`, `opts.Events.*`). |
| Identidad de stream (MEF-ADR-0037) | ok | (1) Ningun formato explicito: `ComputarStreamId` delega en `Identificacion.ToString()`, sin especificador ni `ToUpper()`/`ToLower()` sobre componentes `Guid`. (2) Sin construccion manual de la clave fuera de `ComputarStreamId` en produccion -- la reconstruccion del smoke test es el oraculo independiente deliberado de MEF-ADR-0002. (3) GET con parseo tipado + `400` con mensaje; sin route constraint que sustituya el parseo. Ver la desviacion de la letra, arriba. |
| Contrato HTTP de comandos (MEF-ADR-0043) | n/a | El diff no crea ninguna Function HTTP de **comando** (`git diff --diff-filter=A -- '**/*Function/FunctionEndpoint.cs'` vacio); modifica un endpoint de **query**, como el propio issue declara. Los endpoints de comando preexistentes con rutas PascalCase (`Colaboradores/Terminaciones`, etc.) no se tocan: migrarlos es decision del humano via planner, nunca de oficio. |
| Control de volumen de telemetria (MEF-ADR-0038) | n/a | El diff no toca `ComposicionServicios*`, `ConfiguracionObservabilidad*`, `AddOpenTelemetry`, `SetSampler` ni el callback de Wolverine. |
| Tests via ToString/comportamiento | ok | Nada se verifica por getters expuestos solo para test; la ficha se verifica por la respuesta HTTP publica. |
| Sin numeros magicos | ok | Timeout, tipo de identificacion y rutas son constantes con nombre. |
| Condiciones en positivo | ok | La unica bifurcacion (`if (ficha is null) return NotFound`) es un guard clause / early-return: se mantiene en negativo por doctrina. |

### Elegancia del codigo

- **Produccion**: el endpoint es compacto, idiomatico y correcto tal como lo dejo el implementer -- 20 lineas de cuerpo, un unico `try/catch` acotado al parseo (no envuelve Marten), sin estado intermedio superfluo. No toque su logica: no habia nada que mejorar sin empeorarlo.
- **Tests unitarios**: eran correctos pero repetian el mismo `await Endpoint().Run(FakeHttpRequest(), ..., CancellationToken.None)` tres veces y afirmaban solo el **tipo** del resultado. Extraidos `ObtenerAsync` y `DebeSer400ConMensaje`, y la asercion ahora exige que el 400 **lleve mensaje** -- sin eso, "simplificar" el endpoint a un `BadRequestResult` pelado (lo que MEF-ADR-0037 seccion 2 proscribe expresamente) pasaba los tres tests en verde.
- **Smoke tests**: dos bloques de polling identicos salvo el predicado -> un unico `EsperarFichaAsync(id, ct, hasta?)`. El comentario de cabecera que describia la ruta vieja quedaba factualmente falso y se reescribio.
- **Robustez**: sin `catch` vacios, sin swallowing. El `catch (ArgumentException)` traduce a 400 -- unico punto de traduccion, es la doctrina, no un tragado silencioso.
- **Limpieza**: `dotnet build` de los tres proyectos tocados -> **0 advertencias**. `dotnet format --verify-no-changes` -> **sin hallazgos en ningun archivo de Colaboradores** (los IDE0005 que reporta son preexistentes en `ControlHoras.Tests`, ajenos a esta HU: no los toco, regla 4).

### Criticas y hallazgos

**MAYOR (bloqueante) -- corregido: los smoke tests apuntaban a la ruta eliminada.**
`ObtenerFichaColaboradorSmokeTests.cs` seguia llamando `/api/colaboradores/fichas/{tipo}/{numero}`, la ruta que CA-5 elimina. Causa raiz: el Stage 2b del pipeline (`smoke-test-writer`) **no corrio** -- su heuristica de deteccion busca el patron `Function/` en las rutas del diff y, en un issue que no es `tipo:projection` (este es `tipo:refactor`), una carpeta de query como `ObtenerFichaColaborador/` no matchea. El implementer detecto el gap y lo escalo correctamente en su resumen, pero tiene prohibido tocar tests que el test-writer no toco; me correspondia a mi. Sin esta correccion el PR mergeaba con CA-5 incumplido y con smoke tests que daban **falso verde hoy** (pasaban contra la ruta vieja aun desplegada) y rojo garantizado tras el deploy.
*Efecto secundario asumido y verificado*: la suite de smoke queda roja hasta el deploy (6 fallos, todos por "ruta nueva no desplegada": 3 timeouts de polling y 3 aserciones de 400 que reciben el 404 del host). Es la convencion establecida del proyecto -- misma nota de cabecera que `CorregirNombresSmokeTests` (#377) y que el propio `ObtenerFichaColaboradorSmokeTests` (#356) --, el gate del pipeline y el CI del PR corren solo `*.Tests`, y el propio Stage 2b instruye "solo escribe y compila, NO ejecutes los tests". **Verificado**: los 6 proyectos `*.Tests` quedan en 1160/1160 verdes y el proyecto de smoke compila con 0 warnings.

**MENOR -- corregido: comentario que inventaba un precedente.**
El comentario de cabecera del endpoint citaba `AsignarEtiquetaFunction.FunctionEndpoint` como precedente de parseo de `{id}` de ruta; ese endpoint todavia recibe la identificacion en el **body**. Un comentario asi es la semilla de la proxima violacion por "precedente" (el patron que MEF-ADR-0012 ya sufrio en PR 142/144). Corregido.

**MENOR -- corregido: la asercion del 400 no cubria su propia doctrina.** Ver "Elegancia".

**COSMETICO -- corregido: cabecera de test factualmente vencida.** `FunctionEndpointTests.cs` declaraba "Run() hoy SOLO lanza NotImplementedException" -- cierto en fase roja, falso en el codigo que se mergea. Reemplazado por la nota que justifica la asercion del mensaje.

**Sin hallazgos** en: seguridad de tenancy, serializacion, identidad de eventos persistidos, composicion de ensamblados, telemetria, infraestructura.

### Refactorings aplicados

1. `src/.../ObtenerFichaColaborador/FunctionEndpoint.cs` -- correccion del comentario que citaba un precedente inexistente. Sin cambio de logica.
2. `tests/.../Colaboradores.Tests/ObtenerFichaColaborador/FunctionEndpointTests.cs` -- `ObtenerAsync` + `DebeSer400ConMensaje` (3 call sites, Rule of Three cumplida); asercion reforzada a "400 **con mensaje**"; `FakeHttpRequest` a expresion; cabecera actualizada.
3. `tests/.../Colaboradores.SmokeTests/ObtenerFichaColaborador/ObtenerFichaColaboradorSmokeTests.cs` -- migracion completa a la ruta nueva, `EsperarFichaAsync` (4 call sites), `IdDeRuta` separado del oraculo `ComputarStreamId`, `RutaVieja` acotada al test de CA-5, tres tests nuevos.

Cada cambio se verifico con `dotnet test` sobre los proyectos `*.Tests` (y `dotnet build` sobre el de smoke). Ninguno hubo que revertir.

### Cobertura de criterios de aceptacion

| Criterio | Estado | Test(s) |
|---|---|---|
| CA-1: `GET colaboradores/fichas/{id}` existente -> 200 con el DTO sin cambios | cubierto (smoke, veredicto post-deploy) | `ObtenerFichaColaborador_Retorna200ConVigenteHastaVacio_CuandoLaVinculacionEstaAbierta`, `..._Retorna200ConVigenteHastaReal_CuandoLaVinculacionEstaTerminada` (ambos migrados a la ruta nueva). Forma del DTO: `FichaColaboradorRespuestaTests` (unitario). |
| CA-2: id bien formado sin ficha -> 404 sin body | cubierto (smoke) | `ObtenerFichaColaborador_Retorna404SinBody_CuandoLaFichaNoExiste` |
| CA-3: id malformado -> 400 | cubierto (unitario + smoke) | Unitarios: `..._Retorna400_CuandoIdDeRutaNoTraeGuion`, `..._CuandoElTipoDeLaIdentificacionNoEstaEnLaListaCerrada`, `..._CuandoElNumeroDeLaIdentificacionQuedaVacio` (los tres ahora exigen mensaje). Smoke: los tres equivalentes contra el host real. |
| CA-4: id en minusculas resuelve la misma ficha | **cubierto en esta fase** (antes: sin ningun test) | `ObtenerFichaColaborador_Retorna200ConLaMismaFicha_CuandoElIdDeRutaViajaEnMinusculas` (nuevo) |
| CA-5: la ruta vieja deja de existir; smoke tests contra la ruta nueva | **cubierto en esta fase** (antes: solo por ausencia de referencias, y los smoke tests lo contradecian) | `ObtenerFichaColaborador_Retorna404DelHost_CuandoSeLlamaLaRutaViejaDeDosSegmentos` (nuevo, **no vacuo**: llama la ruta vieja con una identificacion que SI tiene ficha materializada, asi que un 404 solo puede significar que la ruta no enruta) + toda la suite de smoke migrada. |

### Tests agregados

- `ObtenerFichaColaborador_Retorna200ConLaMismaFicha_CuandoElIdDeRutaViajaEnMinusculas` (smoke, CA-4). Espera primero con el id canonico y consulta despues en minusculas: asi un fallo distingue "el worker no proyecto" de "la normalizacion se rompio", en vez de dar un timeout ambiguo.
- `ObtenerFichaColaborador_Retorna404DelHost_CuandoSeLlamaLaRutaViejaDeDosSegmentos` (smoke, CA-5).
- `ObtenerFichaColaborador_Retorna400_CuandoElIdDeRutaNoTraeGuion` y `..._CuandoElNumeroDelIdDeRutaQuedaVacio` (smoke, CA-3): paridad con `CorregirNombresSmokeTests`; contra el entorno real importa distinguir el 400 del parseo del 404 del host.
- Tests de contrato de value objects (`IgualdadTestBase<T>` / round-trip de serializacion): **no aplican** -- el diff no introduce ni modifica ningun value object; `Identificacion` (con su `IEquatable` y su `ConfigurarSerializacion`) llega intacto de #348/#376 y ya tiene sus tests de contrato.

### Escalamientos al planner

1. **Enmienda de MEF-ADR-0037 seccion 2** para contemplar la tercera clase de identidad (VO con `ToString()`/`Parsear` canonicos e inversos -> un unico segmento de ruta es seguro). Ver "Desviaciones".
2. **Heuristica de Stage 2b del pipeline** (`scripts/tdd-pipeline.sh`): un issue que no es `tipo:projection` pero modifica una Function de query (`Obtener{X}`/`Listar{X}s`, carpeta sin sufijo `Function`) **no** dispara al `smoke-test-writer`. En este PR el gap se absorbio aqui; la proxima vez puede pasar inadvertido. El patron de la rama `IS_PROJECTION` (`/(Obtener|Listar)[A-Za-z0-9]*/FunctionEndpoint\.cs$`) deberia aplicarse tambien a la rama general. Es un issue del harness, no de este repo.

</details>

## Commits

0060e68 refactor(hu-386): alinea smoke tests a la ruta nueva y refuerza guardrails del borde HTTP
c2c6380 feat(hu-386): alinea GET colaboradores/fichas/{id} a la forma unica de identidad (fase verde)
5d49c6b test(hu-386): tests para GET colaboradores/fichas/{id} (fase roja)

Closes #386