### PR TITLE
Unificar el parseo del id de ruta en los endpoints de etiquetas

### DIFF
--- a/src/Bitakora.ControlAsistencia.Colaboradores/AsignarEtiquetaFunction/FunctionEndpoint.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/AsignarEtiquetaFunction/FunctionEndpoint.cs
@@ -1,4 +1,3 @@
-using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
 using Bitakora.ControlAsistencia.Colaboradores.Infraestructura;
 using Cosmos.EventSourcing.Abstractions.Commands;
 using Microsoft.AspNetCore.Http;
@@ -12,10 +11,10 @@ namespace Bitakora.ControlAsistencia.Colaboradores.AsignarEtiquetaFunction;
 // MEF-ADR-0006: [Function("AsignarEtiqueta")]; carpeta CON sufijo "Function" -- mismo criterio que
 // los demas comandos del ciclo de vida.
 // Route = "colaboradores/{id}/etiquetas/{categoria}" (kebab-case minusculo, MEF-ADR-0043 seccion 3):
-// {id} es Identificacion.ToString() ("CC-79543210", issue #381) -- se parsea UNA vez con
-// Identificacion.Parsear (unico punto de conversion string->Identificacion, MEF-ADR-0037 seccion 2)
-// y un ArgumentException se traduce a 400 explicito, mismo mecanismo que
-// ObtenerFichaColaborador.FunctionEndpoint. {categoria} viaja crudo (sin normalizar en el endpoint
+// {id} es Identificacion.ToString() ("CC-79543210", issue #381) -- se parsea UNA vez via
+// IdentificacionDeRuta.TryParsear (issue #395), el sitio unico que centraliza el par "parsear el
+// {id} de ruta + 400 explicito si falla" que MEF-ADR-0037 seccion 2 exige, compartido con los demas
+// endpoints del dominio que reciben {id}. {categoria} viaja crudo (sin normalizar en el endpoint
 // -- Etiqueta.Crear normaliza internamente, Tell-don't-Ask, mismo criterio que el resto del ciclo
 // de vida). El body se redujo a { "valor": "..." } (AsignarEtiquetaBody); el endpoint compone el
 // comando interno AsignarEtiqueta (que conserva sus 4 campos primitivos, MEF-ADR-0039 decision 6)
@@ -35,16 +34,8 @@ public class FunctionEndpoint(IRequestValidator requestValidator, ICommandRouter
         string categoria,
         CancellationToken ct)
     {
-        Identificacion identificacion;
-        try
-        {
-            identificacion = Identificacion.Parsear(id);
-        }
-        catch (ArgumentException)
-        {
-            return new BadRequestObjectResult(
-                "El id de la ruta es invalido -- debe tener la forma {Tipo}-{Numero}");
-        }
+        if (!IdentificacionDeRuta.TryParsear(id, out var identificacion, out var errorDeId))
+            return errorDeId;
 
         // MEF-ADR-0004 capa 1 (forma en el borde -> 400): {categoria} llega cruda de la ruta y no la
         // cubre ningun validator -- el body reducido solo trae Valor. Un segmento en blanco ("%20")

--- a/src/Bitakora.ControlAsistencia.Colaboradores/RetirarEtiquetaFunction/FunctionEndpoint.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/RetirarEtiquetaFunction/FunctionEndpoint.cs
@@ -1,4 +1,4 @@
-using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
+using Bitakora.ControlAsistencia.Colaboradores.Infraestructura;
 using Cosmos.EventSourcing.Abstractions.Commands;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -13,12 +13,13 @@ namespace Bitakora.ControlAsistencia.Colaboradores.RetirarEtiquetaFunction;
 // demas comandos del ciclo de vida.
 // Route = "colaboradores/{id}/etiquetas/{categoria}" (kebab-case minusculo, MEF-ADR-0043 seccion 3,
 // MISMA ruta que AsignarEtiqueta -- se distinguen por verbo HTTP): {id} es Identificacion.ToString()
-// ("CC-79543210", issue #381) -- se parsea UNA vez con Identificacion.Parsear (unico punto de
-// conversion string->Identificacion, MEF-ADR-0037 seccion 2) y un ArgumentException se traduce a
-// 400 explicito, mismo mecanismo que ObtenerFichaColaborador.FunctionEndpoint. {categoria} viaja
-// crudo -- el handler la normaliza via Etiqueta.NormalizarCategoria (Tell-don't-Ask). SIN body: no
-// hay IRequestValidator involucrado (RetirarEtiquetaValidator, que validaba el body viejo, se
-// elimino junto con este cambio -- sin body no hay nada que deserializar ni validar en ese punto).
+// ("CC-79543210", issue #381) -- se parsea UNA vez via IdentificacionDeRuta.TryParsear (issue
+// #395), el sitio unico que centraliza el par "parsear el {id} de ruta + 400 explicito si falla"
+// que MEF-ADR-0037 seccion 2 exige, compartido con los demas endpoints del dominio que reciben
+// {id}. {categoria} viaja crudo -- el handler la normaliza via Etiqueta.NormalizarCategoria
+// (Tell-don't-Ask). SIN body: no hay IRequestValidator involucrado (RetirarEtiquetaValidator, que
+// validaba el body viejo, se elimino junto con este cambio -- sin body no hay nada que
+// deserializar ni validar en ese punto).
 // CA-ADR-0030 / MEF-ADR-0004 (precedente AnularTerminacionFunction.FunctionEndpoint): validar id de
 // ruta (400) -> validar categoria de ruta (400) -> despachar comando -> InvalidOperationException ->
 // 409 Conflict, KeyNotFoundException -> 404 NotFound; exito -> 202 Accepted.
@@ -32,16 +33,8 @@ public class FunctionEndpoint(ICommandRouter commandRouter)
         string categoria,
         CancellationToken ct)
     {
-        Identificacion identificacion;
-        try
-        {
-            identificacion = Identificacion.Parsear(id);
-        }
-        catch (ArgumentException)
-        {
-            return new BadRequestObjectResult(
-                "El id de la ruta es invalido -- debe tener la forma {Tipo}-{Numero}");
-        }
+        if (!IdentificacionDeRuta.TryParsear(id, out var identificacion, out var errorDeId))
+            return errorDeId;
 
         // MEF-ADR-0004 capa 1 (forma en el borde -> 400): {categoria} llega cruda de la ruta y, sin
         // body, no la cubre ningun validator. Un segmento en blanco ("%20") SI hace match con la


### PR DESCRIPTION
## Resumen

Pipeline TDD completado (refactoring puro):
- Análisis: no se requieren tests nuevos
- Justificación: Issue #395 unifica el parseo del {id} de ruta en los dos endpoints de etiquetas (AsignarEtiquetaFunction, RetirarEtiquetaFunction) para que usen el helper ya existente IdentificacionDeRuta.TryParsear (creado en #379), en vez del try/catch (ArgumentException) inline alrededor de Identificacion.Parsear(id) con el literal de 400 duplicado. El propio issue lo declara refactor puro: CA-4 exige explicitamente que "los FunctionEndpointTests existentes de ambos endpoints pasan sin modificacion" y el contrato HTTP observable (verbos, rutas, codigos 400/409/404/202, semantica de error) no cambia. Verificado contra el codigo actual de ambos FunctionEndpoint.cs: el patron try/catch inline con el literal "El id de la ruta es invalido -- debe tener la forma {Tipo}-{Numero}" es identico al que ya centralizo el helper (Infraestructura/IdentificacionDeRuta.cs, sin cambios en este issue). No hay comportamiento nuevo que testear: es sustituir 6 lineas de try/catch por un guard clause de 2 lineas (mismo patron que los otros 6 endpoints ya migrados, p. ej. CorregirNombresFunction/FunctionEndpoint.cs). Corri dotnet test sobre Bitakora.ControlAsistencia.Colaboradores.Tests antes de cualquier cambio: 355 tests, 0 errores -- base verde confirmada. No se elimina ni modifica ningun test existente; los FunctionEndpointTests de AsignarEtiquetaFunction y RetirarEtiquetaFunction (que verifican BadRequestObjectResult por tipo, no por texto del mensaje) quedan intactos y deben seguir en verde tras la migracion.
- Baseline: 1174 tests pasando
- Refactoring ejecutado manteniendo todos los tests verdes

## Decisiones del pipeline

<details>
<summary>Test Writer (fase roja) — 1m 54s</summary>

## ES Test Writer - Decisiones

### Tipo de tarea: REFACTORING PURO

Este issue (#395) es refactoring puro, no TDD. Evaluacion segun seccion 2 del rol:

- El issue pide reorganizar codigo existente: reemplazar el `try/catch (ArgumentException)`
  inline alrededor de `Identificacion.Parsear(id)` en dos endpoints por el guard clause de dos
  lineas que usa el helper ya existente `IdentificacionDeRuta.TryParsear` (creado en #379, sin
  cambios en este issue).
- No hay criterios de aceptacion que definan comportamiento nuevo: CA-4 exige explicitamente
  que "los `FunctionEndpointTests` existentes de ambos endpoints pasan sin modificacion" y que
  el contrato HTTP observable (verbos, rutas, codigos 400/409/404/202, semantica de error) no
  cambie.
- Los tests existentes ya cubren la funcionalidad: `AsignarEtiquetaFunction/FunctionEndpointTests.cs`
  y `RetirarEtiquetaFunction/FunctionEndpointTests.cs` verifican el 400 del id invalido afirmando
  el tipo `BadRequestObjectResult`, no el texto del literal -- la migracion al helper los deja
  verdes sin tocarlos (confirmado por inspeccion directa del codigo actual de ambos
  `FunctionEndpoint.cs`, que hoy tienen el patron try/catch inline identico al que documenta el
  encabezado del helper).

**Accion tomada**: no se escribio ningun test nuevo ni se modifico produccion. Se corrio
`dotnet test` sobre `Bitakora.ControlAsistencia.Colaboradores.Tests` para confirmar la base
verde (355 tests, 0 errores) y se creo el archivo senal `pipeline-state/refactor-signal.md` con
`REFACTOR_ONLY=true` y `REMOVED_TESTS=0` (este refactor no deja ningun test existente sin canal
que probar -- los `FunctionEndpointTests` de ambos endpoints siguen verificando exactamente lo
mismo, tipo `BadRequestObjectResult`, independientemente del mecanismo interno de parseo).

### Tests creados

Ninguno -- carril de refactoring puro (ver arriba).

### Estructura elegida

N/A.

### Stubs creados

Ninguno -- no se modifico produccion. La migracion (borrar el try/catch inline, agregar el
guard clause `if (!IdentificacionDeRuta.TryParsear(id, out var identificacion, out var error))
return error;`) es responsabilidad del implementer (Stage 2), siguiendo el patron de referencia
de los seis endpoints ya migrados (p. ej. `CorregirNombresFunction/FunctionEndpoint.cs`).

### Decisiones de diseno

- Se verifico contra el codigo real (no solo contra la narrativa del issue) que ambos
  `FunctionEndpoint.cs` de `AsignarEtiquetaFunction` y `RetirarEtiquetaFunction` efectivamente
  contienen el `try/catch (ArgumentException)` inline con el literal duplicado, y que
  `Infraestructura/IdentificacionDeRuta.cs` ya existe y no requiere cambios.
- Se confirmo que la dependencia (#376 / PR #388) ya esta mergeada a `main` -- el commit
  `25cad4a` en el log de `git log` es el merge de ese PR, por lo que este issue tiene sentido
  ejecutarlo ahora.

### Cobertura de criterios de aceptacion

No aplica cobertura via tests nuevos (refactor puro). Los criterios se verifican por el
reviewer/implementer inspeccionando:

| Criterio de aceptacion | Como se verifica |
|---|---|
| CA-1: `AsignarEtiquetaFunction/FunctionEndpoint.cs` usa el helper, sin try/catch inline | Inspeccion del diff del implementer + `dotnet build` |
| CA-2: `RetirarEtiquetaFunction/FunctionEndpoint.cs` usa el helper, sin try/catch inline | Inspeccion del diff del implementer + `dotnet build` |
| CA-3: guarda de `{categoria}` en blanco se conserva intacta | Inspeccion del diff del implementer |
| CA-4: contrato HTTP observable no cambia, tests existentes pasan sin modificacion | `dotnet test` sobre `Bitakora.ControlAsistencia.Colaboradores.Tests` (base verde ya confirmada: 355/355) |
| CA-5: literal unico en el helper, verificable con grep | `grep -rln "El id de la ruta es invalido" src/Bitakora.ControlAsistencia.Colaboradores/` debe retornar solo `Infraestructura/IdentificacionDeRuta.cs` tras la migracion (hoy retorna 3 archivos: el helper + los dos endpoints) |

### Desviaciones del plan del planner

Ninguna -- las sugerencias del issue fueron aplicables tal cual. El plan mismo identifica
correctamente que se trata de un refactor puro y sugiere el archivo senal de `pipeline-state/`
(MEF-ADR-0017), que es exactamente el carril tomado.

</details>

<details>
<summary>Reviewer (fase refactor) — 8m 49s</summary>

## ES Reviewer - Revision

### Evaluacion general
- Calidad: buena
- Cambios realizados: si (este agente ejecuto el refactor -- carril de refactoring puro, sin fase roja ni verde previas)

**Carril**: refactoring puro (`pipeline-state/refactor-signal.md`, `REFACTOR_ONLY=true`, `REMOVED_TESTS=0`,
MEF-ADR-0017). No existe `stage-2-implementer.md` ni `stage-2-projection-implementer.md`: el
test-writer solo señalizo y no toco produccion ni tests, asi que la ejecucion del refactor recayo en
esta fase.

**Baseline y estado final** (identicos, ningun test tocado):

| Momento | total | error | correcto | omitido |
|---|---|---|---|---|
| Antes del refactor | 1357 | 0 | 1309 | 48 |
| Despues del refactor | 1357 | 0 | 1309 | 48 |

Los 48 omitidos son smoke tests con `Assert.SkipWhen` por fixtures no configurados (Postgres /
Service Bus) -- comportamiento esperado en local, sin relacion con este diff.

### Cumplimiento de ADRs aplicables

| ADR | Cumplimiento | Observacion |
|---|---|---|
| MEF-ADR-0018: heuristicas de evolucion y reuso | ok | El helper es **mecanica neutral del borde**, que la seccion "Lo que esta heuristica NO regula" excluye explicitamente del alcance de la Rule of Three ("Reuso de utilidades sin riesgo de divergencia... la heuristica aplica cuando el codigo expresa reglas del dominio que pueden divergir, no cuando expresa mecanica neutral"). La decision de extraer ya estaba tomada y documentada en #379; este refactor solo alinea los dos rezagados, no origina una extraccion nueva -- por lo que tampoco activa la regla de "autoridad de extraccion" (el reviewer no pide extracciones que el implementer no ofrece). |
| MEF-ADR-0037: identidad del stream y su representacion string | ok | Ver fila dedicada del checklist de convenciones. El par "parsear el `{id}` una vez + 400 explicito" (seccion 2) queda en un sitio unico; `ColaboradorAggregateRoot.ComputarStreamId(identificacion) => identificacion.ToString()` sigue siendo el punto unico de conversion (seccion 1), sin especificador de formato. |
| MEF-ADR-0006: naming de funciones Azure | ok | Sin cambios de nombre de Function, carpeta ni ruta -- restriccion explicita del issue. `[Function("AsignarEtiqueta")]` / `[Function("RetirarEtiqueta")]`, feature folder con sufijo `Function` (comandos), `Route` explicito en ambos, verbo declarado en ambos (seccion "Cada Function declara su verbo, siempre"). |
| MEF-ADR-0043: doctrina HTTP de comandos | ok | Contrato observable intacto y coincidente con el pactado en el issue (ver checklist). |
| MEF-ADR-0009: mensajes en `.resx` | ok (no aplica, evaluacion del planner confirmada) | Verificado contra el ADR: su alcance son mensajes de **logica de negocio del aggregate**, **precondiciones del handler** y **FluentValidation** (inline con `.WithMessage`). El literal del 400 del borde HTTP no cae en ninguna de las tres. El refactor ademas **mejora** la situacion que motiva ese ADR: de 3 copias del literal a 1. |
| MEF-ADR-0012: Tell-don't-Ask | ok (tangencial) | No se crean VOs ni servicios; no hay propiedad nueva, ni clase estatica que opere sobre datos crudos de un VO, ni getter para tests, ni `InternalsVisibleTo` desde ensamblados de eventos. La normalizacion sigue viviendo en `Etiqueta.Crear` / `Etiqueta.NormalizarCategoria` (el endpoint pasa `{categoria}` cruda). Recorri el checklist de 7 antipatrones: ninguno presente. |
| CA-ADR-0030 / MEF-ADR-0004: manejo de errores | ok | La traduccion `InvalidOperationException -> 409` / `KeyNotFoundException -> 404` del despacho no se toco. La guarda de `{categoria}` en blanco (capa 1, forma en el borde -> 400) se conserva intacta con su 400 y su mensaje actual (CA-3). |

### Desviaciones de ADRs

**Ninguna desviacion -- todos los ADRs aplicables se cumplen.**

- **Declaradas por el implementer**: no aplica -- carril de refactoring puro, no hubo fase verde. El
  resumen del test-writer (`stage-1-test-writer.md`) declara explicitamente "Desviaciones del plan
  del planner: Ninguna".
- **Detectadas por el reviewer**: ninguna. El diff aplica exactamente el patron de referencia de los
  seis endpoints ya migrados, incluida la convencion de nombre `errorDeId` para el `out` del guard
  clause (que evita la colision con el `error` de la tupla del `IRequestValidator` en
  `AsignarEtiqueta`).

### Precedentes consultados por el implementer

El issue cita `CorregirNombresFunction/FunctionEndpoint.cs` como patron de referencia. Verificado
contra los ADRs, y ademas contra los **seis** call sites existentes (no solo el citado):

| Precedente | ADR aplicable | Veredicto |
|---|---|---|
| `CorregirNombresFunction/FunctionEndpoint.cs:36-37` | MEF-ADR-0037 seccion 2 | alineado |
| `AnularTerminacionFunction`, `CorregirFechaInicioVinculacionFunction`, `IniciarVinculacionFunction`, `TerminarVinculacionFunction`, `ObtenerFichaColaborador` | MEF-ADR-0037 seccion 2 | alineados -- los seis usan la forma identica `if (!IdentificacionDeRuta.TryParsear(id, out var identificacion, out var errorDeId)) return errorDeId;` |
| `Infraestructura/IdentificacionDeRuta.cs` (helper, sin cambios) | MEF-ADR-0037 s.2, MEF-ADR-0018, MEF-ADR-0009 | alineado -- forma `TryParse` del BCL con atributos de nullable flow (`[MaybeNullWhen(false)]` / `[NotNullWhen(false)]`), que es lo que permite el call site de dos lineas **sin operador null-forgiving** |

Ningun precedente viola su ADR; no hay bug de precedente que reportar.

### Convenciones del pipeline (no ADRs)

| Convencion | Estado | Observacion |
|---|---|---|
| Cada test con `Then()` + `And<>()` | n/a | Refactor puro: no se agregaron tests. Los existentes son tests de endpoint HTTP (`FunctionEndpointTests`), no del DSL `CommandHandlerAsyncTest<T>` -- el par `Then/And` no aplica a esa forma. |
| Overloads correctos para stream IDs compuestos | n/a | El diff no toca tests del DSL. `ColaboradorAggregateRoot` usa clave natural simple (`Identificacion.ToString()`, no compuesta con `:`). |
| Fakes manuales (no NSubstitute) | ok | Los tests preexistentes usan `FakeAsignarEtiquetaBodyRequestValidator`, `FakeAsignarEtiquetaCommandRouter`, `FakeRetirarEtiquetaCommandRouter` -- clases fake concretas. Sin NSubstitute. |
| Feature folders (produccion y tests) | ok | `AsignarEtiquetaFunction/` y `RetirarEtiquetaFunction/` con sufijo `Function` (comandos), `FunctionEndpoint.cs` + subcarpeta `CommandHandler/`; espejo exacto en tests. Sin cambios estructurales. |
| Smoke tests: SkipWhen, secrets, cobertura | n/a | El diff no toca smoke tests ni agrega efectos secundarios: el refactor no cambia ningun efecto observable (mismos codigos HTTP, mismo comando despachado, misma persistencia). No hay efecto nuevo que exigiera cobertura, ni topic nuevo que exigiera suscripcion `smoke-tests`. |
| Proyecciones read-side (partial, inmutabilidad, read APIs, naming MEF-ADR-0041, cuarta isla) | n/a | El diff no toca `ReadModels`, `Projections` ni ninguna Function GET. |
| Antipatrones de habilitacion (MEF-ADR-0039) | n/a | `git diff main...HEAD -- '**/*.csproj'` vacio; ningun tipo de evento nuevo declarado. Los cinco items (a)-(e) no tienen superficie en este diff. |
| Compatibilidad Marten write-side/read-side | n/a | El diff no toca la version de `Cosmos.EventSourcing.CritterStack`/`Abstractions` ni ningun archivo o llamada de configuracion Marten (`ComposicionServicios*`, `ConfiguracionMartenProjections*`, `ConfiguracionSerializacion*`, `IdentidadEventos*`, `opts.Events.*`, `AddEventTypes`, etc.). Sin decompilacion necesaria. |
| Identidad de stream (MEF-ADR-0037) | ok | Gate **activo** (el diff toca el parseo del `{id}` que alimenta `ComputarStreamId` -> `GetAggregateRootAsync`). Los tres puntos verificados: (1) sin `ToString("N"/"B"/"P"/"X")` ni `.ToUpper()/.ToLower()` en todo el dominio -- `grep 'ToString("'` sobre `src/Bitakora.ControlAsistencia.Colaboradores/` retorna **0 coincidencias**; `ComputarStreamId => identificacion.ToString()` sin especificador. (2) Sin reconstruccion paralela de la clave fuera de `ComputarStreamId`: los ocho call sites la invocan. (3) Borde HTTP con **parseo tipado** (`Identificacion.Parsear` dentro del helper) y `400` con `BadRequestObjectResult` **y mensaje** -- nunca un `BadRequestResult` pelado; el texto crudo de la ruta no llega al store. La firma `string id` es la forma canonica del binding y **no** es hallazgo. |
| Contrato HTTP de comandos (MEF-ADR-0043) | ok | Gate **activo** por la via del contrato pactado: el diff no **agrega** ningun `FunctionEndpoint.cs` (`--diff-filter=A` vacio) pero **modifica** dos preexistentes cuyo contrato HTTP el issue declara explicitamente. Puntos 1-7 verificados contra la forma pactada -- detalle abajo. |
| Control de volumen de telemetria (MEF-ADR-0038) | n/a | El diff no toca `ComposicionServicios*`, `ConfiguracionObservabilidad*`, ni ninguna linea con `AddOpenTelemetry`/`UseAzureMonitorExporter`/`SetSampler`/`AgregarWolverineParaComandosServerless`. |
| Tests via ToString/comportamiento | ok | Los tests afirman el **tipo** del `IActionResult` (`BadRequestObjectResult`, `ConflictObjectResult`, `NotFoundObjectResult`, `AcceptedResult`) y el comando recibido por el fake -- nunca el texto del literal. Justamente por eso la migracion los deja verdes sin tocarlos (CA-4). |
| Sin numeros magicos | ok | Ninguno introducido; el diff elimina codigo, no agrega constantes. |
| Condiciones en positivo (guardas if/else afirmativas) | ok | El `if (!IdentificacionDeRuta.TryParsear(...)) return errorDeId;` es un **guard clause / early-return**, el caso que la regla exceptua explicitamente: la negacion expresa la precondicion de salida y no hay rama `else` que permutar. Es ademas la forma canonica `TryParse` del BCL. |

**Detalle del gate MEF-ADR-0043** (puntos 1-7 contra el contrato pactado en el issue, seccion "Contexto"):

| # | Punto | Estado |
|---|---|---|
| 1 | Verbo segun test de precedencia | ok -- `PUT` para `AsignarEtiqueta` (paso 2: reemplazo completo del VO atomico `Etiqueta`, direccionable por categoria); `DELETE` para `RetirarEtiqueta` (paso 3: remocion veraz sin payload). Coincide con lo pactado. |
| 2 | Ruta kebab-case minusculo | ok -- `colaboradores/{id}/etiquetas/{categoria}`, todos los segmentos en minuscula. |
| 3 | Ids URL-safe, `:` reservado para acciones | ok -- `{id}` es `Identificacion.ToString()` = `"CC-79543210"`, separador guion, sin `:`. La clave de stream de este aggregate es **simple**, no compuesta, asi que no hay riesgo de clave concatenada en un solo segmento. |
| 4 | PATCH ausente | ok -- verbos declarados: `"put"` y `"delete"`. |
| 5 | `Route` explicito, nunca el default ni `""` | ok -- ambos declaran `Route` con plantilla no vacia. |
| 6 | Verbo declarado en ambas Functions que comparten segmento | ok -- las dos comparten **plantilla identica** y se distinguen solo por metodo; ambas lo declaran explicitamente. Ninguna omite `Methods`. |
| 7 | Coincide con el contrato pactado en el issue | ok -- verbo, ruta y paso de precedencia identicos a los declarados; ningun codigo de estado cambia. |

### Elegancia del codigo

El diff mejora las seis dimensiones sin costo en ninguna:

- **Compacto**: 12 lineas de `try/catch` (6 por endpoint) se convierten en 4 (2 por endpoint). El
  `Identificacion identificacion;` declarado por adelantado -- necesario solo porque la asignacion
  vivia dentro del `try` -- desaparece a favor de `out var`.
- **Legible**: la intencion queda en el nombre (`TryParsear`) en vez de inferirse de un `catch
  (ArgumentException)` cuyo significado ("el id de ruta esta mal formado") era implicito.
- **Idiomatico**: forma `TryParse` del BCL, con `out` y atributos de nullable flow; guard clause con
  early-return. El call site no necesita operador null-forgiving (`!`) sobre la identificacion,
  precisamente porque el helper declara `[MaybeNullWhen(false)]`.
- **Robusto**: el manejo de error del boundary no se debilita -- el mismo `ArgumentException` se
  captura, ahora en un solo sitio. No se traga ninguna excepcion nueva.
- **Eficiente**: sin impacto (mismo trabajo, un frame de llamada mas).
- **Limpio**: `dotnet build` sin errores ni warnings nuevos. Se retiro ademas el `using
  ...Colaboradores.DomainEvents;` que quedo **sin uso** en ambos archivos al desaparecer la
  declaracion explicita del tipo `Identificacion` (en `RetirarEtiqueta` se sustituyo por el `using
  ...Infraestructura;` que el helper requiere y que ese archivo no tenia). Sin caracteres U+2500
  (verificado con grep: 0 en ambos archivos).

### Criticas y hallazgos

**Ningun hallazgo bloqueante.** Tres observaciones menores, ninguna corregida por quedar fuera del
alcance del issue (regla 4: no refactorizar codigo no relacionado):

1. **[cosmetico, no corregido]** `tests/.../AsignarEtiquetaFunction/FunctionEndpointTests.cs:9`
   tiene un `using Bitakora.ControlAsistencia.Colaboradores.Infraestructura;` que parece innecesario.
   **Deliberadamente no lo toque**: CA-4 exige que los `FunctionEndpointTests` de ambos endpoints
   "pasan sin modificacion", y quitar un using -- por inocuo que sea -- es modificar el archivo.
   Candidato a limpieza en un issue de higiene.
2. **[menor, no corregido]** El literal `"La categoria de la ruta no puede estar en blanco"` sigue
   duplicado en los dos endpoints. Es el mismo tipo de mecanica neutral del borde que motivo el
   helper, pero: (a) CA-3 exige conservar esa guarda **intacta**; (b) son dos copias, no tres
   (MEF-ADR-0018 tolera la duplicacion estable hasta el tercer caso); (c) MEF-ADR-0018 fija que
   "el reviewer no debe pedir extraccion si el implementer no la ofrece, salvo evidencia documentada
   de evolucion conjunta". Queda anotado para cuando aparezca un tercer endpoint con `{categoria}`.
3. **[informativo, riesgo heredado -- NO introducido por este PR]** MEF-ADR-0006 declara *no
   verificado* que dos Functions con **plantilla de ruta identica** y verbos disjuntos convivan sin
   conflicto en el host de Azure Functions ("el par que si comparte plantilla debe verificarse
   empiricamente en el primer dominio que lo implemente"). `AsignarEtiqueta` (PUT) y
   `RetirarEtiqueta` (DELETE) son exactamente ese par, introducido por #376 (PR #388, ya mergeado).
   Este refactor no altera ese riesgo en ningun sentido, y mi propio checklist deja ese gate empirico
   explicitamente fuera del punto 6. Lo dejo escrito para que el humano decida si merece verificacion
   en dev.

**Falso positivo descartado activamente**: el `try/catch` que queda en ambos endpoints alrededor de
`commandRouter.InvokeAsync` **no** es residuo del patron viejo -- es la traduccion 409/404 de
CA-ADR-0030 / MEF-ADR-0004, que el issue excluye del alcance ("la traduccion 409/404 del despacho
del comando no se toca"). Correcto conservarlo.

### Refactorings aplicados

1. **`AsignarEtiquetaFunction/FunctionEndpoint.cs`** (CA-1): `try/catch (ArgumentException)` alrededor
   de `Identificacion.Parsear(id)` -> `if (!IdentificacionDeRuta.TryParsear(id, out var
   identificacion, out var errorDeId)) return errorDeId;`. Nombre `errorDeId` (no `error`) para no
   colisionar con el `error` de la tupla del `IRequestValidator` que viene despues -- misma
   convencion que los seis endpoints ya migrados. `using ...DomainEvents;` retirado (sin uso).
2. **`RetirarEtiquetaFunction/FunctionEndpoint.cs`** (CA-2): misma sustitucion. `using
   ...DomainEvents;` sustituido por `using ...Infraestructura;` (el archivo no lo tenia).
3. **Comentarios de encabezado de ambos** (nota tecnica del issue, redaccion a criterio del
   ejecutor): la descripcion del mecanismo de parseo pasa de "se parsea UNA vez con
   `Identificacion.Parsear` ... y un `ArgumentException` se traduce a 400 explicito" a referenciar el
   sitio unico (`IdentificacionDeRuta.TryParsear`), conservando la cita a MEF-ADR-0037 seccion 2.
   Ademas se reflowearon las lineas del comentario de `RetirarEtiqueta` que quedaron con relleno
   irregular tras la edicion.

**Verificacion tras cada paso** (regla 1): `dotnet build` -> correcto; `dotnet test` tras la
sustitucion -> 1357/0; `dotnet test` tras el reflow de comentarios -> 1357/0. Ningun cambio requirio
`git checkout --`.

**Formato**: `dotnet format` sobre
`src/Bitakora.ControlAsistencia.Colaboradores/Bitakora.ControlAsistencia.Colaboradores.csproj
--verify-no-changes` sale con **exit 0 y 0 warnings**. A nivel de solucion completa el comando sale
con exit 2 por **4 warnings IDE0005 preexistentes** en
`tests/Bitakora.ControlAsistencia.ControlHoras.Tests/` (usings innecesarios en tests de
serializacion de otro dominio) -- ninguno en `Colaboradores`, ninguno en los archivos de este diff,
y ninguno introducido aqui. Fuera del alcance del issue; anotado por si se quiere un issue de
higiene.

### Cobertura de criterios de aceptacion

| Criterio | Estado | Test(s) / verificacion |
|---|---|---|
| CA-1: `AsignarEtiquetaFunction` parsea via el helper; sin `try/catch (ArgumentException)` inline | cubierto | Diff (lineas 37-38) + `AsignarEtiqueta_Retorna400_CuandoIdDeRutaNoTraeGuion`, `AsignarEtiqueta_Retorna400_CuandoElTipoDeLaIdentificacionNoEstaEnLaListaCerrada` (las dos causas de `ArgumentException` que cubre el helper) |
| CA-2: `RetirarEtiquetaFunction` idem | cubierto | Diff (lineas 36-37) + `RetirarEtiqueta_Retorna400_CuandoIdDeRutaNoTraeGuion`, `RetirarEtiqueta_Retorna400_CuandoElTipoDeLaIdentificacionNoEstaEnLaListaCerrada` |
| CA-3: guarda de `{categoria}` en blanco intacta, con su 400 y su mensaje actual | cubierto | Diff (bloque sin cambios en ambos archivos) + `AsignarEtiqueta_Retorna400_CuandoLaCategoriaDeRutaEstaEnBlanco`, `RetirarEtiqueta_Retorna400_CuandoLaCategoriaDeRutaEstaEnBlanco` (ambos verifican ademas que el router **no** se invoca) |
| CA-4: contrato HTTP observable sin cambios; los `FunctionEndpointTests` pasan **sin modificacion** | cubierto | `git diff --name-only` lista **solo los dos archivos de `src/`** -- cero archivos de `tests/` tocados. Suite antes y despues: 1357/0/1309/48, conteos identicos. Verbos, rutas y los cuatro codigos (400/409/404/202) verificados uno a uno en el gate MEF-ADR-0043 |
| CA-5: el literal existe en un unico sitio de `src/.../Colaboradores/`; `dotnet build` y `dotnet test` en verde | cubierto | `grep -rln "El id de la ruta es invalido" src/ tests/` -> **1 archivo**: `Infraestructura/IdentificacionDeRuta.cs` (antes 3). `dotnet build`: "Compilacion correcta". `dotnet test`: 1357 total, 0 errores |

### Tests agregados

Ninguno, y es el resultado correcto para este carril:

- **Refactor puro**: no hay comportamiento nuevo que testear. Todo lo que el diff toca ya esta
  cubierto por los cuatro tests de 400 (dos por endpoint) mas los de 202/409/404, que ejercitan el
  camino completo a traves del helper.
- **Contratos de value objects (paso 4b)**: no aplica. El diff no introduce ninguna clase con
  `IEquatable<T>` ni con `ConfigurarSerializacion`, ni ningun evento con marker de bus
  (`IPrivateEvent`/`IPublicEvent`) que exigiera el guardrail de round-trip con serializador por
  defecto. `IdentificacionDeRuta` es una clase estatica de traduccion del borde HTTP, no un VO.
- **Casos borde**: revise si faltaba alguno de la tercera causa de `ArgumentException` que documenta
  el helper ("numero vacio tras la limpieza"). No lo agregue: ese caso pertenece al contrato de
  `Identificacion.Parsear` / `IdentificacionDeRuta`, no al de estos endpoints, y agregarlo aqui seria
  duplicar cobertura del helper en dos sitios mas -- exactamente el tipo de replica que este issue
  viene a eliminar.

</details>

## Commits

d3e8ff6 refactor(hu-395): unifica el parseo del {id} de ruta en los endpoints de etiquetas

Closes #395