### PR TITLE
infra(dev): #400 Encender always_on en los tres Function Apps de dev

### DIFF
--- a/infra/environments/dev/dominio-colaboradores.tf
+++ b/infra/environments/dev/dominio-colaboradores.tf
@@ -14,8 +14,10 @@
 # UNICO app setting SERVICE_BUS_CONNECTION (sin la topologia interno/externo de MEF-ADR-0024 del
 # harness), y Application Insights se configura con el valor directo de
 # module.monitoring.connection_string (no una referencia de Key Vault, decision #7 de ese ADR).
-# El modulo local infra/modules/service-plan tampoco acepta os_type/worker_count/always_on --
-# solo sku_name (default B1, hardcodea os_type = "Linux").
+# El modulo local infra/modules/service-plan ya acepta los cuatro inputs del contrato de
+# MEF-ADR-0020 (sku_name, os_type, worker_count, always_on -- issue #400, cierra la deriva
+# senalada aqui anteriormente): os_type y worker_count no se pasan explicitos porque sus
+# defaults ("Linux", 1) replican el comportamiento previo sin diff.
 
 resource "random_string" "storage_suffix_colaboradores" {
   length  = 6
@@ -33,12 +35,17 @@ module "storage_colaboradores" {
 
 # Un Service Plan por dominio (ADR-0020): aisla el computo de cada dominio. Mismo patron que
 # Programacion/ControlHoras (Linux, SKU B1 -- el default del modulo).
+#
+# always_on = true (issue #400): ver el comentario extendido junto a
+# module.service_plan_programacion en main.tf -- mismo razonamiento, un plan Basic dedicado
+# factura la VM 24/7 independientemente de Always On.
 module "service_plan_colaboradores" {
   source              = "../../modules/service-plan"
   name                = "asp-${local.prefix_short}-colaboradores"
   resource_group_name = module.resource_group.name
   location            = module.resource_group.location
   sku_name            = "B1"
+  always_on           = true
   tags                = local.tags
 }
 
@@ -50,6 +57,7 @@ module "function_app_colaboradores" {
   service_plan_id                = module.service_plan_colaboradores.id
   storage_account_name           = module.storage_colaboradores.name
   app_insights_connection_string = module.monitoring.connection_string
+  always_on                      = module.service_plan_colaboradores.always_on
   app_settings = {
     SERVICE_BUS_CONNECTION = local.service_bus_connection_kv_ref
     DOMINIO                = "colaboradores"

--- a/infra/environments/dev/main.tf
+++ b/infra/environments/dev/main.tf
@@ -10,12 +10,20 @@ module "resource_group" {
 
 # Un Service Plan por dominio (ADR-0020): aisla el computo de cada dominio.
 # Mismas caracteristicas que el plan compartido anterior: Linux, SKU B1.
+#
+# always_on = true (issue #400): en un plan Basic dedicado la VM se factura
+# 24/7 este o no la app dormida (doc oficial "Cost of App Service plans"),
+# asi que apagar Always On no ahorra nada y ademas interrumpe el poll en
+# background del agente de durabilidad de Wolverine (DurabilityMode.Solo,
+# MEF-ADR-0020). os_type y worker_count no se pasan explicitos: sus defaults
+# ("Linux", 1) replican el comportamiento previo sin diff.
 module "service_plan_programacion" {
   source              = "../../modules/service-plan"
   name                = "asp-${local.prefix_short}-programacion"
   resource_group_name = module.resource_group.name
   location            = module.resource_group.location
   sku_name            = "B1"
+  always_on           = true
   tags                = local.tags
 }
 
@@ -25,6 +33,7 @@ module "service_plan_control_horas" {
   resource_group_name = module.resource_group.name
   location            = module.resource_group.location
   sku_name            = "B1"
+  always_on           = true
   tags                = local.tags
 }
 
@@ -148,6 +157,7 @@ module "function_app_programacion" {
   service_plan_id                = module.service_plan_programacion.id
   storage_account_name           = module.storage_programacion.name
   app_insights_connection_string = module.monitoring.connection_string
+  always_on                      = module.service_plan_programacion.always_on
   app_settings = {
     SERVICE_BUS_CONNECTION = local.service_bus_connection_kv_ref
     DOMINIO                = "programacion"
@@ -178,6 +188,7 @@ module "function_app_control_horas" {
   service_plan_id                = module.service_plan_control_horas.id
   storage_account_name           = module.storage_control_horas.name
   app_insights_connection_string = module.monitoring.connection_string
+  always_on                      = module.service_plan_control_horas.always_on
   app_settings = {
     SERVICE_BUS_CONNECTION = local.service_bus_connection_kv_ref
     DOMINIO                = "control-horas"

--- a/infra/environments/dev/providers.tf
+++ b/infra/environments/dev/providers.tf
@@ -42,8 +42,32 @@ provider "azurerm" {
   # explicitamente los RPs que la configuracion necesita -- como ya haciamos
   # desde el issue #246 -- deja de ser un ajuste puntual para Microsoft.App y
   # pasa a ser la forma canonica de registrar Resource Providers en v5.
+  #
+  # Lista canonica de los trece namespaces del marco (MEF-ADR-0021, issue #439).
+  # Antes solo se declaraba Microsoft.App: los otros doce venian por el
+  # auto-registro implicito del modo "legacy" de v4, que el pin "~> 5.0" de este
+  # entorno ya no provee (default "none"). Sin declararlos, el primer apply que
+  # cree un recurso de un namespace no registrado falla con
+  # 409 MissingSubscriptionRegistration.
+  #
+  # OJO con el casing: es case-sensitive (internal/resourceproviders/required.go
+  # del provider). "microsoft.insights" va en minusculas -- la validacion del
+  # argumento es best-effort y un typo degrada a un [WARN] en el plan, para
+  # reaparecer como 409 en el apply.
   resource_providers_to_register = [
     "Microsoft.App",
+    "Microsoft.Resources",
+    "Microsoft.Storage",
+    "Microsoft.ManagedIdentity",
+    "Microsoft.Authorization",
+    "Microsoft.Web",
+    "Microsoft.KeyVault",
+    "Microsoft.ServiceBus",
+    "Microsoft.DBforPostgreSQL",
+    "Microsoft.OperationalInsights",
+    "microsoft.insights",
+    "Microsoft.ContainerRegistry",
+    "Microsoft.ApiManagement",
   ]
 
   features {

--- a/infra/modules/function-app/main.tf
+++ b/infra/modules/function-app/main.tf
@@ -35,6 +35,19 @@ variable "app_settings" {
   default     = {}
 }
 
+variable "always_on" {
+  description = <<-EOT
+    Always On del site_config (issue #400). Recomendado true en App Service
+    plans dedicados (Basic/Standard/Premium): en esos tiers la VM se factura
+    24/7 este o no la app dormida, asi que apagarlo no ahorra costo (doc
+    oficial, "Cost of App Service plans") y ademas interrumpe el poll en
+    background del agente de durabilidad de Wolverine (DurabilityMode.Solo,
+    MEF-ADR-0020) cuando el host se duerme por inactividad.
+  EOT
+  type        = bool
+  default     = false
+}
+
 variable "tags" {
   description = "Tags comunes del proyecto"
   type        = map(string)
@@ -59,6 +72,8 @@ resource "azurerm_linux_function_app" "this" {
   functions_extension_version = "~4"
 
   site_config {
+    always_on = var.always_on
+
     application_stack {
       dotnet_version              = "10.0"
       use_dotnet_isolated_runtime = true

--- a/infra/modules/service-plan/main.tf
+++ b/infra/modules/service-plan/main.tf
@@ -19,6 +19,31 @@ variable "sku_name" {
   default     = "B1"
 }
 
+variable "os_type" {
+  description = "Sistema operativo del plan. ForceNew en azurerm_service_plan: cambiarlo destruye el plan."
+  type        = string
+  default     = "Linux"
+}
+
+variable "worker_count" {
+  description = "Numero de instancias (workers) del plan. DurabilityMode.Solo de Wolverine (MEF-ADR-0020) exige un unico nodo: no usar este input para escalar out."
+  type        = number
+  default     = 1
+}
+
+variable "always_on" {
+  description = <<-EOT
+    Si el/los Function App(s) de este plan deben correr con Always On. El
+    recurso azurerm_service_plan no tiene este argumento (vive en el
+    site_config de azurerm_linux_function_app): este modulo solo lo recibe y
+    lo reexpone via output para que el modulo function-app lo consuma,
+    centralizando en un unico lugar los parametros de hosting por dominio
+    (contrato de inputs de MEF-ADR-0020).
+  EOT
+  type        = bool
+  default     = false
+}
+
 variable "tags" {
   description = "Tags comunes del proyecto"
   type        = map(string)
@@ -29,11 +54,17 @@ resource "azurerm_service_plan" "this" {
   name                = var.name
   resource_group_name = var.resource_group_name
   location            = var.location
-  os_type             = "Linux"
+  os_type             = var.os_type
   sku_name            = var.sku_name
+  worker_count        = var.worker_count
   tags                = var.tags
 }
 
 output "id" {
   value = azurerm_service_plan.this.id
+}
+
+output "always_on" {
+  description = "Pass-through de var.always_on para que el modulo function-app lo consuma en su site_config."
+  value       = var.always_on
 }


### PR DESCRIPTION
## Infraestructura

Implementa los cambios de infraestructura del issue #400.

- **Ambiente**: dev
- **Estado**: HCL escrito y revisado localmente (sin plan ni apply local); pendiente de aplicar por CI
- **Pipeline**: iac-pipeline.sh

## Decisiones del pipeline

<details>
<summary>infra-writer -- 2m 34s</summary>

_(El agente no genero resumen)_

</details>

<details>
<summary>infra-reviewer -- 1m 55s</summary>

_(El agente no genero resumen)_

</details>

## Cambios Terraform

 infra/environments/dev/dominio-colaboradores.tf | 12 +++++++--
 infra/environments/dev/main.tf                  | 11 +++++++++
 infra/environments/dev/providers.tf             | 24 ++++++++++++++++++
 infra/modules/function-app/main.tf              | 15 +++++++++++
 infra/modules/service-plan/main.tf              | 33 ++++++++++++++++++++++++-
 5 files changed, 92 insertions(+), 3 deletions(-)

## Commits

027fbc2 infra(review): correcciones de seguridad y calidad en dev
dae592b infra(dev): escritura HCL issue #400

> **Apply pendiente en CI**: este PR no cierra el issue #400. El `terraform apply` lo ejecuta el workflow **Infra CD** al mergear este PR a `main` (MEF-ADR-0022); el issue se cierra automaticamente cuando ese apply termine exitosamente.