### PR TITLE
Renombrar a CodigoColaborador y Colaborador las claves EmpleadoId y Empleado de los contratos persistidos, de bus y HTTP

### DIFF
--- a/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/ColaboradorProgramado.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/ColaboradorProgramado.cs
@@ -15,15 +15,20 @@ namespace Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 /// dominio Colaboradores --: lleva calificador de intencion, mismo criterio anti-squatting que dio
 /// SedeProgramada en vez de Sede (#331, #336). Es un gemelo deliberado del ColaboradorProgramado de
 /// Programacion.DomainEvents: mismo nombre simple en otra isla, con paridad de campos y sin
-/// referencia entre ambos (patron SedeProgramada, #336). El rename no toca ninguna clave JSON: este
-/// record no esta en IdentidadEventosControlHoras.TiposPersistidos -- no tiene alias, y STJ no
-/// persiste $type para payload anidado (MEF-ADR-0036 no aplica; precedente #319 CA-2, #322).
+/// referencia entre ambos (patron SedeProgramada, #336). Ese rename de #340 no toco ninguna clave
+/// JSON.
+///
+/// Issue #401: el campo EmpleadoId paso a CodigoColaborador -- aqui SI cambia la clave JSON del
+/// payload anidado. Sin mapeo: los streams de dev se purgan en el mismo despliegue (MEF-ADR-0036
+/// seccion 5). Este record no esta en IdentidadEventosControlHoras.TiposPersistidos -- no tiene
+/// alias propio, y STJ no persiste $type para payload anidado (MEF-ADR-0036 no aplica al TIPO;
+/// precedente #319 CA-2, #322).
 ///
 /// Sin Equals custom: todos los campos son string, asi que la igualdad por valor del record por
 /// defecto ya es correcta (mismo criterio que DetalleColaborador).
 /// </summary>
 public record ColaboradorProgramado(
-    string EmpleadoId,
+    string CodigoColaborador,
     string TipoIdentificacion,
     string NumeroIdentificacion,
     string Nombres,

--- a/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/MarcacionAdicionada.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/MarcacionAdicionada.cs
@@ -8,9 +8,9 @@ namespace Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 // ADR-0024: evento del aggregate (categoria event-sourcing), sin marker de bus.
 public sealed class MarcacionAdicionada
 {
-    // CA-7: Id es el stream ID del ControlDiario: "{EmpleadoId}:{Fecha:yyyy-MM-dd}"
+    // CA-7: Id es el stream ID del ControlDiario: "{CodigoColaborador}:{Fecha:yyyy-MM-dd}"
     public string Id { get; private set; } = null!;
-    public string EmpleadoId { get; private set; } = null!;
+    public string CodigoColaborador { get; private set; } = null!;
 
     // TimestampNormalizado viene ya truncado al minuto desde RegistrarMarcacion (#105)
     public DateTime TimestampNormalizado { get; private set; }
@@ -21,13 +21,13 @@ public sealed class MarcacionAdicionada
 
     public MarcacionAdicionada(
         string id,
-        string empleadoId,
+        string codigoColaborador,
         DateTime timestampNormalizado,
         string? tipoMarcacion,
         string? dispositivoId)
     {
         Id = id;
-        EmpleadoId = empleadoId;
+        CodigoColaborador = codigoColaborador;
         TimestampNormalizado = timestampNormalizado;
         TipoMarcacion = tipoMarcacion;
         DispositivoId = dispositivoId;

--- a/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/MarcacionRegistrada.Mensajes.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/MarcacionRegistrada.Mensajes.cs
@@ -13,7 +13,7 @@ public sealed partial class MarcacionRegistrada
 
     internal static class Mensajes
     {
-        public static string EmpleadoIdVacio =>
-            ResourceManager.GetString(nameof(EmpleadoIdVacio))!;
+        public static string CodigoColaboradorVacio =>
+            ResourceManager.GetString(nameof(CodigoColaboradorVacio))!;
     }
 }

--- a/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/MarcacionRegistrada.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/MarcacionRegistrada.cs
@@ -15,19 +15,19 @@ namespace Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 // necesario: es la unica via de reconstruccion, y solo existe dentro del event store (CA-ADR-0025).
 public sealed partial class MarcacionRegistrada
 {
-    public string EmpleadoId { get; private set; }
+    public string CodigoColaborador { get; private set; }
     public DateTime TimestampNormalizado { get; private set; }
     public string? TipoMarcacion { get; private set; }
     public string? DispositivoId { get; private set; }
 
     // Issue #275 CA-1: constructor real privado -- solo el factory Crear lo invoca
     private MarcacionRegistrada(
-        string empleadoId,
+        string codigoColaborador,
         DateTime timestampNormalizado,
         string? tipoMarcacion,
         string? dispositivoId)
     {
-        EmpleadoId = empleadoId;
+        CodigoColaborador = codigoColaborador;
         TimestampNormalizado = timestampNormalizado;
         TipoMarcacion = tipoMarcacion;
         DispositivoId = dispositivoId;
@@ -35,7 +35,7 @@ public sealed partial class MarcacionRegistrada
 
     // Issue #275 CA-1: constructor vacio privado, solo para Marten/STJ via ConfigurarSerializacion
     // (que repuebla los backing fields por reflexion). El dominio nunca lo invoca.
-    private MarcacionRegistrada() => EmpleadoId = string.Empty;
+    private MarcacionRegistrada() => CodigoColaborador = string.Empty;
 
     // Configuracion de serializacion STJ/Marten: permite deserializar con constructor privado
     // y propiedades con private set. Ver MEF-ADR-0012 y MarcacionRegistradaSerializacionTests.
@@ -64,17 +64,18 @@ public sealed partial class MarcacionRegistrada
     }
 
     // Issue #275 CA-1/CA-2/CA-3: unica via de construccion. Trunca los segundos al minuto (floor) y
-    // rechaza EmpleadoId nulo, vacio o solo espacios en blanco.
+    // rechaza CodigoColaborador nulo, vacio o solo espacios en blanco.
     public static MarcacionRegistrada Crear(
-        string empleadoId,
+        string codigoColaborador,
         DateTime timestampCrudo,
         string? tipoMarcacion,
         string? dispositivoId)
     {
-        if (string.IsNullOrWhiteSpace(empleadoId))
-            throw new ArgumentException(Mensajes.EmpleadoIdVacio, nameof(empleadoId));
+        if (string.IsNullOrWhiteSpace(codigoColaborador))
+            throw new ArgumentException(Mensajes.CodigoColaboradorVacio, nameof(codigoColaborador));
 
-        return new MarcacionRegistrada(empleadoId, TruncarAlMinuto(timestampCrudo), tipoMarcacion, dispositivoId);
+        return new MarcacionRegistrada(
+            codigoColaborador, TruncarAlMinuto(timestampCrudo), tipoMarcacion, dispositivoId);
     }
 
     // Issue #275 CA-2: trunca (floor) el timestamp al minuto, descartando segundos y fracciones

--- a/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/MarcacionRegistradaMensajes.resx
+++ b/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/MarcacionRegistradaMensajes.resx
@@ -20,7 +20,7 @@
   <resheader name="version"><value>2.0</value></resheader>
   <resheader name="reader"><value>System.Resources.ResXResourceReader</value></resheader>
   <resheader name="writer"><value>System.Resources.ResXResourceWriter</value></resheader>
-  <data name="EmpleadoIdVacio" xml:space="preserve">
-    <value>El EmpleadoId de la marcacion no puede estar vacio</value>
+  <data name="CodigoColaboradorVacio" xml:space="preserve">
+    <value>El CodigoColaborador de la marcacion no puede estar vacio</value>
   </data>
 </root>

--- a/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/TurnoDiario.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/TurnoDiario.cs
@@ -1,7 +1,7 @@
 namespace Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 
 /// <summary>
-/// Representacion plana del turno que rige efectivamente a un empleado en una fecha concreta,
+/// Representacion plana del turno que rige efectivamente a un colaborador en una fecha concreta,
 /// propia de este ensamblado (issue #322, payload por rol -- CA-ADR-0029 decision #5 /
 /// MEF-ADR-0039 decision #6). Duplica con paridad exacta de campos a DetalleTurno
 /// (PrivateEvents.Programacion) en vez de importarlo: los tres ensamblados de eventos son tres

--- a/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/TurnoDiarioAsignado.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/TurnoDiarioAsignado.cs
@@ -9,30 +9,32 @@ namespace Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 /// ADR-0024: evento del aggregate (categoria event-sourcing), sin marker de bus.
 /// </summary>
 // HU-12: evento de event sourcing del aggregate ControlDiario
-// CA-5: contiene InformacionEmpleado, Fecha, DetalleTurno y SolicitudId (trazabilidad)
-// Issue #322: InformacionEmpleado y DetalleTurno dejan de ser tipos de PublicEvents/PrivateEvents
+// CA-5: contiene InformacionColaborador, Fecha, DetalleTurno y SolicitudId (trazabilidad)
+// Issue #322: InformacionColaborador y DetalleTurno dejan de ser tipos de PublicEvents/PrivateEvents
 // -- ahora son ColaboradorProgramado y TurnoDiario, propios de este ensamblado (payload por rol,
 // CA-ADR-0029 decision #5). Issue #340: ese payload paso de llamarse Empleado a
-// ColaboradorProgramado (termino proscrito por #330). Los NOMBRES de estas propiedades NO cambian
-// (son las claves JSON persistidas en mt_events); solo cambian los TIPOS. MEF-ADR-0036: el alias
-// del evento no se toca -- deriva del nombre de clase del EVENTO, que no se renombra.
+// ColaboradorProgramado (termino proscrito por #330) -- solo el TIPO, sin tocar claves JSON.
+// Issue #401: la propiedad InformacionEmpleado paso a InformacionColaborador. Aqui SI cambia la
+// clave JSON persistida en mt_events, sin mapeo: los streams de dev se purgan en el mismo
+// despliegue que integra el cambio (MEF-ADR-0036 seccion 5). MEF-ADR-0036: el alias del evento
+// no se toca -- deriva del nombre de clase del EVENTO, que no se renombra.
 public sealed class TurnoDiarioAsignado
 {
     public string Id { get; private set; } = null!;
-    public ColaboradorProgramado InformacionEmpleado { get; private set; } = null!;
+    public ColaboradorProgramado InformacionColaborador { get; private set; } = null!;
     public DateOnly Fecha { get; private set; }
     public TurnoDiario DetalleTurno { get; private set; } = null!;
     public Guid SolicitudId { get; private set; }
 
     public TurnoDiarioAsignado(
         string id,
-        ColaboradorProgramado informacionEmpleado,
+        ColaboradorProgramado informacionColaborador,
         DateOnly fecha,
         TurnoDiario detalleTurno,
         Guid solicitudId)
     {
         Id = id;
-        InformacionEmpleado = informacionEmpleado;
+        InformacionColaborador = informacionColaborador;
         Fecha = fecha;
         DetalleTurno = detalleTurno;
         SolicitudId = solicitudId;

--- a/src/Bitakora.ControlAsistencia.ControlHoras/AdicionarMarcacionCuandoRegistroDeMarcacionCreado/EventHandler/RegistroDeMarcacionCreadoEventHandler.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/AdicionarMarcacionCuandoRegistroDeMarcacionCreado/EventHandler/RegistroDeMarcacionCreadoEventHandler.cs
@@ -50,7 +50,7 @@ public partial class RegistroDeMarcacionCreadoEventHandler
         }
     }
 
-    // Patron crear-o-actualizar con stream ID computado (EmpleadoId + Fecha).
+    // Patron crear-o-actualizar con stream ID computado (CodigoColaborador + Fecha).
     // CA-5: si el ControlDiario no existe se crea con Iniciar(MarcacionAdicionada).
     // CA-4: si existe, el aggregate se encarga de ignorar duplicados por minuto.
     // HU-108: tras procesar la marcacion publica DiaCalculado al topic dia-calculado
@@ -60,10 +60,10 @@ public partial class RegistroDeMarcacionCreadoEventHandler
     private async Task AdicionarAControlDiarioAsync(
         RegistroDeMarcacionCreado @event, DateOnly fecha, CancellationToken ct)
     {
-        var streamId = ControlDiarioAggregateRoot.ComputarStreamId(@event.EmpleadoId, fecha);
+        var streamId = ControlDiarioAggregateRoot.ComputarStreamId(@event.CodigoColaborador, fecha);
         var evento = new MarcacionAdicionada(
             streamId,
-            @event.EmpleadoId,
+            @event.CodigoColaborador,
             @event.TimestampNormalizado,
             @event.TipoMarcacion,
             @event.DispositivoId);

--- a/src/Bitakora.ControlAsistencia.ControlHoras/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/EventHandler/ProgramacionTurnoDiarioSolicitadaEventHandler.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/EventHandler/ProgramacionTurnoDiarioSolicitadaEventHandler.cs
@@ -12,7 +12,7 @@ namespace Bitakora.ControlAsistencia.ControlHoras.AsignarTurnoCuandoProgramacion
 //   equivalente seria un espejo del evento (mismos campos, sin semantica propia), asi que se consume
 //   directo con IPrivateEventHandlerAsync<ProgramacionTurnoDiarioSolicitada> - sin comando espejo.
 // Patron crear-o-actualizar:
-//   - CA-3: si NO existe el stream para EmpleadoId+Fecha -> StartStream
+//   - CA-3: si NO existe el stream para CodigoColaborador+Fecha -> StartStream
 //   - CA-4: si YA existe -> GetAggregateRootAsync + AsignarTurno (SaveChanges automatico)
 // HU-131 / CA-4: publica DiaCalculado via IPublicEventSender tras el Apply(TurnoDiarioAsignado)
 //   que dispara el recalculo reactivo de ControlesDeFranja.
@@ -34,7 +34,7 @@ public partial class ProgramacionTurnoDiarioSolicitadaEventHandler
     public async Task HandleAsync(ProgramacionTurnoDiarioSolicitada @event, CancellationToken ct = default)
     {
         var streamId = ControlDiarioAggregateRoot.ComputarStreamId(
-            @event.Empleado.EmpleadoId, @event.Fecha);
+            @event.Colaborador.CodigoColaborador, @event.Fecha);
 
         // CA-ADR-0029 decision #5 (payload por rol): el evento llega con DetalleColaborador/DetalleTurno
         // (PrivateEvents) y TurnoDiarioAsignado persiste ColaboradorProgramado/TurnoDiario
@@ -42,7 +42,7 @@ public partial class ProgramacionTurnoDiarioSolicitadaEventHandler
         // mapeo vive aqui -- la Function App es el unico proyecto que ve los tres ensamblados de
         // eventos.
         var evento = new TurnoDiarioAsignado(
-            streamId, MapearColaboradorProgramado(@event.Empleado), @event.Fecha,
+            streamId, MapearColaboradorProgramado(@event.Colaborador), @event.Fecha,
             MapearTurnoDiario(@event.DetalleTurno), @event.SolicitudId);
 
         var existe = await _eventStore.ExistsAsync<ControlDiarioAggregateRoot>(streamId, ct);
@@ -68,7 +68,7 @@ public partial class ProgramacionTurnoDiarioSolicitadaEventHandler
     }
 
     private static ColaboradorProgramado MapearColaboradorProgramado(DetalleColaborador colaborador) =>
-        new(colaborador.EmpleadoId, colaborador.TipoIdentificacion, colaborador.NumeroIdentificacion,
+        new(colaborador.CodigoColaborador, colaborador.TipoIdentificacion, colaborador.NumeroIdentificacion,
             colaborador.Nombres, colaborador.Apellidos);
 
     // Issue #322: mapeo mecanico DetalleTurno (PrivateEvents) -> TurnoDiario (ControlHoras.DomainEvents),

--- a/src/Bitakora.ControlAsistencia.ControlHoras/Entities/ControlDiarioAggregateRoot.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Entities/ControlDiarioAggregateRoot.cs
@@ -7,14 +7,15 @@ using Cosmos.EventSourcing.Abstractions;
 namespace Bitakora.ControlAsistencia.ControlHoras.Entities;
 
 // HU-12: Aggregate root del dia de trabajo de un colaborador
-// Identidad: EmpleadoId + Fecha como stream ID determinista (CA-7)
+// Identidad: CodigoColaborador + Fecha como stream ID determinista (CA-7)
 // ADR-0015: partial class para soportar clase Mensajes en archivo separado si se requiere
-// Issue #322: InformacionEmpleado y DetalleTurno cambian de tipo (ColaboradorProgramado/
-// TurnoDiario, propios de ControlHoras.DomainEvents) -- los NOMBRES de las propiedades no cambian.
+// Issue #322: InformacionEmpleado y DetalleTurno cambiaron de tipo (ColaboradorProgramado/
+// TurnoDiario, propios de ControlHoras.DomainEvents) sin tocar los nombres de las propiedades.
+// Issue #401: InformacionEmpleado paso a InformacionColaborador (termino proscrito por #330).
 public partial class ControlDiarioAggregateRoot : AggregateRoot
 {
     // CA-6: estado que actualiza al aplicar TurnoDiarioAsignado
-    public ColaboradorProgramado? InformacionEmpleado { get; private set; }
+    public ColaboradorProgramado? InformacionColaborador { get; private set; }
     public DateOnly Fecha { get; private set; }
     public TurnoDiario? DetalleTurno { get; private set; }
 
@@ -68,17 +69,17 @@ public partial class ControlDiarioAggregateRoot : AggregateRoot
         _desgloseHoras = ConsolidadorDesgloseHoras.Consolidar(desgloses, anomalas);
     }
 
-    // CA-7: stream ID determinista: "{EmpleadoId}:{Fecha:yyyy-MM-dd}"
-    // CA-8: dos mensajes con mismo EmpleadoId+Fecha comparten el mismo stream
-    public static string ComputarStreamId(string empleadoId, DateOnly fecha) =>
-        $"{empleadoId}:{fecha:yyyy-MM-dd}";
+    // CA-7: stream ID determinista: "{CodigoColaborador}:{Fecha:yyyy-MM-dd}"
+    // CA-8: dos mensajes con mismo CodigoColaborador+Fecha comparten el mismo stream
+    public static string ComputarStreamId(string codigoColaborador, DateOnly fecha) =>
+        $"{codigoColaborador}:{fecha:yyyy-MM-dd}";
 
     // CA-6: actualiza estado interno al aplicar el evento
     // public: requerido para que TestStore.ApplyEvent lo encuentre via GetMethods()
     public void Apply(TurnoDiarioAsignado e)
     {
         Id = e.Id;
-        InformacionEmpleado = e.InformacionEmpleado;
+        InformacionColaborador = e.InformacionColaborador;
         Fecha = e.Fecha;
         DetalleTurno = e.DetalleTurno;
         UltimaSolicitudId = e.SolicitudId;
@@ -105,7 +106,7 @@ public partial class ControlDiarioAggregateRoot : AggregateRoot
     // HU-106: Apply que agrega la marcacion a la lista
     // Apply solo proyecta estado; la deteccion de duplicado vive en AdicionarMarcacion (CA-4).
     // Cuando el aggregate nace desde Iniciar(MarcacionAdicionada), este Apply asigna el Id del stream.
-    // HU-108: Fecha se deriva del stream ID (CA-7 codifica EmpleadoId+Fecha) para que el
+    // HU-108: Fecha se deriva del stream ID (CA-7 codifica CodigoColaborador+Fecha) para que el
     //          DiaCalculado emitido tras el recalculo lleve la fecha correcta incluso cuando
     //          el ControlDiario nace solo por marcacion (sin TurnoDiarioAsignado previo).
     // public: requerido para que TestStore.ApplyEvent lo encuentre via GetMethods()
@@ -118,7 +119,7 @@ public partial class ControlDiarioAggregateRoot : AggregateRoot
         RecalcularDesgloseHoras();
     }
 
-    // HU-108: stream ID tiene formato "{EmpleadoId}:{Fecha:yyyy-MM-dd}" (CA-7).
+    // HU-108: stream ID tiene formato "{CodigoColaborador}:{Fecha:yyyy-MM-dd}" (CA-7).
     // Parsea la porcion final como DateOnly para hidratar Fecha cuando no hay TurnoDiarioAsignado.
     private static DateOnly ExtraerFechaDeStreamId(string streamId)
     {
@@ -129,7 +130,7 @@ public partial class ControlDiarioAggregateRoot : AggregateRoot
 
     // HU-106: segundo camino de creacion del ControlDiario, sin turno asignado
     // CA-5: si no existe ControlDiario para la fecha, se crea con este factory
-    // CA-6: InformacionEmpleado y DetalleTurno quedan null
+    // CA-6: InformacionColaborador y DetalleTurno quedan null
     internal static ControlDiarioAggregateRoot Iniciar(MarcacionAdicionada evento)
     {
         var control = new ControlDiarioAggregateRoot();
@@ -158,19 +159,19 @@ public partial class ControlDiarioAggregateRoot : AggregateRoot
     //         Discriminar(). Ya no se mapean los ControlFranja a un DTO rico: el contrato pierde la
     //         senal de anomalia a proposito (riesgo aceptado, diferido al flujo de aprobacion).
     public DiaCalculado CrearDiaCalculado() =>
-        new(MapearInformacionColaborador(InformacionEmpleado), Fecha, _desgloseHoras.Discriminar());
+        new(MapearInformacionColaborador(InformacionColaborador), Fecha, _desgloseHoras.Discriminar());
 
-    // Issue #322: InformacionEmpleado del aggregate ahora es ColaboradorProgramado
-    // (ControlHoras.DomainEvents); DiaCalculado (PublicEvents) sigue esperando
-    // InformacionColaborador (PublicEvents.Colaboradores) -- el aggregate vive en el Function App,
-    // el unico ensamblado que ve los tres ensamblados de eventos, asi que el mapeo vive aqui
-    // (CA-ADR-0029 decision #5). Issue #340: ambos tipos se renombraron; los NOMBRES de propiedad
-    // (claves JSON de mt_events y del bus) no cambian hasta #401.
+    // Issue #322: InformacionColaborador del aggregate es ColaboradorProgramado
+    // (ControlHoras.DomainEvents); DiaCalculado (PublicEvents) espera InformacionColaborador
+    // (PublicEvents.Colaboradores) -- el aggregate vive en el Function App, el unico ensamblado que
+    // ve los tres ensamblados de eventos, asi que el mapeo vive aqui (CA-ADR-0029 decision #5).
+    // Issue #340 renombro ambos TIPOS; issue #401 renombra las CLAVES (propiedad y campo) a ambos
+    // lados del mapeo, de modo que la traduccion sigue siendo campo a campo sin permutacion.
     private static InformacionColaborador? MapearInformacionColaborador(
         ColaboradorProgramado? colaborador) =>
         colaborador is null
             ? null
             : new InformacionColaborador(
-                colaborador.EmpleadoId, colaborador.TipoIdentificacion,
+                colaborador.CodigoColaborador, colaborador.TipoIdentificacion,
                 colaborador.NumeroIdentificacion, colaborador.Nombres, colaborador.Apellidos);
 }

--- a/src/Bitakora.ControlAsistencia.ControlHoras/Entities/RegistroDeMarcacionAggregateRoot.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Entities/RegistroDeMarcacionAggregateRoot.cs
@@ -5,41 +5,41 @@ using Cosmos.EventSourcing.Abstractions;
 namespace Bitakora.ControlAsistencia.ControlHoras.Entities;
 
 // HU-105: Aggregate root que representa el registro puntual de una marcacion
-// Identidad: EmpleadoId + Timestamp crudo como stream ID determinista (CA-5)
+// Identidad: CodigoColaborador + Timestamp crudo como stream ID determinista (CA-5)
 // Unicas responsabilidades: idempotencia por duplicado exacto y normalizacion del timestamp
 // ADR-0015: partial class para soportar clase Mensajes en archivo separado si se requiere
 public partial class RegistroDeMarcacionAggregateRoot : AggregateRoot
 {
     // CA-5: estado que refleja la marcacion persistida
-    public string EmpleadoId { get; private set; } = null!;
+    public string CodigoColaborador { get; private set; } = null!;
     public DateTime TimestampCrudo { get; private set; }
     public DateTime TimestampNormalizado { get; private set; }
     public string? TipoMarcacion { get; private set; }
     public string? DispositivoId { get; private set; }
 
-    // CA-5: stream ID determinista: "{EmpleadoId}:{Timestamp:yyyy-MM-ddTHH:mm:ss}"
+    // CA-5: stream ID determinista: "{CodigoColaborador}:{Timestamp:yyyy-MM-ddTHH:mm:ss}"
     // Cambiar el separador invalidaria la identidad de todos los streams ya escritos, por eso vive
     // como constante privada: nadie lo compone a mano desde afuera.
     private const char SeparadorStreamId = ':';
 
-    public static string ComputarStreamId(string empleadoId, DateTime timestamp) =>
-        $"{empleadoId}{SeparadorStreamId}{timestamp:yyyy-MM-ddTHH:mm:ss}";
+    public static string ComputarStreamId(string codigoColaborador, DateTime timestamp) =>
+        $"{codigoColaborador}{SeparadorStreamId}{timestamp:yyyy-MM-ddTHH:mm:ss}";
 
-    // Issue #279 CA-3: un EmpleadoId que contenga el separador vuelve ambigua la composicion del
-    // stream ID -- dos combinaciones distintas de empleado y timestamp pueden producir el mismo id, y
+    // Issue #279 CA-3: un CodigoColaborador que contenga el separador vuelve ambigua la composicion del
+    // stream ID -- dos combinaciones distintas de colaborador y timestamp pueden producir el mismo id, y
     // como la idempotencia se decide por existencia del stream, una marcacion legitima se descartaria
     // como "duplicado exacto". La regla vive junto al formato que la origina (MEF-ADR-0012,
     // Tell-don't-Ask): el validator del borde la invoca en vez de repetir el literal del separador.
     // ControlDiarioAggregateRoot compone su stream ID con el mismo separador, asi que rechazarlo en el
     // borde protege ambos streams; unificar el separador entre ambos aggregates queda pendiente.
-    public static bool EsComponenteValidoDeStreamId(string empleadoId) =>
-        !empleadoId.Contains(SeparadorStreamId);
+    public static bool EsComponenteValidoDeStreamId(string codigoColaborador) =>
+        !codigoColaborador.Contains(SeparadorStreamId);
 
     // Apply: reconstruye el estado del aggregate desde MarcacionRegistrada
     // public: requerido para que TestStore.ApplyEvent lo encuentre via GetMethods()
     public void Apply(MarcacionRegistrada e)
     {
-        EmpleadoId = e.EmpleadoId;
+        CodigoColaborador = e.CodigoColaborador;
         TimestampNormalizado = e.TimestampNormalizado;
         TipoMarcacion = e.TipoMarcacion;
         DispositivoId = e.DispositivoId;
@@ -66,5 +66,5 @@ public partial class RegistroDeMarcacionAggregateRoot : AggregateRoot
     // el contrato ya empaquetado al handler -- espejo exacto de
     // ControlDiarioAggregateRoot.CrearDiaCalculado(). El handler no construye el contrato campo por campo.
     public RegistroDeMarcacionCreado CrearRegistroDeMarcacionCreado() =>
-        new(EmpleadoId, TimestampNormalizado, TipoMarcacion, DispositivoId);
+        new(CodigoColaborador, TimestampNormalizado, TipoMarcacion, DispositivoId);
 }

--- a/src/Bitakora.ControlAsistencia.ControlHoras/ListarTurnosVigentes/FunctionEndpoint.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ListarTurnosVigentes/FunctionEndpoint.cs
@@ -16,22 +16,22 @@ namespace Bitakora.ControlAsistencia.ControlHoras.ListarTurnosVigentes;
 // (ObtenerTurnoVigente/RegistrarMarcacionFunction/...) porque cada una vive en su propio
 // namespace.
 //
-// Ruta sin {empleadoId}/{fecha}: reutiliza el mismo segmento de recurso
+// Ruta sin {codigoColaborador}/{fecha}: reutiliza el mismo segmento de recurso
 // "control-horas/turnos-vigentes" que ObtenerTurnoVigente (#328) -- naming.md: "una query reutiliza
 // el mismo segmento de recurso que ya usa el comando/query de ese recurso". Sin colision de
-// plantilla: la de ObtenerTurnoVigente lleva dos segmentos adicionales ({empleadoId}/{fecha}).
+// plantilla: la de ObtenerTurnoVigente lleva dos segmentos adicionales ({codigoColaborador}/{fecha}).
 //
 // CA-1/CA-2: la QuerySession se abre SIEMPRE acotada al tenant que resuelve ITenantResolver --
 // nunca a un tenant id que llegue por query string (MEF-ADR-0028/skills/projections/read-apis.md,
-// mitigacion estructural contra BOLA/IDOR). desde/hasta/empleadoId SI vienen del query string: son
+// mitigacion estructural contra BOLA/IDOR). desde/hasta/codigoColaborador SI vienen del query string: son
 // el filtro del recurso, no el tenant.
 //
 // Contrato de la consulta: desde/hasta obligatorios con formato yyyy-MM-dd (CA-4), rango invertido
-// rechazado con 400, empleadoId opcional filtra a un solo empleado (CA-2), recorte de rango con
+// rechazado con 400, codigoColaborador opcional filtra a un solo colaborador (CA-2), recorte de rango con
 // RangoConsulta.Recortar (CA-3) y 200 con lista vacia cuando no hay datos en el rango (CA-4)
 // -- nunca 404: un rango sin turnos asignados no es un error.
 //
-// Issue #337 (CA-2/CA-3/CA-4): sedeId es un tercer filtro opcional, combinable con empleadoId y el
+// Issue #337 (CA-2/CA-3/CA-4): sedeId es un tercer filtro opcional, combinable con codigoColaborador y el
 // rango -- "dias donde AL MENOS un bloque rige en esa sede" (issue #337, "Contexto"), por eso el
 // predicado es Bloques.Any(b => b.SedeId == sedeId) y no un campo a nivel de TurnoVigente (la sede
 // va por bloque, nunca por dia). Sigue siendo la via de consulta (a') de MEF-ADR-0035 (LINQ sobre
@@ -64,14 +64,14 @@ public class FunctionEndpoint(IDocumentStore store, ITenantResolver tenantResolv
         if (hasta < desde)
             return new BadRequestObjectResult("El parametro 'hasta' no puede ser anterior a 'desde'");
 
-        // CA-2: empleadoId es opcional -- ausente = panorama de todos los empleados (consulta del
-        // Programador); presente = filtrado a un solo empleado (consulta del Trabajador).
+        // CA-2: codigoColaborador es opcional -- ausente = panorama de todos los colaboradores (consulta del
+        // Programador); presente = filtrado a un solo colaborador (consulta del Trabajador).
         // StringValues.ToString() devuelve cadena vacia cuando el parametro no viene, asi que
-        // ausente y vacio se tratan igual -- sin filtro por empleado.
-        var empleadoId = req.Query["empleadoId"].ToString();
+        // ausente y vacio se tratan igual -- sin filtro por colaborador.
+        var codigoColaborador = req.Query["codigoColaborador"].ToString();
 
         // Issue #337, CA-2/CA-3: sedeId es opcional -- ausente = sin filtro por sede (regresion de
-        // #329 intacta, CA-3). Mismo tratamiento de StringValues.ToString() que empleadoId: ausente
+        // #329 intacta, CA-3). Mismo tratamiento de StringValues.ToString() que codigoColaborador: ausente
         // y vacio se comportan igual.
         var sedeId = req.Query["sedeId"].ToString();
 
@@ -81,27 +81,27 @@ public class FunctionEndpoint(IDocumentStore store, ITenantResolver tenantResolv
         // CA-1/CA-2: la QuerySession se abre SIEMPRE acotada al tenant que resuelve
         // ITenantResolver -- nunca a un tenant id que llegara por query string (mitigacion
         // estructural contra BOLA/IDOR, MEF-ADR-0028/skills/projections/read-apis.md).
-        // empleadoId/desde/hasta SI vienen del query string: son el filtro del recurso, no el
+        // codigoColaborador/desde/hasta SI vienen del query string: son el filtro del recurso, no el
         // tenant.
         await using var session = store.QuerySession(tenantResolver.TenantId);
 
-        // Composicion en pasos (no un unico Where con el filtro de empleadoId embebido
+        // Composicion en pasos (no un unico Where con el filtro de codigoColaborador embebido
         // condicionalmente): mas legible que anidar el ternario dentro de la expresion LINQ.
         IQueryable<TurnoVigente> query = session.Query<TurnoVigente>()
             .Where(v => v.Fecha >= desde && v.Fecha <= rangoAplicado.HastaAplicado);
 
-        if (!string.IsNullOrEmpty(empleadoId))
-            query = query.Where(v => v.EmpleadoId == empleadoId);
+        if (!string.IsNullOrEmpty(codigoColaborador))
+            query = query.Where(v => v.CodigoColaborador == codigoColaborador);
 
         // CA-2 (issue #337): "dias donde al menos un bloque rige en esa sede" -- un dia multi-sede
         // (turno partido Suba/Chapinero) aparece bajo cualquiera de las sedes de sus bloques.
         if (!string.IsNullOrEmpty(sedeId))
             query = query.Where(v => v.Bloques.Any(b => b.SedeId == sedeId));
 
-        // Orden sugerido por la investigacion del planner: por EmpleadoId y luego por Fecha --
-        // estable para pintar grillas multi-empleado x rango de fechas.
+        // Orden sugerido por la investigacion del planner: por CodigoColaborador y luego por Fecha --
+        // estable para pintar grillas multi-colaborador x rango de fechas.
         var turnos = await query
-            .OrderBy(v => v.EmpleadoId)
+            .OrderBy(v => v.CodigoColaborador)
             .ThenBy(v => v.Fecha)
             .ToListAsync(ct);
 

--- a/src/Bitakora.ControlAsistencia.ControlHoras/ObtenerTurnoVigente/FunctionEndpoint.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ObtenerTurnoVigente/FunctionEndpoint.cs
@@ -15,7 +15,7 @@ namespace Bitakora.ControlAsistencia.ControlHoras.ObtenerTurnoVigente;
 // con ListarTurnosVigentes/RegistrarMarcacionFunction/... porque cada una vive en su propio
 // namespace.
 //
-// La ruta recibe empleadoId y fecha como los componentes tipados de la clave natural compuesta
+// La ruta recibe codigoColaborador y fecha como los componentes tipados de la clave natural compuesta
 // -- la clave se reconstruye con ControlDiarioAggregateRoot.ComputarStreamId, nunca con una
 // concatenacion propia del endpoint (MEF-ADR-0037). CA-4: fecha invalida -> 400 explicito; 200 con
 // la vista completa (Id incluido -- la UI lo necesita como ancla de comandos, ver issue "Notas
@@ -26,9 +26,9 @@ public class FunctionEndpoint(IDocumentStore store, ITenantResolver tenantResolv
 
     [Function("ObtenerTurnoVigente")]
     public async Task<IActionResult> Run(
-        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "control-horas/turnos-vigentes/{empleadoId}/{fecha}")]
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "control-horas/turnos-vigentes/{codigoColaborador}/{fecha}")]
         HttpRequest req,
-        string empleadoId,
+        string codigoColaborador,
         string fecha,
         CancellationToken ct)
     {
@@ -40,16 +40,16 @@ public class FunctionEndpoint(IDocumentStore store, ITenantResolver tenantResolv
             return new BadRequestObjectResult(
                 $"El parametro 'fecha' debe tener el formato {FormatoFecha}");
 
-        var streamKey = ControlDiarioAggregateRoot.ComputarStreamId(empleadoId, fechaParseada);
+        var streamKey = ControlDiarioAggregateRoot.ComputarStreamId(codigoColaborador, fechaParseada);
 
         // CA-4: la QuerySession se abre SIEMPRE acotada al tenant que resuelve ITenantResolver --
         // nunca a un tenant id que llegara por ruta o query string (mitigacion estructural contra
-        // BOLA/IDOR, MEF-ADR-0028/skills/projections/read-apis.md). empleadoId y fecha SI vienen de
+        // BOLA/IDOR, MEF-ADR-0028/skills/projections/read-apis.md). codigoColaborador y fecha SI vienen de
         // la ruta: son el recurso, no el tenant.
         await using var session = store.QuerySession(tenantResolver.TenantId);
         var vista = await session.LoadAsync<TurnoVigente>(streamKey, ct);
 
-        // CA-4: 404 sin body cuando no hay turno vigente para ese (empleado, fecha) -- no es un
+        // CA-4: 404 sin body cuando no hay turno vigente para ese (colaborador, fecha) -- no es un
         // error, significa que ese dia no tiene turno asignado.
         if (vista is null)
             return new NotFoundResult();

--- a/src/Bitakora.ControlAsistencia.ControlHoras/RegistrarMarcacionFunction/CommandHandler/RegistrarMarcacionCommandHandler.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/RegistrarMarcacionFunction/CommandHandler/RegistrarMarcacionCommandHandler.cs
@@ -11,7 +11,7 @@ namespace Bitakora.ControlAsistencia.ControlHoras.RegistrarMarcacionFunction.Com
 // Issue #270 CA-4: tras StartStream, publica el contrato de bus RegistroDeMarcacionCreado empaquetado
 // por el traductor del aggregate (Tell-don't-Ask) via IPrivateEventSender. MarcacionRegistrada (evento
 // de dominio persistido) ya no cruza el bus.
-// Issue #275 CA-4: la normalizacion (truncar segundos) y la validacion de EmpleadoId ya no viven aqui
+// Issue #275 CA-4: la normalizacion (truncar segundos) y la validacion de CodigoColaborador ya no viven aqui
 // -- son responsabilidad del factory MarcacionRegistrada.Crear (MEF-ADR-0012: el handler construye el
 // evento antes de pasarlo al aggregate; si la construccion falla, el throw ocurre aqui, no dentro del
 // aggregate -- MEF-ADR-0004 se mantiene). La firma de Iniciar(streamId, timestampCrudo, evento) no cambia.
@@ -30,17 +30,17 @@ public partial class RegistrarMarcacionCommandHandler : ICommandHandlerAsync<Reg
     public async Task HandleAsync(RegistrarMarcacion command, CancellationToken ct = default)
     {
         var streamId = RegistroDeMarcacionAggregateRoot.ComputarStreamId(
-            command.EmpleadoId, command.Timestamp);
+            command.CodigoColaborador, command.Timestamp);
 
         // CA-4, CA-9: duplicado exacto -> retorno silencioso, sin persistir ni publicar
         var existe = await _eventStore.ExistsAsync<RegistroDeMarcacionAggregateRoot>(streamId, ct);
         if (existe)
             return;
 
-        // Issue #275 CA-1/CA-2/CA-3: el factory trunca el timestamp al minuto y valida EmpleadoId.
+        // Issue #275 CA-1/CA-2/CA-3: el factory trunca el timestamp al minuto y valida CodigoColaborador.
         // Si falla, el throw ocurre aqui (borde del handler), no dentro del aggregate.
         var evento = MarcacionRegistrada.Crear(
-            command.EmpleadoId,
+            command.CodigoColaborador,
             command.Timestamp,
             command.TipoMarcacion,
             command.DispositivoId);

--- a/src/Bitakora.ControlAsistencia.ControlHoras/RegistrarMarcacionFunction/CommandHandler/RegistrarMarcacionValidator.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/RegistrarMarcacionFunction/CommandHandler/RegistrarMarcacionValidator.cs
@@ -10,16 +10,16 @@ public class RegistrarMarcacionValidator : AbstractValidator<RegistrarMarcacion>
 {
     public RegistrarMarcacionValidator()
     {
-        // CA-2: EmpleadoId nulo, vacio o solo espacios en blanco produce 400.
-        // CA-3: EmpleadoId con el separador del stream ID produce 400. La regla vive en el aggregate,
+        // CA-2: CodigoColaborador nulo, vacio o solo espacios en blanco produce 400.
+        // CA-3: CodigoColaborador con el separador del stream ID produce 400. La regla vive en el aggregate,
         // junto al formato que la origina (RegistroDeMarcacionAggregateRoot.ComputarStreamId), para no
         // duplicar aqui el literal del separador.
-        // Cascade(Stop) evita que el Must evalue un EmpleadoId nulo que NotEmpty ya rechazo.
-        RuleFor(x => x.EmpleadoId)
+        // Cascade(Stop) evita que el Must evalue un CodigoColaborador nulo que NotEmpty ya rechazo.
+        RuleFor(x => x.CodigoColaborador)
             .Cascade(CascadeMode.Stop)
             .NotEmpty()
             .Must(RegistroDeMarcacionAggregateRoot.EsComponenteValidoDeStreamId)
-            .WithMessage("EmpleadoId no puede contener ':' (separador del identificador de marcacion)");
+            .WithMessage("CodigoColaborador no puede contener ':' (separador del identificador de marcacion)");
 
         // CA-4: Timestamp con el valor default de DateTime produce 400.
         RuleFor(x => x.Timestamp).NotEqual(default(DateTime));

--- a/src/Bitakora.ControlAsistencia.ControlHoras/RegistrarMarcacionFunction/RegistrarMarcacion.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/RegistrarMarcacionFunction/RegistrarMarcacion.cs
@@ -1,10 +1,10 @@
 namespace Bitakora.ControlAsistencia.ControlHoras.RegistrarMarcacionFunction;
 
-// HU-105: Comando para registrar una marcacion de entrada o salida de un empleado
+// HU-105: Comando para registrar una marcacion de entrada o salida de un colaborador
 // Trigger: HTTP POST, Route: control-horas/marcaciones
-// CA-5: stream ID determinista: {EmpleadoId}:{Timestamp:yyyy-MM-ddTHH:mm:ss}
+// CA-5: stream ID determinista: {CodigoColaborador}:{Timestamp:yyyy-MM-ddTHH:mm:ss}
 public record RegistrarMarcacion(
-    string EmpleadoId,
+    string CodigoColaborador,
     DateTime Timestamp,
     string? TipoMarcacion,
     string? DispositivoId);

--- a/src/Bitakora.ControlAsistencia.PrivateEvents/ControlHoras/RegistroDeMarcacionCreado.cs
+++ b/src/Bitakora.ControlAsistencia.PrivateEvents/ControlHoras/RegistroDeMarcacionCreado.cs
@@ -20,7 +20,7 @@ namespace Bitakora.ControlAsistencia.PrivateEvents.ControlHoras;
 // Nunca se persiste: no entra en ConfiguracionSerializacionControlHoras ni en
 // IdentidadEventosControlHoras.TiposPersistidos. Vive solo en el canal.
 public record RegistroDeMarcacionCreado(
-    string EmpleadoId,
+    string CodigoColaborador,
     DateTime TimestampNormalizado,
     string? TipoMarcacion,
     string? DispositivoId) : IPrivateEvent;

--- a/src/Bitakora.ControlAsistencia.PrivateEvents/Programacion/DetalleColaborador.cs
+++ b/src/Bitakora.ControlAsistencia.PrivateEvents/Programacion/DetalleColaborador.cs
@@ -17,15 +17,19 @@ namespace Bitakora.ControlAsistencia.PrivateEvents.Programacion;
 /// pertenece al concepto rico del dominio Colaboradores --: mismo criterio anti-squatting que dio
 /// SedeProgramada en vez de Sede (#331, #336). Es el gemelo de bus interno de los
 /// ColaboradorProgramado de Programacion/ControlHoras.DomainEvents y de InformacionColaborador
-/// (PublicEvents), con paridad de campos. El rename no toca ninguna clave JSON del bus: solo
-/// cambia el TIPO; los nombres de propiedad se conservan hasta #401.
+/// (PublicEvents), con paridad de campos. Ese rename de #340 solo cambio el TIPO, sin tocar
+/// ninguna clave JSON del bus.
+///
+/// Issue #401: el campo EmpleadoId paso a CodigoColaborador -- aqui SI cambia la clave JSON que
+/// viaja por el bus interno. Sin mapeo (nada de JsonPropertyName): productor y consumidor de este
+/// contrato viven en el mismo Bounded Context y se despliegan juntos.
 ///
 /// Sin Equals custom: todos los campos son string, asi que la igualdad por valor del record por
 /// defecto ya es correcta (a diferencia de DetalleTurno/DetalleFranjaOrdinaria/DetalleSubFranja,
 /// cuyas IReadOnlyList el record compararia por referencia -- MEF-ADR-0012).
 /// </remarks>
 public record DetalleColaborador(
-    string EmpleadoId,
+    string CodigoColaborador,
     string TipoIdentificacion,
     string NumeroIdentificacion,
     string Nombres,

--- a/src/Bitakora.ControlAsistencia.PrivateEvents/Programacion/ProgramacionTurnoDiarioSolicitada.cs
+++ b/src/Bitakora.ControlAsistencia.PrivateEvents/Programacion/ProgramacionTurnoDiarioSolicitada.cs
@@ -14,7 +14,7 @@ namespace Bitakora.ControlAsistencia.PrivateEvents.Programacion;
 public sealed class ProgramacionTurnoDiarioSolicitada : IPrivateEvent
 {
     public Guid SolicitudId { get; private set; }
-    public DetalleColaborador Empleado { get; private set; } = null!;
+    public DetalleColaborador Colaborador { get; private set; } = null!;
     public DateOnly Fecha { get; private set; }
     public DetalleTurno DetalleTurno { get; private set; } = null!;
 
@@ -25,13 +25,13 @@ public sealed class ProgramacionTurnoDiarioSolicitada : IPrivateEvent
 
     public ProgramacionTurnoDiarioSolicitada(
         Guid solicitudId,
-        DetalleColaborador empleado,
+        DetalleColaborador colaborador,
         DateOnly fecha,
         DetalleTurno detalleTurno,
         DetalleSede? sede = null)
     {
         SolicitudId = solicitudId;
-        Empleado = empleado;
+        Colaborador = colaborador;
         Fecha = fecha;
         DetalleTurno = detalleTurno;
         Sede = sede;

--- a/src/Bitakora.ControlAsistencia.Programacion.DomainEvents/ColaboradorProgramado.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion.DomainEvents/ColaboradorProgramado.cs
@@ -17,16 +17,20 @@ namespace Bitakora.ControlAsistencia.Programacion.DomainEvents;
 /// SedeProgramada en vez de Sede (#331, #336). Esto diverge deliberadamente de #319, que habia
 /// elegido "nombre puro del lenguaje ubicuo" para los payloads. Es un gemelo deliberado del
 /// ColaboradorProgramado de ControlHoras.DomainEvents: mismo nombre en otra isla, con paridad de
-/// campos y sin referencia entre ambos (patron SedeProgramada, #336). El rename no toca ninguna
-/// clave JSON: los NOMBRES de las propiedades siguen siendo los de #401, y este record no esta en
-/// IdentidadEventosProgramacion.TiposPersistidos -- no tiene alias, y STJ no persiste $type para
-/// payload anidado (MEF-ADR-0036 no aplica; precedente #319 CA-2, #322).
+/// campos y sin referencia entre ambos (patron SedeProgramada, #336). Ese rename de #340 no toco
+/// ninguna clave JSON.
+///
+/// Issue #401: el campo EmpleadoId paso a CodigoColaborador -- aqui SI cambia la clave JSON del
+/// payload anidado. Sin mapeo: los streams de dev se purgan en el mismo despliegue (MEF-ADR-0036
+/// seccion 5). Este record no esta en IdentidadEventosProgramacion.TiposPersistidos -- no tiene
+/// alias propio, y STJ no persiste $type para payload anidado (MEF-ADR-0036 no aplica al TIPO;
+/// precedente #319 CA-2, #322).
 ///
 /// Sin comportamiento, sin Equals custom: todos los campos son string, la igualdad por valor
 /// del record por defecto ya es correcta (mismo criterio que DetalleColaborador, issue #318).
 /// </remarks>
 public record ColaboradorProgramado(
-    string EmpleadoId,
+    string CodigoColaborador,
     string TipoIdentificacion,
     string NumeroIdentificacion,
     string Nombres,

--- a/src/Bitakora.ControlAsistencia.Programacion.DomainEvents/ProgramacionTurnoSolicitada.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion.DomainEvents/ProgramacionTurnoSolicitada.cs
@@ -5,19 +5,21 @@ namespace Bitakora.ControlAsistencia.Programacion.DomainEvents;
 /// No se publica al Service Bus.
 /// </summary>
 /// <remarks>
-/// Issue #319 (tres islas, MEF-ADR-0039 decision 2 y 6): Empleado y DetalleTurno tipan con los
+/// Issue #319 (tres islas, MEF-ADR-0039 decision 2 y 6): Colaborador y DetalleTurno tipan con los
 /// records propios de este ensamblado (ColaboradorProgramado, TurnoProgramado) en vez de
-/// InformacionColaborador (PublicEvents) y DetalleTurno (PrivateEvents). Issue #340: el record
-/// paso de llamarse Empleado a ColaboradorProgramado -- solo el TIPO; el nombre de la propiedad
-/// (la clave JSON "Empleado") se conserva hasta #401. Los NOMBRES de las propiedades no cambian --
-/// son las claves JSON persistidas en mt_events (CA-2); solo cambian los TIPOS. Sin migracion de
-/// datos: STJ no persiste $type para records anidados, asi que el JSON ya escrito deserializa
-/// identico contra los tipos nuevos (ver ProgramacionTurnoSolicitadaSerializacionTests).
+/// InformacionColaborador (PublicEvents) y DetalleTurno (PrivateEvents). Issue #340 renombro el
+/// TIPO del payload (de Empleado a ColaboradorProgramado) conservando las claves JSON.
+///
+/// Issue #401: la propiedad paso de Empleado a Colaborador -- este si cambia la clave JSON
+/// persistida en mt_events, a diferencia de #319/#322/#340. Sin mapeo (nada de JsonPropertyName ni
+/// upcasters): los streams de dev se purgan en el mismo despliegue que integra el cambio
+/// (MEF-ADR-0036 seccion 5) y los smoke tests los repueblan con el vocabulario nuevo. El alias del
+/// evento NO se toca: deriva del nombre simple de la clase, que no se renombra.
 /// </remarks>
 public sealed class ProgramacionTurnoSolicitada
 {
     public Guid Id { get; private set; }
-    public ColaboradorProgramado Empleado { get; private set; } = null!;
+    public ColaboradorProgramado Colaborador { get; private set; } = null!;
     public IReadOnlyList<DateOnly> Fechas { get; private set; } = [];
     public TurnoProgramado DetalleTurno { get; private set; } = null!;
 
@@ -29,13 +31,13 @@ public sealed class ProgramacionTurnoSolicitada
 
     public ProgramacionTurnoSolicitada(
         Guid id,
-        ColaboradorProgramado empleado,
+        ColaboradorProgramado colaborador,
         IReadOnlyList<DateOnly> fechas,
         TurnoProgramado detalleTurno,
         SedeProgramada? sede = null)
     {
         Id = id;
-        Empleado = empleado;
+        Colaborador = colaborador;
         Fechas = fechas;
         DetalleTurno = detalleTurno;
         Sede = sede;

--- a/src/Bitakora.ControlAsistencia.Programacion.DomainEvents/SedeProgramada.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion.DomainEvents/SedeProgramada.cs
@@ -4,10 +4,10 @@ namespace Bitakora.ControlAsistencia.Programacion.DomainEvents;
 /// Sede efectiva donde rige la programacion del turno para el dia solicitado.
 /// </summary>
 /// <remarks>
-/// Issue #331: snapshot de la sede resuelta por el cliente (sede natural del empleado como
+/// Issue #331: snapshot de la sede resuelta por el cliente (sede natural del colaborador como
 /// default silencioso, o la que el Programador indique) -- el servidor NUNCA consulta el maestro
 /// de sedes (#330), la verdad queda grabada en el evento. Id es un identificador opaco provisto
-/// por el cliente (mismo precedente que EmpleadoId/DispositivoId: puede o no ser un guid). Nombre
+/// por el cliente (mismo precedente que CodigoColaborador/DispositivoId: puede o no ser un guid). Nombre
 /// viaja para que el evento persistido quede autocontenido.
 /// Sin Equals custom: todos los campos son string, la igualdad por valor del record por defecto ya
 /// es correcta (mismo criterio que ColaboradorProgramado, issue #319).

--- a/src/Bitakora.ControlAsistencia.Programacion/Entities/SolicitudProgramacionAggregateRoot.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/Entities/SolicitudProgramacionAggregateRoot.cs
@@ -3,13 +3,14 @@ using Cosmos.EventSourcing.Abstractions;
 
 namespace Bitakora.ControlAsistencia.Programacion.Entities;
 
-// Issue #319 (tres islas, MEF-ADR-0039 decision 2): Empleado y DetalleTurno tipan con los records
+// Issue #319 (tres islas, MEF-ADR-0039 decision 2): Colaborador y DetalleTurno tipan con los records
 // propios del dominio (Programacion.DomainEvents) -- ya no con InformacionColaborador
 // (PublicEvents) ni DetalleTurno (PrivateEvents). Issue #340: el record del colaborador se llama
-// ColaboradorProgramado; el nombre de la propiedad (clave JSON) se conserva hasta #401.
+// ColaboradorProgramado. Issue #401: la propiedad paso de Empleado a Colaborador, alineada con la
+// clave JSON del evento persistido que la hidrata.
 public partial class SolicitudProgramacionAggregateRoot : AggregateRoot
 {
-    internal ColaboradorProgramado? Empleado { get; private set; }
+    internal ColaboradorProgramado? Colaborador { get; private set; }
     internal IReadOnlyList<DateOnly> Fechas { get; private set; } = [];
     internal TurnoProgramado? DetalleTurno { get; private set; }
 
@@ -19,7 +20,7 @@ public partial class SolicitudProgramacionAggregateRoot : AggregateRoot
     public void Apply(ProgramacionTurnoSolicitada e)
     {
         Id = e.Id.ToString();
-        Empleado = e.Empleado;
+        Colaborador = e.Colaborador;
         Fechas = e.Fechas;
         DetalleTurno = e.DetalleTurno;
         Sede = e.Sede;

--- a/src/Bitakora.ControlAsistencia.Programacion/SolicitarProgramacionTurnoFunction/CommandHandler/SolicitarProgramacionTurnoCommandHandler.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/SolicitarProgramacionTurnoFunction/CommandHandler/SolicitarProgramacionTurnoCommandHandler.cs
@@ -45,7 +45,7 @@ public partial class SolicitarProgramacionTurnoCommandHandler
 
         // Issue #319 CA-2/CA-5: el comando HTTP conserva el tipo de PublicEvents (fuera de alcance);
         // el evento persistido tipa con ColaboradorProgramado (dominio) -- el mapeo vive aqui.
-        var colaboradorDominio = MapearColaboradorProgramado(command.Empleado);
+        var colaboradorDominio = MapearColaboradorProgramado(command.Colaborador);
         var evento = new ProgramacionTurnoSolicitada(
             command.Id, colaboradorDominio, fechas, turnoProgramado, command.Sede);
         var solicitud = SolicitudProgramacionAggregateRoot.Iniciar(evento);
@@ -57,7 +57,7 @@ public partial class SolicitarProgramacionTurnoCommandHandler
         // CA-ADR-0029 decision #5 (payload por rol): el comando HTTP trae InformacionColaborador
         // (PublicEvents) y el evento privado lleva DetalleColaborador, asi que el mapeo vive aqui --
         // la Function App es el unico proyecto que ve ambos ensamblados.
-        var colaborador = MapearDetalleColaborador(command.Empleado);
+        var colaborador = MapearDetalleColaborador(command.Colaborador);
         // Issue #319 CA-5: DetalleTurno (PrivateEvents) se deriva de TurnoProgramado (dominio),
         // no directamente del catalogo -- unico punto de mapeo hacia el payload de bus.
         var detalleTurno = MapearTurno(turnoProgramado);
@@ -73,14 +73,14 @@ public partial class SolicitarProgramacionTurnoCommandHandler
     }
 
     private static DetalleColaborador MapearDetalleColaborador(InformacionColaborador colaborador) =>
-        new(colaborador.EmpleadoId, colaborador.TipoIdentificacion, colaborador.NumeroIdentificacion,
+        new(colaborador.CodigoColaborador, colaborador.TipoIdentificacion, colaborador.NumeroIdentificacion,
             colaborador.Nombres, colaborador.Apellidos);
 
     // Issue #319 CA-5: mapeo campo a campo hacia el record propio del dominio
     // (Programacion.DomainEvents.ColaboradorProgramado), tipo del evento persistido
     // ProgramacionTurnoSolicitada.
     private static ColaboradorProgramado MapearColaboradorProgramado(InformacionColaborador colaborador) =>
-        new(colaborador.EmpleadoId, colaborador.TipoIdentificacion, colaborador.NumeroIdentificacion,
+        new(colaborador.CodigoColaborador, colaborador.TipoIdentificacion, colaborador.NumeroIdentificacion,
             colaborador.Nombres, colaborador.Apellidos);
 
     // Issue #319 CA-5: unico punto de traduccion desde TurnoProgramado (dominio) hacia el payload

--- a/src/Bitakora.ControlAsistencia.Programacion/SolicitarProgramacionTurnoFunction/CommandHandler/SolicitarProgramacionTurnoValidator.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/SolicitarProgramacionTurnoFunction/CommandHandler/SolicitarProgramacionTurnoValidator.cs
@@ -10,14 +10,14 @@ public class SolicitarProgramacionTurnoValidator
         RuleFor(x => x.Id).NotEmpty();
         RuleFor(x => x.TurnoId).NotEmpty();
 
-        RuleFor(x => x.Empleado).NotNull();
-        When(x => x.Empleado is not null, () =>
+        RuleFor(x => x.Colaborador).NotNull();
+        When(x => x.Colaborador is not null, () =>
         {
-            RuleFor(x => x.Empleado.EmpleadoId).NotEmpty();
-            RuleFor(x => x.Empleado.TipoIdentificacion).NotEmpty();
-            RuleFor(x => x.Empleado.NumeroIdentificacion).NotEmpty();
-            RuleFor(x => x.Empleado.Nombres).NotEmpty();
-            RuleFor(x => x.Empleado.Apellidos).NotEmpty();
+            RuleFor(x => x.Colaborador.CodigoColaborador).NotEmpty();
+            RuleFor(x => x.Colaborador.TipoIdentificacion).NotEmpty();
+            RuleFor(x => x.Colaborador.NumeroIdentificacion).NotEmpty();
+            RuleFor(x => x.Colaborador.Nombres).NotEmpty();
+            RuleFor(x => x.Colaborador.Apellidos).NotEmpty();
         });
 
         RuleFor(x => x.Fechas).NotEmpty();

--- a/src/Bitakora.ControlAsistencia.Programacion/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurno.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurno.cs
@@ -8,11 +8,13 @@ namespace Bitakora.ControlAsistencia.Programacion.SolicitarProgramacionTurnoFunc
 // maestro de sedes (#330). Reutiliza SedeProgramada (Programacion.DomainEvents), mismo precedente
 // que el colaborador reutilizando InformacionColaborador (PublicEvents).
 // Issue #340: el tipo paso de InformacionEmpleado a InformacionColaborador (termino proscrito por
-// #330). El nombre del parametro posicional -- la clave del body HTTP -- no cambia: el contrato
-// HTTP queda intacto (lo renombra #401).
+// #330), sin tocar el contrato HTTP.
+// Issue #401: el parametro posicional paso de Empleado a Colaborador -- aqui SI cambia la clave del
+// body HTTP (POST programacion/solicitudes). Verbo y ruta quedan intactos: ya son conformes y el
+// test de precedencia de MEF-ADR-0043 no se re-ejecuta por un cambio de claves del body.
 public record SolicitarProgramacionTurno(
     Guid Id,
     Guid TurnoId,
-    InformacionColaborador Empleado,
+    InformacionColaborador Colaborador,
     List<DateOnly> Fechas,
     SedeProgramada? Sede = null);

--- a/src/Bitakora.ControlAsistencia.Projections/ControlHoras/TurnoVigenteProjection.cs
+++ b/src/Bitakora.ControlAsistencia.Projections/ControlHoras/TurnoVigenteProjection.cs
@@ -10,7 +10,7 @@ namespace Bitakora.ControlAsistencia.Projections.ControlHoras;
 
 /// <summary>
 /// Clase de proyeccion companion de TurnoVigente (issue #328, receta N1 -- un solo stream,
-/// (EmpleadoId, Fecha), MEF-ADR-0035). Vive en el worker (Bitakora.ControlAsistencia.Projections),
+/// (CodigoColaborador, Fecha), MEF-ADR-0035). Vive en el worker (Bitakora.ControlAsistencia.Projections),
 /// el ensamblado que si referencia Marten y el analizador JasperFx.Events.SourceGenerator.
 ///
 /// partial es obligatorio (skills/projections/modelos-marten.md): el source generator descubre
@@ -39,16 +39,16 @@ public sealed partial class TurnoVigenteProjection : SingleStreamProjection<Turn
     public static TurnoVigente Create(TurnoDiarioAsignado evento) =>
         new(
             evento.Id,
-            evento.InformacionEmpleado.EmpleadoId,
-            NombreCompleto(evento.InformacionEmpleado),
+            evento.InformacionColaborador.CodigoColaborador,
+            NombreCompleto(evento.InformacionColaborador),
             evento.Fecha,
             evento.DetalleTurno.Nombre,
             evento.DetalleTurno.Descripcion,
             MapearBloques(evento));
 
-    // CA-2: "el ultimo gana" -- una reasignacion sobre el mismo (empleado, fecha) sobrescribe
-    // turno, horario y bloques. Id, EmpleadoId y Fecha no cambian: son la identidad del stream
-    // ("{EmpleadoId}:{Fecha:yyyy-MM-dd}"), invariante para todos los eventos del mismo documento.
+    // CA-2: "el ultimo gana" -- una reasignacion sobre el mismo (colaborador, fecha) sobrescribe
+    // turno, horario y bloques. Id, CodigoColaborador y Fecha no cambian: son la identidad del stream
+    // ("{CodigoColaborador}:{Fecha:yyyy-MM-dd}"), invariante para todos los eventos del mismo documento.
     //
     // NombreCompleto SI se refresca: cada TurnoDiarioAsignado trae el payload del colaborador
     // completo, y el criterio del "ultimo gana" aplica igual a un nombre corregido aguas arriba --
@@ -56,7 +56,7 @@ public sealed partial class TurnoVigenteProjection : SingleStreamProjection<Turn
     public static TurnoVigente Apply(TurnoDiarioAsignado evento, TurnoVigente vista) =>
         vista with
         {
-            NombreCompleto = NombreCompleto(evento.InformacionEmpleado),
+            NombreCompleto = NombreCompleto(evento.InformacionColaborador),
             NombreTurno = evento.DetalleTurno.Nombre,
             HorarioResumido = evento.DetalleTurno.Descripcion,
             Bloques = MapearBloques(evento)

--- a/src/Bitakora.ControlAsistencia.Projections/Infraestructura/ConfiguracionMartenProjectionsControlHoras.cs
+++ b/src/Bitakora.ControlAsistencia.Projections/Infraestructura/ConfiguracionMartenProjectionsControlHoras.cs
@@ -46,7 +46,7 @@ public static class ConfiguracionMartenProjectionsControlHoras
                 // Replica de la identidad de stream que el write-side ya declara
                 // (Cosmos.EventSourcing.CritterStack 2.1.0, AgregarConfiguracionMartenComandos:
                 // Events.StreamIdentity = AsString): el stream key de este dominio lo computa
-                // ControlDiarioAggregateRoot.ComputarStreamId como "{EmpleadoId}:{Fecha:yyyy-MM-dd}",
+                // ControlDiarioAggregateRoot.ComputarStreamId como "{CodigoColaborador}:{Fecha:yyyy-MM-dd}",
                 // un valor que ni por accidente es un Guid. Sin esta linea Marten aplica su default
                 // AsGuid ("Event Store Configuration" -> "Stream Identity" en
                 // https://martendb.io/events/configuration.html#stream-identity) y el daemon leeria
@@ -104,7 +104,7 @@ public static class ConfiguracionMartenProjectionsControlHoras
                 });
 
                 // Issue #328 CA-3: proyeccion del turno vigente. N1 -- un solo stream
-                // (EmpleadoId, Fecha) -- lifecycle Async es el canonico del worker (MEF-ADR-0034
+                // (CodigoColaborador, Fecha) -- lifecycle Async es el canonico del worker (MEF-ADR-0034
                 // seccion 3); Inline solo seria valido con justificacion explicita del issue, que
                 // este no la da. Aqui mismo, y por esta via, el issue #323 retiro la proyeccion
                 // del read model anterior (#289).

--- a/src/Bitakora.ControlAsistencia.PublicEvents/Colaboradores/InformacionColaborador.cs
+++ b/src/Bitakora.ControlAsistencia.PublicEvents/Colaboradores/InformacionColaborador.cs
@@ -10,12 +10,15 @@ namespace Bitakora.ControlAsistencia.PublicEvents.Colaboradores;
 /// vigente (Informacion*) y NO toma el nombre puro Colaborador -- ese pertenece al concepto rico
 /// del dominio Colaboradores --: mismo criterio anti-squatting que dio SedeProgramada en vez de
 /// Sede (#331, #336). Es el gemelo publico, con paridad de campos, de los ColaboradorProgramado de
-/// Programacion/ControlHoras.DomainEvents y de DetalleColaborador (PrivateEvents). El rename no
-/// toca ninguna clave JSON del bus: solo cambia el TIPO y su namespace; los nombres de propiedad
-/// se conservan hasta #401.
+/// Programacion/ControlHoras.DomainEvents y de DetalleColaborador (PrivateEvents). Ese rename de
+/// #340 solo cambio el TIPO y su namespace, sin tocar ninguna clave JSON del bus.
+///
+/// Issue #401: el campo EmpleadoId paso a CodigoColaborador -- aqui SI cambia la clave JSON que
+/// viaja por el bus. Es el identificador que emite el maestro Colaboradores (#330): el vocabulario
+/// del Published Language queda unificado con el del dominio que lo origina.
 /// </remarks>
 public record InformacionColaborador(
-    string EmpleadoId,
+    string CodigoColaborador,
     string TipoIdentificacion,
     string NumeroIdentificacion,
     string Nombres,

--- a/src/Bitakora.ControlAsistencia.PublicEvents/ControlHoras/DiaCalculado.cs
+++ b/src/Bitakora.ControlAsistencia.PublicEvents/ControlHoras/DiaCalculado.cs
@@ -6,9 +6,12 @@ namespace Bitakora.ControlAsistencia.PublicEvents.ControlHoras;
 // HU-108: Evento publico que se publica al Service Bus via IPublicEventSender.
 // Representa el resultado del calculo del dia de trabajo de un colaborador tras una
 // marcacion o asignacion de turno.
-// Issue #340: el payload pasa de InformacionEmpleado a InformacionColaborador (termino proscrito
-// por #330). Solo cambia el TIPO: el nombre de la propiedad -- la clave JSON que viaja por el bus
-// -- se conserva hasta #401.
+// Issue #340: el payload paso de InformacionEmpleado a InformacionColaborador (termino proscrito
+// por #330) -- solo el TIPO, sin tocar la clave JSON.
+// Issue #401: la propiedad InformacionEmpleado paso a InformacionColaborador y su campo EmpleadoId
+// a CodigoColaborador. Aqui SI cambian las claves JSON que viajan por el bus hacia el consumidor
+// de nomina; sin mapeo, el vocabulario del contrato publico queda unificado con el del maestro
+// Colaboradores (#330).
 // Issue #183: el payload es 100% primitivo (HorasDiscriminadas). Se elimino el modelo rico
 // (ControlesDeFranja: IReadOnlyList<DetalleControlFranja> y el antiguo DesgloseHoras) que dependia
 // del resolver custom de Marten y se serializaba lossy en el canal de publicacion a Service Bus.
@@ -22,16 +25,16 @@ namespace Bitakora.ControlAsistencia.PublicEvents.ControlHoras;
 public sealed class DiaCalculado : IPublicEvent
 {
     // Puede ser null cuando el ControlDiario nacio solo por marcacion sin turno previo.
-    public InformacionColaborador? InformacionEmpleado { get; private set; }
+    public InformacionColaborador? InformacionColaborador { get; private set; }
     public DateOnly Fecha { get; private set; }
     public HorasDiscriminadas HorasDiscriminadas { get; private set; } = null!;
 
     public DiaCalculado(
-        InformacionColaborador? informacionEmpleado,
+        InformacionColaborador? informacionColaborador,
         DateOnly fecha,
         HorasDiscriminadas horasDiscriminadas)
     {
-        InformacionEmpleado = informacionEmpleado;
+        InformacionColaborador = informacionColaborador;
         Fecha = fecha;
         HorasDiscriminadas = horasDiscriminadas;
     }

--- a/src/Bitakora.ControlAsistencia.ReadModels/ControlHoras/TurnoVigente.cs
+++ b/src/Bitakora.ControlAsistencia.ReadModels/ControlHoras/TurnoVigente.cs
@@ -1,7 +1,7 @@
 namespace Bitakora.ControlAsistencia.ReadModels.ControlHoras;
 
 /// <summary>
-/// Read model del turno que rige a un empleado en una fecha (issue #328), disenado desde la
+/// Read model del turno que rige a un colaborador en una fecha (issue #328), disenado desde la
 /// necesidad de lectura (panorama del programador, consulta del trabajador, consulta puntual del
 /// aprobador) y no desde el evento disponible. Reemplazo del read model anterior del issue #289,
 /// que la contraccion del issue #323 ya retiro.
@@ -18,17 +18,17 @@ namespace Bitakora.ControlAsistencia.ReadModels.ControlHoras;
 /// de infraestructura del issue #317 CA-2 al read-side (ver issue #328, "ADRs aplicables").
 ///
 /// Id es el stream key que compone ControlDiarioAggregateRoot.ComputarStreamId:
-/// "{EmpleadoId}:{Fecha:yyyy-MM-dd}" -- nunca un Guid (Events.StreamIdentity = AsString). Excluye
+/// "{CodigoColaborador}:{Fecha:yyyy-MM-dd}" -- nunca un Guid (Events.StreamIdentity = AsString). Excluye
 /// deliberadamente la trazabilidad interna hacia la solicitud de programacion y la identificacion
-/// completa del empleado (ambas las cargaba el read model del issue #289, que ningun cliente de
-/// calendario consumia): solo EmpleadoId (lookup/resourceId) y NombreCompleto (un solo campo,
+/// completa del colaborador (ambas las cargaba el read model del issue #289, que ningun cliente de
+/// calendario consumia): solo CodigoColaborador (lookup/resourceId) y NombreCompleto (un solo campo,
 /// concatenado por la proyeccion desde ColaboradorProgramado.Nombres +
 /// ColaboradorProgramado.Apellidos -- unico lugar del sistema donde se hace, issue #328
 /// "Investigacion del planner").
 /// </summary>
 public sealed record TurnoVigente(
     string Id,
-    string EmpleadoId,
+    string CodigoColaborador,
     string NombreCompleto,
     DateOnly Fecha,
     string NombreTurno,

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/AsignarTurnoViaSbSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/AsignarTurnoViaSbSmokeTests.cs
@@ -27,15 +27,15 @@ public class AsignarTurnoViaSbSmokeTests(ServiceBusFixture serviceBus, PostgresF
         // Arrange
         var correlationId = Guid.CreateVersion7().ToString();
         var solicitudId = Guid.CreateVersion7();
-        var empleadoId = Guid.CreateVersion7().ToString();
+        var codigoColaborador = Guid.CreateVersion7().ToString();
         var fecha = new DateOnly(2026, 4, 9);
 
         var evento = new
         {
             SolicitudId = solicitudId,
-            Empleado = new
+            Colaborador = new
             {
-                EmpleadoId = empleadoId,
+                CodigoColaborador = codigoColaborador,
                 TipoIdentificacion = "CC",
                 NumeroIdentificacion = "999888777",
                 Nombres = "[TEST] Smoke ServiceBus",
@@ -67,7 +67,7 @@ public class AsignarTurnoViaSbSmokeTests(ServiceBusFixture serviceBus, PostgresF
         await serviceBus.PublishAsync(TopicEntrada, evento, correlationId);
 
         // Assert: verificar que el evento TurnoDiarioAsignado fue persistido en PostgreSQL
-        var streamId = $"{empleadoId}:{fecha:yyyy-MM-dd}";
+        var streamId = $"{codigoColaborador}:{fecha:yyyy-MM-dd}";
         var tipoEvento = "turno_diario_asignado";
 
         var existe = await postgres.ExisteEventoAsync(
@@ -78,20 +78,21 @@ public class AsignarTurnoViaSbSmokeTests(ServiceBusFixture serviceBus, PostgresF
             $"el evento {tipoEvento} con SolicitudId {solicitudId} deberia existir en el stream {streamId}");
 
         // Assert detallado: obtener el evento especifico y comparar value objects.
-        // Issue #322: InformacionEmpleado/DetalleTurno son las CLAVES JSON persistidas (no cambian,
-        // MEF-ADR-0036), pero el evento persistido ya no tipa esos campos con InformacionEmpleado
-        // (PublicEvents) ni DetalleTurno (PrivateEvents) -- ahora son Empleado y TurnoDiario, propios
-        // de ControlHoras.DomainEvents (payload por rol). El smoke test deserializa con el tipo que
-        // realmente posee el payload persistido.
+        // InformacionColaborador/DetalleTurno son las CLAVES JSON persistidas. El evento no tipa
+        // esos campos con InformacionColaborador (PublicEvents) ni DetalleTurno (PrivateEvents) --
+        // son ColaboradorProgramado y TurnoDiario, propios de ControlHoras.DomainEvents (payload
+        // por rol, issue #322). El smoke test deserializa con el tipo que realmente posee el payload
+        // persistido. Issue #401: la clave era InformacionEmpleado (con EmpleadoId anidado); el
+        // alias del evento no cambia -- solo estas claves, contra un dev ya purgado.
         var eventoPersistido = await postgres.ObtenerEventoAsync<JsonElement>(
             SchemaControlHoras, streamId, tipoEvento,
             "SolicitudId", solicitudId.ToString(), TimeSpan.FromSeconds(5));
 
-        var empleadoEsperado = new ColaboradorProgramado(
-            empleadoId, "CC", "999888777", "[TEST] Smoke ServiceBus", "[TEST] Verificacion");
-        var empleadoPersistido = eventoPersistido
-            .GetProperty("InformacionEmpleado").Deserialize<ColaboradorProgramado>();
-        empleadoPersistido.Should().Be(empleadoEsperado);
+        var colaboradorEsperado = new ColaboradorProgramado(
+            codigoColaborador, "CC", "999888777", "[TEST] Smoke ServiceBus", "[TEST] Verificacion");
+        var colaboradorPersistido = eventoPersistido
+            .GetProperty("InformacionColaborador").Deserialize<ColaboradorProgramado>();
+        colaboradorPersistido.Should().Be(colaboradorEsperado);
 
         // Issue #288: el mensaje crudo publicado arriba (objeto anonimo) no lleva "Descripcion" -- el
         // dato derivado solo lo asigna Programacion en produccion (CatalogoTurnos/FranjaOrdinaria/
@@ -112,11 +113,11 @@ public class AsignarTurnoViaSbSmokeTests(ServiceBusFixture serviceBus, PostgresF
         // Se emite siempre, incluso si ControlesDeFranja queda vacio tras la depuracion reactiva.
         var diaCalculado = await serviceBus.WaitForMessageAsync<DiaCalculado>(
             TopicDiaCalculado, SuscripcionSmokeTests,
-            e => e.InformacionEmpleado != null && e.InformacionEmpleado.EmpleadoId == empleadoId,
+            e => e.InformacionColaborador != null && e.InformacionColaborador.CodigoColaborador == codigoColaborador,
             Timeout);
 
         diaCalculado.Fecha.Should().Be(fecha);
-        diaCalculado.InformacionEmpleado!.EmpleadoId.Should().Be(empleadoId);
+        diaCalculado.InformacionColaborador!.CodigoColaborador.Should().Be(codigoColaborador);
         // Issue #183 CA-6: el payload viaja plano (HorasDiscriminadas), deserializado con el serializador
         // POR DEFECTO del fixture (sin resolver custom). El turno se asigno sin marcaciones previas: la
         // franja queda anomala -> sin minutos calculables -> MinutosPorConcepto vacio.
@@ -133,13 +134,13 @@ public class AsignarTurnoViaSbSmokeTests(ServiceBusFixture serviceBus, PostgresF
             solicitudId, SuscripcionConsumidor);
 
         // Assert: verificar ausencia de dead letter de ESTA corrida en la suscripcion smoke-tests
-        // del topic dia-calculado (issue #223: acotado por EmpleadoId).
+        // del topic dia-calculado (issue #223: acotado por CodigoColaborador).
         var existeDeadLetterDiaCalculado = await serviceBus.ExisteDeadLetterDeEstaCorridaAsync<DiaCalculadoMinimo>(
-            TopicDiaCalculado, SuscripcionSmokeTests, e => e.InformacionEmpleado?.EmpleadoId == empleadoId);
+            TopicDiaCalculado, SuscripcionSmokeTests, e => e.InformacionColaborador?.CodigoColaborador == codigoColaborador);
 
         existeDeadLetterDiaCalculado.Should().BeFalse(
-            "no deberia haber un dead letter de esta corrida (EmpleadoId {0}) en '{1}' del topic '{2}'",
-            empleadoId, SuscripcionSmokeTests, TopicDiaCalculado);
+            "no deberia haber un dead letter de esta corrida (CodigoColaborador {0}) en '{1}' del topic '{2}'",
+            codigoColaborador, SuscripcionSmokeTests, TopicDiaCalculado);
     }
 
     // Issue #336 CA-1/CA-3: el evento de bus trae la sede EFECTIVA ya resuelta por la cascada del
@@ -166,15 +167,15 @@ public class AsignarTurnoViaSbSmokeTests(ServiceBusFixture serviceBus, PostgresF
         // Arrange
         var correlationId = Guid.CreateVersion7().ToString();
         var solicitudId = Guid.CreateVersion7();
-        var empleadoId = Guid.CreateVersion7().ToString();
+        var codigoColaborador = Guid.CreateVersion7().ToString();
         var fecha = new DateOnly(2026, 4, 11);
 
         var evento = new
         {
             SolicitudId = solicitudId,
-            Empleado = new
+            Colaborador = new
             {
-                EmpleadoId = empleadoId,
+                CodigoColaborador = codigoColaborador,
                 TipoIdentificacion = "CC",
                 NumeroIdentificacion = "222333444",
                 Nombres = "[TEST] Smoke Sede",
@@ -218,7 +219,7 @@ public class AsignarTurnoViaSbSmokeTests(ServiceBusFixture serviceBus, PostgresF
         await serviceBus.PublishAsync(TopicEntrada, evento, correlationId);
 
         // Assert: verificar que el evento TurnoDiarioAsignado fue persistido en PostgreSQL
-        var streamId = $"{empleadoId}:{fecha:yyyy-MM-dd}";
+        var streamId = $"{codigoColaborador}:{fecha:yyyy-MM-dd}";
         var tipoEvento = "turno_diario_asignado";
 
         var existe = await postgres.ExisteEventoAsync(
@@ -255,11 +256,11 @@ public class AsignarTurnoViaSbSmokeTests(ServiceBusFixture serviceBus, PostgresF
         // franjas traen sede -- el mapeo nuevo no interrumpe la cadena reactiva existente.
         var diaCalculado = await serviceBus.WaitForMessageAsync<DiaCalculado>(
             TopicDiaCalculado, SuscripcionSmokeTests,
-            e => e.InformacionEmpleado != null && e.InformacionEmpleado.EmpleadoId == empleadoId,
+            e => e.InformacionColaborador != null && e.InformacionColaborador.CodigoColaborador == codigoColaborador,
             Timeout);
 
         diaCalculado.Fecha.Should().Be(fecha);
-        diaCalculado.InformacionEmpleado!.EmpleadoId.Should().Be(empleadoId);
+        diaCalculado.InformacionColaborador!.CodigoColaborador.Should().Be(codigoColaborador);
 
         // Assert: ausencia de dead letter de ESTA corrida en la suscripcion del consumidor de
         // entrada -- confirma que el mapeo DetalleSede -> SedeProgramada no rompe el handler
@@ -292,7 +293,7 @@ public class AsignarTurnoViaSbSmokeTests(ServiceBusFixture serviceBus, PostgresF
         // Arrange: mensaje en camelCase, exactamente como lo serializa Wolverine
         var correlationId = Guid.CreateVersion7().ToString();
         var solicitudId = Guid.CreateVersion7();
-        var empleadoId = Guid.CreateVersion7().ToString();
+        var codigoColaborador = Guid.CreateVersion7().ToString();
         var fecha = new DateOnly(2026, 4, 10);
 
         // Propiedades en camelCase simulan la serializacion real de Wolverine.
@@ -301,9 +302,9 @@ public class AsignarTurnoViaSbSmokeTests(ServiceBusFixture serviceBus, PostgresF
         var eventoEnFormatoWolverine = new
         {
             solicitudId = solicitudId,
-            empleado = new
+            colaborador = new
             {
-                empleadoId = empleadoId,
+                codigoColaborador = codigoColaborador,
                 tipoIdentificacion = "CC",
                 numeroIdentificacion = "111222333",
                 nombres = "[TEST] Smoke Wolverine",
@@ -336,7 +337,7 @@ public class AsignarTurnoViaSbSmokeTests(ServiceBusFixture serviceBus, PostgresF
         // Assert: verificar persistencia en Postgres.
         // Si la deserializacion falla (propiedades null), el handler lanza
         // NullReferenceException, el mensaje va a dead-letter y NUNCA se persiste.
-        var streamId = $"{empleadoId}:{fecha:yyyy-MM-dd}";
+        var streamId = $"{codigoColaborador}:{fecha:yyyy-MM-dd}";
         var tipoEvento = "turno_diario_asignado";
 
         var existe = await postgres.ExisteEventoAsync(
@@ -348,18 +349,18 @@ public class AsignarTurnoViaSbSmokeTests(ServiceBusFixture serviceBus, PostgresF
             $"Si falla, ServiceBusDeserializador no esta usando PropertyNameCaseInsensitive=true.");
 
         // Assert detallado: verificar que los datos se mapearon correctamente.
-        // Issue #322: el evento persistido tipa InformacionEmpleado/DetalleTurno con Empleado/
+        // Issue #322: el evento persistido tipa InformacionColaborador/DetalleTurno con Colaborador/
         // TurnoDiario (ControlHoras.DomainEvents), no con los tipos de bus -- ver comentario del
         // primer test de esta clase.
         var eventoPersistido = await postgres.ObtenerEventoAsync<JsonElement>(
             SchemaControlHoras, streamId, tipoEvento,
             "SolicitudId", solicitudId.ToString(), TimeSpan.FromSeconds(5));
 
-        var empleadoEsperado = new ColaboradorProgramado(
-            empleadoId, "CC", "111222333", "[TEST] Smoke Wolverine", "[TEST] CamelCase Fix");
-        var empleadoPersistido = eventoPersistido
-            .GetProperty("InformacionEmpleado").Deserialize<ColaboradorProgramado>();
-        empleadoPersistido.Should().Be(empleadoEsperado);
+        var colaboradorEsperado = new ColaboradorProgramado(
+            codigoColaborador, "CC", "111222333", "[TEST] Smoke Wolverine", "[TEST] CamelCase Fix");
+        var colaboradorPersistido = eventoPersistido
+            .GetProperty("InformacionColaborador").Deserialize<ColaboradorProgramado>();
+        colaboradorPersistido.Should().Be(colaboradorEsperado);
 
         // Issue #288: mismo motivo que el test anterior -- el mensaje crudo en camelCase no lleva
         // "descripcion", asi que se excluye de la comparacion estructural.
@@ -377,11 +378,11 @@ public class AsignarTurnoViaSbSmokeTests(ServiceBusFixture serviceBus, PostgresF
         // Valida que la cadena completa (deserializacion case-insensitive -> handler -> publicacion) funciona.
         var diaCalculado = await serviceBus.WaitForMessageAsync<DiaCalculado>(
             TopicDiaCalculado, SuscripcionSmokeTests,
-            e => e.InformacionEmpleado != null && e.InformacionEmpleado.EmpleadoId == empleadoId,
+            e => e.InformacionColaborador != null && e.InformacionColaborador.CodigoColaborador == codigoColaborador,
             Timeout);
 
         diaCalculado.Fecha.Should().Be(fecha);
-        diaCalculado.InformacionEmpleado!.EmpleadoId.Should().Be(empleadoId);
+        diaCalculado.InformacionColaborador!.CodigoColaborador.Should().Be(codigoColaborador);
         // Issue #183 CA-6: el payload plano (HorasDiscriminadas) se deserializa con el serializador POR
         // DEFECTO del fixture (sin resolver custom) incluso cuando el mensaje llega en camelCase. El turno
         // se asigno sin marcaciones: franja anomala -> MinutosPorConcepto vacio.

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests.csproj
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests.csproj
@@ -20,7 +20,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Bitakora.ControlAsistencia.PublicEvents\Bitakora.ControlAsistencia.PublicEvents.csproj" />
     <ProjectReference Include="..\..\src\Bitakora.ControlAsistencia.PrivateEvents\Bitakora.ControlAsistencia.PrivateEvents.csproj" />
-    <!-- Issue #322: TurnoDiarioAsignado persiste Empleado/TurnoDiario propios de este ensamblado
+    <!-- Issue #322: TurnoDiarioAsignado persiste Colaborador/TurnoDiario propios de este ensamblado
          (payload por rol, CA-ADR-0029 decision #5). El smoke test verifica el evento realmente
          persistido con su tipo dueno, no con un tipo de bus que ya no describe ese payload. -->
     <ProjectReference Include="..\..\src\Bitakora.ControlAsistencia.ControlHoras.DomainEvents\Bitakora.ControlAsistencia.ControlHoras.DomainEvents.csproj" />

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/Fixtures/DeadLetterMinimos.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/Fixtures/DeadLetterMinimos.cs
@@ -6,6 +6,6 @@ namespace Bitakora.ControlAsistencia.ControlHoras.SmokeTests.Fixtures;
 // serializador por defecto basta para deserializar solo el identificador.
 public sealed record ProgramacionTurnoDiarioSolicitadaMinimo(Guid SolicitudId);
 
-public sealed record DiaCalculadoMinimo(InformacionColaboradorMinimo? InformacionEmpleado);
+public sealed record DiaCalculadoMinimo(InformacionColaboradorMinimo? InformacionColaborador);
 
-public sealed record InformacionColaboradorMinimo(string EmpleadoId);
+public sealed record InformacionColaboradorMinimo(string CodigoColaborador);

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/Fixtures/WarmupFixture.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/Fixtures/WarmupFixture.cs
@@ -84,15 +84,15 @@ public class WarmupFixture : IAsyncLifetime
     {
         var stopwatch = Stopwatch.StartNew();
 
-        // CA-4: identificadores descartables y unicos. El stream {empleadoId}:{fecha} queda aislado;
+        // CA-4: identificadores descartables y unicos. El stream {codigoColaborador}:{fecha} queda aislado;
         // no toca los streams ni las suscripciones que verifican los tests reales. No leemos ni
         // purgamos la suscripcion smoke-tests de dia-calculado: el DiaCalculado que emite este
-        // cebado lleva un EmpleadoId distinto (los tests filtran por el suyo) y, ademas, el test
+        // cebado lleva un CodigoColaborador distinto (los tests filtran por el suyo) y, ademas, el test
         // real purga esa suscripcion antes de su Act. Confirmamos el cebado solo via Postgres,
         // que ya prueba que ambos listeners procesaron.
-        var empleadoId = Guid.CreateVersion7().ToString();
+        var codigoColaborador = Guid.CreateVersion7().ToString();
         var fecha = new DateOnly(2026, 1, 1);
-        var streamId = $"{empleadoId}:{fecha:yyyy-MM-dd}";
+        var streamId = $"{codigoColaborador}:{fecha:yyyy-MM-dd}";
 
         // Salto 1: publicar programacion-turno-diario-solicitada -> calienta el listener AsignarTurno,
         // que persiste turno_diario_asignado en el stream.
@@ -100,9 +100,9 @@ public class WarmupFixture : IAsyncLifetime
         var programacionPayload = new
         {
             SolicitudId = solicitudId,
-            Empleado = new
+            Colaborador = new
             {
-                EmpleadoId = empleadoId,
+                CodigoColaborador = codigoColaborador,
                 TipoIdentificacion = "CC",
                 NumeroIdentificacion = "000000000",
                 Nombres = "[WARMUP] Cebado cadena SB",
@@ -143,7 +143,7 @@ public class WarmupFixture : IAsyncLifetime
         var timestamp = new DateTime(fecha, new TimeOnly(8, 0, 0), DateTimeKind.Utc);
         var marcacionPayload = new
         {
-            empleadoId,
+            codigoColaborador,
             timestamp = timestamp.ToString("yyyy-MM-ddTHH:mm:ss") + "Z",
             tipoMarcacion = "ENTRADA",
             dispositivoId = "[WARMUP] DEV-SMOKE-166"
@@ -154,7 +154,7 @@ public class WarmupFixture : IAsyncLifetime
 
         var marcacionAdicionada = await postgres.ExisteEventoAsync(
             SchemaControlHoras, streamId, TipoEventoMarcacionAdicionada, WarmupTimeout,
-            campoJson: "EmpleadoId", valorJson: empleadoId);
+            campoJson: "CodigoColaborador", valorJson: codigoColaborador);
 
         if (!marcacionAdicionada)
             throw new TimeoutException(

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/ListarTurnosVigentes/ListarTurnosVigentesSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/ListarTurnosVigentes/ListarTurnosVigentesSmokeTests.cs
@@ -7,7 +7,7 @@ using Bitakora.ControlAsistencia.ControlHoras.SmokeTests.Fixtures;
 namespace Bitakora.ControlAsistencia.ControlHoras.SmokeTests.ListarTurnosVigentes;
 
 // Issue #329: smoke tests de ListarTurnosVigentes, GET control-horas/turnos-vigentes con desde/hasta
-// obligatorios y empleadoId opcional. Tercera Function GET read-side del BC sobre la MISMA vista
+// obligatorios y codigoColaborador opcional. Tercera Function GET read-side del BC sobre la MISMA vista
 // TurnoVigente que ya materializa #328 -- se siembran datos publicando ProgramacionTurnoDiario-
 // Solicitada al bus interno, exactamente el mismo mecanismo de ObtenerTurnoVigenteSmokeTests (#328)
 // y la suite del listado anterior (#290).
@@ -89,7 +89,7 @@ public class ListarTurnosVigentesSmokeTests(ApiFixture api, ServiceBusFixture se
 
     private sealed record TurnoVigenteRespuestaSmoke(
         string Id,
-        string EmpleadoId,
+        string CodigoColaborador,
         string NombreCompleto,
         DateOnly Fecha,
         string NombreTurno,
@@ -103,11 +103,11 @@ public class ListarTurnosVigentesSmokeTests(ApiFixture api, ServiceBusFixture se
         IReadOnlyList<TurnoVigenteRespuestaSmoke> Turnos);
 
     private static string Ruta(
-        DateOnly desde, DateOnly hasta, string? empleadoId = null, string? sedeId = null)
+        DateOnly desde, DateOnly hasta, string? codigoColaborador = null, string? sedeId = null)
     {
         var query = $"desde={desde:yyyy-MM-dd}&hasta={hasta:yyyy-MM-dd}";
-        if (empleadoId is not null)
-            query += $"&empleadoId={Uri.EscapeDataString(empleadoId)}";
+        if (codigoColaborador is not null)
+            query += $"&codigoColaborador={Uri.EscapeDataString(codigoColaborador)}";
         if (sedeId is not null)
             query += $"&sedeId={Uri.EscapeDataString(sedeId)}";
 
@@ -115,21 +115,21 @@ public class ListarTurnosVigentesSmokeTests(ApiFixture api, ServiceBusFixture se
     }
 
     // Envelope UNICO de ProgramacionTurnoDiarioSolicitada para toda la suite: entre escenarios solo
-    // cambian las franjas y la descripcion del turno, nunca el empleado ni la forma del evento
+    // cambian las franjas y la descripcion del turno, nunca el colaborador ni la forma del evento
     // (antes del issue #337 esta misma forma vivia triplicada -- MEF-ADR-0018, Rule of Three).
     // FranjasOrdinarias viaja como object[] porque las franjas con y sin la clave "Sede" son tipos
     // anonimos distintos; STJ serializa cada elemento por su tipo en tiempo de ejecucion, asi que
     // ninguna pierde campos al convivir en el mismo arreglo.
     private async Task PublicarProgramacionAsync(
-        Guid solicitudId, string empleadoId, DateOnly fecha, string nombreTurno,
+        Guid solicitudId, string codigoColaborador, DateOnly fecha, string nombreTurno,
         string descripcionTurno, params object[] franjasOrdinarias)
     {
         var evento = new
         {
             SolicitudId = solicitudId,
-            Empleado = new
+            Colaborador = new
             {
-                EmpleadoId = empleadoId,
+                CodigoColaborador = codigoColaborador,
                 TipoIdentificacion = "CC",
                 NumeroIdentificacion = "444555666",
                 Nombres = "[TEST] Smoke Listar",
@@ -177,18 +177,18 @@ public class ListarTurnosVigentesSmokeTests(ApiFixture api, ServiceBusFixture se
         };
 
     private Task PublicarTurnoAsync(
-        Guid solicitudId, string empleadoId, DateOnly fecha, string nombreTurno) =>
+        Guid solicitudId, string codigoColaborador, DateOnly fecha, string nombreTurno) =>
         PublicarProgramacionAsync(
-            solicitudId, empleadoId, fecha, nombreTurno, DescripcionTurnoSinSede,
+            solicitudId, codigoColaborador, fecha, nombreTurno, DescripcionTurnoSinSede,
             FranjaOrdinaria("08:00:00", "16:00:00"));
 
-    // Issue #337: una sola franja que SI trae sede -- escenario de combinacion sedeId + empleadoId
+    // Issue #337: una sola franja que SI trae sede -- escenario de combinacion sedeId + codigoColaborador
     // (CA-3).
     private Task PublicarTurnoConSedeAsync(
-        Guid solicitudId, string empleadoId, DateOnly fecha, string nombreTurno,
+        Guid solicitudId, string codigoColaborador, DateOnly fecha, string nombreTurno,
         string sedeId, string nombreSede) =>
         PublicarProgramacionAsync(
-            solicitudId, empleadoId, fecha, nombreTurno, $"[TEST] {nombreTurno}",
+            solicitudId, codigoColaborador, fecha, nombreTurno, $"[TEST] {nombreTurno}",
             FranjaOrdinaria("08:00:00", "16:00:00", sedeId, nombreSede));
 
     // Issue #337: turno partido en DOS franjas, cada una en su propia sede -- el escenario del
@@ -196,30 +196,30 @@ public class ListarTurnosVigentesSmokeTests(ApiFixture api, ServiceBusFixture se
     // Ordinaria cada una (sin cruce de horario, sin solape) para que la vista materialice un dia
     // multi-sede real.
     private Task PublicarTurnoMultiSedeAsync(
-        Guid solicitudId, string empleadoId, DateOnly fecha, string nombreTurno,
+        Guid solicitudId, string codigoColaborador, DateOnly fecha, string nombreTurno,
         string sedeIdManana, string nombreSedeManana,
         string sedeIdTarde, string nombreSedeTarde) =>
         PublicarProgramacionAsync(
-            solicitudId, empleadoId, fecha, nombreTurno, $"[TEST] {nombreTurno}",
+            solicitudId, codigoColaborador, fecha, nombreTurno, $"[TEST] {nombreTurno}",
             FranjaOrdinaria("08:00:00", "12:00:00", sedeIdManana, nombreSedeManana),
             FranjaOrdinaria("14:00:00", "18:00:00", sedeIdTarde, nombreSedeTarde));
 
     // Sensa la materializacion asincrona consultando ESTE mismo endpoint sobre un rango de un solo
-    // dia (desde == hasta) filtrado por empleadoId, que nunca activa el recorte -- no via
+    // dia (desde == hasta) filtrado por codigoColaborador, que nunca activa el recorte -- no via
     // ObtenerTurnoVigente (#328), para no acoplar el veredicto de este archivo a la salud de otra
     // Function.
     private async Task<bool> EsperarTurnoEnLaListaAsync(
-        string empleadoId, DateOnly fecha, CancellationToken ct)
+        string codigoColaborador, DateOnly fecha, CancellationToken ct)
     {
         return await Polling.WaitUntilTrueAsync(async () =>
         {
-            var response = await _client.GetAsync(Ruta(fecha, fecha, empleadoId), ct);
+            var response = await _client.GetAsync(Ruta(fecha, fecha, codigoColaborador), ct);
             if (response.StatusCode != HttpStatusCode.OK)
                 return false;
 
             var body = await response.Content.ReadFromJsonAsync<ListaTurnosVigentesSmoke>(
                 JsonOptions, cancellationToken: ct);
-            return body?.Turnos.Any(t => t.EmpleadoId == empleadoId && t.Fecha == fecha) ?? false;
+            return body?.Turnos.Any(t => t.CodigoColaborador == codigoColaborador && t.Fecha == fecha) ?? false;
         }, Timeout);
     }
 
@@ -286,16 +286,16 @@ public class ListarTurnosVigentesSmokeTests(ApiFixture api, ServiceBusFixture se
 
     [Fact]
     [Trait("Category", "Smoke")]
-    public async Task ListarTurnosVigentes_Retorna200ConListaVacia_CuandoNoHayTurnoVigenteParaEseEmpleado()
+    public async Task ListarTurnosVigentes_Retorna200ConListaVacia_CuandoNoHayTurnoVigenteParaEseColaborador()
     {
         var ct = TestContext.Current.CancellationToken;
 
-        // Arrange: empleadoId nuevo, nunca creado por ningun test -- no puede tener turno vigente.
-        var empleadoId = Guid.CreateVersion7().ToString();
+        // Arrange: codigoColaborador nuevo, nunca creado por ningun test -- no puede tener turno vigente.
+        var codigoColaborador = Guid.CreateVersion7().ToString();
         var desde = new DateOnly(2026, 5, 1);
         var hasta = new DateOnly(2026, 5, 5);
 
-        var response = await _client.GetAsync(Ruta(desde, hasta, empleadoId), ct);
+        var response = await _client.GetAsync(Ruta(desde, hasta, codigoColaborador), ct);
 
         // Assert: CA-4 -- 200 con Turnos: [], nunca 404. Rango dentro de la cota, sin recorte.
         response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -311,24 +311,24 @@ public class ListarTurnosVigentesSmokeTests(ApiFixture api, ServiceBusFixture se
 
     [Fact]
     [Trait("Category", "Smoke")]
-    public async Task ListarTurnosVigentes_Retorna200ConElTurnoDelEmpleado_CuandoSeConsultaConEmpleadoId()
+    public async Task ListarTurnosVigentes_Retorna200ConElTurnoDelColaborador_CuandoSeConsultaConCodigoColaborador()
     {
-        // CA-2: la consulta del Trabajador -- empleadoId presente filtra la lista a ese empleado.
+        // CA-2: la consulta del Trabajador -- codigoColaborador presente filtra la lista a ese colaborador.
         Assert.SkipWhen(!serviceBus.IsConfigured,
             "ServiceBus no configurado. Usa appsettings.local.json o variable ServiceBus__ConnectionString.");
 
         var ct = TestContext.Current.CancellationToken;
 
         var solicitudId = Guid.CreateVersion7();
-        var empleadoId = Guid.CreateVersion7().ToString();
+        var codigoColaborador = Guid.CreateVersion7().ToString();
         var fechaTurno = new DateOnly(2026, 5, 10);
         var desde = new DateOnly(2026, 5, 1);
         var hasta = new DateOnly(2026, 5, 15); // 15 dias, dentro de la cota de 31
 
-        await PublicarTurnoAsync(solicitudId, empleadoId, fechaTurno, "[TEST] Turno Vigente Trabajador");
+        await PublicarTurnoAsync(solicitudId, codigoColaborador, fechaTurno, "[TEST] Turno Vigente Trabajador");
 
         // Act + Assert: reintentar el GET hasta que la proyeccion asincrona materialice la vista.
-        var ruta = Ruta(desde, hasta, empleadoId);
+        var ruta = Ruta(desde, hasta, codigoColaborador);
         var respuesta = await Polling.WaitUntilAsync(async () =>
         {
             var response = await _client.GetAsync(ruta, ct);
@@ -339,7 +339,7 @@ public class ListarTurnosVigentesSmokeTests(ApiFixture api, ServiceBusFixture se
             return body is { Turnos.Count: > 0 } ? body : null;
         }, Timeout);
 
-        // Assert: CA-4 -- rango dentro de la cota, sin recorte. Filtrado por empleadoId (GUID unico
+        // Assert: CA-4 -- rango dentro de la cota, sin recorte. Filtrado por codigoColaborador (GUID unico
         // de esta ejecucion), asi que la lista contiene exactamente el turno sembrado.
         respuesta.DesdeAplicado.Should().Be(desde);
         respuesta.HastaAplicado.Should().Be(hasta);
@@ -350,8 +350,8 @@ public class ListarTurnosVigentesSmokeTests(ApiFixture api, ServiceBusFixture se
         // decision de entrevista del issue #329, "Notas tecnicas": una sola proyeccion sirve grilla
         // y calendario).
         var turno = respuesta.Turnos[0];
-        turno.Id.Should().Be($"{empleadoId}:{fechaTurno:yyyy-MM-dd}");
-        turno.EmpleadoId.Should().Be(empleadoId);
+        turno.Id.Should().Be($"{codigoColaborador}:{fechaTurno:yyyy-MM-dd}");
+        turno.CodigoColaborador.Should().Be(codigoColaborador);
         turno.NombreCompleto.Should().Be("[TEST] Smoke Listar [TEST] TurnosVigentes");
         turno.Fecha.Should().Be(fechaTurno);
         turno.NombreTurno.Should().Be("[TEST] Turno Vigente Trabajador");
@@ -368,10 +368,10 @@ public class ListarTurnosVigentesSmokeTests(ApiFixture api, ServiceBusFixture se
 
     [Fact]
     [Trait("Category", "Smoke")]
-    public async Task ListarTurnosVigentes_IncluyeATodosLosEmpleados_CuandoNoSeFiltraPorEmpleadoId()
+    public async Task ListarTurnosVigentes_IncluyeATodosLosColaboradores_CuandoNoSeFiltraPorCodigoColaborador()
     {
-        // CA-1: el panorama del Programador -- SIN empleadoId, la lista trae los turnos vigentes de
-        // TODOS los empleados en el rango. Se publican 2 empleados distintos (no 1) para distinguir
+        // CA-1: el panorama del Programador -- SIN codigoColaborador, la lista trae los turnos vigentes de
+        // TODOS los colaboradores en el rango. Se publican 2 colaboradores distintos (no 1) para distinguir
         // "trae el panorama completo" de "trae un solo turno".
         Assert.SkipWhen(!serviceBus.IsConfigured,
             "ServiceBus no configurado. Usa appsettings.local.json o variable ServiceBus__ConnectionString.");
@@ -381,15 +381,15 @@ public class ListarTurnosVigentesSmokeTests(ApiFixture api, ServiceBusFixture se
         var fecha = new DateOnly(2026, 5, 20);
         var solicitudA = Guid.CreateVersion7();
         var solicitudB = Guid.CreateVersion7();
-        var empleadoIdA = Guid.CreateVersion7().ToString();
-        var empleadoIdB = Guid.CreateVersion7().ToString();
+        var codigoColaboradorA = Guid.CreateVersion7().ToString();
+        var codigoColaboradorB = Guid.CreateVersion7().ToString();
 
-        await PublicarTurnoAsync(solicitudA, empleadoIdA, fecha, "[TEST] Turno Panorama A");
-        await PublicarTurnoAsync(solicitudB, empleadoIdB, fecha, "[TEST] Turno Panorama B");
+        await PublicarTurnoAsync(solicitudA, codigoColaboradorA, fecha, "[TEST] Turno Panorama A");
+        await PublicarTurnoAsync(solicitudB, codigoColaboradorB, fecha, "[TEST] Turno Panorama B");
 
-        // Sin empleadoId: la lista puede incluir turnos de otras ejecuciones de esta suite (sin
+        // Sin codigoColaborador: la lista puede incluir turnos de otras ejecuciones de esta suite (sin
         // cleanup, GUIDs unicos por corrida) -- se espera a que AMBOS aparezcan antes de assertar,
-        // filtrando siempre por EmpleadoId, nunca por posicion/indice.
+        // filtrando siempre por CodigoColaborador, nunca por posicion/indice.
         var ambosMaterializados = await Polling.WaitUntilTrueAsync(async () =>
         {
             var response = await _client.GetAsync(Ruta(fecha, fecha), ct);
@@ -398,12 +398,12 @@ public class ListarTurnosVigentesSmokeTests(ApiFixture api, ServiceBusFixture se
 
             var body = await response.Content.ReadFromJsonAsync<ListaTurnosVigentesSmoke>(
                 JsonOptions, cancellationToken: ct);
-            return (body?.Turnos.Any(t => t.EmpleadoId == empleadoIdA) ?? false)
-                && (body?.Turnos.Any(t => t.EmpleadoId == empleadoIdB) ?? false);
+            return (body?.Turnos.Any(t => t.CodigoColaborador == codigoColaboradorA) ?? false)
+                && (body?.Turnos.Any(t => t.CodigoColaborador == codigoColaboradorB) ?? false);
         }, Timeout);
 
         ambosMaterializados.Should().BeTrue(
-            "ambos empleados deberian aparecer en el panorama dentro del timeout");
+            "ambos colaboradores deberian aparecer en el panorama dentro del timeout");
 
         var response = await _client.GetAsync(Ruta(fecha, fecha), ct);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -412,9 +412,9 @@ public class ListarTurnosVigentesSmokeTests(ApiFixture api, ServiceBusFixture se
             JsonOptions, cancellationToken: ct);
         respuesta.Should().NotBeNull();
 
-        // Assert: CA-1 -- el panorama trae ambos empleados, cada uno con su propio turno.
-        var turnoA = respuesta!.Turnos.Single(t => t.EmpleadoId == empleadoIdA);
-        var turnoB = respuesta.Turnos.Single(t => t.EmpleadoId == empleadoIdB);
+        // Assert: CA-1 -- el panorama trae ambos colaboradores, cada uno con su propio turno.
+        var turnoA = respuesta!.Turnos.Single(t => t.CodigoColaborador == codigoColaboradorA);
+        var turnoB = respuesta.Turnos.Single(t => t.CodigoColaborador == codigoColaboradorB);
         turnoA.NombreTurno.Should().Be("[TEST] Turno Panorama A");
         turnoB.NombreTurno.Should().Be("[TEST] Turno Panorama B");
         respuesta.RangoRecortado.Should().BeFalse();
@@ -431,7 +431,7 @@ public class ListarTurnosVigentesSmokeTests(ApiFixture api, ServiceBusFixture se
 
         var ct = TestContext.Current.CancellationToken;
 
-        var empleadoId = Guid.CreateVersion7().ToString();
+        var codigoColaborador = Guid.CreateVersion7().ToString();
         var desde = new DateOnly(2026, 6, 1);
         var hastaSolicitado = new DateOnly(2026, 9, 30); // ~121 dias, muy por encima de la cota
         var hastaAplicadaEsperada = desde.AddDays(30); // CA-3: cota de 31 dias inclusive
@@ -441,20 +441,20 @@ public class ListarTurnosVigentesSmokeTests(ApiFixture api, ServiceBusFixture se
         var fechaDentro = desde; // dentro del rango recortado
         var fechaFuera = hastaAplicadaEsperada.AddDays(5); // dentro de lo pedido, fuera del recorte
 
-        await PublicarTurnoAsync(solicitudDentro, empleadoId, fechaDentro, "[TEST] Turno Vigente Dentro De La Cota");
-        await PublicarTurnoAsync(solicitudFuera, empleadoId, fechaFuera, "[TEST] Turno Vigente Fuera De La Cota");
+        await PublicarTurnoAsync(solicitudDentro, codigoColaborador, fechaDentro, "[TEST] Turno Vigente Dentro De La Cota");
+        await PublicarTurnoAsync(solicitudFuera, codigoColaborador, fechaFuera, "[TEST] Turno Vigente Fuera De La Cota");
 
         // Espera a que AMBAS vistas esten materializadas antes de verificar el recorte: si no
         // esperaramos, la ausencia de "fuera" podria deberse a lag asincrono y no al recorte mismo.
-        var dentroMaterializado = await EsperarTurnoEnLaListaAsync(empleadoId, fechaDentro, ct);
+        var dentroMaterializado = await EsperarTurnoEnLaListaAsync(codigoColaborador, fechaDentro, ct);
         dentroMaterializado.Should().BeTrue(
-            $"la vista de {empleadoId} en {fechaDentro} deberia materializarse dentro del timeout");
+            $"la vista de {codigoColaborador} en {fechaDentro} deberia materializarse dentro del timeout");
 
-        var fueraMaterializado = await EsperarTurnoEnLaListaAsync(empleadoId, fechaFuera, ct);
+        var fueraMaterializado = await EsperarTurnoEnLaListaAsync(codigoColaborador, fechaFuera, ct);
         fueraMaterializado.Should().BeTrue(
-            $"la vista de {empleadoId} en {fechaFuera} deberia materializarse dentro del timeout");
+            $"la vista de {codigoColaborador} en {fechaFuera} deberia materializarse dentro del timeout");
 
-        var response = await _client.GetAsync(Ruta(desde, hastaSolicitado, empleadoId), ct);
+        var response = await _client.GetAsync(Ruta(desde, hastaSolicitado, codigoColaborador), ct);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
         var respuesta = await response.Content.ReadFromJsonAsync<ListaTurnosVigentesSmoke>(
@@ -485,28 +485,28 @@ public class ListarTurnosVigentesSmokeTests(ApiFixture api, ServiceBusFixture se
         var ct = TestContext.Current.CancellationToken;
 
         var solicitudId = Guid.CreateVersion7();
-        var empleadoId = Guid.CreateVersion7().ToString();
+        var codigoColaborador = Guid.CreateVersion7().ToString();
         var fecha = new DateOnly(2026, 6, 5);
         var sedeIdManana = Guid.CreateVersion7().ToString();
         var sedeIdTarde = Guid.CreateVersion7().ToString();
-        var sedeIdSinTurnosDeEsteEmpleado = Guid.CreateVersion7().ToString();
+        var sedeIdSinTurnosDeEsteColaborador = Guid.CreateVersion7().ToString();
         const string nombreSedeManana = "[TEST] Sede Suba";
         const string nombreSedeTarde = "[TEST] Sede Chapinero";
 
         await PublicarTurnoMultiSedeAsync(
-            solicitudId, empleadoId, fecha, "[TEST] Turno Multi Sede",
+            solicitudId, codigoColaborador, fecha, "[TEST] Turno Multi Sede",
             sedeIdManana, nombreSedeManana, sedeIdTarde, nombreSedeTarde);
 
-        var materializado = await EsperarTurnoEnLaListaAsync(empleadoId, fecha, ct);
+        var materializado = await EsperarTurnoEnLaListaAsync(codigoColaborador, fecha, ct);
         materializado.Should().BeTrue(
-            $"la vista de {empleadoId} en {fecha} deberia materializarse dentro del timeout");
+            $"la vista de {codigoColaborador} en {fecha} deberia materializarse dentro del timeout");
 
         // Assert: aparece filtrando por la sede de la franja de la manana...
-        var responseManana = await _client.GetAsync(Ruta(fecha, fecha, empleadoId, sedeIdManana), ct);
+        var responseManana = await _client.GetAsync(Ruta(fecha, fecha, codigoColaborador, sedeIdManana), ct);
         responseManana.StatusCode.Should().Be(HttpStatusCode.OK);
         var respuestaManana = await responseManana.Content.ReadFromJsonAsync<ListaTurnosVigentesSmoke>(
             JsonOptions, cancellationToken: ct);
-        respuestaManana!.Turnos.Should().Contain(t => t.EmpleadoId == empleadoId && t.Fecha == fecha);
+        respuestaManana!.Turnos.Should().Contain(t => t.CodigoColaborador == codigoColaborador && t.Fecha == fecha);
 
         // Assert (CA-1 de punta a punta): la sede no solo filtra, tambien VIAJA al cliente en cada
         // bloque -- cada uno con la sede de SU PROPIA franja, no la del dia. Filtrar por la sede de
@@ -514,7 +514,7 @@ public class ListarTurnosVigentesSmokeTests(ApiFixture api, ServiceBusFixture se
         // evidencia de que el predicado es "al menos un bloque rige en esa sede", no un recorte de
         // los bloques devueltos.
         var turnoMultiSede = respuestaManana.Turnos.Single(
-            t => t.EmpleadoId == empleadoId && t.Fecha == fecha);
+            t => t.CodigoColaborador == codigoColaborador && t.Fecha == fecha);
         turnoMultiSede.Bloques.Should().BeEquivalentTo(new[]
         {
             new BloqueSmoke(
@@ -528,19 +528,19 @@ public class ListarTurnosVigentesSmokeTests(ApiFixture api, ServiceBusFixture se
         });
 
         // ...y TAMBIEN filtrando por la sede de la franja de la tarde -- mismo dia, dos sedes.
-        var responseTarde = await _client.GetAsync(Ruta(fecha, fecha, empleadoId, sedeIdTarde), ct);
+        var responseTarde = await _client.GetAsync(Ruta(fecha, fecha, codigoColaborador, sedeIdTarde), ct);
         responseTarde.StatusCode.Should().Be(HttpStatusCode.OK);
         var respuestaTarde = await responseTarde.Content.ReadFromJsonAsync<ListaTurnosVigentesSmoke>(
             JsonOptions, cancellationToken: ct);
-        respuestaTarde!.Turnos.Should().Contain(t => t.EmpleadoId == empleadoId && t.Fecha == fecha);
+        respuestaTarde!.Turnos.Should().Contain(t => t.CodigoColaborador == codigoColaborador && t.Fecha == fecha);
 
         // Assert: NO aparece bajo una sede que ningun bloque de este turno tiene.
         var responseOtraSede = await _client.GetAsync(
-            Ruta(fecha, fecha, empleadoId, sedeIdSinTurnosDeEsteEmpleado), ct);
+            Ruta(fecha, fecha, codigoColaborador, sedeIdSinTurnosDeEsteColaborador), ct);
         responseOtraSede.StatusCode.Should().Be(HttpStatusCode.OK);
         var respuestaOtraSede = await responseOtraSede.Content.ReadFromJsonAsync<ListaTurnosVigentesSmoke>(
             JsonOptions, cancellationToken: ct);
-        respuestaOtraSede!.Turnos.Should().NotContain(t => t.EmpleadoId == empleadoId && t.Fecha == fecha);
+        respuestaOtraSede!.Turnos.Should().NotContain(t => t.CodigoColaborador == codigoColaborador && t.Fecha == fecha);
     }
 
     [Fact]
@@ -556,46 +556,46 @@ public class ListarTurnosVigentesSmokeTests(ApiFixture api, ServiceBusFixture se
         var ct = TestContext.Current.CancellationToken;
 
         var solicitudId = Guid.CreateVersion7();
-        var empleadoId = Guid.CreateVersion7().ToString();
+        var codigoColaborador = Guid.CreateVersion7().ToString();
         var fecha = new DateOnly(2026, 6, 6);
         var sedeIdCualquiera = Guid.CreateVersion7().ToString();
 
         // PublicarTurnoAsync (helper de #329) nunca incluye la clave "Sede" en la franja --
         // equivalente comportamental a un bloque con SedeId/NombreSede null (CA-4/CA-5).
-        await PublicarTurnoAsync(solicitudId, empleadoId, fecha, "[TEST] Turno Sin Sede");
+        await PublicarTurnoAsync(solicitudId, codigoColaborador, fecha, "[TEST] Turno Sin Sede");
 
-        var materializado = await EsperarTurnoEnLaListaAsync(empleadoId, fecha, ct);
+        var materializado = await EsperarTurnoEnLaListaAsync(codigoColaborador, fecha, ct);
         materializado.Should().BeTrue(
-            $"la vista de {empleadoId} en {fecha} deberia materializarse dentro del timeout");
+            $"la vista de {codigoColaborador} en {fecha} deberia materializarse dentro del timeout");
 
         // Assert: filtrando por CUALQUIER sedeId, el dia sin sede queda fuera.
         var responseFiltrada = await _client.GetAsync(
-            Ruta(fecha, fecha, empleadoId, sedeIdCualquiera), ct);
+            Ruta(fecha, fecha, codigoColaborador, sedeIdCualquiera), ct);
         responseFiltrada.StatusCode.Should().Be(HttpStatusCode.OK);
         var respuestaFiltrada = await responseFiltrada.Content.ReadFromJsonAsync<ListaTurnosVigentesSmoke>(
             JsonOptions, cancellationToken: ct);
-        respuestaFiltrada!.Turnos.Should().NotContain(t => t.EmpleadoId == empleadoId && t.Fecha == fecha);
+        respuestaFiltrada!.Turnos.Should().NotContain(t => t.CodigoColaborador == codigoColaborador && t.Fecha == fecha);
 
         // Assert: sin filtro de sede, el dia SI aparece -- regresion de #329 intacta.
-        var responseSinFiltro = await _client.GetAsync(Ruta(fecha, fecha, empleadoId), ct);
+        var responseSinFiltro = await _client.GetAsync(Ruta(fecha, fecha, codigoColaborador), ct);
         responseSinFiltro.StatusCode.Should().Be(HttpStatusCode.OK);
         var respuestaSinFiltro = await responseSinFiltro.Content.ReadFromJsonAsync<ListaTurnosVigentesSmoke>(
             JsonOptions, cancellationToken: ct);
-        respuestaSinFiltro!.Turnos.Should().Contain(t => t.EmpleadoId == empleadoId && t.Fecha == fecha);
+        respuestaSinFiltro!.Turnos.Should().Contain(t => t.CodigoColaborador == codigoColaborador && t.Fecha == fecha);
 
         // Assert (CA-5): el dia se consulta SIN ERROR y sus bloques llegan con ambos campos de sede
         // en null -- el mismo contrato que devuelve un documento proyectado antes de #336/#337.
         var turnoSinSede = respuestaSinFiltro.Turnos.Single(
-            t => t.EmpleadoId == empleadoId && t.Fecha == fecha);
+            t => t.CodigoColaborador == codigoColaborador && t.Fecha == fecha);
         turnoSinSede.Bloques.Should().OnlyContain(b => b.SedeId == null && b.NombreSede == null);
     }
 
     [Fact]
     [Trait("Category", "Smoke")]
-    public async Task ListarTurnosVigentes_CombinaSedeIdConEmpleadoId_CuandoAmbosFiltrosSeAplican()
+    public async Task ListarTurnosVigentes_CombinaSedeIdConCodigoColaborador_CuandoAmbosFiltrosSeAplican()
     {
-        // CA-3 (issue #337): sedeId es combinable con empleadoId -- misma sede, dos empleados
-        // distintos, el filtro compuesto (AND) devuelve solo al empleado pedido.
+        // CA-3 (issue #337): sedeId es combinable con codigoColaborador -- misma sede, dos colaboradores
+        // distintos, el filtro compuesto (AND) devuelve solo al colaborador pedido.
         Assert.SkipWhen(!serviceBus.IsConfigured,
             "ServiceBus no configurado. Usa appsettings.local.json o variable ServiceBus__ConnectionString.");
 
@@ -605,24 +605,24 @@ public class ListarTurnosVigentesSmokeTests(ApiFixture api, ServiceBusFixture se
         var sedeId = Guid.CreateVersion7().ToString();
         var solicitudA = Guid.CreateVersion7();
         var solicitudB = Guid.CreateVersion7();
-        var empleadoIdA = Guid.CreateVersion7().ToString();
-        var empleadoIdB = Guid.CreateVersion7().ToString();
+        var codigoColaboradorA = Guid.CreateVersion7().ToString();
+        var codigoColaboradorB = Guid.CreateVersion7().ToString();
 
         await PublicarTurnoConSedeAsync(
-            solicitudA, empleadoIdA, fecha, "[TEST] Turno Combinado A", sedeId, "[TEST] Sede Combinada");
+            solicitudA, codigoColaboradorA, fecha, "[TEST] Turno Combinado A", sedeId, "[TEST] Sede Combinada");
         await PublicarTurnoConSedeAsync(
-            solicitudB, empleadoIdB, fecha, "[TEST] Turno Combinado B", sedeId, "[TEST] Sede Combinada");
+            solicitudB, codigoColaboradorB, fecha, "[TEST] Turno Combinado B", sedeId, "[TEST] Sede Combinada");
 
-        var aMaterializado = await EsperarTurnoEnLaListaAsync(empleadoIdA, fecha, ct);
+        var aMaterializado = await EsperarTurnoEnLaListaAsync(codigoColaboradorA, fecha, ct);
         aMaterializado.Should().BeTrue(
-            $"la vista de {empleadoIdA} en {fecha} deberia materializarse dentro del timeout");
+            $"la vista de {codigoColaboradorA} en {fecha} deberia materializarse dentro del timeout");
 
-        var bMaterializado = await EsperarTurnoEnLaListaAsync(empleadoIdB, fecha, ct);
+        var bMaterializado = await EsperarTurnoEnLaListaAsync(codigoColaboradorB, fecha, ct);
         bMaterializado.Should().BeTrue(
-            $"la vista de {empleadoIdB} en {fecha} deberia materializarse dentro del timeout");
+            $"la vista de {codigoColaboradorB} en {fecha} deberia materializarse dentro del timeout");
 
-        // Act: combinar sedeId (compartido por A y B) + empleadoId=A.
-        var response = await _client.GetAsync(Ruta(fecha, fecha, empleadoIdA, sedeId), ct);
+        // Act: combinar sedeId (compartido por A y B) + codigoColaborador=A.
+        var response = await _client.GetAsync(Ruta(fecha, fecha, codigoColaboradorA, sedeId), ct);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
         var respuesta = await response.Content.ReadFromJsonAsync<ListaTurnosVigentesSmoke>(
@@ -630,7 +630,7 @@ public class ListarTurnosVigentesSmokeTests(ApiFixture api, ServiceBusFixture se
         respuesta.Should().NotBeNull();
 
         // Assert: solo el turno de A -- el filtro compuesto excluye a B aunque comparta la sede.
-        respuesta!.Turnos.Should().ContainSingle(t => t.EmpleadoId == empleadoIdA && t.Fecha == fecha);
-        respuesta.Turnos.Should().NotContain(t => t.EmpleadoId == empleadoIdB);
+        respuesta!.Turnos.Should().ContainSingle(t => t.CodigoColaborador == codigoColaboradorA && t.Fecha == fecha);
+        respuesta.Turnos.Should().NotContain(t => t.CodigoColaborador == codigoColaboradorB);
     }
 }

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/ObtenerTurnoVigente/ObtenerTurnoVigenteSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/ObtenerTurnoVigente/ObtenerTurnoVigenteSmokeTests.cs
@@ -6,7 +6,7 @@ using Bitakora.ControlAsistencia.ControlHoras.SmokeTests.Fixtures;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.SmokeTests.ObtenerTurnoVigente;
 
-// Issue #328: smoke tests de ObtenerTurnoVigente, GET control-horas/turnos-vigentes/{empleadoId}/{fecha}.
+// Issue #328: smoke tests de ObtenerTurnoVigente, GET control-horas/turnos-vigentes/{codigoColaborador}/{fecha}.
 // Function GET read-side sobre la proyeccion TurnoVigente (receta N1, MEF-ADR-0034/0035) --
 // reemplazo del read model del issue #289, retirado por la contraccion del issue #323. Mismo
 // mecanismo de siembra que uso la suite de aquel read model (#289): se publica
@@ -62,20 +62,20 @@ public class ObtenerTurnoVigenteSmokeTests(ApiFixture api, ServiceBusFixture ser
 
     private sealed record TurnoVigenteRespuestaSmoke(
         string Id,
-        string EmpleadoId,
+        string CodigoColaborador,
         string NombreCompleto,
         DateOnly Fecha,
         string NombreTurno,
         string HorarioResumido,
         IReadOnlyList<BloqueSmoke> Bloques);
 
-    private static string Ruta(string empleadoId, DateOnly fecha) =>
-        $"/api/control-horas/turnos-vigentes/{empleadoId}/{fecha:yyyy-MM-dd}";
+    private static string Ruta(string codigoColaborador, DateOnly fecha) =>
+        $"/api/control-horas/turnos-vigentes/{codigoColaborador}/{fecha:yyyy-MM-dd}";
 
     // Mismo formato que ControlDiarioAggregateRoot.ComputarStreamId, reconstruido localmente:
     // el smoke test no referencia el Function App (ControlHoras.Entities).
-    private static string ComputarStreamId(string empleadoId, DateOnly fecha) =>
-        $"{empleadoId}:{fecha:yyyy-MM-dd}";
+    private static string ComputarStreamId(string codigoColaborador, DateOnly fecha) =>
+        $"{codigoColaborador}:{fecha:yyyy-MM-dd}";
 
     [Fact]
     [Trait("Category", "Smoke")]
@@ -97,15 +97,15 @@ public class ObtenerTurnoVigenteSmokeTests(ApiFixture api, ServiceBusFixture ser
 
         // Arrange: identificadores unicos por ejecucion y fecha fija (nunca DateTime.UtcNow).
         var solicitudId = Guid.CreateVersion7();
-        var empleadoId = Guid.CreateVersion7().ToString();
+        var codigoColaborador = Guid.CreateVersion7().ToString();
         var fecha = new DateOnly(2026, 4, 9);
 
         var evento = new
         {
             SolicitudId = solicitudId,
-            Empleado = new
+            Colaborador = new
             {
-                EmpleadoId = empleadoId,
+                CodigoColaborador = codigoColaborador,
                 TipoIdentificacion = "CC",
                 NumeroIdentificacion = "111222333",
                 Nombres = "[TEST] Smoke",
@@ -136,7 +136,7 @@ public class ObtenerTurnoVigenteSmokeTests(ApiFixture api, ServiceBusFixture ser
         await serviceBus.PublishAsync(TopicEntrada, evento, solicitudId.ToString());
 
         // Act + Assert: reintentar el GET hasta que la proyeccion asincrona materialice la vista.
-        var ruta = Ruta(empleadoId, fecha);
+        var ruta = Ruta(codigoColaborador, fecha);
         var respuesta = await Polling.WaitUntilAsync(async () =>
         {
             var response = await _client.GetAsync(ruta, ct);
@@ -153,8 +153,8 @@ public class ObtenerTurnoVigenteSmokeTests(ApiFixture api, ServiceBusFixture ser
 
         // Assert: Id como stream key -- ancla para comandos/lookups de la UI, no se pinta pero SI
         // viaja en la respuesta (decision de entrevista, "Notas tecnicas" del issue #328).
-        respuesta.Id.Should().Be(ComputarStreamId(empleadoId, fecha));
-        respuesta.EmpleadoId.Should().Be(empleadoId);
+        respuesta.Id.Should().Be(ComputarStreamId(codigoColaborador, fecha));
+        respuesta.CodigoColaborador.Should().Be(codigoColaborador);
         respuesta.NombreCompleto.Should().Be("[TEST] Smoke [TEST] TurnoVigente");
         respuesta.Fecha.Should().Be(fecha);
         respuesta.NombreTurno.Should().Be("[TEST] Turno Vigente Query");
@@ -171,15 +171,15 @@ public class ObtenerTurnoVigenteSmokeTests(ApiFixture api, ServiceBusFixture ser
 
     [Fact]
     [Trait("Category", "Smoke")]
-    public async Task ObtenerTurnoVigente_Retorna404_CuandoNoHayTurnoVigenteParaEseEmpleadoYFecha()
+    public async Task ObtenerTurnoVigente_Retorna404_CuandoNoHayTurnoVigenteParaEseColaboradorYFecha()
     {
         var ct = TestContext.Current.CancellationToken;
 
-        // Arrange: empleadoId nuevo, nunca creado por ningun test -- no puede tener turno vigente.
-        var empleadoId = Guid.CreateVersion7().ToString();
+        // Arrange: codigoColaborador nuevo, nunca creado por ningun test -- no puede tener turno vigente.
+        var codigoColaborador = Guid.CreateVersion7().ToString();
         var fecha = new DateOnly(2026, 4, 10);
 
-        var response = await _client.GetAsync(Ruta(empleadoId, fecha), ct);
+        var response = await _client.GetAsync(Ruta(codigoColaborador, fecha), ct);
 
         // Assert: CA-4 -- 404 SIN BODY (mismo criterio que #289): distingue el
         // NotFoundResult() del endpoint de un 404 con payload de error, y de la pagina de error del
@@ -195,10 +195,10 @@ public class ObtenerTurnoVigenteSmokeTests(ApiFixture api, ServiceBusFixture ser
         var ct = TestContext.Current.CancellationToken;
 
         // Arrange: formato DD-MM-YYYY en vez de yyyy-MM-dd (mismo criterio que #289).
-        var empleadoId = Guid.CreateVersion7().ToString();
+        var codigoColaborador = Guid.CreateVersion7().ToString();
 
         var response = await _client.GetAsync(
-            $"/api/control-horas/turnos-vigentes/{empleadoId}/09-04-2026", ct);
+            $"/api/control-horas/turnos-vigentes/{codigoColaborador}/09-04-2026", ct);
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/RegistrarMarcacionFunction/RegistrarMarcacionSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/RegistrarMarcacionFunction/RegistrarMarcacionSmokeTests.cs
@@ -27,7 +27,7 @@ namespace Bitakora.ControlAsistencia.ControlHoras.SmokeTests.RegistrarMarcacionF
 // Issue #275: protege MarcacionRegistrada con factory y ctores privados, sin efectos nuevos
 // observables desde afuera. El truncamiento al minuto solo cambio de casa (handler -> factory) y
 // DebeRetornar202YPersistirEvento_CuandoMarcacionEsValida lo sigue verificando end-to-end; el
-// EmpleadoId vacio ya lo rechaza el validator con 400 (#279, arriba) antes de llegar al factory.
+// CodigoColaborador vacio ya lo rechaza el validator con 400 (#279, arriba) antes de llegar al factory.
 // El resto de sus CAs son invariantes internas del tipo (ctores privados, serializacion), cubiertas
 // en *.Tests por MarcacionRegistradaTests y MarcacionRegistradaSerializacionTests.
 public class RegistrarMarcacionSmokeTests(
@@ -47,22 +47,22 @@ public class RegistrarMarcacionSmokeTests(
     private const string SuscripcionSmokeTests = "smoke-tests";
     private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
 
-    // Issue #279: timestamp valido y fijo para los casos donde lo invalido es el EmpleadoId, no la
+    // Issue #279: timestamp valido y fijo para los casos donde lo invalido es el CodigoColaborador, no la
     // fecha; asi el 400 esperado solo puede venir de la regla bajo prueba.
     private static readonly DateTime TimestampValido = new(2026, 4, 20, 8, 0, 0, DateTimeKind.Utc);
 
-    // CA-5: stream ID determinista = "{EmpleadoId}:{Timestamp:yyyy-MM-ddTHH:mm:ss}"
+    // CA-5: stream ID determinista = "{CodigoColaborador}:{Timestamp:yyyy-MM-ddTHH:mm:ss}"
     // El timestamp que se usa para el stream ID es el crudo (antes de normalizar al minuto).
-    private static string ComputarStreamId(string empleadoId, DateTime timestampCrudo) =>
-        $"{empleadoId}:{timestampCrudo:yyyy-MM-ddTHH:mm:ss}";
+    private static string ComputarStreamId(string codigoColaborador, DateTime timestampCrudo) =>
+        $"{codigoColaborador}:{timestampCrudo:yyyy-MM-ddTHH:mm:ss}";
 
-    // Issue #279: los casos de rechazo por forma solo varian en EmpleadoId o Timestamp; el resto del
+    // Issue #279: los casos de rechazo por forma solo varian en CodigoColaborador o Timestamp; el resto del
     // payload es identico. Se envia el timestamp con el mismo formato que el resto del archivo.
     private Task<HttpResponseMessage> PostMarcacionAsync(
-        string empleadoId, DateTime timestamp, string dispositivoId) =>
+        string codigoColaborador, DateTime timestamp, string dispositivoId) =>
         _client.PostAsJsonAsync(Ruta, new
         {
-            empleadoId,
+            codigoColaborador,
             timestamp = timestamp.ToString("yyyy-MM-ddTHH:mm:ss") + "Z",
             tipoMarcacion = "ENTRADA",
             dispositivoId
@@ -88,12 +88,12 @@ public class RegistrarMarcacionSmokeTests(
 
         // Arrange: timestamp fijo para que el stream ID sea determinista y el test sea reproducible.
         // CA-2: el handler trunca al minuto antes de emitir; el stream ID usa el timestamp crudo.
-        var empleadoId = Guid.CreateVersion7().ToString();
+        var codigoColaborador = Guid.CreateVersion7().ToString();
         var timestamp = new DateTime(2026, 4, 17, 8, 9, 43, DateTimeKind.Utc);
 
         var payload = new
         {
-            empleadoId,
+            codigoColaborador,
             timestamp = timestamp.ToString("yyyy-MM-ddTHH:mm:ss") + "Z",
             tipoMarcacion = "ENTRADA",
             dispositivoId = "[TEST] DEV-SMOKE-001"
@@ -106,7 +106,7 @@ public class RegistrarMarcacionSmokeTests(
         response.StatusCode.Should().Be(HttpStatusCode.Accepted);
 
         // Assert persistencia: el evento marcacion_registrada debe existir en el stream
-        var streamId = ComputarStreamId(empleadoId, timestamp);
+        var streamId = ComputarStreamId(codigoColaborador, timestamp);
 
         var existe = await postgres.ExisteEventoAsync(
             SchemaControlHoras, streamId, TipoEvento, Timeout);
@@ -120,10 +120,10 @@ public class RegistrarMarcacionSmokeTests(
 
         var eventoPersistido = await postgres.ObtenerEventoAsync<JsonElement>(
             SchemaControlHoras, streamId, TipoEvento,
-            campoJson: "EmpleadoId", valorJson: empleadoId, TimeSpan.FromSeconds(5));
+            campoJson: "CodigoColaborador", valorJson: codigoColaborador, TimeSpan.FromSeconds(5));
 
-        eventoPersistido.GetProperty("EmpleadoId").GetString()
-            .Should().Be(empleadoId);
+        eventoPersistido.GetProperty("CodigoColaborador").GetString()
+            .Should().Be(codigoColaborador);
 
         eventoPersistido.GetProperty("TipoMarcacion").GetString()
             .Should().Be("ENTRADA");
@@ -146,12 +146,12 @@ public class RegistrarMarcacionSmokeTests(
         var ct = TestContext.Current.CancellationToken;
 
         // Arrange: TipoMarcacion y DispositivoId son opcionales (CA-3), se envian como null
-        var empleadoId = Guid.CreateVersion7().ToString();
+        var codigoColaborador = Guid.CreateVersion7().ToString();
         var timestamp = new DateTime(2026, 4, 17, 9, 30, 15, DateTimeKind.Utc);
 
         var payload = new
         {
-            empleadoId,
+            codigoColaborador,
             timestamp = timestamp.ToString("yyyy-MM-ddTHH:mm:ss") + "Z",
             tipoMarcacion = (string?)null,
             dispositivoId = (string?)null
@@ -164,7 +164,7 @@ public class RegistrarMarcacionSmokeTests(
         response.StatusCode.Should().Be(HttpStatusCode.Accepted);
 
         // Assert persistencia: el evento debe existir aunque los campos opcionales sean null
-        var streamId = ComputarStreamId(empleadoId, timestamp);
+        var streamId = ComputarStreamId(codigoColaborador, timestamp);
 
         var existe = await postgres.ExisteEventoAsync(
             SchemaControlHoras, streamId, TipoEvento, Timeout);
@@ -179,13 +179,13 @@ public class RegistrarMarcacionSmokeTests(
     {
         var ct = TestContext.Current.CancellationToken;
 
-        // Arrange: mismo empleadoId y mismo timestamp -> mismo stream ID -> duplicado exacto (CA-4, CA-9)
-        var empleadoId = Guid.CreateVersion7().ToString();
+        // Arrange: mismo codigoColaborador y mismo timestamp -> mismo stream ID -> duplicado exacto (CA-4, CA-9)
+        var codigoColaborador = Guid.CreateVersion7().ToString();
         var timestamp = new DateTime(2026, 4, 17, 10, 0, 0, DateTimeKind.Utc);
 
         var payload = new
         {
-            empleadoId,
+            codigoColaborador,
             timestamp = timestamp.ToString("yyyy-MM-ddTHH:mm:ss") + "Z",
             tipoMarcacion = "SALIDA",
             dispositivoId = "[TEST] DEV-SMOKE-DUP"
@@ -195,7 +195,7 @@ public class RegistrarMarcacionSmokeTests(
         var primeraRespuesta = await _client.PostAsJsonAsync(Ruta, payload, ct);
         primeraRespuesta.StatusCode.Should().Be(HttpStatusCode.Accepted);
 
-        // Act 2: duplicado exacto (mismo empleadoId + mismo timestamp = mismo stream ID)
+        // Act 2: duplicado exacto (mismo codigoColaborador + mismo timestamp = mismo stream ID)
         var segundaRespuesta = await _client.PostAsJsonAsync(Ruta, payload, ct);
 
         // CA-4, CA-6: duplicado silencioso -> 202 Accepted (no 409)
@@ -234,34 +234,34 @@ public class RegistrarMarcacionSmokeTests(
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
-    // Issue #279 CA-2: EmpleadoId vacio produce 400.
+    // Issue #279 CA-2: CodigoColaborador vacio produce 400.
     [Fact]
     [Trait("Category", "Smoke")]
-    public async Task RegistrarMarcacion_Retorna400_CuandoEmpleadoIdEsVacio()
+    public async Task RegistrarMarcacion_Retorna400_CuandoCodigoColaboradorEsVacio()
     {
         var response = await PostMarcacionAsync(
-            empleadoId: "", TimestampValido, "[TEST] DEV-SMOKE-CA2-VACIO");
+            codigoColaborador: "", TimestampValido, "[TEST] DEV-SMOKE-CA2-VACIO");
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
-    // Issue #279 CA-2: EmpleadoId con solo espacios en blanco produce 400.
+    // Issue #279 CA-2: CodigoColaborador con solo espacios en blanco produce 400.
     [Fact]
     [Trait("Category", "Smoke")]
-    public async Task RegistrarMarcacion_Retorna400_CuandoEmpleadoIdSonSoloEspacios()
+    public async Task RegistrarMarcacion_Retorna400_CuandoCodigoColaboradorSonSoloEspacios()
     {
         var response = await PostMarcacionAsync(
-            empleadoId: "   ", TimestampValido, "[TEST] DEV-SMOKE-CA2-ESPACIOS");
+            codigoColaborador: "   ", TimestampValido, "[TEST] DEV-SMOKE-CA2-ESPACIOS");
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
-    // Issue #279 CA-3: EmpleadoId con ':' produce 400. ComputarStreamId usa ':' como separador entre
-    // EmpleadoId y Timestamp; sin esta regla, un EmpleadoId con ':' podria fabricar el mismo stream ID
+    // Issue #279 CA-3: CodigoColaborador con ':' produce 400. ComputarStreamId usa ':' como separador entre
+    // CodigoColaborador y Timestamp; sin esta regla, un CodigoColaborador con ':' podria fabricar el mismo stream ID
     // que otra combinacion legitima (colision descrita en el Contexto del issue).
     [Fact]
     [Trait("Category", "Smoke")]
-    public async Task RegistrarMarcacion_Retorna400_CuandoEmpleadoIdContieneDosPuntos()
+    public async Task RegistrarMarcacion_Retorna400_CuandoCodigoColaboradorContieneDosPuntos()
     {
         var response = await PostMarcacionAsync(
             $"EMP:{Guid.CreateVersion7()}", TimestampValido, "[TEST] DEV-SMOKE-CA3");
@@ -281,10 +281,10 @@ public class RegistrarMarcacionSmokeTests(
     }
 
     // HU-108: tras el POST, el handler in-process AdicionarMarcacionCuandoRegistroDeMarcacionCreado
-    // persiste marcacion_adicionada en el stream {empleadoId}:{fecha} y publica DiaCalculado.
+    // persiste marcacion_adicionada en el stream {codigoColaborador}:{fecha} y publica DiaCalculado.
     // Setup: se publica programacion-turno-diario-solicitada para que el aggregate tenga
-    // turno previo, asegurando que DiaCalculado.InformacionEmpleado no sea null y se pueda
-    // filtrar por EmpleadoId en la suscripcion smoke-tests.
+    // turno previo, asegurando que DiaCalculado.InformacionColaborador no sea null y se pueda
+    // filtrar por CodigoColaborador en la suscripcion smoke-tests.
     // Issue #270: este es el test que cierra el circuito completo del contrato de bus
     // RegistroDeMarcacionCreado -- el POST solo puede llegar a persistir marcacion_adicionada si
     // RegistrarMarcacionCommandHandler publico RegistroDeMarcacionCreado correctamente al topic
@@ -304,9 +304,9 @@ public class RegistrarMarcacionSmokeTests(
         var ct = TestContext.Current.CancellationToken;
 
         // Arrange: identificadores unicos por ejecucion
-        var empleadoId = Guid.CreateVersion7().ToString();
+        var codigoColaborador = Guid.CreateVersion7().ToString();
         var fecha = new DateOnly(2026, 4, 27);
-        var streamId = $"{empleadoId}:{fecha:yyyy-MM-dd}";
+        var streamId = $"{codigoColaborador}:{fecha:yyyy-MM-dd}";
 
         // Setup: publicar programacion-turno-diario-solicitada y esperar a que ControlHoras
         // persista turno_diario_asignado. Asi el ControlDiario tendra TurnoDiarioAsignado previo
@@ -315,9 +315,9 @@ public class RegistrarMarcacionSmokeTests(
         var programacionPayload = new
         {
             SolicitudId = solicitudId,
-            Empleado = new
+            Colaborador = new
             {
-                EmpleadoId = empleadoId,
+                CodigoColaborador = codigoColaborador,
                 TipoIdentificacion = "CC",
                 NumeroIdentificacion = "888777666",
                 Nombres = "[TEST] Smoke DiaCalculado",
@@ -359,7 +359,7 @@ public class RegistrarMarcacionSmokeTests(
         var timestamp = new DateTime(fecha, new TimeOnly(8, 0, 0), DateTimeKind.Utc);
         var payload = new
         {
-            empleadoId,
+            codigoColaborador,
             timestamp = timestamp.ToString("yyyy-MM-ddTHH:mm:ss") + "Z",
             tipoMarcacion = "ENTRADA",
             dispositivoId = "[TEST] DEV-SMOKE-HU108"
@@ -374,19 +374,19 @@ public class RegistrarMarcacionSmokeTests(
         // Assert persistencia: marcacion_adicionada en el stream del ControlDiario.
         var marcacionAdicionada = await postgres.ExisteEventoAsync(
             SchemaControlHoras, streamId, TipoEventoMarcacionAdicionada, Timeout,
-            campoJson: "EmpleadoId", valorJson: empleadoId);
+            campoJson: "CodigoColaborador", valorJson: codigoColaborador);
 
         marcacionAdicionada.Should().BeTrue(
             $"el evento {TipoEventoMarcacionAdicionada} deberia existir en el stream {streamId} tras el POST");
 
-        // Assert publicacion: DiaCalculado emitido al topic dia-calculado, filtrado por EmpleadoId.
+        // Assert publicacion: DiaCalculado emitido al topic dia-calculado, filtrado por CodigoColaborador.
         var diaCalculado = await serviceBus.WaitForMessageAsync<DiaCalculado>(
             TopicDiaCalculado, SuscripcionSmokeTests,
-            e => e.InformacionEmpleado != null && e.InformacionEmpleado.EmpleadoId == empleadoId,
+            e => e.InformacionColaborador != null && e.InformacionColaborador.CodigoColaborador == codigoColaborador,
             Timeout);
 
         diaCalculado.Fecha.Should().Be(fecha);
-        diaCalculado.InformacionEmpleado!.EmpleadoId.Should().Be(empleadoId);
+        diaCalculado.InformacionColaborador!.CodigoColaborador.Should().Be(codigoColaborador);
         // Issue #183 CA-6: el payload viaja plano (HorasDiscriminadas) y se deserializo con el
         // serializador POR DEFECTO del fixture (sin resolver custom). Esta marcacion es solo ENTRADA:
         // la franja queda anomala (sin salida) -> sin minutos calculables -> MinutosPorConcepto vacio.
@@ -396,13 +396,13 @@ public class RegistrarMarcacionSmokeTests(
             "una entrada sola deja la franja anomala, sin minutos por concepto");
 
         // Assert: ausencia de dead letter de ESTA corrida en la suscripcion smoke-tests del topic
-        // dia-calculado (issue #223: acotado por EmpleadoId, no "DLQ globalmente vacio").
+        // dia-calculado (issue #223: acotado por CodigoColaborador, no "DLQ globalmente vacio").
         var existeDeadLetter = await serviceBus.ExisteDeadLetterDeEstaCorridaAsync<DiaCalculadoMinimo>(
-            TopicDiaCalculado, SuscripcionSmokeTests, e => e.InformacionEmpleado?.EmpleadoId == empleadoId);
+            TopicDiaCalculado, SuscripcionSmokeTests, e => e.InformacionColaborador?.CodigoColaborador == codigoColaborador);
 
         existeDeadLetter.Should().BeFalse(
-            "no deberia haber un dead letter de esta corrida (EmpleadoId {0}) en '{1}' del topic '{2}'",
-            empleadoId, SuscripcionSmokeTests, TopicDiaCalculado);
+            "no deberia haber un dead letter de esta corrida (CodigoColaborador {0}) en '{1}' del topic '{2}'",
+            codigoColaborador, SuscripcionSmokeTests, TopicDiaCalculado);
     }
 
     // HU-181 CA-5: camino feliz completo (turno + entrada + salida) -> el DiaCalculado publicado
@@ -426,9 +426,9 @@ public class RegistrarMarcacionSmokeTests(
         var ct = TestContext.Current.CancellationToken;
 
         // Arrange: identificadores unicos por ejecucion.
-        var empleadoId = Guid.CreateVersion7().ToString();
+        var codigoColaborador = Guid.CreateVersion7().ToString();
         var fecha = new DateOnly(2026, 4, 28);
-        var streamId = $"{empleadoId}:{fecha:yyyy-MM-dd}";
+        var streamId = $"{codigoColaborador}:{fecha:yyyy-MM-dd}";
 
         // Setup: turno 08:00-16:00 via Service Bus; esperar a que ControlHoras persista
         // turno_diario_asignado antes de registrar las marcaciones.
@@ -436,9 +436,9 @@ public class RegistrarMarcacionSmokeTests(
         var programacionPayload = new
         {
             SolicitudId = solicitudId,
-            Empleado = new
+            Colaborador = new
             {
-                EmpleadoId = empleadoId,
+                CodigoColaborador = codigoColaborador,
                 TipoIdentificacion = "CC",
                 NumeroIdentificacion = "777666555",
                 Nombres = "[TEST] Smoke Desglose Real",
@@ -475,7 +475,7 @@ public class RegistrarMarcacionSmokeTests(
         var entradaTimestamp = new DateTime(fecha, new TimeOnly(8, 0, 0), DateTimeKind.Utc);
         var entradaResponse = await _client.PostAsJsonAsync(Ruta, new
         {
-            empleadoId,
+            codigoColaborador,
             timestamp = entradaTimestamp.ToString("yyyy-MM-ddTHH:mm:ss") + "Z",
             tipoMarcacion = "ENTRADA",
             dispositivoId = "[TEST] DEV-SMOKE-HU181"
@@ -486,20 +486,20 @@ public class RegistrarMarcacionSmokeTests(
         // antes de purgar, de modo que el purge elimine el evento de la entrada (no el de la salida).
         var entradaPersistida = await postgres.ExisteEventoAsync(
             SchemaControlHoras, streamId, TipoEventoMarcacionAdicionada, Timeout,
-            campoJson: "EmpleadoId", valorJson: empleadoId);
+            campoJson: "CodigoColaborador", valorJson: codigoColaborador);
 
         entradaPersistida.Should().BeTrue(
             $"el evento {TipoEventoMarcacionAdicionada} de la entrada deberia existir antes de purgar");
 
         // Purge-before-act: limpiar la suscripcion para que el unico DiaCalculado restante de este
-        // empleado sea el que publique la salida (descarta los del turno y la entrada).
+        // colaborador sea el que publique la salida (descarta los del turno y la entrada).
         await serviceBus.PurgeAsync(TopicDiaCalculado, SuscripcionSmokeTests);
 
         // Act 2: SALIDA 16:00. Completa la franja (entrada 08:00 + salida 16:00) -> desglose real.
         var salidaTimestamp = new DateTime(fecha, new TimeOnly(16, 0, 0), DateTimeKind.Utc);
         var salidaResponse = await _client.PostAsJsonAsync(Ruta, new
         {
-            empleadoId,
+            codigoColaborador,
             timestamp = salidaTimestamp.ToString("yyyy-MM-ddTHH:mm:ss") + "Z",
             tipoMarcacion = "SALIDA",
             dispositivoId = "[TEST] DEV-SMOKE-HU181"
@@ -507,10 +507,10 @@ public class RegistrarMarcacionSmokeTests(
         salidaResponse.StatusCode.Should().Be(HttpStatusCode.Accepted);
 
         // Assert publicacion: el DiaCalculado posterior a la salida lleva el desglose real,
-        // filtrado por EmpleadoId (unico por ejecucion).
+        // filtrado por CodigoColaborador (unico por ejecucion).
         var diaCalculado = await serviceBus.WaitForMessageAsync<DiaCalculado>(
             TopicDiaCalculado, SuscripcionSmokeTests,
-            e => e.InformacionEmpleado != null && e.InformacionEmpleado.EmpleadoId == empleadoId,
+            e => e.InformacionColaborador != null && e.InformacionColaborador.CodigoColaborador == codigoColaborador,
             Timeout);
 
         diaCalculado.Fecha.Should().Be(fecha);
@@ -526,12 +526,12 @@ public class RegistrarMarcacionSmokeTests(
                 "el desglose real discriminado lleva horas ordinarias diurnas (no un payload vacio)");
 
         // Assert: ausencia de dead letter de ESTA corrida en la suscripcion smoke-tests del topic
-        // dia-calculado (issue #223: acotado por EmpleadoId, no "DLQ globalmente vacio").
+        // dia-calculado (issue #223: acotado por CodigoColaborador, no "DLQ globalmente vacio").
         var existeDeadLetter = await serviceBus.ExisteDeadLetterDeEstaCorridaAsync<DiaCalculadoMinimo>(
-            TopicDiaCalculado, SuscripcionSmokeTests, e => e.InformacionEmpleado?.EmpleadoId == empleadoId);
+            TopicDiaCalculado, SuscripcionSmokeTests, e => e.InformacionColaborador?.CodigoColaborador == codigoColaborador);
 
         existeDeadLetter.Should().BeFalse(
-            "no deberia haber un dead letter de esta corrida (EmpleadoId {0}) en '{1}' del topic '{2}'",
-            empleadoId, SuscripcionSmokeTests, TopicDiaCalculado);
+            "no deberia haber un dead letter de esta corrida (CodigoColaborador {0}) en '{1}' del topic '{2}'",
+            codigoColaborador, SuscripcionSmokeTests, TopicDiaCalculado);
     }
 }

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoRegistroDeMarcacionCreado/DepurarAlAdicionarMarcacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoRegistroDeMarcacionCreado/DepurarAlAdicionarMarcacionTests.cs
@@ -20,18 +20,18 @@ namespace Bitakora.ControlAsistencia.ControlHoras.Tests.AdicionarMarcacionCuando
 public class DepurarAlAdicionarMarcacionTests : PrivateEventHandlerAsyncTest<RegistroDeMarcacionCreado>
 {
     // Datos de prueba fijos - misma ancla de fecha que los tests del handler
-    private const string EmpleadoId = "EMP-001";
+    private const string CodigoColaborador = "EMP-001";
     private static readonly DateOnly Fecha = new(2026, 3, 15);
-    private static readonly string StreamId = $"{EmpleadoId}:{Fecha:yyyy-MM-dd}";
-    private static readonly string StreamIdDiaAnterior = $"{EmpleadoId}:2026-03-14";
+    private static readonly string StreamId = $"{CodigoColaborador}:{Fecha:yyyy-MM-dd}";
+    private static readonly string StreamIdDiaAnterior = $"{CodigoColaborador}:2026-03-14";
 
-    // Issue #322: Empleado (ControlHoras.DomainEvents) para construir TurnoDiarioAsignado en Given.
-    private static readonly ColaboradorProgramado EmpleadoPersistido = new(
-        EmpleadoId, "CC", "1234567890", "Luis Augusto", "Barreto");
+    // Issue #322: Colaborador (ControlHoras.DomainEvents) para construir TurnoDiarioAsignado en Given.
+    private static readonly ColaboradorProgramado ColaboradorPersistido = new(
+        CodigoColaborador, "CC", "1234567890", "Luis Augusto", "Barreto");
 
-    // InformacionEmpleado (PublicEvents) -- lo que espera DiaCalculado, evento publico sin cambios.
-    private static readonly InformacionColaborador EmpleadoPublico = new(
-        EmpleadoId, "CC", "1234567890", "Luis Augusto", "Barreto");
+    // InformacionColaborador (PublicEvents) -- lo que espera DiaCalculado, evento publico sin cambios.
+    private static readonly InformacionColaborador ColaboradorPublico = new(
+        CodigoColaborador, "CC", "1234567890", "Luis Augusto", "Barreto");
     private static readonly Guid SolicitudId = Guid.Parse("019600c0-0000-7000-8000-000000000001");
 
     // CA-1: franja unica 06:00-14:00
@@ -56,13 +56,13 @@ public class DepurarAlAdicionarMarcacionTests : PrivateEventHandlerAsyncTest<Reg
         new RegistroDeMarcacionCreadoEventHandler(EventStore, PublicEventSender);
 
     private static RegistroDeMarcacionCreado CrearRegistroDeMarcacionCreado(DateTime timestamp) =>
-        new(EmpleadoId, timestamp, "ENTRADA", "DEV-001");
+        new(CodigoColaborador, timestamp, "ENTRADA", "DEV-001");
 
     private static MarcacionAdicionada CrearMarcacionAdicionada(DateTime timestamp) =>
-        new(StreamId, EmpleadoId, timestamp, "ENTRADA", "DEV-001");
+        new(StreamId, CodigoColaborador, timestamp, "ENTRADA", "DEV-001");
 
     private static TurnoDiarioAsignado CrearTurnoDiarioAsignado(TurnoDiario detalleTurno) =>
-        new(StreamId, EmpleadoPersistido, Fecha, detalleTurno, SolicitudId);
+        new(StreamId, ColaboradorPersistido, Fecha, detalleTurno, SolicitudId);
 
     // Issue #184: oraculo independiente de una linea de trazabilidad (memoria de calculo). Se arma a
     // mano desde IntervaloTemporal.ToString() (primitiva ya probada) y la etiqueta traducida del recurso
@@ -74,7 +74,7 @@ public class DepurarAlAdicionarMarcacionTests : PrivateEventHandlerAsyncTest<Reg
     // CA-1 (HU-123): con TurnoDiarioAsignado (franja unica 06:00-14:00) previo y RegistroDeMarcacionCreado a las 07:00,
     //        ControlesDeFranja debe quedar con un ControlFranja(Franja06_14, Entrada=07:00, Salida=null).
     //        Verifica que el hook reactivo se dispara desde Apply(MarcacionAdicionada).
-    // CA-1 (HU-108): el handler publica DiaCalculado con InformacionEmpleado, Fecha y ControlesDeFranja correctos.
+    // CA-1 (HU-108): el handler publica DiaCalculado con InformacionColaborador, Fecha y ControlesDeFranja correctos.
     [Fact]
     public async Task RegistroDeMarcacionCreado_CalculaControlFranja_CuandoHayTurnoYLlegaMarcacion()
     {
@@ -95,7 +95,7 @@ public class DepurarAlAdicionarMarcacionTests : PrivateEventHandlerAsyncTest<Reg
         // que MinutosPorConcepto viaja vacio. Nota del issue (riesgo aceptado): el contrato plano ya no
         // distingue "franja anomala" de "dia sin horas"; ambos publican el mismo diccionario vacio.
         ThenIsPublishedPublicly(new DiaCalculado(
-            EmpleadoPublico,
+            ColaboradorPublico,
             Fecha,
             new HorasDiscriminadas(new Dictionary<string, int>(), [])));
     }
@@ -116,7 +116,7 @@ public class DepurarAlAdicionarMarcacionTests : PrivateEventHandlerAsyncTest<Reg
             StreamId, c => c.ControlesDeFranja.Count, 0);
 
         // HU-108 CA-4: se publica DiaCalculado aunque no haya turno.
-        // InformacionEmpleado es null porque el ControlDiario nacio solo por marcacion.
+        // InformacionColaborador es null porque el ControlDiario nacio solo por marcacion.
         // Issue #183 CA-6: sin turno no hay nada que consolidar -> MinutosPorConcepto viaja vacio.
         ThenIsPublishedPublicly(new DiaCalculado(
             null,
@@ -164,7 +164,7 @@ public class DepurarAlAdicionarMarcacionTests : PrivateEventHandlerAsyncTest<Reg
         // con LineaConcepto desde su intervalo y la etiqueta traducida. F2 es anomala (Salida null): no
         // aporta intervalos ni lineas.
         ThenIsPublishedPublicly(new DiaCalculado(
-            EmpleadoPublico,
+            ColaboradorPublico,
             Fecha,
             new HorasDiscriminadas(
                 new Dictionary<string, int>
@@ -194,12 +194,12 @@ public class DepurarAlAdicionarMarcacionTests : PrivateEventHandlerAsyncTest<Reg
 
         // Verificar que cada stream tiene exactamente un MarcacionAdicionada
         Then(StreamId,
-            new MarcacionAdicionada(StreamId, EmpleadoId, timestampNocturno, "ENTRADA", "DEV-001"));
+            new MarcacionAdicionada(StreamId, CodigoColaborador, timestampNocturno, "ENTRADA", "DEV-001"));
         Then(StreamIdDiaAnterior,
-            new MarcacionAdicionada(StreamIdDiaAnterior, EmpleadoId, timestampNocturno, "ENTRADA", "DEV-001"));
+            new MarcacionAdicionada(StreamIdDiaAnterior, CodigoColaborador, timestampNocturno, "ENTRADA", "DEV-001"));
 
         // CA-5: dos DiaCalculado publicados, en orden: dia calendario primero, dia anterior segundo.
-        // Ambos sin turno previo (InformacionEmpleado=null).
+        // Ambos sin turno previo (InformacionColaborador=null).
         // Issue #183 CA-6: sin turno en ninguno de los dos streams, MinutosPorConcepto viaja vacio en ambos.
         ThenIsPublishedPublicly(
             new DiaCalculado(null, fechaDiaCal, new HorasDiscriminadas(new Dictionary<string, int>(), [])),

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoRegistroDeMarcacionCreado/DesgloseHorasTrasAdicionarMarcacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoRegistroDeMarcacionCreado/DesgloseHorasTrasAdicionarMarcacionTests.cs
@@ -25,13 +25,13 @@ namespace Bitakora.ControlAsistencia.ControlHoras.Tests.AdicionarMarcacionCuando
 public class DesgloseHorasTrasAdicionarMarcacionTests : PrivateEventHandlerAsyncTest<RegistroDeMarcacionCreado>
 {
     // Datos de prueba fijos - mismo ancla de fecha y stream ID compuesto que los tests del handler
-    private const string EmpleadoId = "EMP-001";
+    private const string CodigoColaborador = "EMP-001";
     private static readonly DateOnly Fecha = new(2026, 3, 15);
-    private static readonly string StreamId = $"{EmpleadoId}:{Fecha:yyyy-MM-dd}";
+    private static readonly string StreamId = $"{CodigoColaborador}:{Fecha:yyyy-MM-dd}";
 
-    // Issue #322: Empleado (ControlHoras.DomainEvents) -- el tipo que persiste TurnoDiarioAsignado.
-    private static readonly ColaboradorProgramado Empleado = new(
-        EmpleadoId, "CC", "1234567890", "Luis Augusto", "Barreto");
+    // Issue #322: Colaborador (ControlHoras.DomainEvents) -- el tipo que persiste TurnoDiarioAsignado.
+    private static readonly ColaboradorProgramado Colaborador = new(
+        CodigoColaborador, "CC", "1234567890", "Luis Augusto", "Barreto");
     private static readonly Guid SolicitudId = Guid.Parse("019600c0-0000-7000-8000-000000000003");
 
     // CA-1: turno partido con dos franjas ordinarias 08:00-12:00 y 14:00-18:00
@@ -52,13 +52,13 @@ public class DesgloseHorasTrasAdicionarMarcacionTests : PrivateEventHandlerAsync
         new RegistroDeMarcacionCreadoEventHandler(EventStore, PublicEventSender);
 
     private static RegistroDeMarcacionCreado CrearRegistroDeMarcacionCreado(DateTime timestamp) =>
-        new(EmpleadoId, timestamp, "ENTRADA", "DEV-001");
+        new(CodigoColaborador, timestamp, "ENTRADA", "DEV-001");
 
     private static MarcacionAdicionada CrearMarcacionAdicionada(DateTime timestamp) =>
-        new(StreamId, EmpleadoId, timestamp, "ENTRADA", "DEV-001");
+        new(StreamId, CodigoColaborador, timestamp, "ENTRADA", "DEV-001");
 
     private static TurnoDiarioAsignado CrearTurnoDiarioAsignado(TurnoDiario detalleTurno) =>
-        new(StreamId, Empleado, Fecha, detalleTurno, SolicitudId);
+        new(StreamId, Colaborador, Fecha, detalleTurno, SolicitudId);
 
     // CA-1: con TurnoDiarioAsignado (turno partido 08:00-12:00 y 14:00-18:00) previo y
     //       MarcacionAdicionada previas (08:00, 12:05, 14:10), el RegistroDeMarcacionCreado a las 18:30

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoRegistroDeMarcacionCreado/Eventos/DiaCalculadoSerializacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoRegistroDeMarcacionCreado/Eventos/DiaCalculadoSerializacionTests.cs
@@ -19,7 +19,7 @@ namespace Bitakora.ControlAsistencia.ControlHoras.Tests.AdicionarMarcacionCuando
 
 public class DiaCalculadoSerializacionTests
 {
-    private static readonly InformacionColaborador Empleado =
+    private static readonly InformacionColaborador Colaborador =
         new("EMP-001", "CC", "1234567890", "Luis Augusto", "Barreto");
 
     private static readonly DateOnly Fecha = new(2026, 3, 15);
@@ -43,23 +43,23 @@ public class DiaCalculadoSerializacionTests
     [Fact]
     public void RoundTrip_PreservaTodosLosCampos_ConSerializadorPorDefectoDelPublisher()
     {
-        var original = new DiaCalculado(Empleado, Fecha, HorasConDatos());
+        var original = new DiaCalculado(Colaborador, Fecha, HorasConDatos());
         var opciones = OpcionesPorDefectoDelPublisher();
 
         var json = JsonSerializer.Serialize(original, opciones);
         var restaurado = JsonSerializer.Deserialize<DiaCalculado>(json, opciones);
 
         restaurado.Should().NotBeNull();
-        restaurado!.InformacionEmpleado.Should().Be(Empleado);
+        restaurado!.InformacionColaborador.Should().Be(Colaborador);
         restaurado.Fecha.Should().Be(Fecha);
         restaurado.HorasDiscriminadas.MinutosPorConcepto.Should().BeEquivalentTo(
             original.HorasDiscriminadas.MinutosPorConcepto);
         restaurado.HorasDiscriminadas.Trazabilidad.Should().BeEmpty();
     }
 
-    // CA-6: roundtrip con InformacionEmpleado null (caso "marcacion sin turno previo").
+    // CA-6: roundtrip con InformacionColaborador null (caso "marcacion sin turno previo").
     [Fact]
-    public void RoundTrip_PreservaCampos_CuandoInformacionEmpleadoEsNula()
+    public void RoundTrip_PreservaCampos_CuandoInformacionColaboradorEsNula()
     {
         var original = new DiaCalculado(
             null, Fecha, new HorasDiscriminadas(new Dictionary<string, int>(), []));
@@ -69,7 +69,7 @@ public class DiaCalculadoSerializacionTests
         var restaurado = JsonSerializer.Deserialize<DiaCalculado>(json, opciones);
 
         restaurado.Should().NotBeNull();
-        restaurado!.InformacionEmpleado.Should().BeNull();
+        restaurado!.InformacionColaborador.Should().BeNull();
         restaurado.Fecha.Should().Be(Fecha);
         restaurado.HorasDiscriminadas.MinutosPorConcepto.Should().BeEmpty();
     }
@@ -81,7 +81,7 @@ public class DiaCalculadoSerializacionTests
     [Fact]
     public void Deserializar_TieneExito_ConResolverPorDefectoSinRegistros()
     {
-        var original = new DiaCalculado(Empleado, Fecha, HorasConDatos());
+        var original = new DiaCalculado(Colaborador, Fecha, HorasConDatos());
         var json = JsonSerializer.Serialize(original);
 
         var opcionesSinRegistros = new JsonSerializerOptions

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoRegistroDeMarcacionCreado/Eventos/MarcacionAdicionadaSerializacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoRegistroDeMarcacionCreado/Eventos/MarcacionAdicionadaSerializacionTests.cs
@@ -17,7 +17,7 @@ namespace Bitakora.ControlAsistencia.ControlHoras.Tests.AdicionarMarcacionCuando
 public class MarcacionAdicionadaSerializacionTests
 {
     private static readonly string StreamId = "EMP-001:2026-03-15";
-    private static readonly string EmpleadoId = "EMP-001";
+    private static readonly string CodigoColaborador = "EMP-001";
     private static readonly DateTime Timestamp = new DateTime(2026, 3, 15, 8, 15, 0);
 
     // Regla 16: usa CrearOpcionesMarten() que registra ConfigurarSerializacion de todos los tipos
@@ -25,7 +25,7 @@ public class MarcacionAdicionadaSerializacionTests
     [Fact]
     public void Deserializar_ReconstruyeEvento_ConTodosLosCampos()
     {
-        var evento = new MarcacionAdicionada(StreamId, EmpleadoId, Timestamp, "ENTRADA", "DEV-001");
+        var evento = new MarcacionAdicionada(StreamId, CodigoColaborador, Timestamp, "ENTRADA", "DEV-001");
         var opciones = ConfiguracionSerializacionControlHoras.CrearOpcionesMarten();
 
         var json = JsonSerializer.Serialize(evento, opciones);
@@ -33,7 +33,7 @@ public class MarcacionAdicionadaSerializacionTests
 
         deserializado.Should().NotBeNull();
         deserializado!.Id.Should().Be(StreamId);
-        deserializado.EmpleadoId.Should().Be(EmpleadoId);
+        deserializado.CodigoColaborador.Should().Be(CodigoColaborador);
         deserializado.TimestampNormalizado.Should().Be(Timestamp);
         deserializado.TipoMarcacion.Should().Be("ENTRADA");
         deserializado.DispositivoId.Should().Be("DEV-001");
@@ -43,7 +43,7 @@ public class MarcacionAdicionadaSerializacionTests
     [Fact]
     public void Deserializar_ReconstruyeEvento_CuandoCamposOpcionalesSonNulos()
     {
-        var evento = new MarcacionAdicionada(StreamId, EmpleadoId, Timestamp, null, null);
+        var evento = new MarcacionAdicionada(StreamId, CodigoColaborador, Timestamp, null, null);
         var opciones = ConfiguracionSerializacionControlHoras.CrearOpcionesMarten();
 
         var json = JsonSerializer.Serialize(evento, opciones);
@@ -51,7 +51,7 @@ public class MarcacionAdicionadaSerializacionTests
 
         deserializado.Should().NotBeNull();
         deserializado!.Id.Should().Be(StreamId);
-        deserializado.EmpleadoId.Should().Be(EmpleadoId);
+        deserializado.CodigoColaborador.Should().Be(CodigoColaborador);
         deserializado.TimestampNormalizado.Should().Be(Timestamp);
         deserializado.TipoMarcacion.Should().BeNull();
         deserializado.DispositivoId.Should().BeNull();

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoRegistroDeMarcacionCreado/FunctionEndpointTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoRegistroDeMarcacionCreado/FunctionEndpointTests.cs
@@ -21,12 +21,12 @@ namespace Bitakora.ControlAsistencia.ControlHoras.Tests.AdicionarMarcacionCuando
 public class FunctionEndpointTests
 {
     // JSON en formato camelCase - Wolverine serializa con camelCase por defecto al publicar al Service Bus.
-    // Mismos campos que RegistroDeMarcacionCreadoDeserializacionTests (EmpleadoId, TimestampNormalizado,
+    // Mismos campos que RegistroDeMarcacionCreadoDeserializacionTests (CodigoColaborador, TimestampNormalizado,
     // TipoMarcacion, DispositivoId); RegistroDeMarcacionCreado es un record con constructor primario
     // publico, por lo que ServiceBusDeserializador (case-insensitive) lo resuelve via ese constructor.
     private const string JsonFormatoWolverine = """
         {
-          "empleadoId": "EMP-001",
+          "codigoColaborador": "EMP-001",
           "timestampNormalizado": "2026-03-15T08:09:00",
           "tipoMarcacion": "ENTRADA",
           "dispositivoId": "DEV-001"

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoRegistroDeMarcacionCreado/RegistroDeMarcacionCreadoDeserializacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoRegistroDeMarcacionCreado/RegistroDeMarcacionCreadoDeserializacionTests.cs
@@ -24,7 +24,7 @@ public class RegistroDeMarcacionCreadoDeserializacionTests
     // JSON en formato camelCase - exactamente como Wolverine lo serializa al publicar al Service Bus.
     private const string JsonFormatoWolverine = """
         {
-          "empleadoId": "EMP-001",
+          "codigoColaborador": "EMP-001",
           "timestampNormalizado": "2026-03-15T08:09:00",
           "tipoMarcacion": "ENTRADA",
           "dispositivoId": "DEV-001"
@@ -40,7 +40,7 @@ public class RegistroDeMarcacionCreadoDeserializacionTests
         var evento = ServiceBusDeserializador.Deserializar<RegistroDeMarcacionCreado>(body);
 
         evento.Should().NotBeNull();
-        evento.EmpleadoId.Should().Be("EMP-001");
+        evento.CodigoColaborador.Should().Be("EMP-001");
         evento.TimestampNormalizado.Should().Be(new DateTime(2026, 3, 15, 8, 9, 0));
         evento.TipoMarcacion.Should().Be("ENTRADA");
         evento.DispositivoId.Should().Be("DEV-001");
@@ -52,7 +52,7 @@ public class RegistroDeMarcacionCreadoDeserializacionTests
     {
         var body = BinaryData.FromString("""
             {
-              "empleadoId": "EMP-002",
+              "codigoColaborador": "EMP-002",
               "timestampNormalizado": "2026-03-15T08:09:00"
             }
             """);
@@ -60,7 +60,7 @@ public class RegistroDeMarcacionCreadoDeserializacionTests
         var evento = ServiceBusDeserializador.Deserializar<RegistroDeMarcacionCreado>(body);
 
         evento.Should().NotBeNull();
-        evento.EmpleadoId.Should().Be("EMP-002");
+        evento.CodigoColaborador.Should().Be("EMP-002");
         evento.TimestampNormalizado.Should().Be(new DateTime(2026, 3, 15, 8, 9, 0));
         evento.TipoMarcacion.Should().BeNull();
         evento.DispositivoId.Should().BeNull();

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoRegistroDeMarcacionCreado/RegistroDeMarcacionCreadoEventHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoRegistroDeMarcacionCreado/RegistroDeMarcacionCreadoEventHandlerTests.cs
@@ -15,7 +15,7 @@ public class RegistroDeMarcacionCreadoEventHandlerTests
     : PrivateEventHandlerAsyncTest<RegistroDeMarcacionCreado>
 {
     // Datos de prueba fijos
-    private const string EmpleadoId = "EMP-001";
+    private const string CodigoColaborador = "EMP-001";
 
     // CA-1: hora fuera de ventana nocturna (>= 04:00) - solo dia calendario
     private static readonly DateTime TimestampFueraDeVentana = new DateTime(2026, 3, 15, 8, 15, 0);
@@ -24,8 +24,8 @@ public class RegistroDeMarcacionCreadoEventHandlerTests
     private static readonly DateTime TimestampDentroDeVentana = new DateTime(2026, 3, 15, 2, 30, 0);
 
     // CA-7, CA-8: stream IDs computados desde TimestampNormalizado
-    private static readonly string StreamIdDia15 = $"{EmpleadoId}:2026-03-15";
-    private static readonly string StreamIdDia14 = $"{EmpleadoId}:2026-03-14";
+    private static readonly string StreamIdDia15 = $"{CodigoColaborador}:2026-03-15";
+    private static readonly string StreamIdDia14 = $"{CodigoColaborador}:2026-03-14";
 
     protected override IPrivateEventHandlerAsync<RegistroDeMarcacionCreado> Handler =>
         new RegistroDeMarcacionCreadoEventHandler(EventStore, PublicEventSender);
@@ -35,7 +35,7 @@ public class RegistroDeMarcacionCreadoEventHandlerTests
         DateTime timestampNormalizado,
         string? tipoMarcacion = "ENTRADA",
         string? dispositivoId = "DEV-001") =>
-        new(EmpleadoId, timestampNormalizado, tipoMarcacion, dispositivoId);
+        new(CodigoColaborador, timestampNormalizado, tipoMarcacion, dispositivoId);
 
     // Factory para MarcacionAdicionada (evento emitido al stream del ControlDiario)
     private static MarcacionAdicionada CrearMarcacionAdicionada(
@@ -43,12 +43,12 @@ public class RegistroDeMarcacionCreadoEventHandlerTests
         DateTime timestampNormalizado,
         string? tipoMarcacion = "ENTRADA",
         string? dispositivoId = "DEV-001") =>
-        new(streamId, EmpleadoId, timestampNormalizado, tipoMarcacion, dispositivoId);
+        new(streamId, CodigoColaborador, timestampNormalizado, tipoMarcacion, dispositivoId);
 
     // CA-1: hora fuera de ventana nocturna (08:15) -> un solo ControlDiario para dia calendario
     // CA-5: si no existe ControlDiario, se crea con Iniciar(MarcacionAdicionada)
-    // CA-6: ControlDiario creado solo por marcacion tiene InformacionEmpleado y DetalleTurno nulos
-    // CA-7: stream ID es "{EmpleadoId}:{Fecha:yyyy-MM-dd}"
+    // CA-6: ControlDiario creado solo por marcacion tiene InformacionColaborador y DetalleTurno nulos
+    // CA-7: stream ID es "{CodigoColaborador}:{Fecha:yyyy-MM-dd}"
     // CA-8: la fecha se extrae del TimestampNormalizado del evento
     [Fact]
     public async Task RegistroDeMarcacionCreado_CreaControlDiarioConMarcacion_CuandoNoExisteYHoraFueraDeVentanaNocturna()
@@ -58,7 +58,7 @@ public class RegistroDeMarcacionCreadoEventHandlerTests
 
         Then(StreamIdDia15, CrearMarcacionAdicionada(StreamIdDia15, TimestampFueraDeVentana));
         And<ControlDiarioAggregateRoot, ColaboradorProgramado?>(
-            StreamIdDia15, c => c.InformacionEmpleado, null);
+            StreamIdDia15, c => c.InformacionColaborador, null);
         And<ControlDiarioAggregateRoot, TurnoDiario?>(
             StreamIdDia15, c => c.DetalleTurno, null);
         And<ControlDiarioAggregateRoot, int>(

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/DepurarAlAsignarTurnoTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/DepurarAlAsignarTurnoTests.cs
@@ -18,25 +18,25 @@ namespace Bitakora.ControlAsistencia.ControlHoras.Tests.AsignarTurnoCuandoProgra
 public class DepurarAlAsignarTurnoTests
     : PrivateEventHandlerAsyncTest<ProgramacionTurnoDiarioSolicitada>
 {
-    // Datos de prueba fijos - el stream ID es determinista a partir de EmpleadoId+Fecha
+    // Datos de prueba fijos - el stream ID es determinista a partir de CodigoColaborador+Fecha
     private static readonly Guid SolicitudId =
         Guid.Parse("019600c0-0000-7000-8000-000000000002");
 
-    // Issue #322: Empleado (ControlHoras.DomainEvents) -- el tipo que persiste TurnoDiarioAsignado.
-    private static readonly ColaboradorProgramado Empleado = new(
+    // Issue #322: Colaborador (ControlHoras.DomainEvents) -- el tipo que persiste TurnoDiarioAsignado.
+    private static readonly ColaboradorProgramado Colaborador = new(
         "EMP-001", "CC", "1234567890", "Luis Augusto", "Barreto");
 
-    // InformacionEmpleado (PublicEvents) -- lo que espera DiaCalculado, evento publico sin cambios.
-    private static readonly InformacionColaborador EmpleadoPublico = new(
+    // InformacionColaborador (PublicEvents) -- lo que espera DiaCalculado, evento publico sin cambios.
+    private static readonly InformacionColaborador ColaboradorPublico = new(
         "EMP-001", "CC", "1234567890", "Luis Augusto", "Barreto");
 
-    // Mismo empleado, en la forma con que llega dentro del evento privado; el handler lo mapea
-    // a Empleado para TurnoDiarioAsignado (CA-ADR-0029 decision #5).
-    private static readonly DetalleColaborador EmpleadoDetalle = new(
+    // Mismo colaborador, en la forma con que llega dentro del evento privado; el handler lo mapea
+    // a Colaborador para TurnoDiarioAsignado (CA-ADR-0029 decision #5).
+    private static readonly DetalleColaborador ColaboradorDetalle = new(
         "EMP-001", "CC", "1234567890", "Luis Augusto", "Barreto");
 
     private static readonly DateOnly Fecha = new(2026, 3, 15);
-    private static readonly string StreamId = $"{Empleado.EmpleadoId}:{Fecha:yyyy-MM-dd}";
+    private static readonly string StreamId = $"{Colaborador.CodigoColaborador}:{Fecha:yyyy-MM-dd}";
 
     // CA-4: franja unica 06:00-14:00 para el turno asignado -- FranjaProgramada (ControlHoras.DomainEvents)
     // es lo que el ControlDiario persiste; DetalleFranjaOrdinaria (PrivateEvents) es lo que trae el
@@ -55,13 +55,13 @@ public class DepurarAlAsignarTurnoTests
         new ProgramacionTurnoDiarioSolicitadaEventHandler(EventStore, PublicEventSender);
 
     private static ProgramacionTurnoDiarioSolicitada CrearEvento(DetalleTurno detalleTurno) =>
-        new(SolicitudId, EmpleadoDetalle, Fecha, detalleTurno);
+        new(SolicitudId, ColaboradorDetalle, Fecha, detalleTurno);
 
     private static TurnoDiarioAsignado CrearTurnoDiarioAsignado(TurnoDiario turnoDiario) =>
-        new(StreamId, Empleado, Fecha, turnoDiario, SolicitudId);
+        new(StreamId, Colaborador, Fecha, turnoDiario, SolicitudId);
 
     private static MarcacionAdicionada CrearMarcacionAdicionada(DateTime timestamp) =>
-        new(StreamId, Empleado.EmpleadoId, timestamp, "ENTRADA", "DEV-001");
+        new(StreamId, Colaborador.CodigoColaborador, timestamp, "ENTRADA", "DEV-001");
 
     // Issue #184: oraculo independiente de una linea de trazabilidad (memoria de calculo). Se arma a
     // mano desde IntervaloTemporal.ToString() (primitiva ya probada) y la etiqueta traducida del recurso
@@ -75,7 +75,7 @@ public class DepurarAlAsignarTurnoTests
     //        el Apply(TurnoDiarioAsignado) dispara Depurar() y ControlesDeFranja
     //        queda con ControlFranja(Franja06_14, Entrada=07:00, Salida=15:00).
     //        Verifica el caso "marcaciones llegaron antes que el turno".
-    // CA-1 (HU-131): el handler publica DiaCalculado con InformacionEmpleado, Fecha
+    // CA-1 (HU-131): el handler publica DiaCalculado con InformacionColaborador, Fecha
     //        y ControlesDeFranja actualizados (Entrada y Salida presentes, EsAnomala=false).
     [Fact]
     public async Task ProgramacionTurnoDiarioSolicitada_CalculaControlFranja_CuandoMarcacionesLlegaronAntesQueTurno()
@@ -106,7 +106,7 @@ public class DepurarAlAsignarTurnoTests
         // unico concepto del dia (ordinaria 07:00-14:00, DominicalFestivaDiurna) genera una sola linea,
         // construida con LineaConcepto desde el intervalo 07:00-14:00 y la etiqueta traducida del recurso.
         ThenIsPublishedPublicly(new DiaCalculado(
-            EmpleadoPublico,
+            ColaboradorPublico,
             Fecha,
             new HorasDiscriminadas(
                 new Dictionary<string, int> { ["DominicalFestivaDiurna"] = 420 },
@@ -135,7 +135,7 @@ public class DepurarAlAsignarTurnoTests
         // Issue #183 CA-6: la franja anomala no aporta minutos calculables y no hay retardo, asi que
         // MinutosPorConcepto viaja vacio. El contrato plano no lleva senal de anomalia (riesgo aceptado).
         ThenIsPublishedPublicly(new DiaCalculado(
-            EmpleadoPublico,
+            ColaboradorPublico,
             Fecha,
             new HorasDiscriminadas(new Dictionary<string, int>(), [])));
     }
@@ -159,7 +159,7 @@ public class DepurarAlAsignarTurnoTests
         // HU-131 CA-2: DiaCalculado se publica aunque el turno no tenga franjas.
         // Issue #183 CA-6: sin franjas que consolidar ni retardo, MinutosPorConcepto viaja vacio.
         ThenIsPublishedPublicly(new DiaCalculado(
-            EmpleadoPublico,
+            ColaboradorPublico,
             Fecha,
             new HorasDiscriminadas(new Dictionary<string, int>(), [])));
     }

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/DesgloseHorasTrasAsignarTurnoTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/DesgloseHorasTrasAsignarTurnoTests.cs
@@ -21,21 +21,21 @@ namespace Bitakora.ControlAsistencia.ControlHoras.Tests.AsignarTurnoCuandoProgra
 public class DesgloseHorasTrasAsignarTurnoTests
     : PrivateEventHandlerAsyncTest<ProgramacionTurnoDiarioSolicitada>
 {
-    // Datos de prueba fijos - el stream ID es determinista a partir de EmpleadoId+Fecha
+    // Datos de prueba fijos - el stream ID es determinista a partir de CodigoColaborador+Fecha
     private static readonly Guid SolicitudId =
         Guid.Parse("019600c0-0000-7000-8000-000000000004");
 
-    // Issue #322: Empleado (ControlHoras.DomainEvents) -- el tipo que persiste TurnoDiarioAsignado.
-    private static readonly ColaboradorProgramado Empleado = new(
+    // Issue #322: Colaborador (ControlHoras.DomainEvents) -- el tipo que persiste TurnoDiarioAsignado.
+    private static readonly ColaboradorProgramado Colaborador = new(
         "EMP-001", "CC", "1234567890", "Luis Augusto", "Barreto");
 
-    // Mismo empleado, en la forma con que llega dentro del evento privado; el handler lo mapea
-    // a Empleado para TurnoDiarioAsignado (CA-ADR-0029 decision #5).
-    private static readonly DetalleColaborador EmpleadoDetalle = new(
+    // Mismo colaborador, en la forma con que llega dentro del evento privado; el handler lo mapea
+    // a Colaborador para TurnoDiarioAsignado (CA-ADR-0029 decision #5).
+    private static readonly DetalleColaborador ColaboradorDetalle = new(
         "EMP-001", "CC", "1234567890", "Luis Augusto", "Barreto");
 
     private static readonly DateOnly Fecha = new(2026, 3, 15);
-    private static readonly string StreamId = $"{Empleado.EmpleadoId}:{Fecha:yyyy-MM-dd}";
+    private static readonly string StreamId = $"{Colaborador.CodigoColaborador}:{Fecha:yyyy-MM-dd}";
 
     // CA-3: franja unica 06:00-14:00 para el turno asignado -- FranjaProgramada (ControlHoras.DomainEvents)
     // es lo que el ControlDiario persiste; DetalleFranjaOrdinaria (PrivateEvents) es lo que trae el
@@ -63,13 +63,13 @@ public class DesgloseHorasTrasAsignarTurnoTests
         new ProgramacionTurnoDiarioSolicitadaEventHandler(EventStore, PublicEventSender);
 
     private static ProgramacionTurnoDiarioSolicitada CrearEvento(DetalleTurno detalleTurno) =>
-        new(SolicitudId, EmpleadoDetalle, Fecha, detalleTurno);
+        new(SolicitudId, ColaboradorDetalle, Fecha, detalleTurno);
 
     private static TurnoDiarioAsignado CrearTurnoDiarioAsignado(TurnoDiario turnoDiario) =>
-        new(StreamId, Empleado, Fecha, turnoDiario, SolicitudId);
+        new(StreamId, Colaborador, Fecha, turnoDiario, SolicitudId);
 
     private static MarcacionAdicionada CrearMarcacionAdicionada(DateTime timestamp) =>
-        new(StreamId, Empleado.EmpleadoId, timestamp, "ENTRADA", "DEV-001");
+        new(StreamId, Colaborador.CodigoColaborador, timestamp, "ENTRADA", "DEV-001");
 
     // CA-3: con 2 MarcacionAdicionada previas (07:00, 15:00) sin turno, al procesar
     //       ProgramacionTurnoDiarioSolicitada con franja 06:00-14:00 el Apply(TurnoDiarioAsignado)

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/ColaboradorProgramadoIgualdadTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/ColaboradorProgramadoIgualdadTests.cs
@@ -1,5 +1,5 @@
-// Issue #322: paridad de campos e igualdad de Empleado (ControlHoras.DomainEvents) con
-// InformacionEmpleado (PublicEvents.Colaboradores) y DetalleColaborador (PrivateEvents.Programacion)
+// Issue #322: paridad de campos e igualdad de Colaborador (ControlHoras.DomainEvents) con
+// InformacionColaborador (PublicEvents.Colaboradores) y DetalleColaborador (PrivateEvents.Programacion)
 // -- payload por rol, CA-ADR-0029 decision #5.
 // CA-1: todos los campos son string, asi que la igualdad por valor del record por defecto ya es
 // correcta y no lleva Equals/GetHashCode custom. Este test congela ese contrato: el dia que alguien
@@ -21,7 +21,7 @@ public class ColaboradorProgramadoIgualdadTests : IgualdadTestBase<ColaboradorPr
 
     protected override IEnumerable<(string, ColaboradorProgramado)> CrearInstanciasDiferentes()
     {
-        yield return ("EmpleadoId",
+        yield return ("CodigoColaborador",
             new ColaboradorProgramado("EMP-002", "CC", "1234567890", "Luis Augusto", "Barreto"));
         yield return ("TipoIdentificacion",
             new ColaboradorProgramado("EMP-001", "CE", "1234567890", "Luis Augusto", "Barreto"));

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/ProgramacionTurnoDiarioSolicitadaPortabilidadTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/ProgramacionTurnoDiarioSolicitadaPortabilidadTests.cs
@@ -20,8 +20,8 @@ public class ProgramacionTurnoDiarioSolicitadaPortabilidadTests
     private static readonly Guid SolicitudId =
         Guid.Parse("019600b0-0000-7000-8000-000000000009");
 
-    // Issue #318 CA-2: Empleado ahora tipa con DetalleColaborador (payload propio de PrivateEvents).
-    private static readonly DetalleColaborador Empleado = new(
+    // Issue #318 CA-2: Colaborador ahora tipa con DetalleColaborador (payload propio de PrivateEvents).
+    private static readonly DetalleColaborador Colaborador = new(
         "EMP-001", "CC", "1234567890", "Luis Augusto", "Barreto");
 
     private static readonly DateOnly Fecha = new(2026, 3, 15);
@@ -45,7 +45,7 @@ public class ProgramacionTurnoDiarioSolicitadaPortabilidadTests
     public void RoundTrip_PreservaDescripcion_ConSerializadorPorDefectoDelBus()
     {
         var detalleTurno = CrearDetalleTurno();
-        var evento = new ProgramacionTurnoDiarioSolicitada(SolicitudId, Empleado, Fecha, detalleTurno);
+        var evento = new ProgramacionTurnoDiarioSolicitada(SolicitudId, Colaborador, Fecha, detalleTurno);
 
         // El productor publica con sus propias opciones (sin resolver custom, DTO plano)...
         var json = JsonSerializer.Serialize(evento, CrearOpcionesProductor());
@@ -70,7 +70,7 @@ public class ProgramacionTurnoDiarioSolicitadaPortabilidadTests
     {
         var detalleTurno = CrearDetalleTurno();
         var sede = new DetalleSede("SEDE-01", "Sede Principal");
-        var evento = new ProgramacionTurnoDiarioSolicitada(SolicitudId, Empleado, Fecha, detalleTurno, sede);
+        var evento = new ProgramacionTurnoDiarioSolicitada(SolicitudId, Colaborador, Fecha, detalleTurno, sede);
 
         var json = JsonSerializer.Serialize(evento, CrearOpcionesProductor());
 
@@ -104,7 +104,7 @@ public class ProgramacionTurnoDiarioSolicitadaPortabilidadTests
     private static string JsonSinLaClaveSede()
     {
         var conSede = new ProgramacionTurnoDiarioSolicitada(
-            SolicitudId, Empleado, Fecha, CrearDetalleTurno(), new DetalleSede("SEDE-01", "Sede Principal"));
+            SolicitudId, Colaborador, Fecha, CrearDetalleTurno(), new DetalleSede("SEDE-01", "Sede Principal"));
 
         var nodo = JsonNode.Parse(JsonSerializer.Serialize(conSede, CrearOpcionesProductor()))!;
         nodo.AsObject().Remove("sede").Should().BeTrue(
@@ -125,7 +125,7 @@ public class ProgramacionTurnoDiarioSolicitadaPortabilidadTests
         var franja = new DetalleFranjaOrdinaria(
             new TimeOnly(8, 0), new TimeOnly(16, 0), 0, [], [], "(08:00-16:00)[sede:Suba]", sedeFranja);
         var detalleTurno = new DetalleTurno("Turno Manana", [franja], "Turno Manana (08:00-16:00)[sede:Suba]");
-        var evento = new ProgramacionTurnoDiarioSolicitada(SolicitudId, Empleado, Fecha, detalleTurno);
+        var evento = new ProgramacionTurnoDiarioSolicitada(SolicitudId, Colaborador, Fecha, detalleTurno);
 
         var json = JsonSerializer.Serialize(evento, CrearOpcionesProductor());
 
@@ -159,7 +159,7 @@ public class ProgramacionTurnoDiarioSolicitadaPortabilidadTests
             new TimeOnly(8, 0), new TimeOnly(16, 0), 0, [], [], "(08:00-16:00)[sede:Suba]",
             new DetalleSede("SEDE-SUBA", "Suba"));
         var detalleTurno = new DetalleTurno("Turno Manana", [franjaConSede], "Turno Manana (08:00-16:00)[sede:Suba]");
-        var conSede = new ProgramacionTurnoDiarioSolicitada(SolicitudId, Empleado, Fecha, detalleTurno);
+        var conSede = new ProgramacionTurnoDiarioSolicitada(SolicitudId, Colaborador, Fecha, detalleTurno);
 
         var nodo = JsonNode.Parse(JsonSerializer.Serialize(conSede, CrearOpcionesProductor()))!;
         var franjaNodo = nodo["detalleTurno"]!["franjasOrdinarias"]![0]!.AsObject();
@@ -179,8 +179,8 @@ public class ProgramacionTurnoDiarioSolicitadaPortabilidadTests
         const string jsonPrevioAlCampo = """
             {
               "solicitudId": "019600b0-0000-7000-8000-000000000009",
-              "informacionEmpleado": {
-                "empleadoId": "EMP-001", "tipoDocumento": "CC", "numeroDocumento": "1234567890",
+              "informacionColaborador": {
+                "codigoColaborador": "EMP-001", "tipoDocumento": "CC", "numeroDocumento": "1234567890",
                 "nombres": "Luis Augusto", "apellidos": "Barreto"
               },
               "fecha": "2026-03-15",

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/SedeProgramadaIgualdadTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/SedeProgramadaIgualdadTests.cs
@@ -1,7 +1,7 @@
 // Issue #336: Tests de contrato IEquatable para SedeProgramada (record propio de
 // ControlHoras.DomainEvents). Todos los campos son string: la igualdad por valor del record por
 // defecto ya es correcta, sin Equals/GetHashCode custom -- mismo criterio que SedeProgramada
-// (Programacion.DomainEvents, issue #331) y Empleado (issue #319).
+// (Programacion.DomainEvents, issue #331) y Colaborador (issue #319).
 
 using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 using Bitakora.ControlAsistencia.ControlHoras.Tests.ValueObjects;

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/TurnoDiarioAsignadoSerializacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/TurnoDiarioAsignadoSerializacionTests.cs
@@ -12,16 +12,20 @@ namespace Bitakora.ControlAsistencia.ControlHoras.Tests.AsignarTurnoCuandoProgra
 /// y el evento tiene constructor privado y propiedades con private set.
 /// Ver ADR-0013 y feedback de memoria: ConfigurarSerializacion es obligatorio.
 ///
-/// Issue #322: InformacionEmpleado y DetalleTurno cambian de tipo (Empleado/TurnoDiario, propios
-/// de ControlHoras.DomainEvents) pero NO de nombre de propiedad -- son las claves JSON que ya
-/// estan persistidas en mt_events.
+/// Issue #322: InformacionEmpleado y DetalleTurno cambiaron de TIPO (ColaboradorProgramado/
+/// TurnoDiario, propios de ControlHoras.DomainEvents) sin cambiar el nombre de propiedad.
+///
+/// Issue #401: la propiedad paso a InformacionColaborador y su campo anidado a CodigoColaborador --
+/// aqui SI cambian las claves JSON de mt_events. El JSON literal de estos tests se reescribio a las
+/// claves nuevas y por eso ya no acredita compatibilidad con los streams viejos: esos se purgan en
+/// el mismo despliegue (MEF-ADR-0036 seccion 5). Lo que fija desde ahora es la forma canonica.
 /// </summary>
 public class TurnoDiarioAsignadoSerializacionTests
 {
     private static readonly Guid SolicitudId =
         Guid.Parse("019600b0-0000-7000-8000-000000000001");
 
-    private static readonly ColaboradorProgramado EmpleadoDePrueba = new(
+    private static readonly ColaboradorProgramado ColaboradorDePrueba = new(
         "EMP-001", "CC", "1234567890", "Luis Augusto", "Barreto");
 
     private static readonly DateOnly Fecha = new DateOnly(2026, 3, 15);
@@ -33,14 +37,14 @@ public class TurnoDiarioAsignadoSerializacionTests
         [new FranjaProgramada(new TimeOnly(8, 0), new TimeOnly(16, 0), 0, [], [], "(08:00-16:00)")],
         "Turno Manana (08:00-16:00)");
 
-    private static readonly string StreamId = $"{EmpleadoDePrueba.EmpleadoId}:{Fecha:yyyy-MM-dd}";
+    private static readonly string StreamId = $"{ColaboradorDePrueba.CodigoColaborador}:{Fecha:yyyy-MM-dd}";
 
     // Regla 16: todo evento persistido en Marten debe tener test de serializacion roundtrip
     // Verifica con datos reales y completos (no listas vacias para VOs anidados)
     [Fact]
     public void Deserializar_ReconstruyeEvento_ConTodosLosCampos()
     {
-        var evento = new TurnoDiarioAsignado(StreamId, EmpleadoDePrueba, Fecha, TurnoDiarioDePrueba, SolicitudId);
+        var evento = new TurnoDiarioAsignado(StreamId, ColaboradorDePrueba, Fecha, TurnoDiarioDePrueba, SolicitudId);
         var opciones = ConfiguracionSerializacionControlHoras.CrearOpcionesMarten();
 
         var json = JsonSerializer.Serialize(evento, opciones);
@@ -50,8 +54,8 @@ public class TurnoDiarioAsignadoSerializacionTests
         deserializado!.Id.Should().Be(StreamId);
         deserializado.SolicitudId.Should().Be(SolicitudId);
         deserializado.Fecha.Should().Be(Fecha);
-        deserializado.InformacionEmpleado.EmpleadoId.Should().Be(EmpleadoDePrueba.EmpleadoId);
-        deserializado.InformacionEmpleado.Nombres.Should().Be(EmpleadoDePrueba.Nombres);
+        deserializado.InformacionColaborador.CodigoColaborador.Should().Be(ColaboradorDePrueba.CodigoColaborador);
+        deserializado.InformacionColaborador.Nombres.Should().Be(ColaboradorDePrueba.Nombres);
         deserializado.DetalleTurno.Nombre.Should().Be(TurnoDiarioDePrueba.Nombre);
         deserializado.DetalleTurno.FranjasOrdinarias.Should().HaveCount(1);
         deserializado.DetalleTurno.FranjasOrdinarias[0].HoraInicio
@@ -64,12 +68,13 @@ public class TurnoDiarioAsignadoSerializacionTests
             .Should().Be(TurnoDiarioDePrueba.FranjasOrdinarias[0].Descripcion);
     }
 
-    // Issue #322 CA-2 / Nota de seguridad de datos (critica): JSON con la FORMA EXACTA que Marten
-    // ya escribio en mt_events ANTES de este issue (PascalCase, PropertyNamingPolicy=null). Los
-    // nombres de propiedad (InformacionEmpleado, Fecha, DetalleTurno, SolicitudId) no cambian --
-    // solo los tipos anidados (Empleado/TurnoDiario en vez de InformacionEmpleado/DetalleTurno de
-    // PublicEvents/PrivateEvents). Este round-trip demuestra que un evento ya persistido se relee
-    // identico, sin ninguna migracion de datos (MEF-ADR-0036: el alias del evento no se toca).
+    // Nota de seguridad de datos (critica): JSON con la FORMA EXACTA que Marten escribe en
+    // mt_events desde #401 (PascalCase, PropertyNamingPolicy=null) -- claves InformacionColaborador
+    // (con CodigoColaborador anidado), Fecha, DetalleTurno y SolicitudId. En #322 este mismo test
+    // acreditaba que un cambio de TIPO no alteraba la forma del wire; en #401 las claves si cambian,
+    // asi que el literal se reescribio y lo que custodia ahora es la forma canonica hacia adelante.
+    // La compatibilidad hacia atras se resuelve con la purga del mismo despliegue, no con mapeo
+    // (MEF-ADR-0036 seccion 5). El alias del evento sigue intacto: la CLASE no se renombra.
     //
     // La comparacion es por igualdad estructural completa (.Should().Be() sobre el objeto
     // compuesto, no solo sus campos escalares): asi el test tambien exige que TurnoDiario/
@@ -81,8 +86,8 @@ public class TurnoDiarioAsignadoSerializacionTests
         const string jsonPersistidoHoy = """
             {
               "Id": "EMP-001:2026-03-15",
-              "InformacionEmpleado": {
-                "EmpleadoId": "EMP-001",
+              "InformacionColaborador": {
+                "CodigoColaborador": "EMP-001",
                 "TipoIdentificacion": "CC",
                 "NumeroIdentificacion": "1234567890",
                 "Nombres": "Luis Augusto",
@@ -110,7 +115,7 @@ public class TurnoDiarioAsignadoSerializacionTests
 
         var deserializado = JsonSerializer.Deserialize<TurnoDiarioAsignado>(jsonPersistidoHoy, opciones);
 
-        var empleadoEsperado = new ColaboradorProgramado("EMP-001", "CC", "1234567890", "Luis Augusto", "Barreto");
+        var colaboradorEsperado = new ColaboradorProgramado("EMP-001", "CC", "1234567890", "Luis Augusto", "Barreto");
         var turnoEsperado = new TurnoDiario(
             "Turno Manana",
             [new FranjaProgramada(new TimeOnly(8, 0), new TimeOnly(16, 0), 0, [], [], "(08:00-16:00)")],
@@ -120,7 +125,7 @@ public class TurnoDiarioAsignadoSerializacionTests
         deserializado!.Id.Should().Be("EMP-001:2026-03-15");
         deserializado.SolicitudId.Should().Be(Guid.Parse("019600b0-0000-7000-8000-000000000001"));
         deserializado.Fecha.Should().Be(new DateOnly(2026, 3, 15));
-        deserializado.InformacionEmpleado.Should().Be(empleadoEsperado);
+        deserializado.InformacionColaborador.Should().Be(colaboradorEsperado);
         deserializado.DetalleTurno.Should().Be(turnoEsperado);
     }
 
@@ -135,8 +140,8 @@ public class TurnoDiarioAsignadoSerializacionTests
         const string jsonPersistidoConSubFranjas = """
             {
               "Id": "EMP-001:2026-03-15",
-              "InformacionEmpleado": {
-                "EmpleadoId": "EMP-001",
+              "InformacionColaborador": {
+                "CodigoColaborador": "EMP-001",
                 "TipoIdentificacion": "CC",
                 "NumeroIdentificacion": "1234567890",
                 "Nombres": "Luis Augusto",
@@ -209,8 +214,8 @@ public class TurnoDiarioAsignadoSerializacionTests
         const string jsonPersistidoAntesDeDescripcion = """
             {
               "Id": "EMP-001:2026-03-15",
-              "InformacionEmpleado": {
-                "EmpleadoId": "EMP-001",
+              "InformacionColaborador": {
+                "CodigoColaborador": "EMP-001",
                 "TipoIdentificacion": "CC",
                 "NumeroIdentificacion": "1234567890",
                 "Nombres": "Luis Augusto",
@@ -274,8 +279,8 @@ public class TurnoDiarioAsignadoSerializacionTests
         const string jsonPersistidoSinSede = """
             {
               "Id": "EMP-001:2026-03-15",
-              "InformacionEmpleado": {
-                "EmpleadoId": "EMP-001",
+              "InformacionColaborador": {
+                "CodigoColaborador": "EMP-001",
                 "TipoIdentificacion": "CC",
                 "NumeroIdentificacion": "1234567890",
                 "Nombres": "Luis Augusto",
@@ -324,7 +329,7 @@ public class TurnoDiarioAsignadoSerializacionTests
                     new TimeOnly(14, 0), new TimeOnly(18, 0), 0, [], [], "(14:00-18:00)", sedeChapinero)
             ],
             "Turno Partido");
-        var evento = new TurnoDiarioAsignado(StreamId, EmpleadoDePrueba, Fecha, turnoConSedes, SolicitudId);
+        var evento = new TurnoDiarioAsignado(StreamId, ColaboradorDePrueba, Fecha, turnoConSedes, SolicitudId);
         var opciones = ConfiguracionSerializacionControlHoras.CrearOpcionesMarten();
 
         var json = JsonSerializer.Serialize(evento, opciones);

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/FunctionEndpointTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/FunctionEndpointTests.cs
@@ -22,8 +22,8 @@ public class FunctionEndpointTests
     private const string JsonFormatoWolverine = """
         {
           "solicitudId": "019600b0-0000-7000-8000-000000000001",
-          "empleado": {
-            "empleadoId": "EMP-001",
+          "colaborador": {
+            "codigoColaborador": "EMP-001",
             "tipoIdentificacion": "CC",
             "numeroIdentificacion": "1234567890",
             "nombres": "Luis Augusto",

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/ProgramacionTurnoDiarioSolicitadaDeserializacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/ProgramacionTurnoDiarioSolicitadaDeserializacionTests.cs
@@ -11,7 +11,7 @@ namespace Bitakora.ControlAsistencia.ControlHoras.Tests.AsignarTurnoCuandoProgra
 /// Verifica que ProgramacionTurnoDiarioSolicitada se deserializa correctamente
 /// desde el formato que produce Wolverine al publicar al Service Bus (camelCase JSON).
 /// Sin PropertyNameCaseInsensitive=true, todas las propiedades quedan null
-/// provocando NullReferenceException en el handler (linea: command.Empleado.EmpleadoId).
+/// provocando NullReferenceException en el handler (linea: command.Colaborador.CodigoColaborador).
 /// </summary>
 public class ProgramacionTurnoDiarioSolicitadaDeserializacionTests
 {
@@ -23,8 +23,8 @@ public class ProgramacionTurnoDiarioSolicitadaDeserializacionTests
     private const string JsonFormatoWolverine = """
         {
           "solicitudId": "019600b0-0000-7000-8000-000000000001",
-          "empleado": {
-            "empleadoId": "EMP-001",
+          "colaborador": {
+            "codigoColaborador": "EMP-001",
             "tipoIdentificacion": "CC",
             "numeroIdentificacion": "1234567890",
             "nombres": "Luis Augusto",
@@ -57,12 +57,12 @@ public class ProgramacionTurnoDiarioSolicitadaDeserializacionTests
 
         evento.Should().NotBeNull();
         evento.SolicitudId.Should().Be(SolicitudId);
-        evento.Empleado.Should().NotBeNull();
-        evento.Empleado.EmpleadoId.Should().Be("EMP-001");
-        evento.Empleado.TipoIdentificacion.Should().Be("CC");
-        evento.Empleado.NumeroIdentificacion.Should().Be("1234567890");
-        evento.Empleado.Nombres.Should().Be("Luis Augusto");
-        evento.Empleado.Apellidos.Should().Be("Barreto");
+        evento.Colaborador.Should().NotBeNull();
+        evento.Colaborador.CodigoColaborador.Should().Be("EMP-001");
+        evento.Colaborador.TipoIdentificacion.Should().Be("CC");
+        evento.Colaborador.NumeroIdentificacion.Should().Be("1234567890");
+        evento.Colaborador.Nombres.Should().Be("Luis Augusto");
+        evento.Colaborador.Apellidos.Should().Be("Barreto");
         evento.Fecha.Should().Be(new DateOnly(2026, 3, 15));
         evento.DetalleTurno.Should().NotBeNull();
         evento.DetalleTurno.Nombre.Should().Be("Turno Manana");

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/ProgramacionTurnoDiarioSolicitadaEventHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/ProgramacionTurnoDiarioSolicitadaEventHandlerTests.cs
@@ -13,23 +13,23 @@ namespace Bitakora.ControlAsistencia.ControlHoras.Tests.AsignarTurnoCuandoProgra
 public class ProgramacionTurnoDiarioSolicitadaEventHandlerTests
     : PrivateEventHandlerAsyncTest<ProgramacionTurnoDiarioSolicitada>
 {
-    // Datos de prueba fijos - el stream ID es determinista a partir de EmpleadoId+Fecha
+    // Datos de prueba fijos - el stream ID es determinista a partir de CodigoColaborador+Fecha
     private static readonly Guid SolicitudId =
         Guid.Parse("019600b0-0000-7000-8000-000000000001");
 
-    // Issue #322: Empleado (ControlHoras.DomainEvents) -- el tipo que persiste TurnoDiarioAsignado.
-    private static readonly ColaboradorProgramado Empleado = new(
+    // Issue #322: Colaborador (ControlHoras.DomainEvents) -- el tipo que persiste TurnoDiarioAsignado.
+    private static readonly ColaboradorProgramado Colaborador = new(
         "EMP-001", "CC", "1234567890", "Luis Augusto", "Barreto");
 
-    // Mismo empleado, en la forma con que llega dentro del evento privado; el handler lo mapea
-    // a Empleado para TurnoDiarioAsignado (CA-ADR-0029 decision #5).
-    private static readonly DetalleColaborador EmpleadoDetalle = new(
+    // Mismo colaborador, en la forma con que llega dentro del evento privado; el handler lo mapea
+    // a Colaborador para TurnoDiarioAsignado (CA-ADR-0029 decision #5).
+    private static readonly DetalleColaborador ColaboradorDetalle = new(
         "EMP-001", "CC", "1234567890", "Luis Augusto", "Barreto");
 
     private static readonly DateOnly Fecha = new DateOnly(2026, 3, 15);
 
     // CA-7: stream ID determinista que el handler debe computar internamente
-    private static readonly string StreamId = $"{Empleado.EmpleadoId}:{Fecha:yyyy-MM-dd}";
+    private static readonly string StreamId = $"{Colaborador.CodigoColaborador}:{Fecha:yyyy-MM-dd}";
 
     // El evento privado sigue trayendo DetalleTurno (PrivateEvents) sin cambios.
     // Issue #288: Descripcion (dato derivado) es irrelevante para este test -> placeholder "".
@@ -49,36 +49,36 @@ public class ProgramacionTurnoDiarioSolicitadaEventHandlerTests
         new ProgramacionTurnoDiarioSolicitadaEventHandler(EventStore, PublicEventSender);
 
     private static ProgramacionTurnoDiarioSolicitada CrearEvento() =>
-        new(SolicitudId, EmpleadoDetalle, Fecha, DetalleTurnoTest);
+        new(SolicitudId, ColaboradorDetalle, Fecha, DetalleTurnoTest);
 
     private static TurnoDiarioAsignado CrearTurnoDiarioAsignado() =>
-        new(StreamId, Empleado, Fecha, TurnoDiarioTest, SolicitudId);
+        new(StreamId, Colaborador, Fecha, TurnoDiarioTest, SolicitudId);
 
-    // CA-3: NO existe ControlDiario para EmpleadoId+Fecha - el handler inicia el stream
-    // CA-5: el evento incluye InformacionEmpleado, Fecha, DetalleTurno y SolicitudId
-    // CA-6: el aggregate actualiza InformacionEmpleado, Fecha y DetalleTurno
-    // CA-7: el stream ID resultante es "{EmpleadoId}:{Fecha:yyyy-MM-dd}"
+    // CA-3: NO existe ControlDiario para CodigoColaborador+Fecha - el handler inicia el stream
+    // CA-5: el evento incluye InformacionColaborador, Fecha, DetalleTurno y SolicitudId
+    // CA-6: el aggregate actualiza InformacionColaborador, Fecha y DetalleTurno
+    // CA-7: el stream ID resultante es "{CodigoColaborador}:{Fecha:yyyy-MM-dd}"
     [Fact]
     public async Task ProgramacionTurnoDiarioSolicitada_EmiteTurnoDiarioAsignado_CuandoNoExisteControlDiario()
     {
-        // Sin Given - el stream no existe para este EmpleadoId+Fecha
+        // Sin Given - el stream no existe para este CodigoColaborador+Fecha
         await WhenAsync(CrearEvento());
 
         Then(StreamId, CrearTurnoDiarioAsignado());
         And<ControlDiarioAggregateRoot, string>(StreamId, c => c.Id, StreamId);
-        And<ControlDiarioAggregateRoot, ColaboradorProgramado?>(StreamId, c => c.InformacionEmpleado, Empleado);
+        And<ControlDiarioAggregateRoot, ColaboradorProgramado?>(StreamId, c => c.InformacionColaborador, Colaborador);
         And<ControlDiarioAggregateRoot, DateOnly>(StreamId, c => c.Fecha, Fecha);
         And<ControlDiarioAggregateRoot, string?>(StreamId, c => c.DetalleTurno!.Nombre, TurnoDiarioTest.Nombre);
     }
 
-    // CA-4: YA existe ControlDiario para EmpleadoId+Fecha - el handler agrega al stream existente
+    // CA-4: YA existe ControlDiario para CodigoColaborador+Fecha - el handler agrega al stream existente
     // CA-5: el nuevo evento contiene todos los campos actualizados
-    // CA-8: el segundo mensaje opera sobre el mismo stream (mismo EmpleadoId+Fecha = mismo StreamId)
+    // CA-8: el segundo mensaje opera sobre el mismo stream (mismo CodigoColaborador+Fecha = mismo StreamId)
     [Fact]
     public async Task ProgramacionTurnoDiarioSolicitada_EmiteTurnoDiarioAsignado_CuandoYaExisteControlDiario()
     {
         var solicitudAnteriorId = Guid.Parse("019600b0-0000-7000-8000-000000000002");
-        var turnoAnterior = new TurnoDiarioAsignado(StreamId, Empleado, Fecha, TurnoDiarioTest, solicitudAnteriorId);
+        var turnoAnterior = new TurnoDiarioAsignado(StreamId, Colaborador, Fecha, TurnoDiarioTest, solicitudAnteriorId);
 
         // Pre-carga el stream con el mismo StreamId que usara el handler (CA-8)
         Given(StreamId, turnoAnterior);
@@ -110,7 +110,7 @@ public class ProgramacionTurnoDiarioSolicitadaEventHandlerTests
             "Turno Nocturno (22:00-06:00+1)");
 
         await WhenAsync(new ProgramacionTurnoDiarioSolicitada(
-            SolicitudId, EmpleadoDetalle, Fecha, turnoEntrante));
+            SolicitudId, ColaboradorDetalle, Fecha, turnoEntrante));
 
         // Oraculo construido a mano, no derivado del mapeo bajo prueba (MEF-ADR-0002).
         var turnoPersistidoEsperado = new TurnoDiario(
@@ -125,7 +125,7 @@ public class ProgramacionTurnoDiarioSolicitadaEventHandlerTests
             "Turno Nocturno (22:00-06:00+1)");
 
         Then(StreamId, new TurnoDiarioAsignado(
-            StreamId, Empleado, Fecha, turnoPersistidoEsperado, SolicitudId));
+            StreamId, Colaborador, Fecha, turnoPersistidoEsperado, SolicitudId));
         And<ControlDiarioAggregateRoot, TurnoDiario?>(
             StreamId, c => c.DetalleTurno, turnoPersistidoEsperado);
     }
@@ -149,7 +149,7 @@ public class ProgramacionTurnoDiarioSolicitadaEventHandlerTests
             "Turno Partido");
 
         await WhenAsync(new ProgramacionTurnoDiarioSolicitada(
-            SolicitudId, EmpleadoDetalle, Fecha, turnoEntrante));
+            SolicitudId, ColaboradorDetalle, Fecha, turnoEntrante));
 
         // Oraculo construido a mano, no derivado del mapeo bajo prueba (MEF-ADR-0002).
         var sedeSubaEsperada = new SedeProgramada("SEDE-SUBA", "Suba");
@@ -164,7 +164,7 @@ public class ProgramacionTurnoDiarioSolicitadaEventHandlerTests
             "Turno Partido");
 
         Then(StreamId, new TurnoDiarioAsignado(
-            StreamId, Empleado, Fecha, turnoPersistidoEsperado, SolicitudId));
+            StreamId, Colaborador, Fecha, turnoPersistidoEsperado, SolicitudId));
         And<ControlDiarioAggregateRoot, SedeProgramada?>(
             StreamId, c => c.DetalleTurno!.FranjasOrdinarias[0].Sede, sedeSubaEsperada);
         And<ControlDiarioAggregateRoot, SedeProgramada?>(

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/CrearDiaCalculadoConHorasDiscriminadasTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/CrearDiaCalculadoConHorasDiscriminadasTests.cs
@@ -34,19 +34,19 @@ namespace Bitakora.ControlAsistencia.ControlHoras.Tests.Entities;
 
 public class CrearDiaCalculadoConHorasDiscriminadasTests
 {
-    // Datos compartidos - el stream ID es determinista a partir de EmpleadoId+Fecha.
+    // Datos compartidos - el stream ID es determinista a partir de CodigoColaborador+Fecha.
     // private static: las nested classes acceden a los miembros privados de la clase contenedora.
-    // Issue #322: Empleado (ControlHoras.DomainEvents) -- el tipo que persiste TurnoDiarioAsignado.
-    private static readonly ColaboradorProgramado Empleado = new(
+    // Issue #322: Colaborador (ControlHoras.DomainEvents) -- el tipo que persiste TurnoDiarioAsignado.
+    private static readonly ColaboradorProgramado Colaborador = new(
         "EMP-001", "CC", "1234567890", "Luis Augusto", "Barreto");
 
-    // Mismo empleado, en la forma con que llega dentro del evento privado; el handler lo mapea
-    // a Empleado para TurnoDiarioAsignado (CA-ADR-0029 decision #5).
-    private static readonly DetalleColaborador EmpleadoDetalle = new(
+    // Mismo colaborador, en la forma con que llega dentro del evento privado; el handler lo mapea
+    // a Colaborador para TurnoDiarioAsignado (CA-ADR-0029 decision #5).
+    private static readonly DetalleColaborador ColaboradorDetalle = new(
         "EMP-001", "CC", "1234567890", "Luis Augusto", "Barreto");
 
     private static readonly DateOnly Fecha = new(2026, 3, 15);
-    private static readonly string StreamId = $"{Empleado.EmpleadoId}:{Fecha:yyyy-MM-dd}";
+    private static readonly string StreamId = $"{Colaborador.CodigoColaborador}:{Fecha:yyyy-MM-dd}";
     private static readonly Guid SolicitudId = Guid.Parse("019600d0-0000-7000-8000-000000000001");
 
     // Franja unica 06:00-14:00 usada por los escenarios de turno. FranjaProgramada
@@ -63,10 +63,10 @@ public class CrearDiaCalculadoConHorasDiscriminadasTests
     private static readonly DateTime Timestamp15_00 = new(2026, 3, 15, 15, 0, 0);
 
     private static MarcacionAdicionada CrearMarcacionAdicionada(DateTime timestamp) =>
-        new(StreamId, Empleado.EmpleadoId, timestamp, "ENTRADA", "DEV-001");
+        new(StreamId, Colaborador.CodigoColaborador, timestamp, "ENTRADA", "DEV-001");
 
     private static TurnoDiarioAsignado CrearTurnoDiarioAsignado(TurnoDiario turnoDiario) =>
-        new(StreamId, Empleado, Fecha, turnoDiario, SolicitudId);
+        new(StreamId, Colaborador, Fecha, turnoDiario, SolicitudId);
 
     // Oraculo independiente: dia con franja 06:00-14:00 trabajada 07:00-15:00 (domingo 2026-03-15,
     // no anomala). El retardo 60min (06:00-07:00) se compensa con el excedente 60min (14:00-15:00) ->
@@ -83,7 +83,7 @@ public class CrearDiaCalculadoConHorasDiscriminadasTests
                 EventStore, PublicEventSender);
 
         private static ProgramacionTurnoDiarioSolicitada CrearEvento(DetalleTurno detalleTurno) =>
-            new(SolicitudId, EmpleadoDetalle, Fecha, detalleTurno);
+            new(SolicitudId, ColaboradorDetalle, Fecha, detalleTurno);
 
         // CA-4: con turno (franja 06:00-14:00) y marcaciones previas que la completan (07:00, 15:00),
         //       la franja queda NO anomala. CrearDiaCalculado() debe empaquetar el payload plano
@@ -146,7 +146,7 @@ public class CrearDiaCalculadoConHorasDiscriminadasTests
                 EventStore, PublicEventSender);
 
         private static RegistroDeMarcacionCreado CrearRegistroDeMarcacionCreado(DateTime timestamp) =>
-            new(Empleado.EmpleadoId, timestamp, "ENTRADA", "DEV-001");
+            new(Colaborador.CodigoColaborador, timestamp, "ENTRADA", "DEV-001");
 
         // CA-4 (sin turno): la marcacion crea el aggregate sin DetalleTurno -> Depurar() retorna lista
         //       vacia -> no hay ControlesDeFranja que consolidar. CrearDiaCalculado() empaqueta el

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/ComposicionServiciosTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/ComposicionServiciosTests.cs
@@ -254,7 +254,7 @@ public class ComposicionServiciosTests
     // Functions isolated worker).
     //
     // Se prueba solo la RESOLUCION de IDocumentStore/ITenantResolver por constructor -- no el
-    // comportamiento de Run (parseo de empleadoId/fecha con 400 explicito, session.LoadAsync y el
+    // comportamiento de Run (parseo de codigoColaborador/fecha con 400 explicito, session.LoadAsync y el
     // 200/404, CA-4), que es responsabilidad de projection-implementer y del smoke test (CA-8), no
     // de este guardrail de wiring. Por eso este test queda en verde tan pronto exista el
     // FunctionEndpoint stub con el constructor correcto -- no es la guarda que fuerza el rojo de
@@ -328,7 +328,7 @@ public class ComposicionServiciosTests
     // worker, sin levantar el host real (Alt 1 de MEF-ADR-0029).
     //
     // Se prueba solo la RESOLUCION de IDocumentStore/ITenantResolver por constructor -- no el
-    // comportamiento de Run (parseo de desde/hasta/empleadoId, recorte de rango, session.Query y
+    // comportamiento de Run (parseo de desde/hasta/codigoColaborador, recorte de rango, session.Query y
     // mapeo al envelope de respuesta), que es responsabilidad de projection-implementer y del smoke
     // test, no de este guardrail de wiring. Este issue no crea proyeccion nueva ni toca el seam del
     // worker (issue #329, "Necesidad de lectura"): esta es la UNICA capa read-side declarada para

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ListarTurnosVigentes/FunctionEndpointTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ListarTurnosVigentes/FunctionEndpointTests.cs
@@ -85,11 +85,11 @@ public class FunctionEndpointTests
     }
 
     [Fact]
-    public async Task ListarTurnosVigentes_Retorna400_CuandoEmpleadoIdEsValidoPeroElRangoNoLoEs()
+    public async Task ListarTurnosVigentes_Retorna400_CuandoCodigoColaboradorEsValidoPeroElRangoNoLoEs()
     {
-        // CA-2 + CA-4: la presencia del filtro opcional empleadoId no relaja la validacion del
+        // CA-2 + CA-4: la presencia del filtro opcional codigoColaborador no relaja la validacion del
         // rango -- la consulta del Trabajador pasa por el mismo borde que la del Programador.
-        var resultado = await EjecutarEsperandoBadRequest("?desde=2026-05-10&hasta=2026-05-05&empleadoId=EMP-001");
+        var resultado = await EjecutarEsperandoBadRequest("?desde=2026-05-10&hasta=2026-05-05&codigoColaborador=EMP-001");
 
         resultado.Value.Should().BeOfType<string>().Which.Should().Contain("anterior");
     }
@@ -97,13 +97,13 @@ public class FunctionEndpointTests
     [Fact]
     public async Task ListarTurnosVigentes_Retorna400_CuandoSedeIdEsValidoPeroElRangoNoLoEs()
     {
-        // Issue #337 CA-3: el tercer filtro opcional (sedeId, combinable con empleadoId) tampoco
+        // Issue #337 CA-3: el tercer filtro opcional (sedeId, combinable con codigoColaborador) tampoco
         // relaja la validacion del rango -- la consulta del jefe de sede pasa por el mismo borde.
         // Es la unica rama del filtro por sede ejercitable sin Postgres: el predicado
         // Bloques.Any(...) lo resuelve Marten contra la base real y queda cubierto por el smoke test
         // contra dev (MEF-ADR-0013), no por este archivo -- que corre con store nulo a proposito.
         var resultado = await EjecutarEsperandoBadRequest(
-            "?desde=2026-05-10&hasta=2026-05-05&empleadoId=EMP-001&sedeId=SD-SUBA");
+            "?desde=2026-05-10&hasta=2026-05-05&codigoColaborador=EMP-001&sedeId=SD-SUBA");
 
         resultado.Value.Should().BeOfType<string>().Which.Should().Contain("anterior");
     }

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/RegistrarMarcacionFunction/Eventos/MarcacionRegistradaSerializacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/RegistrarMarcacionFunction/Eventos/MarcacionRegistradaSerializacionTests.cs
@@ -17,7 +17,7 @@ namespace Bitakora.ControlAsistencia.ControlHoras.Tests.RegistrarMarcacionFuncti
 /// </summary>
 public class MarcacionRegistradaSerializacionTests
 {
-    private const string EmpleadoId = "EMP-001";
+    private const string CodigoColaborador = "EMP-001";
     private static readonly DateTime TimestampConSegundos = new(2026, 3, 15, 8, 9, 59);
     private static readonly DateTime TimestampNormalizadoEsperado = new(2026, 3, 15, 8, 9, 0);
 
@@ -34,14 +34,14 @@ public class MarcacionRegistradaSerializacionTests
     [Fact]
     public void RoundTrip_ReconstruyeEvento_CuandoDatosCompletos()
     {
-        var evento = MarcacionRegistrada.Crear(EmpleadoId, TimestampConSegundos, "ENTRADA", "DEV-001");
+        var evento = MarcacionRegistrada.Crear(CodigoColaborador, TimestampConSegundos, "ENTRADA", "DEV-001");
         var opciones = CrearOpcionesMarten();
 
         var json = JsonSerializer.Serialize(evento, opciones);
         var deserializado = JsonSerializer.Deserialize<MarcacionRegistrada>(json, opciones);
 
         deserializado.Should().NotBeNull();
-        deserializado!.EmpleadoId.Should().Be(EmpleadoId);
+        deserializado!.CodigoColaborador.Should().Be(CodigoColaborador);
         deserializado.TimestampNormalizado.Should().Be(TimestampNormalizadoEsperado);
         deserializado.TipoMarcacion.Should().Be("ENTRADA");
         deserializado.DispositivoId.Should().Be("DEV-001");
@@ -58,7 +58,7 @@ public class MarcacionRegistradaSerializacionTests
         var deserializado = JsonSerializer.Deserialize<MarcacionRegistrada>(json, opciones);
 
         deserializado.Should().NotBeNull();
-        deserializado!.EmpleadoId.Should().Be("EMP-002");
+        deserializado!.CodigoColaborador.Should().Be("EMP-002");
         deserializado.TimestampNormalizado.Should().Be(TimestampNormalizadoEsperado);
         deserializado.TipoMarcacion.Should().BeNull();
         deserializado.DispositivoId.Should().BeNull();
@@ -72,7 +72,7 @@ public class MarcacionRegistradaSerializacionTests
     public void Deserializar_LanzaNotSupportedException_CuandoElResolverNoRegistraElTipo()
     {
         var evento = MarcacionRegistrada.Crear(
-            EmpleadoId, TimestampNormalizadoEsperado, "ENTRADA", "DEV-001");
+            CodigoColaborador, TimestampNormalizadoEsperado, "ENTRADA", "DEV-001");
         var opcionesSinRegistro = new JsonSerializerOptions
         {
             TypeInfoResolver = new DefaultJsonTypeInfoResolver(),
@@ -95,7 +95,7 @@ public class MarcacionRegistradaSerializacionTests
     public void Deserializar_LanzaNotSupportedException_CuandoUsaElSerializadorDelCanalDeBus()
     {
         var evento = MarcacionRegistrada.Crear(
-            EmpleadoId, TimestampNormalizadoEsperado, "ENTRADA", "DEV-001");
+            CodigoColaborador, TimestampNormalizadoEsperado, "ENTRADA", "DEV-001");
         var opcionesDelBus = new JsonSerializerOptions(JsonSerializerDefaults.Web);
         var json = JsonSerializer.Serialize(evento, opcionesDelBus);
 

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/RegistrarMarcacionFunction/Eventos/MarcacionRegistradaTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/RegistrarMarcacionFunction/Eventos/MarcacionRegistradaTests.cs
@@ -1,5 +1,5 @@
 // Issue #275: Proteger el evento de dominio MarcacionRegistrada con factory y ctor privado.
-// Interfaz publica: Crear(...), EmpleadoId, TimestampNormalizado, TipoMarcacion, DispositivoId.
+// Interfaz publica: Crear(...), CodigoColaborador, TimestampNormalizado, TipoMarcacion, DispositivoId.
 // El evento nunca cruzo el bus como razon para tener ctor publico (#270 ya lo saco del canal);
 // este issue le da, por primera vez, la proteccion que ese rol impedia (ver contexto del issue).
 
@@ -10,7 +10,7 @@ namespace Bitakora.ControlAsistencia.ControlHoras.Tests.RegistrarMarcacionFuncti
 
 public class MarcacionRegistradaTests
 {
-    private const string EmpleadoId = "EMP-001";
+    private const string CodigoColaborador = "EMP-001";
     private static readonly DateTime TimestampConSegundos = new(2026, 3, 15, 8, 9, 59);
     private static readonly DateTime TimestampNormalizadoEsperado = new(2026, 3, 15, 8, 9, 0);
 
@@ -25,9 +25,9 @@ public class MarcacionRegistradaTests
     [Fact]
     public void Crear_RetornaMarcacionRegistrada_CuandoDatosSonValidos()
     {
-        var evento = MarcacionRegistrada.Crear(EmpleadoId, TimestampConSegundos, "ENTRADA", "DEV-001");
+        var evento = MarcacionRegistrada.Crear(CodigoColaborador, TimestampConSegundos, "ENTRADA", "DEV-001");
 
-        evento.EmpleadoId.Should().Be(EmpleadoId);
+        evento.CodigoColaborador.Should().Be(CodigoColaborador);
         evento.TipoMarcacion.Should().Be("ENTRADA");
         evento.DispositivoId.Should().Be("DEV-001");
     }
@@ -37,7 +37,7 @@ public class MarcacionRegistradaTests
     [Fact]
     public void Crear_TruncaSegundosAlMinuto_CuandoTimestampTraeSegundos()
     {
-        var evento = MarcacionRegistrada.Crear(EmpleadoId, TimestampConSegundos, "ENTRADA", "DEV-001");
+        var evento = MarcacionRegistrada.Crear(CodigoColaborador, TimestampConSegundos, "ENTRADA", "DEV-001");
 
         evento.TimestampNormalizado.Should().Be(TimestampNormalizadoEsperado);
     }
@@ -46,7 +46,7 @@ public class MarcacionRegistradaTests
     public void Crear_ConservaTimestamp_CuandoYaVieneSinSegundos()
     {
         var evento = MarcacionRegistrada.Crear(
-            EmpleadoId, TimestampNormalizadoEsperado, "ENTRADA", "DEV-001");
+            CodigoColaborador, TimestampNormalizadoEsperado, "ENTRADA", "DEV-001");
 
         evento.TimestampNormalizado.Should().Be(TimestampNormalizadoEsperado);
     }
@@ -58,7 +58,7 @@ public class MarcacionRegistradaTests
     {
         var conTicks = TimestampConSegundos.AddTicks(1234567);
 
-        var evento = MarcacionRegistrada.Crear(EmpleadoId, conTicks, "ENTRADA", "DEV-001");
+        var evento = MarcacionRegistrada.Crear(CodigoColaborador, conTicks, "ENTRADA", "DEV-001");
 
         evento.TimestampNormalizado.Should().Be(TimestampNormalizadoEsperado);
     }
@@ -70,40 +70,40 @@ public class MarcacionRegistradaTests
     {
         var utcConSegundos = new DateTime(2026, 3, 15, 8, 9, 59, DateTimeKind.Utc);
 
-        var evento = MarcacionRegistrada.Crear(EmpleadoId, utcConSegundos, "ENTRADA", "DEV-001");
+        var evento = MarcacionRegistrada.Crear(CodigoColaborador, utcConSegundos, "ENTRADA", "DEV-001");
 
         evento.TimestampNormalizado.Kind.Should().Be(DateTimeKind.Utc);
         evento.TimestampNormalizado.Should().Be(
             new DateTime(2026, 3, 15, 8, 9, 0, DateTimeKind.Utc));
     }
 
-    // ---------- CA-3: EmpleadoId nulo, vacio o solo espacios es rechazado ----------
+    // ---------- CA-3: CodigoColaborador nulo, vacio o solo espacios es rechazado ----------
 
     [Fact]
-    public void Crear_LanzaArgumentException_CuandoEmpleadoIdEsNulo()
+    public void Crear_LanzaArgumentException_CuandoCodigoColaboradorEsNulo()
     {
         var act = () => MarcacionRegistrada.Crear(null!, TimestampConSegundos, "ENTRADA", "DEV-001");
 
         act.Should().ThrowExactly<ArgumentException>()
-            .WithMessage($"*{MarcacionRegistrada.Mensajes.EmpleadoIdVacio}*");
+            .WithMessage($"*{MarcacionRegistrada.Mensajes.CodigoColaboradorVacio}*");
     }
 
     [Fact]
-    public void Crear_LanzaArgumentException_CuandoEmpleadoIdEsVacio()
+    public void Crear_LanzaArgumentException_CuandoCodigoColaboradorEsVacio()
     {
         var act = () => MarcacionRegistrada.Crear(string.Empty, TimestampConSegundos, "ENTRADA", "DEV-001");
 
         act.Should().ThrowExactly<ArgumentException>()
-            .WithMessage($"*{MarcacionRegistrada.Mensajes.EmpleadoIdVacio}*");
+            .WithMessage($"*{MarcacionRegistrada.Mensajes.CodigoColaboradorVacio}*");
     }
 
     [Fact]
-    public void Crear_LanzaArgumentException_CuandoEmpleadoIdEsSoloEspacios()
+    public void Crear_LanzaArgumentException_CuandoCodigoColaboradorEsSoloEspacios()
     {
         var act = () => MarcacionRegistrada.Crear("   ", TimestampConSegundos, "ENTRADA", "DEV-001");
 
         act.Should().ThrowExactly<ArgumentException>()
-            .WithMessage($"*{MarcacionRegistrada.Mensajes.EmpleadoIdVacio}*");
+            .WithMessage($"*{MarcacionRegistrada.Mensajes.CodigoColaboradorVacio}*");
     }
 
     // ---------- TipoMarcacion y DispositivoId son opcionales (nullable) ----------
@@ -111,7 +111,7 @@ public class MarcacionRegistradaTests
     [Fact]
     public void Crear_AceptaCamposOpcionalesNulos()
     {
-        var evento = MarcacionRegistrada.Crear(EmpleadoId, TimestampConSegundos, null, null);
+        var evento = MarcacionRegistrada.Crear(CodigoColaborador, TimestampConSegundos, null, null);
 
         evento.TipoMarcacion.Should().BeNull();
         evento.DispositivoId.Should().BeNull();

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/RegistrarMarcacionFunction/RegistrarMarcacionCommandHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/RegistrarMarcacionFunction/RegistrarMarcacionCommandHandlerTests.cs
@@ -22,7 +22,7 @@ namespace Bitakora.ControlAsistencia.ControlHoras.Tests.RegistrarMarcacionFuncti
 public class RegistrarMarcacionCommandHandlerTests : CommandHandlerAsyncTest<RegistrarMarcacion>
 {
     // Datos de prueba fijos
-    private const string EmpleadoId = "EMP-001";
+    private const string CodigoColaborador = "EMP-001";
 
     // Timestamp crudo con segundos para verificar la normalizacion al minuto (CA-2)
     private static readonly DateTime Timestamp = new DateTime(2026, 3, 15, 8, 9, 59);
@@ -30,12 +30,12 @@ public class RegistrarMarcacionCommandHandlerTests : CommandHandlerAsyncTest<Reg
     // CA-2: 08:09:59 truncado al minuto -> 08:09:00
     private static readonly DateTime TimestampNormalizado = new DateTime(2026, 3, 15, 8, 9, 0);
 
-    // CA-5: stream ID determinista {EmpleadoId}:{Timestamp:yyyy-MM-ddTHH:mm:ss}
-    private static readonly string StreamId = $"{EmpleadoId}:{Timestamp:yyyy-MM-ddTHH:mm:ss}";
+    // CA-5: stream ID determinista {CodigoColaborador}:{Timestamp:yyyy-MM-ddTHH:mm:ss}
+    private static readonly string StreamId = $"{CodigoColaborador}:{Timestamp:yyyy-MM-ddTHH:mm:ss}";
 
     // Issue #275: el stream que el handler habria abierto si el factory no hubiera rechazado el
-    // EmpleadoId vacio -- se afirma vacio para probar que el throw precede a cualquier escritura.
-    private static readonly string StreamIdSinEmpleado = $":{Timestamp:yyyy-MM-ddTHH:mm:ss}";
+    // CodigoColaborador vacio -- se afirma vacio para probar que el throw precede a cualquier escritura.
+    private static readonly string StreamIdSinColaborador = $":{Timestamp:yyyy-MM-ddTHH:mm:ss}";
 
     protected override ICommandHandlerAsync<RegistrarMarcacion> Handler =>
         new RegistrarMarcacionCommandHandler(EventStore, PrivateEventSender);
@@ -47,7 +47,7 @@ public class RegistrarMarcacionCommandHandlerTests : CommandHandlerAsyncTest<Reg
     private static MarcacionRegistrada CrearMarcacionRegistrada(
         string? tipoMarcacion = "ENTRADA",
         string? dispositivoId = "DEV-001") =>
-        MarcacionRegistrada.Crear(EmpleadoId, Timestamp, tipoMarcacion, dispositivoId);
+        MarcacionRegistrada.Crear(CodigoColaborador, Timestamp, tipoMarcacion, dispositivoId);
 
     // Issue #270 CA-4: el contrato de bus que se espera publicado -- construido a mano como oraculo
     // independiente (regla 20), con la misma paridad de campos que MarcacionRegistrada, sin invocar
@@ -55,7 +55,7 @@ public class RegistrarMarcacionCommandHandlerTests : CommandHandlerAsyncTest<Reg
     private static RegistroDeMarcacionCreado CrearRegistroDeMarcacionCreado(
         string? tipoMarcacion = "ENTRADA",
         string? dispositivoId = "DEV-001") =>
-        new(EmpleadoId, TimestampNormalizado, tipoMarcacion, dispositivoId);
+        new(CodigoColaborador, TimestampNormalizado, tipoMarcacion, dispositivoId);
 
     // CA-1, CA-2, CA-5: marcacion nueva persiste MarcacionRegistrada en el stream y publica
     // RegistroDeMarcacionCreado (no MarcacionRegistrada) via IPrivateEventSender.
@@ -63,11 +63,11 @@ public class RegistrarMarcacionCommandHandlerTests : CommandHandlerAsyncTest<Reg
     [Fact]
     public async Task RegistrarMarcacion_EmiteMarcacionRegistradaYPublicaRegistroDeMarcacionCreado_CuandoMarcacionEsNueva()
     {
-        await WhenAsync(new RegistrarMarcacion(EmpleadoId, Timestamp, "ENTRADA", "DEV-001"));
+        await WhenAsync(new RegistrarMarcacion(CodigoColaborador, Timestamp, "ENTRADA", "DEV-001"));
 
         Then(StreamId, CrearMarcacionRegistrada());
         ThenIsPublishedPrivately(CrearRegistroDeMarcacionCreado());
-        And<RegistroDeMarcacionAggregateRoot, string>(StreamId, r => r.EmpleadoId, EmpleadoId);
+        And<RegistroDeMarcacionAggregateRoot, string>(StreamId, r => r.CodigoColaborador, CodigoColaborador);
         And<RegistroDeMarcacionAggregateRoot, DateTime>(
             StreamId, r => r.TimestampNormalizado, TimestampNormalizado);
     }
@@ -76,7 +76,7 @@ public class RegistrarMarcacionCommandHandlerTests : CommandHandlerAsyncTest<Reg
     [Fact]
     public async Task RegistrarMarcacion_PropagaCamposOpcionalesNulos_CuandoElComandoNoLosTrae()
     {
-        await WhenAsync(new RegistrarMarcacion(EmpleadoId, Timestamp, null, null));
+        await WhenAsync(new RegistrarMarcacion(CodigoColaborador, Timestamp, null, null));
 
         Then(StreamId, CrearMarcacionRegistrada(tipoMarcacion: null, dispositivoId: null));
         ThenIsPublishedPrivately(CrearRegistroDeMarcacionCreado(tipoMarcacion: null, dispositivoId: null));
@@ -84,7 +84,7 @@ public class RegistrarMarcacionCommandHandlerTests : CommandHandlerAsyncTest<Reg
         And<RegistroDeMarcacionAggregateRoot, string?>(StreamId, r => r.DispositivoId, null);
     }
 
-    // CA-4, CA-9: duplicado exacto (mismo EmpleadoId + mismo Timestamp crudo = mismo stream ID)
+    // CA-4, CA-9: duplicado exacto (mismo CodigoColaborador + mismo Timestamp crudo = mismo stream ID)
     // Handler retorna silenciosamente: sin nuevos eventos en stream, sin eventos publicados (ninguno
     // de los dos tipos).
     [Fact]
@@ -92,27 +92,27 @@ public class RegistrarMarcacionCommandHandlerTests : CommandHandlerAsyncTest<Reg
     {
         Given(StreamId, CrearMarcacionRegistrada());
 
-        await WhenAsync(new RegistrarMarcacion(EmpleadoId, Timestamp, "ENTRADA", "DEV-001"));
+        await WhenAsync(new RegistrarMarcacion(CodigoColaborador, Timestamp, "ENTRADA", "DEV-001"));
 
         Then(StreamId);
         ThenIsPublishedPrivately();
-        And<RegistroDeMarcacionAggregateRoot, string>(StreamId, r => r.EmpleadoId, EmpleadoId);
+        And<RegistroDeMarcacionAggregateRoot, string>(StreamId, r => r.CodigoColaborador, CodigoColaborador);
     }
 
-    // Issue #275 CA-3/CA-4: el factory MarcacionRegistrada.Crear valida el EmpleadoId; el throw
+    // Issue #275 CA-3/CA-4: el factory MarcacionRegistrada.Crear valida el CodigoColaborador; el throw
     // ocurre en el borde del handler (MEF-ADR-0004), nunca dentro del aggregate. No es un evento de
     // fallo del aggregate -- es un dato invalido que nunca deberia haber llegado hasta aqui.
     // El throw ocurre ANTES de tocar el event store: ni se abre el stream ni se publica el contrato
     // de bus, de modo que un dato invalido no deja rastro parcial.
     [Fact]
-    public async Task RegistrarMarcacion_PropagaArgumentExceptionSinPersistirNiPublicar_CuandoEmpleadoIdEsVacio()
+    public async Task RegistrarMarcacion_PropagaArgumentExceptionSinPersistirNiPublicar_CuandoCodigoColaboradorEsVacio()
     {
         var act = async () => await WhenAsync(
             new RegistrarMarcacion(string.Empty, Timestamp, "ENTRADA", "DEV-001"));
 
         await act.Should().ThrowExactlyAsync<ArgumentException>()
-            .WithMessage($"*{MarcacionRegistrada.Mensajes.EmpleadoIdVacio}*");
-        Then(StreamIdSinEmpleado);
+            .WithMessage($"*{MarcacionRegistrada.Mensajes.CodigoColaboradorVacio}*");
+        Then(StreamIdSinColaborador);
         ThenIsPublishedPrivately();
     }
 }

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/RegistrarMarcacionFunction/RegistrarMarcacionValidatorTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/RegistrarMarcacionFunction/RegistrarMarcacionValidatorTests.cs
@@ -36,52 +36,52 @@ public class RegistrarMarcacionValidatorTests
         resultado.IsValid.Should().BeTrue();
     }
 
-    // CA-2: EmpleadoId nulo produce 400
+    // CA-2: CodigoColaborador nulo produce 400
     [Fact]
-    public async Task Validar_RechazaEmpleadoId_CuandoEsNull()
+    public async Task Validar_RechazaCodigoColaborador_CuandoEsNull()
     {
-        var resultado = await Validar(ComandoValido() with { EmpleadoId = null! });
+        var resultado = await Validar(ComandoValido() with { CodigoColaborador = null! });
 
         resultado.IsValid.Should().BeFalse();
         resultado.Errors.Should().Contain(e =>
-            e.PropertyName == nameof(RegistrarMarcacion.EmpleadoId));
+            e.PropertyName == nameof(RegistrarMarcacion.CodigoColaborador));
     }
 
-    // CA-2: EmpleadoId vacio produce 400
+    // CA-2: CodigoColaborador vacio produce 400
     [Fact]
-    public async Task Validar_RechazaEmpleadoId_CuandoEstaVacio()
+    public async Task Validar_RechazaCodigoColaborador_CuandoEstaVacio()
     {
-        var resultado = await Validar(ComandoValido() with { EmpleadoId = "" });
+        var resultado = await Validar(ComandoValido() with { CodigoColaborador = "" });
 
         resultado.IsValid.Should().BeFalse();
         resultado.Errors.Should().Contain(e =>
-            e.PropertyName == nameof(RegistrarMarcacion.EmpleadoId));
+            e.PropertyName == nameof(RegistrarMarcacion.CodigoColaborador));
     }
 
-    // CA-2: EmpleadoId con solo espacios en blanco produce 400
+    // CA-2: CodigoColaborador con solo espacios en blanco produce 400
     [Fact]
-    public async Task Validar_RechazaEmpleadoId_CuandoSonSoloEspacios()
+    public async Task Validar_RechazaCodigoColaborador_CuandoSonSoloEspacios()
     {
-        var resultado = await Validar(ComandoValido() with { EmpleadoId = "   " });
+        var resultado = await Validar(ComandoValido() with { CodigoColaborador = "   " });
 
         resultado.IsValid.Should().BeFalse();
         resultado.Errors.Should().Contain(e =>
-            e.PropertyName == nameof(RegistrarMarcacion.EmpleadoId));
+            e.PropertyName == nameof(RegistrarMarcacion.CodigoColaborador));
     }
 
-    // CA-3: EmpleadoId que contiene ':' produce 400 - cierra la colision de stream ID descrita
-    // en el Contexto del issue (ComputarStreamId usa ':' como separador entre EmpleadoId y
-    // Timestamp; un EmpleadoId con ':' puede fabricar el mismo stream ID que otra combinacion
+    // CA-3: CodigoColaborador que contiene ':' produce 400 - cierra la colision de stream ID descrita
+    // en el Contexto del issue (ComputarStreamId usa ':' como separador entre CodigoColaborador y
+    // Timestamp; un CodigoColaborador con ':' puede fabricar el mismo stream ID que otra combinacion
     // legitima). El valor no esta vacio, asi que el unico error posible proviene de la regla del
     // separador y no de NotEmpty.
     [Fact]
-    public async Task Validar_RechazaEmpleadoId_CuandoContieneDosPuntos()
+    public async Task Validar_RechazaCodigoColaborador_CuandoContieneDosPuntos()
     {
-        var resultado = await Validar(ComandoValido() with { EmpleadoId = "EMP:001" });
+        var resultado = await Validar(ComandoValido() with { CodigoColaborador = "EMP:001" });
 
         resultado.IsValid.Should().BeFalse();
         resultado.Errors.Should().Contain(e =>
-            e.PropertyName == nameof(RegistrarMarcacion.EmpleadoId));
+            e.PropertyName == nameof(RegistrarMarcacion.CodigoColaborador));
     }
 
     // CA-4: Timestamp con el valor default de DateTime produce 400

--- a/tests/Bitakora.ControlAsistencia.PrivateEvents.Tests/ControlHoras/RegistroDeMarcacionCreadoTests.cs
+++ b/tests/Bitakora.ControlAsistencia.PrivateEvents.Tests/ControlHoras/RegistroDeMarcacionCreadoTests.cs
@@ -56,7 +56,7 @@ public class RegistroDeMarcacionCreadoTests
         // (MEF-ADR-0005): el consumidor debe reconstruirlas en null, no fallar.
         var json = """
             {
-              "empleadoId": "EMP-002",
+              "codigoColaborador": "EMP-002",
               "timestampNormalizado": "2026-03-15T08:09:00"
             }
             """;

--- a/tests/Bitakora.ControlAsistencia.PrivateEvents.Tests/Programacion/DetalleColaboradorIgualdadTests.cs
+++ b/tests/Bitakora.ControlAsistencia.PrivateEvents.Tests/Programacion/DetalleColaboradorIgualdadTests.cs
@@ -18,7 +18,7 @@ public class DetalleColaboradorIgualdadTests : IgualdadTestBase<DetalleColaborad
 
     protected override IEnumerable<(string, DetalleColaborador)> CrearInstanciasDiferentes()
     {
-        yield return ("EmpleadoId",
+        yield return ("CodigoColaborador",
             new DetalleColaborador("EMP-002", "CC", "1234567890", "Luis Augusto", "Barreto"));
         yield return ("TipoIdentificacion",
             new DetalleColaborador("EMP-001", "CE", "1234567890", "Luis Augusto", "Barreto"));

--- a/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/Bitakora.ControlAsistencia.Programacion.SmokeTests.csproj
+++ b/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/Bitakora.ControlAsistencia.Programacion.SmokeTests.csproj
@@ -19,7 +19,7 @@
 
   <!-- Programacion no publica eventos publicos: sus smoke tests solo consumen el bus interno.
        Sin referencia a PublicEvents, un smoke test no puede volver a tipar el payload del evento
-       privado con InformacionEmpleado sin que el compilador lo delate (CA-ADR-0029 decision #5). -->
+       privado con InformacionColaborador sin que el compilador lo delate (CA-ADR-0029 decision #5). -->
   <ItemGroup>
     <ProjectReference Include="..\..\src\Bitakora.ControlAsistencia.PrivateEvents\Bitakora.ControlAsistencia.PrivateEvents.csproj" />
   </ItemGroup>

--- a/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.SmokeTests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoSmokeTests.cs
@@ -65,9 +65,9 @@ public class SolicitarProgramacionTurnoSmokeTests(
     {
         id = id ?? Guid.CreateVersion7(),
         turnoId = turnoId ?? Guid.CreateVersion7(),
-        empleado = new
+        colaborador = new
         {
-            empleadoId = Guid.CreateVersion7().ToString(),
+            codigoColaborador = Guid.CreateVersion7().ToString(),
             tipoIdentificacion = "CC",
             numeroIdentificacion = "123456789",
             nombres = "[TEST] Juan Carlos",
@@ -110,16 +110,16 @@ public class SolicitarProgramacionTurnoSmokeTests(
 
         // Arrange: preparar solicitud con dos fechas para verificar emision de un evento por fecha
         var solicitudId = Guid.CreateVersion7();
-        var empleadoId = Guid.CreateVersion7().ToString();
+        var codigoColaborador = Guid.CreateVersion7().ToString();
         var fecha1 = "2026-04-15";
         var fecha2 = "2026-04-16";
         var payload = new
         {
             id = solicitudId,
             turnoId,
-            empleado = new
+            colaborador = new
             {
-                empleadoId,
+                codigoColaborador,
                 tipoIdentificacion = "CC",
                 numeroIdentificacion = "555666777",
                 nombres = "[TEST] Smoke ServiceBus",
@@ -142,12 +142,12 @@ public class SolicitarProgramacionTurnoSmokeTests(
         new[] { evento1.Fecha, evento2.Fecha }.Should()
             .BeEquivalentTo(new[] { DateOnly.Parse(fecha1), DateOnly.Parse(fecha2) });
 
-        // Verificar datos del empleado y turno en uno de los eventos. El payload del empleado es
+        // Verificar datos del colaborador y turno en uno de los eventos. El payload del colaborador es
         // DetalleColaborador (PrivateEvents): con la paridad de campos el JSON del cable no cambia,
         // asi que este smoke test tambien evidencia la compatibilidad del despliegue rolling.
-        var empleadoEsperado = new DetalleColaborador(
-            empleadoId, "CC", "555666777", "[TEST] Smoke ServiceBus", "[TEST] Publicacion");
-        evento1.Empleado.Should().Be(empleadoEsperado);
+        var colaboradorEsperado = new DetalleColaborador(
+            codigoColaborador, "CC", "555666777", "[TEST] Smoke ServiceBus", "[TEST] Publicacion");
+        evento1.Colaborador.Should().Be(colaboradorEsperado);
 
         evento1.DetalleTurno.Should().NotBeNull();
         evento1.DetalleTurno.Nombre.Should().Be("[TEST] Turno Smoke SB");
@@ -205,16 +205,16 @@ public class SolicitarProgramacionTurnoSmokeTests(
 
         // Arrange: solicitud con sede -- issue #331 CA-1
         var solicitudId = Guid.CreateVersion7();
-        var empleadoId = Guid.CreateVersion7().ToString();
+        var codigoColaborador = Guid.CreateVersion7().ToString();
         var sedeId = "SEDE-01";
         var sedeNombre = "[TEST] Sede Principal";
         var payload = new
         {
             id = solicitudId,
             turnoId,
-            empleado = new
+            colaborador = new
             {
-                empleadoId,
+                codigoColaborador,
                 tipoIdentificacion = "CC",
                 numeroIdentificacion = "111222333",
                 nombres = "[TEST] Smoke Sede",
@@ -277,14 +277,14 @@ public class SolicitarProgramacionTurnoSmokeTests(
 
         // Arrange: solicitud CON sede -- issue #341 CA-1
         var solicitudId = Guid.CreateVersion7();
-        var empleadoId = Guid.CreateVersion7().ToString();
+        var codigoColaborador = Guid.CreateVersion7().ToString();
         var payload = new
         {
             id = solicitudId,
             turnoId,
-            empleado = new
+            colaborador = new
             {
-                empleadoId,
+                codigoColaborador,
                 tipoIdentificacion = "CC",
                 numeroIdentificacion = "444555666",
                 nombres = "[TEST] Smoke Cascada",
@@ -349,9 +349,9 @@ public class SolicitarProgramacionTurnoSmokeTests(
         {
             id = solicitudId,
             turnoId,
-            empleado = new
+            colaborador = new
             {
-                empleadoId = Guid.CreateVersion7().ToString(),
+                codigoColaborador = Guid.CreateVersion7().ToString(),
                 tipoIdentificacion = "CC",
                 numeroIdentificacion = "888999000",
                 nombres = "[TEST] Smoke Persistencia",
@@ -422,14 +422,14 @@ public class SolicitarProgramacionTurnoSmokeTests(
         // Arrange: solicitud SIN sede -- issue #341 CA-2: la franja con sede del catalogo la
         // conserva (el catalogo le gana al "sin sede" de la solicitud tambien).
         var solicitudId = Guid.CreateVersion7();
-        var empleadoId = Guid.CreateVersion7().ToString();
+        var codigoColaborador = Guid.CreateVersion7().ToString();
         var payload = new
         {
             id = solicitudId,
             turnoId,
-            empleado = new
+            colaborador = new
             {
-                empleadoId,
+                codigoColaborador,
                 tipoIdentificacion = "CC",
                 numeroIdentificacion = "777888999",
                 nombres = "[TEST] Smoke Prearmada",
@@ -527,9 +527,9 @@ public class SolicitarProgramacionTurnoSmokeTests(
         {
             id = Guid.Empty,
             turnoId = Guid.CreateVersion7(),
-            empleado = new
+            colaborador = new
             {
-                empleadoId = Guid.CreateVersion7().ToString(),
+                codigoColaborador = Guid.CreateVersion7().ToString(),
                 tipoIdentificacion = "CC",
                 numeroIdentificacion = "123456789",
                 nombres = "[TEST] Juan",
@@ -552,9 +552,9 @@ public class SolicitarProgramacionTurnoSmokeTests(
         {
             id = Guid.CreateVersion7(),
             turnoId = Guid.Empty,
-            empleado = new
+            colaborador = new
             {
-                empleadoId = Guid.CreateVersion7().ToString(),
+                codigoColaborador = Guid.CreateVersion7().ToString(),
                 tipoIdentificacion = "CC",
                 numeroIdentificacion = "123456789",
                 nombres = "[TEST] Juan",
@@ -570,16 +570,16 @@ public class SolicitarProgramacionTurnoSmokeTests(
 
     [Fact]
     [Trait("Category", "Smoke")]
-    public async Task SolicitarProgramacionTurno_DebeRetornar400_CuandoEmpleadoTieneCamposVacios()
+    public async Task SolicitarProgramacionTurno_DebeRetornar400_CuandoColaboradorTieneCamposVacios()
     {
         var ct = TestContext.Current.CancellationToken;
         var payload = new
         {
             id = Guid.CreateVersion7(),
             turnoId = Guid.CreateVersion7(),
-            empleado = new
+            colaborador = new
             {
-                empleadoId = "",
+                codigoColaborador = "",
                 tipoIdentificacion = "",
                 numeroIdentificacion = "",
                 nombres = "",
@@ -595,14 +595,14 @@ public class SolicitarProgramacionTurnoSmokeTests(
 
     [Fact]
     [Trait("Category", "Smoke")]
-    public async Task SolicitarProgramacionTurno_DebeRetornar400_CuandoEmpleadoEsNull()
+    public async Task SolicitarProgramacionTurno_DebeRetornar400_CuandoColaboradorEsNull()
     {
         var ct = TestContext.Current.CancellationToken;
         var payload = new
         {
             id = Guid.CreateVersion7(),
             turnoId = Guid.CreateVersion7(),
-            empleado = (object?)null,
+            colaborador = (object?)null,
             fechas = new[] { "2025-08-01" }
         };
 
@@ -620,9 +620,9 @@ public class SolicitarProgramacionTurnoSmokeTests(
         {
             id = Guid.CreateVersion7(),
             turnoId = Guid.CreateVersion7(),
-            empleado = new
+            colaborador = new
             {
-                empleadoId = Guid.CreateVersion7().ToString(),
+                codigoColaborador = Guid.CreateVersion7().ToString(),
                 tipoIdentificacion = "CC",
                 numeroIdentificacion = "123456789",
                 nombres = "[TEST] Juan",
@@ -646,9 +646,9 @@ public class SolicitarProgramacionTurnoSmokeTests(
         {
             id = Guid.CreateVersion7(),
             turnoId = Guid.CreateVersion7(),
-            empleado = new
+            colaborador = new
             {
-                empleadoId = Guid.CreateVersion7().ToString(),
+                codigoColaborador = Guid.CreateVersion7().ToString(),
                 tipoIdentificacion = "CC",
                 numeroIdentificacion = "123456789",
                 nombres = "[TEST] Juan",
@@ -673,9 +673,9 @@ public class SolicitarProgramacionTurnoSmokeTests(
         {
             id = Guid.CreateVersion7(),
             turnoId = Guid.CreateVersion7(),
-            empleado = new
+            colaborador = new
             {
-                empleadoId = Guid.CreateVersion7().ToString(),
+                codigoColaborador = Guid.CreateVersion7().ToString(),
                 tipoIdentificacion = "CC",
                 numeroIdentificacion = "123456789",
                 nombres = "[TEST] Juan",

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/DetalleColaboradorParidadConInformacionColaboradorTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/DetalleColaboradorParidadConInformacionColaboradorTests.cs
@@ -1,7 +1,7 @@
 // Guardrail de la duplicacion deliberada de payload por rol (CA-ADR-0029 decision #5):
-// DetalleColaborador (PrivateEvents) e InformacionEmpleado (PublicEvents) declaran el mismo dato en
+// DetalleColaborador (PrivateEvents) e InformacionColaborador (PublicEvents) declaran el mismo dato en
 // dos ensamblados que no se referencian, y solo esta Function App ve ambos.
-// Sin este test, agregar un campo a uno de los dos no rompe nada: MapearEmpleado sigue
+// Sin este test, agregar un campo a uno de los dos no rompe nada: MapearColaborador sigue
 // compilando, el campo nuevo nunca cruza el bus y el consumidor lo recibe en su valor default --
 // perdida silenciosa, sin excepcion, que es el modo de fallo que ese ADR documenta.
 // El JSON del cable tampoco cambia mientras la paridad se mantenga (compatibilidad del despliegue

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/Eventos/ProgramacionTurnoSolicitadaSerializacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/Eventos/ProgramacionTurnoSolicitadaSerializacionTests.cs
@@ -1,14 +1,20 @@
-// Issue #319 CA-2: guardrail decisivo de seguridad de datos. ProgramacionTurnoSolicitada SE
-// PERSISTE (stream de SolicitudProgramacionAggregateRoot); sus propiedades Empleado/DetalleTurno
-// cambiaron de tipo (InformacionEmpleado/DetalleTurno, PublicEvents/PrivateEvents) a los records
-// propios del dominio (Empleado/TurnoProgramado, Programacion.DomainEvents) -- MISMOS nombres de
-// propiedad y de campo anidado, tipos nuevos.
+// Guardrail de la FORMA persistida de ProgramacionTurnoSolicitada, el evento del stream de
+// SolicitudProgramacionAggregateRoot. Fija las claves JSON crudas de mt_events para que un cambio
+// accidental de nombre de propiedad (o de campo anidado) no pase inadvertido: el JSON se construye
+// como texto/tipo anonimo, sin pasar por el tipo bajo prueba, y se deserializa con las mismas
+// opciones que Marten usa en produccion (CrearOpcionesMarten()).
 //
-// Estos tests construyen el JSON con la FORMA en la que Marten ya persistio este evento antes del
-// cambio de tipos (mismos nombres de propiedad, con los tipos viejos) y lo deserializan contra el
-// tipo NUEVO usando las mismas opciones que Marten usa en produccion (CrearOpcionesMarten()). STJ
-// no persiste $type para records/clases anidadas -- ningun dato existente se pierde. Sin este
-// guardrail, el cambio de tipo podria romper en silencio la lectura de streams ya escritos.
+// Issue #319 CA-2: cuando las propiedades Empleado/DetalleTurno cambiaron de TIPO
+// (InformacionEmpleado/DetalleTurno de PublicEvents/PrivateEvents -> records propios del dominio),
+// estos tests probaron que la forma del wire NO cambiaba -- STJ no persiste $type para
+// records/clases anidadas, asi que los streams ya escritos seguian leyendose.
+//
+// Issue #401: aqui las claves SI cambian ("Empleado" -> "Colaborador", "EmpleadoId" ->
+// "CodigoColaborador"). Por eso estas formas se reescribieron a las claves NUEVAS y ya no
+// demuestran compatibilidad hacia atras: los streams escritos con el vocabulario viejo no
+// deserializan contra este tipo, y se purgan en el mismo despliegue que integra el cambio
+// (MEF-ADR-0036 seccion 5, decision deliberada -- sin JsonPropertyName ni upcasters). Lo que
+// estos tests custodian desde ahora es la forma canonica hacia adelante.
 //
 // La forma de prueba lleva descansos y extras poblados a proposito: es el UNICO sitio donde el
 // nivel mas interno de la jerarquia persistida (SubFranjaProgramada, antes DetalleSubFranja) se
@@ -38,7 +44,7 @@ public class ProgramacionTurnoSolicitadaSerializacionTests
     private const string DescripcionDescanso = "(12:00-12:30)";
     private const string DescripcionExtra = "(13:00-14:00)";
 
-    private static readonly ColaboradorProgramado EmpleadoEsperado =
+    private static readonly ColaboradorProgramado ColaboradorEsperado =
         new("E001", "CC", "12345678", "Juan", "Perez");
 
     // Issue #331: sede efectiva del dia, campo aditivo y opcional.
@@ -55,19 +61,19 @@ public class ProgramacionTurnoSolicitadaSerializacionTests
         }.AsReadOnly(),
         DescripcionTurno);
 
-    // Forma EXACTA en la que Marten persistio este evento ANTES de este issue: mismos nombres de
-    // propiedad ("Empleado", "Fechas", "DetalleTurno" y sus anidados) que hoy tipan con
-    // InformacionEmpleado/DetalleTurno (PublicEvents/PrivateEvents). Un tipo anonimo local basta
-    // para reproducir la FORMA sin necesitar referenciar esos ensamblados: lo unico que importa
-    // para el guardrail es que las claves JSON coincidan.
-    private static string JsonConFormaPersistidaAntesDelCambioDeTipos()
+    // Forma EXACTA con la que Marten persiste este evento desde #401: claves "Colaborador",
+    // "Fechas", "DetalleTurno" y sus anidados ("CodigoColaborador" dentro de "Colaborador"). Un
+    // tipo anonimo local basta para reproducir la FORMA sin referenciar los ensamblados de los
+    // tipos reales: lo unico que importa para el guardrail es que las claves JSON coincidan --
+    // construirla desde el propio tipo bajo prueba haria el test ciego a un rename.
+    private static string JsonConLaFormaPersistidaEnMtEvents()
     {
         var forma = new
         {
             Id,
-            Empleado = new
+            Colaborador = new
             {
-                EmpleadoId = "E001",
+                CodigoColaborador = "E001",
                 TipoIdentificacion = "CC",
                 NumeroIdentificacion = "12345678",
                 Nombres = "Juan",
@@ -123,7 +129,7 @@ public class ProgramacionTurnoSolicitadaSerializacionTests
     // canonico expresa esa relacion mejor que reescribir la forma completa a mano.
     private static string JsonConFormaPersistidaSinDescripcion()
     {
-        var nodo = JsonNode.Parse(JsonConFormaPersistidaAntesDelCambioDeTipos())!;
+        var nodo = JsonNode.Parse(JsonConLaFormaPersistidaEnMtEvents())!;
         QuitarDescripcion(nodo);
         return nodo.ToJsonString();
     }
@@ -152,12 +158,12 @@ public class ProgramacionTurnoSolicitadaSerializacionTests
     }
 
     [Fact]
-    public void Deserializar_ReconstruyeEventoIdentico_ConLaFormaPersistidaAntesDelCambioDeTipos()
+    public void Deserializar_ReconstruyeEventoIdentico_ConLaFormaPersistidaEnMtEvents()
     {
-        var evento = Deserializar(JsonConFormaPersistidaAntesDelCambioDeTipos());
+        var evento = Deserializar(JsonConLaFormaPersistidaEnMtEvents());
 
         evento.Id.Should().Be(Id);
-        evento.Empleado.Should().Be(EmpleadoEsperado);
+        evento.Colaborador.Should().Be(ColaboradorEsperado);
         evento.Fechas.Should().Equal(Fecha1, Fecha2);
         evento.DetalleTurno.Should().Be(TurnoEsperado);
     }
@@ -167,9 +173,9 @@ public class ProgramacionTurnoSolicitadaSerializacionTests
     // anterior NO la compara: sin este test, un cambio de tipos que perdiera la Descripcion ya
     // persistida pasaria en verde. Se afirma en los tres niveles de la jerarquia.
     [Fact]
-    public void Deserializar_ConservaLaDescripcionDeLosTresNiveles_ConLaFormaPersistidaAntesDelCambioDeTipos()
+    public void Deserializar_ConservaLaDescripcionDeLosTresNiveles_ConLaFormaPersistidaEnMtEvents()
     {
-        var evento = Deserializar(JsonConFormaPersistidaAntesDelCambioDeTipos());
+        var evento = Deserializar(JsonConLaFormaPersistidaEnMtEvents());
         var franja = evento.DetalleTurno.FranjasOrdinarias.Single();
 
         evento.DetalleTurno.Descripcion.Should().Be(DescripcionTurno);
@@ -201,7 +207,7 @@ public class ProgramacionTurnoSolicitadaSerializacionTests
     {
         var evento = Deserializar(JsonConFormaPersistidaSinDescripcion());
 
-        evento.Empleado.Should().Be(EmpleadoEsperado);
+        evento.Colaborador.Should().Be(ColaboradorEsperado);
         evento.DetalleTurno.Should().Be(TurnoEsperado);
     }
 
@@ -211,7 +217,7 @@ public class ProgramacionTurnoSolicitadaSerializacionTests
     [Fact]
     public void Deserializar_DejaSedeEnNull_CuandoElJsonPersistidoNoLlevaEseCampo()
     {
-        var evento = Deserializar(JsonConFormaPersistidaAntesDelCambioDeTipos());
+        var evento = Deserializar(JsonConLaFormaPersistidaEnMtEvents());
 
         evento.Sede.Should().BeNull();
     }
@@ -222,7 +228,7 @@ public class ProgramacionTurnoSolicitadaSerializacionTests
     public void RoundTrip_PreservaLaSede_CuandoLaSedeEstaPoblada()
     {
         var evento = new ProgramacionTurnoSolicitada(
-            Id, EmpleadoEsperado, [Fecha1], TurnoEsperado, SedeEsperada);
+            Id, ColaboradorEsperado, [Fecha1], TurnoEsperado, SedeEsperada);
         var opciones = ConfiguracionSerializacionProgramacion.CrearOpcionesMarten();
 
         var json = JsonSerializer.Serialize(evento, opciones);
@@ -239,7 +245,7 @@ public class ProgramacionTurnoSolicitadaSerializacionTests
     [Fact]
     public void Deserializar_DejaSedeDeCadaFranjaEnNull_CuandoElJsonPersistidoNoLlevaEseCampo()
     {
-        var evento = Deserializar(JsonConFormaPersistidaAntesDelCambioDeTipos());
+        var evento = Deserializar(JsonConLaFormaPersistidaEnMtEvents());
 
         evento.DetalleTurno.FranjasOrdinarias.Single().Sede.Should().BeNull();
     }
@@ -261,7 +267,7 @@ public class ProgramacionTurnoSolicitadaSerializacionTests
             }.AsReadOnly(),
             DescripcionTurno);
         var evento = new ProgramacionTurnoSolicitada(
-            Id, EmpleadoEsperado, [Fecha1], turnoConSedePorFranja, SedeEsperada);
+            Id, ColaboradorEsperado, [Fecha1], turnoConSedePorFranja, SedeEsperada);
         var opciones = ConfiguracionSerializacionProgramacion.CrearOpcionesMarten();
 
         var json = JsonSerializer.Serialize(evento, opciones);

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoCommandHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoCommandHandlerTests.cs
@@ -27,17 +27,17 @@ public class SolicitarProgramacionTurnoCommandHandlerTests
     private static readonly DateOnly Fecha1 = new(2026, 4, 7);
     private static readonly DateOnly Fecha2 = new(2026, 4, 8);
 
-    private static readonly InformacionColaborador Empleado =
+    private static readonly InformacionColaborador Colaborador =
         new("E001", "CC", "12345678", "Juan", "Perez");
 
-    // Mismo empleado, en la forma que el handler debe producir para el evento privado
+    // Mismo colaborador, en la forma que el handler debe producir para el evento privado
     // (CA-ADR-0029 decision #5): si el mapeo pierde o permuta un campo, estos tests lo delatan.
-    private static readonly DetalleColaborador EmpleadoDetalle =
+    private static readonly DetalleColaborador ColaboradorDetalle =
         new("E001", "CC", "12345678", "Juan", "Perez");
 
-    // Issue #319 CA-2/CA-5: mismo empleado, en el record propio de Programacion.DomainEvents que
-    // ahora tipa ProgramacionTurnoSolicitada.Empleado (tres islas, MEF-ADR-0039 decision 2).
-    private static readonly ColaboradorProgramado EmpleadoProgramado =
+    // Issue #319 CA-2/CA-5: mismo colaborador, en el record propio de Programacion.DomainEvents que
+    // ahora tipa ProgramacionTurnoSolicitada.Colaborador (tres islas, MEF-ADR-0039 decision 2).
+    private static readonly ColaboradorProgramado ColaboradorProgramadoEsperado =
         new("E001", "CC", "12345678", "Juan", "Perez");
 
     // El DetalleTurno esperado corresponde al catalogo creado en CrearEventoTurno(). Forma de BUS
@@ -243,12 +243,12 @@ public class SolicitarProgramacionTurnoCommandHandlerTests
     {
         Given(TurnoId.ToString(), CrearEventoTurno());
         await WhenAsync(new SolicitarProgramacionTurno(
-            GuidAggregateId, TurnoId, Empleado, [Fecha1]));
+            GuidAggregateId, TurnoId, Colaborador, [Fecha1]));
 
         Then(new ProgramacionTurnoSolicitada(
-            GuidAggregateId, EmpleadoProgramado, [Fecha1], TurnoProgramadoEsperado));
+            GuidAggregateId, ColaboradorProgramadoEsperado, [Fecha1], TurnoProgramadoEsperado));
         ThenIsPublishedPrivately(new ProgramacionTurnoDiarioSolicitada(
-            GuidAggregateId, EmpleadoDetalle, Fecha1, DetalleEsperado));
+            GuidAggregateId, ColaboradorDetalle, Fecha1, DetalleEsperado));
         And<SolicitudProgramacionAggregateRoot, int>(s => s.Fechas.Count, 1);
     }
 
@@ -265,12 +265,12 @@ public class SolicitarProgramacionTurnoCommandHandlerTests
     {
         Given(TurnoConHijasId.ToString(), CrearEventoTurnoConHijas());
         await WhenAsync(new SolicitarProgramacionTurno(
-            GuidAggregateId, TurnoConHijasId, Empleado, [Fecha1]));
+            GuidAggregateId, TurnoConHijasId, Colaborador, [Fecha1]));
 
         Then(new ProgramacionTurnoSolicitada(
-            GuidAggregateId, EmpleadoProgramado, [Fecha1], TurnoConHijasProgramadoEsperado));
+            GuidAggregateId, ColaboradorProgramadoEsperado, [Fecha1], TurnoConHijasProgramadoEsperado));
         ThenIsPublishedPrivately(new ProgramacionTurnoDiarioSolicitada(
-            GuidAggregateId, EmpleadoDetalle, Fecha1, DetalleConHijasEsperado));
+            GuidAggregateId, ColaboradorDetalle, Fecha1, DetalleConHijasEsperado));
         And<SolicitudProgramacionAggregateRoot, int>(
             s => s.DetalleTurno!.FranjasOrdinarias[0].Descansos.Count, 1);
         And<SolicitudProgramacionAggregateRoot, int>(
@@ -283,15 +283,15 @@ public class SolicitarProgramacionTurnoCommandHandlerTests
     {
         Given(TurnoId.ToString(), CrearEventoTurno());
         await WhenAsync(new SolicitarProgramacionTurno(
-            GuidAggregateId, TurnoId, Empleado, [Fecha1, Fecha2]));
+            GuidAggregateId, TurnoId, Colaborador, [Fecha1, Fecha2]));
 
         Then(new ProgramacionTurnoSolicitada(
-            GuidAggregateId, EmpleadoProgramado, [Fecha1, Fecha2], TurnoProgramadoEsperado));
+            GuidAggregateId, ColaboradorProgramadoEsperado, [Fecha1, Fecha2], TurnoProgramadoEsperado));
         ThenIsPublishedPrivately(
             new ProgramacionTurnoDiarioSolicitada(
-                GuidAggregateId, EmpleadoDetalle, Fecha1, DetalleEsperado),
+                GuidAggregateId, ColaboradorDetalle, Fecha1, DetalleEsperado),
             new ProgramacionTurnoDiarioSolicitada(
-                GuidAggregateId, EmpleadoDetalle, Fecha2, DetalleEsperado));
+                GuidAggregateId, ColaboradorDetalle, Fecha2, DetalleEsperado));
         And<SolicitudProgramacionAggregateRoot, int>(s => s.Fechas.Count, 2);
     }
 
@@ -308,15 +308,15 @@ public class SolicitarProgramacionTurnoCommandHandlerTests
     {
         Given(TurnoId.ToString(), CrearEventoTurno());
         await WhenAsync(new SolicitarProgramacionTurno(
-            GuidAggregateId, TurnoId, Empleado, [Fecha1, Fecha2], SedePrincipal));
+            GuidAggregateId, TurnoId, Colaborador, [Fecha1, Fecha2], SedePrincipal));
 
         Then(new ProgramacionTurnoSolicitada(
-            GuidAggregateId, EmpleadoProgramado, [Fecha1, Fecha2], TurnoProgramadoConSedeAplicadaEsperado, SedePrincipal));
+            GuidAggregateId, ColaboradorProgramadoEsperado, [Fecha1, Fecha2], TurnoProgramadoConSedeAplicadaEsperado, SedePrincipal));
         ThenIsPublishedPrivately(
             new ProgramacionTurnoDiarioSolicitada(
-                GuidAggregateId, EmpleadoDetalle, Fecha1, DetalleConSedeAplicadaEsperado, SedePrincipalDetalle),
+                GuidAggregateId, ColaboradorDetalle, Fecha1, DetalleConSedeAplicadaEsperado, SedePrincipalDetalle),
             new ProgramacionTurnoDiarioSolicitada(
-                GuidAggregateId, EmpleadoDetalle, Fecha2, DetalleConSedeAplicadaEsperado, SedePrincipalDetalle));
+                GuidAggregateId, ColaboradorDetalle, Fecha2, DetalleConSedeAplicadaEsperado, SedePrincipalDetalle));
         And<SolicitudProgramacionAggregateRoot, SedeProgramada?>(s => s.Sede, SedePrincipal);
         And<SolicitudProgramacionAggregateRoot, SedeProgramada?>(
             s => s.DetalleTurno!.FranjasOrdinarias[0].Sede, SedePrincipal);
@@ -332,12 +332,12 @@ public class SolicitarProgramacionTurnoCommandHandlerTests
     {
         Given(TurnoConFranjasMixtasId.ToString(), CrearEventoTurnoConFranjasMixtas());
         await WhenAsync(new SolicitarProgramacionTurno(
-            GuidAggregateId, TurnoConFranjasMixtasId, Empleado, [Fecha1], SedePrincipal));
+            GuidAggregateId, TurnoConFranjasMixtasId, Colaborador, [Fecha1], SedePrincipal));
 
         Then(new ProgramacionTurnoSolicitada(
-            GuidAggregateId, EmpleadoProgramado, [Fecha1], TurnoMixtoConCascadaEsperado, SedePrincipal));
+            GuidAggregateId, ColaboradorProgramadoEsperado, [Fecha1], TurnoMixtoConCascadaEsperado, SedePrincipal));
         ThenIsPublishedPrivately(new ProgramacionTurnoDiarioSolicitada(
-            GuidAggregateId, EmpleadoDetalle, Fecha1, DetalleMixtoConCascadaEsperado, SedePrincipalDetalle));
+            GuidAggregateId, ColaboradorDetalle, Fecha1, DetalleMixtoConCascadaEsperado, SedePrincipalDetalle));
         And<SolicitudProgramacionAggregateRoot, SedeProgramada?>(
             s => s.DetalleTurno!.FranjasOrdinarias[0].Sede, SedeSuba);
         And<SolicitudProgramacionAggregateRoot, SedeProgramada?>(
@@ -352,12 +352,12 @@ public class SolicitarProgramacionTurnoCommandHandlerTests
     {
         Given(TurnoId.ToString(), CrearEventoTurno());
         await WhenAsync(new SolicitarProgramacionTurno(
-            GuidAggregateId, TurnoId, Empleado, [Fecha1]));
+            GuidAggregateId, TurnoId, Colaborador, [Fecha1]));
 
         Then(new ProgramacionTurnoSolicitada(
-            GuidAggregateId, EmpleadoProgramado, [Fecha1], TurnoProgramadoEsperado, sede: null));
+            GuidAggregateId, ColaboradorProgramadoEsperado, [Fecha1], TurnoProgramadoEsperado, sede: null));
         ThenIsPublishedPrivately(new ProgramacionTurnoDiarioSolicitada(
-            GuidAggregateId, EmpleadoDetalle, Fecha1, DetalleEsperado, sede: null));
+            GuidAggregateId, ColaboradorDetalle, Fecha1, DetalleEsperado, sede: null));
         And<SolicitudProgramacionAggregateRoot, SedeProgramada?>(s => s.Sede, null);
     }
 
@@ -372,12 +372,12 @@ public class SolicitarProgramacionTurnoCommandHandlerTests
     {
         Given(TurnoConSedePrearmadaId.ToString(), CrearEventoTurnoConSedePrearmada());
         await WhenAsync(new SolicitarProgramacionTurno(
-            GuidAggregateId, TurnoConSedePrearmadaId, Empleado, [Fecha1]));
+            GuidAggregateId, TurnoConSedePrearmadaId, Colaborador, [Fecha1]));
 
         Then(new ProgramacionTurnoSolicitada(
-            GuidAggregateId, EmpleadoProgramado, [Fecha1], TurnoConSedePrearmadaEsperado, sede: null));
+            GuidAggregateId, ColaboradorProgramadoEsperado, [Fecha1], TurnoConSedePrearmadaEsperado, sede: null));
         ThenIsPublishedPrivately(new ProgramacionTurnoDiarioSolicitada(
-            GuidAggregateId, EmpleadoDetalle, Fecha1, DetalleConSedePrearmadaEsperado, sede: null));
+            GuidAggregateId, ColaboradorDetalle, Fecha1, DetalleConSedePrearmadaEsperado, sede: null));
         And<SolicitudProgramacionAggregateRoot, SedeProgramada?>(
             s => s.DetalleTurno!.FranjasOrdinarias[0].Sede, SedeSuba);
     }
@@ -388,10 +388,10 @@ public class SolicitarProgramacionTurnoCommandHandlerTests
     {
         Given(TurnoId.ToString(), CrearEventoTurno());
         Given(new ProgramacionTurnoSolicitada(
-            GuidAggregateId, EmpleadoProgramado, [Fecha1], TurnoProgramadoEsperado));
+            GuidAggregateId, ColaboradorProgramadoEsperado, [Fecha1], TurnoProgramadoEsperado));
 
         var act = async () => await WhenAsync(new SolicitarProgramacionTurno(
-            GuidAggregateId, TurnoId, Empleado, [Fecha1]));
+            GuidAggregateId, TurnoId, Colaborador, [Fecha1]));
 
         await act.Should().ThrowExactlyAsync<InvalidOperationException>()
             .WithMessage($"*{SolicitarProgramacionTurnoCommandHandler.Mensajes.SolicitudYaExiste}*");
@@ -402,7 +402,7 @@ public class SolicitarProgramacionTurnoCommandHandlerTests
     public async Task DebeLanzarExcepcion_CuandoTurnoNoExisteEnElCatalogo()
     {
         var act = async () => await WhenAsync(new SolicitarProgramacionTurno(
-            GuidAggregateId, TurnoId, Empleado, [Fecha1]));
+            GuidAggregateId, TurnoId, Colaborador, [Fecha1]));
 
         await act.Should().ThrowExactlyAsync<KeyNotFoundException>()
             .WithMessage($"*{SolicitarProgramacionTurnoCommandHandler.Mensajes.TurnoNoEncontrado}*");

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoValidatorTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/SolicitarProgramacionTurnoFunction/SolicitarProgramacionTurnoValidatorTests.cs
@@ -12,13 +12,13 @@ public class SolicitarProgramacionTurnoValidatorTests
 {
     private readonly SolicitarProgramacionTurnoValidator _validator = new();
 
-    private static InformacionColaborador DatosEmpleadoValidos() =>
+    private static InformacionColaborador DatosColaboradorValidos() =>
         new("E001", "CC", "12345678", "Juan", "Perez");
 
     private static SolicitarProgramacionTurno ComandoValido() => new(
         Guid.NewGuid(),
         Guid.NewGuid(),
-        DatosEmpleadoValidos(),
+        DatosColaboradorValidos(),
         [new DateOnly(2026, 4, 7)]);
 
     // Camino feliz - todos los campos correctos
@@ -59,27 +59,27 @@ public class SolicitarProgramacionTurnoValidatorTests
             e.PropertyName == nameof(SolicitarProgramacionTurno.TurnoId));
     }
 
-    // CA-3: EmpleadoId no puede estar vacio
+    // CA-3: CodigoColaborador no puede estar vacio
     [Fact]
-    public async Task DebeTenerError_CuandoEmpleadoIdEstaVacio()
+    public async Task DebeTenerError_CuandoCodigoColaboradorEstaVacio()
     {
-        var datosInvalidos = DatosEmpleadoValidos() with { EmpleadoId = "" };
-        var comando = ComandoValido() with { Empleado = datosInvalidos };
+        var datosInvalidos = DatosColaboradorValidos() with { CodigoColaborador = "" };
+        var comando = ComandoValido() with { Colaborador = datosInvalidos };
 
         var resultado = await _validator.ValidateAsync(
             comando, TestContext.Current.CancellationToken);
 
         resultado.IsValid.Should().BeFalse();
         resultado.Errors.Should().Contain(e =>
-            e.PropertyName.Contains(nameof(InformacionColaborador.EmpleadoId)));
+            e.PropertyName.Contains(nameof(InformacionColaborador.CodigoColaborador)));
     }
 
     // CA-3: TipoIdentificacion no puede estar vacio
     [Fact]
     public async Task DebeTenerError_CuandoTipoIdentificacionEstaVacio()
     {
-        var datosInvalidos = DatosEmpleadoValidos() with { TipoIdentificacion = "" };
-        var comando = ComandoValido() with { Empleado = datosInvalidos };
+        var datosInvalidos = DatosColaboradorValidos() with { TipoIdentificacion = "" };
+        var comando = ComandoValido() with { Colaborador = datosInvalidos };
 
         var resultado = await _validator.ValidateAsync(
             comando, TestContext.Current.CancellationToken);
@@ -93,8 +93,8 @@ public class SolicitarProgramacionTurnoValidatorTests
     [Fact]
     public async Task DebeTenerError_CuandoNumeroIdentificacionEstaVacio()
     {
-        var datosInvalidos = DatosEmpleadoValidos() with { NumeroIdentificacion = " " };
-        var comando = ComandoValido() with { Empleado = datosInvalidos };
+        var datosInvalidos = DatosColaboradorValidos() with { NumeroIdentificacion = " " };
+        var comando = ComandoValido() with { Colaborador = datosInvalidos };
 
         var resultado = await _validator.ValidateAsync(
             comando, TestContext.Current.CancellationToken);
@@ -108,8 +108,8 @@ public class SolicitarProgramacionTurnoValidatorTests
     [Fact]
     public async Task DebeTenerError_CuandoNombresEstanVacios()
     {
-        var datosInvalidos = DatosEmpleadoValidos() with { Nombres = "" };
-        var comando = ComandoValido() with { Empleado = datosInvalidos };
+        var datosInvalidos = DatosColaboradorValidos() with { Nombres = "" };
+        var comando = ComandoValido() with { Colaborador = datosInvalidos };
 
         var resultado = await _validator.ValidateAsync(
             comando, TestContext.Current.CancellationToken);
@@ -123,8 +123,8 @@ public class SolicitarProgramacionTurnoValidatorTests
     [Fact]
     public async Task DebeTenerError_CuandoApellidosEstanVacios()
     {
-        var datosInvalidos = DatosEmpleadoValidos() with { Apellidos = "   " };
-        var comando = ComandoValido() with { Empleado = datosInvalidos };
+        var datosInvalidos = DatosColaboradorValidos() with { Apellidos = "   " };
+        var comando = ComandoValido() with { Colaborador = datosInvalidos };
 
         var resultado = await _validator.ValidateAsync(
             comando, TestContext.Current.CancellationToken);
@@ -134,20 +134,20 @@ public class SolicitarProgramacionTurnoValidatorTests
             e.PropertyName.Contains(nameof(InformacionColaborador.Apellidos)));
     }
 
-    // HU-225 / CA-1: Empleado null no debe lanzar excepcion (NullReferenceException por
+    // HU-225 / CA-1: Colaborador null no debe lanzar excepcion (NullReferenceException por
     // desreferencia encadenada); debe reportar IsValid == false con un error asociado a
-    // la propiedad Empleado.
+    // la propiedad Colaborador.
     [Fact]
-    public async Task Validar_TieneErrorEnEmpleado_CuandoEmpleadoEsNull()
+    public async Task Validar_TieneErrorEnColaborador_CuandoColaboradorEsNull()
     {
-        var comando = ComandoValido() with { Empleado = null! };
+        var comando = ComandoValido() with { Colaborador = null! };
 
         var resultado = await _validator.ValidateAsync(
             comando, TestContext.Current.CancellationToken);
 
         resultado.IsValid.Should().BeFalse();
         resultado.Errors.Should().Contain(e =>
-            e.PropertyName == nameof(SolicitarProgramacionTurno.Empleado));
+            e.PropertyName == nameof(SolicitarProgramacionTurno.Colaborador));
     }
 
     // CA-4: Fechas debe tener al menos un elemento

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/ValueObjects/ColaboradorProgramadoIgualdadTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/ValueObjects/ColaboradorProgramadoIgualdadTests.cs
@@ -1,4 +1,4 @@
-// Issue #319: Tests de contrato IEquatable para Empleado (record propio de Programacion.DomainEvents,
+// Issue #319: Tests de contrato IEquatable para Colaborador (record propio de Programacion.DomainEvents,
 // tres islas). Todos los campos son string: la igualdad por valor del record por defecto ya es
 // correcta, sin Equals/GetHashCode custom -- mismo criterio que DetalleColaborador (issue #318).
 
@@ -16,7 +16,7 @@ public class ColaboradorProgramadoIgualdadTests : IgualdadTestBase<ColaboradorPr
 
     protected override IEnumerable<(string, ColaboradorProgramado)> CrearInstanciasDiferentes()
     {
-        yield return ("EmpleadoId",
+        yield return ("CodigoColaborador",
             new ColaboradorProgramado("EMP-002", "CC", "1234567890", "Luis Augusto", "Barreto"));
         yield return ("TipoIdentificacion",
             new ColaboradorProgramado("EMP-001", "CE", "1234567890", "Luis Augusto", "Barreto"));

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/ValueObjects/ColaboradorProgramadoParidadConInformacionColaboradorTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/ValueObjects/ColaboradorProgramadoParidadConInformacionColaboradorTests.cs
@@ -1,5 +1,5 @@
 // Issue #319 CA-1: guardrail de la duplicacion deliberada de payload por rol (tres islas,
-// MEF-ADR-0039 decision 2 y 6): Empleado (Programacion.DomainEvents) e InformacionEmpleado
+// MEF-ADR-0039 decision 2 y 6): Colaborador (Programacion.DomainEvents) e InformacionColaborador
 // (PublicEvents) declaran el mismo dato en dos ensamblados que no se referencian entre si.
 // Sin este guardrail, agregar un campo a uno de los dos no rompe nada y el dato se pierde en
 // silencio al construir el evento persistido ProgramacionTurnoSolicitada -- mismo modo de fallo

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/ValueObjects/SedeProgramadaIgualdadTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/ValueObjects/SedeProgramadaIgualdadTests.cs
@@ -1,6 +1,6 @@
 // Issue #331: Tests de contrato IEquatable para SedeProgramada (record propio de
 // Programacion.DomainEvents). Todos los campos son string: la igualdad por valor del record por
-// defecto ya es correcta, sin Equals/GetHashCode custom -- mismo criterio que Empleado (issue #319).
+// defecto ya es correcta, sin Equals/GetHashCode custom -- mismo criterio que Colaborador (issue #319).
 
 using Bitakora.ControlAsistencia.Programacion.DomainEvents;
 

--- a/tests/Bitakora.ControlAsistencia.Projections.Tests/ConfiguracionMartenProjectionsTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Projections.Tests/ConfiguracionMartenProjectionsTests.cs
@@ -28,7 +28,7 @@ public class ConfiguracionMartenProjectionsTests
     private const string ConnectionStringDummy = "Host=localhost;Database=dummy";
 
     // Issue #268 CA-2: identidad del canario de round-trip de Programacion (el de ControlHoras,
-    // MarcacionRegistrada, se identifica por EmpleadoId string y no necesita ninguna). El valor en
+    // MarcacionRegistrada, se identifica por CodigoColaborador string y no necesita ninguna). El valor en
     // si es irrelevante: solo debe ser estable para que el test sea reproducible.
     private static readonly Guid TurnoIdCanario = Guid.Parse("019600a0-0000-7000-8000-000000000099");
 
@@ -273,7 +273,7 @@ public class ConfiguracionMartenProjectionsTests
             .DeserializarConResolverDeSerializacionCustom(evento);
 
         restaurado.Should().NotBeNull();
-        restaurado.EmpleadoId.Should().Be("1098765432");
+        restaurado.CodigoColaborador.Should().Be("1098765432");
         restaurado.TimestampNormalizado.Should().Be(new DateTime(2026, 7, 31, 8, 0, 0));
         restaurado.TipoMarcacion.Should().Be("Entrada");
         restaurado.DispositivoId.Should().Be("disp-01");
@@ -297,7 +297,7 @@ public class ConfiguracionMartenProjectionsTests
     }
 
     // Issue #328 CA-3: proyeccion concreta del dominio (N1, SingleStreamProjection<TurnoVigente,
-    // string> sobre el stream (EmpleadoId, Fecha)). Complementa
+    // string> sobre el stream (CodigoColaborador, Fecha)). Complementa
     // ConfigurarControlHoras_NoRegistraNingunaProyeccionInline: aquella prueba que NADA quedo
     // Inline -- una lista vacia la pasaria --, esta prueba que la proyeccion CONCRETA si se
     // registro con lifecycle Async, el canonico del worker (MEF-ADR-0034 seccion 3).

--- a/tests/Bitakora.ControlAsistencia.Projections.Tests/ControlHoras/TurnoVigenteProjectionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Projections.Tests/ControlHoras/TurnoVigenteProjectionTests.cs
@@ -13,7 +13,7 @@
 //
 // using TipoBloqueVigente: alias obligatorio -- DomainEvents.TipoBloque (necesario para construir
 // el evento fundacional) y ReadModels.ControlHoras.TipoBloque (necesario para el oraculo de la
-// vista) comparten nombre a proposito, mismo criterio de "tres islas" que ya aplican Empleado/
+// vista) comparten nombre a proposito, mismo criterio de "tres islas" que ya aplican Colaborador/
 // TurnoDiario/FranjaProgramada entre los ensamblados de eventos. Con ambos "using" activos el
 // simbolo corto "TipoBloque" queda ambiguo (CS0104); el alias resuelve solo el lado ReadModels.
 //
@@ -33,17 +33,17 @@ namespace Bitakora.ControlAsistencia.Projections.Tests.ControlHoras;
 
 public class TurnoVigenteProjectionTests
 {
-    private static ColaboradorProgramado EmpleadoDePrueba() =>
+    private static ColaboradorProgramado ColaboradorDePrueba() =>
         new("EMP-001", "CC", "1098765432", "Ana", "Ramirez");
 
-    // CA-1: Create mapea stream key, EmpleadoId, NombreCompleto (concatenado Nombres+Apellidos --
+    // CA-1: Create mapea stream key, CodigoColaborador, NombreCompleto (concatenado Nombres+Apellidos --
     // unico lugar del sistema donde se hace, issue #328 "Investigacion del planner"), NombreTurno,
     // HorarioResumido (la Descripcion textual que el evento ya trae) y los Bloques que produce
     // Segmentar, con los tres tipos posibles (Ordinaria/Descanso/Extra) representados.
     [Fact]
     public void Create_ProyectaElTurnoVigenteCompleto_DesdeTurnoDiarioAsignado()
     {
-        var empleado = EmpleadoDePrueba();
+        var colaborador = ColaboradorDePrueba();
         var fecha = new DateOnly(2026, 8, 3);
         var streamKey = "EMP-001:2026-08-03";
 
@@ -62,7 +62,7 @@ public class TurnoVigenteProjectionTests
             [franja],
             "Turno Manana: (06:00-14:00)[Descansos:(10:00-10:15)][Extras:(05:00-06:00)]");
         var solicitudId = Guid.NewGuid();
-        var evento = new TurnoDiarioAsignado(streamKey, empleado, fecha, turnoDiario, solicitudId);
+        var evento = new TurnoDiarioAsignado(streamKey, colaborador, fecha, turnoDiario, solicitudId);
 
         var vista = TurnoVigenteProjection.Create(evento);
 
@@ -76,7 +76,7 @@ public class TurnoVigenteProjectionTests
         };
 
         vista.Id.Should().Be(streamKey);
-        vista.EmpleadoId.Should().Be("EMP-001");
+        vista.CodigoColaborador.Should().Be("EMP-001");
         vista.NombreCompleto.Should().Be("Ana Ramirez");
         vista.Fecha.Should().Be(fecha);
         vista.NombreTurno.Should().Be("Turno Manana");
@@ -86,13 +86,13 @@ public class TurnoVigenteProjectionTests
     }
 
     // CA-2: la reasignacion sobrescribe -- dos TurnoDiarioAsignado consecutivos sobre el mismo
-    // (empleado, fecha) dejan la vista con el NombreTurno, HorarioResumido y Bloques del SEGUNDO
-    // evento ("el ultimo gana"). Id, EmpleadoId y Fecha no cambian (mismo stream key). Sin
+    // (colaborador, fecha) dejan la vista con el NombreTurno, HorarioResumido y Bloques del SEGUNDO
+    // evento ("el ultimo gana"). Id, CodigoColaborador y Fecha no cambian (mismo stream key). Sin
     // ShouldDelete (el turno vigente nunca se borra, solo se reasigna) -- no hay metodo que probar.
     [Fact]
     public void Apply_SobrescribeTurnoHorarioYBloques_CuandoLlegaOtroTurnoDiarioAsignado()
     {
-        var empleado = EmpleadoDePrueba();
+        var colaborador = ColaboradorDePrueba();
         var fecha = new DateOnly(2026, 8, 3);
         var streamKey = "EMP-001:2026-08-03";
         var medianoche = fecha.ToDateTime(TimeOnly.MinValue);
@@ -112,12 +112,12 @@ public class TurnoVigenteProjectionTests
             Descansos: [], Extras: [], Descripcion: "(14:00-22:00)");
         var turnoTarde = new TurnoDiario("Turno Tarde", [franjaTarde], "Turno Tarde: (14:00-22:00)");
         var nuevaSolicitudId = Guid.NewGuid();
-        var segundoEvento = new TurnoDiarioAsignado(streamKey, empleado, fecha, turnoTarde, nuevaSolicitudId);
+        var segundoEvento = new TurnoDiarioAsignado(streamKey, colaborador, fecha, turnoTarde, nuevaSolicitudId);
 
         var vista = TurnoVigenteProjection.Apply(segundoEvento, vistaPrevia);
 
         vista.Id.Should().Be(streamKey);
-        vista.EmpleadoId.Should().Be("EMP-001");
+        vista.CodigoColaborador.Should().Be("EMP-001");
         vista.Fecha.Should().Be(fecha);
         vista.NombreCompleto.Should().Be("Ana Ramirez");
         vista.NombreTurno.Should().Be("Turno Tarde");
@@ -127,10 +127,10 @@ public class TurnoVigenteProjectionTests
     }
 
     // CA-2 (borde que el test de arriba no discrimina, porque ahi los dos eventos traen el MISMO
-    // empleado): cada TurnoDiarioAsignado carga el payload Empleado completo, asi que una correccion
+    // colaborador): cada TurnoDiarioAsignado carga el payload Colaborador completo, asi que una correccion
     // del nombre aguas arriba llega con la reasignacion y el "ultimo gana" tambien le aplica --
     // congelar el nombre de la primera asignacion dejaria la vista mostrando un dato viejo para
-    // siempre. Id, EmpleadoId y Fecha si son invariantes (identidad del stream), y se verifican aqui
+    // siempre. Id, CodigoColaborador y Fecha si son invariantes (identidad del stream), y se verifican aqui
     // junto al refresco para que el test no pueda pasar por sobrescribir la vista entera.
     [Fact]
     public void Apply_RefrescaElNombreCompleto_CuandoLaReasignacionTraeElNombreCorregido()
@@ -148,8 +148,8 @@ public class TurnoVigenteProjectionTests
             "Turno Manana: (06:00-14:00)",
             [new Bloque(TipoBloqueVigente.Ordinaria, medianoche.AddHours(6), medianoche.AddHours(14))]);
 
-        // Mismo EmpleadoId, nombre corregido aguas arriba (dos nombres y dos apellidos).
-        var empleadoCorregido = new ColaboradorProgramado("EMP-001", "CC", "1098765432", "Ana Maria", "Ramirez Solano");
+        // Mismo CodigoColaborador, nombre corregido aguas arriba (dos nombres y dos apellidos).
+        var colaboradorCorregido = new ColaboradorProgramado("EMP-001", "CC", "1098765432", "Ana Maria", "Ramirez Solano");
         var turnoTarde = new TurnoDiario(
             "Turno Tarde",
             [new FranjaProgramada(
@@ -157,13 +157,13 @@ public class TurnoVigenteProjectionTests
                 Descansos: [], Extras: [], Descripcion: "(14:00-22:00)")],
             "Turno Tarde: (14:00-22:00)");
         var segundoEvento = new TurnoDiarioAsignado(
-            streamKey, empleadoCorregido, fecha, turnoTarde, Guid.NewGuid());
+            streamKey, colaboradorCorregido, fecha, turnoTarde, Guid.NewGuid());
 
         var vista = TurnoVigenteProjection.Apply(segundoEvento, vistaPrevia);
 
         vista.NombreCompleto.Should().Be("Ana Maria Ramirez Solano");
         vista.Id.Should().Be(streamKey);
-        vista.EmpleadoId.Should().Be("EMP-001");
+        vista.CodigoColaborador.Should().Be("EMP-001");
         vista.Fecha.Should().Be(fecha);
     }
 
@@ -176,7 +176,7 @@ public class TurnoVigenteProjectionTests
     [Fact]
     public void Create_MapeaSedeIdYNombreSede_DesdeLaSedeDeLaFranja()
     {
-        var empleado = EmpleadoDePrueba();
+        var colaborador = ColaboradorDePrueba();
         var fecha = new DateOnly(2026, 8, 3);
         var streamKey = "EMP-001:2026-08-03";
         var sede = new SedeProgramada("SD-SUBA", "Suba");
@@ -185,7 +185,7 @@ public class TurnoVigenteProjectionTests
             new TimeOnly(6, 0), new TimeOnly(14, 0), DiaOffsetFin: 0,
             Descansos: [], Extras: [], Descripcion: "(06:00-14:00)", Sede: sede);
         var turnoDiario = new TurnoDiario("Turno Manana", [franja], "Turno Manana: (06:00-14:00)");
-        var evento = new TurnoDiarioAsignado(streamKey, empleado, fecha, turnoDiario, Guid.NewGuid());
+        var evento = new TurnoDiarioAsignado(streamKey, colaborador, fecha, turnoDiario, Guid.NewGuid());
 
         var vista = TurnoVigenteProjection.Create(evento);
 
@@ -203,7 +203,7 @@ public class TurnoVigenteProjectionTests
     [Fact]
     public void Create_HeredaLaSedeDeLaFranjaEnBloquesDeDescansoYExtra()
     {
-        var empleado = EmpleadoDePrueba();
+        var colaborador = ColaboradorDePrueba();
         var fecha = new DateOnly(2026, 8, 3);
         var streamKey = "EMP-001:2026-08-03";
         var sede = new SedeProgramada("SD-SUBA", "Suba");
@@ -220,7 +220,7 @@ public class TurnoVigenteProjectionTests
             "Turno Manana",
             [franja],
             "Turno Manana: (06:00-14:00)[Descansos:(10:00-10:15)][Extras:(05:00-06:00)]");
-        var evento = new TurnoDiarioAsignado(streamKey, empleado, fecha, turnoDiario, Guid.NewGuid());
+        var evento = new TurnoDiarioAsignado(streamKey, colaborador, fecha, turnoDiario, Guid.NewGuid());
 
         var vista = TurnoVigenteProjection.Create(evento);
 
@@ -242,7 +242,7 @@ public class TurnoVigenteProjectionTests
     [Fact]
     public void Create_DejaSedeIdYNombreSedeNulos_CuandoLaFranjaNoTraeSede()
     {
-        var empleado = EmpleadoDePrueba();
+        var colaborador = ColaboradorDePrueba();
         var fecha = new DateOnly(2026, 8, 3);
         var streamKey = "EMP-001:2026-08-03";
 
@@ -250,7 +250,7 @@ public class TurnoVigenteProjectionTests
             new TimeOnly(6, 0), new TimeOnly(14, 0), DiaOffsetFin: 0,
             Descansos: [], Extras: [], Descripcion: "(06:00-14:00)");
         var turnoDiario = new TurnoDiario("Turno Manana", [franja], "Turno Manana: (06:00-14:00)");
-        var evento = new TurnoDiarioAsignado(streamKey, empleado, fecha, turnoDiario, Guid.NewGuid());
+        var evento = new TurnoDiarioAsignado(streamKey, colaborador, fecha, turnoDiario, Guid.NewGuid());
 
         var vista = TurnoVigenteProjection.Create(evento);
 
@@ -266,7 +266,7 @@ public class TurnoVigenteProjectionTests
     [Fact]
     public void Create_MapeaSedesDistintasPorBloque_CuandoElTurnoTieneFranjasEnSedesDistintas()
     {
-        var empleado = EmpleadoDePrueba();
+        var colaborador = ColaboradorDePrueba();
         var fecha = new DateOnly(2026, 8, 3);
         var streamKey = "EMP-001:2026-08-03";
         var suba = new SedeProgramada("SD-SUBA", "Suba");
@@ -280,7 +280,7 @@ public class TurnoVigenteProjectionTests
             Descansos: [], Extras: [], Descripcion: "(14:00-22:00)", Sede: chapinero);
         var turnoDiario = new TurnoDiario(
             "Turno Partido", [franjaManana, franjaTarde], "Turno Partido: (06:00-14:00)/(14:00-22:00)");
-        var evento = new TurnoDiarioAsignado(streamKey, empleado, fecha, turnoDiario, Guid.NewGuid());
+        var evento = new TurnoDiarioAsignado(streamKey, colaborador, fecha, turnoDiario, Guid.NewGuid());
 
         var vista = TurnoVigenteProjection.Create(evento);
 
@@ -322,7 +322,7 @@ public class TurnoVigenteProjectionTests
             Descansos: [], Extras: [], Descripcion: "(14:00-22:00)", Sede: chapinero);
         var turnoTarde = new TurnoDiario("Turno Tarde", [franjaTarde], "Turno Tarde: (14:00-22:00)");
         var segundoEvento = new TurnoDiarioAsignado(
-            streamKey, EmpleadoDePrueba(), fecha, turnoTarde, Guid.NewGuid());
+            streamKey, ColaboradorDePrueba(), fecha, turnoTarde, Guid.NewGuid());
 
         var vista = TurnoVigenteProjection.Apply(segundoEvento, vistaPrevia);
 

--- a/tests/Bitakora.ControlAsistencia.Projections.Tests/Infraestructura/AssertsProyecciones.cs
+++ b/tests/Bitakora.ControlAsistencia.Projections.Tests/Infraestructura/AssertsProyecciones.cs
@@ -94,7 +94,7 @@ public static class AssertsProyecciones
     /// El named store lee el event store con la misma identidad de stream que el write-side ya
     /// declara (Cosmos.EventSourcing.CritterStack 2.1.0: Events.StreamIdentity = AsString): los
     /// stream keys de este BC son siempre strings -- e.Id.ToString() en la raiz de solicitud,
-    /// ComputarStreamId -> "{EmpleadoId}:{Fecha:yyyy-MM-dd}" en control diario --, nunca el Guid
+    /// ComputarStreamId -> "{CodigoColaborador}:{Fecha:yyyy-MM-dd}" en control diario --, nunca el Guid
     /// crudo. Con el default de Marten (AsGuid cuando nadie lo configura, docs "Event Store
     /// Configuration" -> "Stream Identity": https://martendb.io/events/configuration.html#stream-identity)
     /// el daemon leeria stream_id varchar como si fuera uuid y no encontraria ningun stream.


### PR DESCRIPTION
## Resumen

Pipeline TDD completado (refactoring puro):
- Análisis: no se requieren tests nuevos
- Justificación: Issue #401 renombra CLAVES (nombres de propiedad, campos de records anidados y
- Baseline: 1174 tests pasando
- Refactoring ejecutado manteniendo todos los tests verdes

## Decisiones del pipeline

<details>
<summary>Test Writer (fase roja) — 4m 57s</summary>

_(El agente no generó resumen)_

</details>

<details>
<summary>Reviewer (fase refactor) — 18m 6s</summary>

## ES Reviewer - Revision (issue #401, carril de refactor puro)

### Evaluacion general
- Calidad: buena
- Cambios realizados: si (el refactor completo lo ejecuto este agente -- carril `REFACTOR_ONLY`,
  sin fases roja ni verde previas)

### Contexto del carril

`pipeline-state/refactor-signal.md` declara `REFACTOR_ONLY=true` con `REMOVED_TESTS=0`. La
justificacion del test-writer esta bien fundada y la verifique de forma independiente: renombrar una
propiedad obliga a produccion y tests a cambiar juntos **solo para compilar**, asi que no existe un
test nuevo capaz de fallar en rojo controlado. Encaja en el caso mandatorio de cambio de firma.

Baseline confirmado antes de tocar nada: **1357 tests, 0 errores, 1309 correctos, 48 omitidos** --
identico a lo que declaro la señal.

### Cumplimiento de ADRs aplicables

| ADR | Cumplimiento | Observacion |
|---|---|---|
| MEF-ADR-0036: identidad del evento persistido | ok | **Verificado, no asumido**: ningun nombre de CLASE de evento cambia (`git diff` sobre declaraciones de tipo: vacio) y ningun `IdentidadEventos*.cs` se toca. Los alias derivan del nombre simple de la clase, asi que quedan intactos y **no aplica** el protocolo de dos despliegues (seccion 5). La purga que si aplica esta declarada en el mismo despliegue, nunca diferida |
| CA-ADR-0029 decision #6: proscripcion de `MapEventType` / `EventNamingStyle` | ok | Cero ocurrencias de `MapEventType`, `JsonPropertyName` y `Upcast` en el diff y en `src/`. El rename no introduce ningun mapeo de identidad ni de claves |
| CA-ADR-0025 / MEF-ADR-0023: lo que cruza el bus es plano | ok | Los tres contratos de bus siguen siendo records/DTOs planos de primitivos. El rename no altera la forma, solo el nombre de los campos |
| MEF-ADR-0043: contrato HTTP de comandos | ok | Verbo y ruta de los dos POST **sin cambio** (`git diff` sobre `HttpTrigger` de comandos: vacio). El unico `HttpTrigger` tocado es un GET de consulta, fuera del gate de comandos |
| MEF-ADR-0009: mensajes en `.resx` | ok | `EmpleadoIdVacio` -> `CodigoColaboradorVacio`, **con el texto del valor tambien renombrado** (no solo la clave). El mensaje de FluentValidation del validator igual |
| MEF-ADR-0034 / MEF-ADR-0035: read model y proyeccion | ok | `TurnoVigente.CodigoColaborador` y `TurnoVigenteProjection` alineados. La forma del documento cambia -- la resuelve el rebuild declarado, no un mapeo |
| MEF-ADR-0013: smoke tests contra dev | ok con rojo ambiental | Ver "Criticas y hallazgos" y `blockage-report.md` |
| MEF-ADR-0002 / MEF-ADR-0016: tests de serializacion | ok | Reescritos a las claves nuevas crudas. Naming de los tests preservado y coherente tras el swap |
| MEF-ADR-0012: encapsulamiento y serializacion | ok | Recorri el checklist de antipatrones: sin propiedad publica nueva, sin clase estatica sobre datos de un VO, sin getter solo-para-test, sin `InternalsVisibleTo` nuevo, sin `[JsonConstructor]`, sin `record` con `IReadOnlyList` en igualdad, y ningun evento con marker de bus gano payload rico. Un rename puro no mueve ninguno de esos ejes |
| MEF-ADR-0039: composicion por rol de evento | ok | **Cero** `<ProjectReference>`/`<PackageReference>` agregadas o quitadas en todo el diff. Las tres islas de eventos y la cuarta (`ReadModels`) siguen con cero referencias reales |

### Desviaciones de ADRs

**Declaradas por el implementer**: no aplica -- carril de refactor puro, sin fase verde.

**Detectadas por el reviewer**:

Ninguna desviacion de ADR. Si hay una **desviacion respecto de la investigacion del issue** (que no
es un ADR), documentada abajo como hallazgo mayor.

### Convenciones del pipeline (no ADRs)

| Convencion | Estado | Observacion |
|---|---|---|
| Cada test con `Then()` + `And<>()` | n/a | No se agrego ningun test: el refactor no cambia comportamiento |
| Overloads correctos para stream IDs compuestos | ok | Sin cambio; los tests siguen usando los overloads con `streamId` explicito |
| Fakes manuales (no NSubstitute) | ok | Sin cambio |
| Feature folders (produccion y tests) | ok | Ningun archivo se movio de carpeta |
| Smoke tests: SkipWhen, secrets, cobertura | ok | `Assert.SkipWhen` intacto; `appsettings.json` sin secretos; cobertura de efectos sin cambio |
| Proyecciones read-side | ok | `partial` sobre la clase companion, read model `record` plano sin sufijo de implementacion, `ReadModels` sin `ProjectReference` |
| Antipatrones de habilitacion (MEF-ADR-0039) | ok | Ningun `.csproj` de las islas gano referencias; ningun tipo de bus homonimo nuevo |
| Compatibilidad Marten write-side/read-side | ok | Gate **disparado** (el diff toca `ConfiguracionMartenProjectionsControlHoras.cs`), pero el cambio ahi es **solo de comentarios**: ningun atributo de la columna "debe coincidir" se altera. `StreamIdentity`, schema, serializador y tipos registrados quedan iguales. Par 2 (read models): el shape de `TurnoVigente` si cambia, pero **simetricamente** -- worker y query-side comparten el mismo tipo de `ReadModels`, asi que no puede divergir en compilacion; los documentos ya materializados los resuelve el rebuild declarado |
| Identidad de stream (MEF-ADR-0037) | ok | Gate disparado. (1) Cero `ToString("N"/"B"/...)` o `.ToUpper()`/`.ToLower()` introducidos. (2) En `src/` la unica composicion `"{codigo}:{fecha}"` vive **dentro** de `ComputarStreamId`; las demas estan en tests, como literal esperado, y son preexistentes. (3) `ObtenerTurnoVigente` mantiene un componente por segmento, `fecha` parseada con `TryParseExact` + 400 con mensaje, y la clave reconstruida con `ComputarStreamId` |
| Contrato HTTP de comandos (MEF-ADR-0043) | ok | El diff **no agrega** ningun endpoint de comando. Modifica dos preexistentes cuya migracion el issue **si pacto** (claves de body), con verbo y ruta intactos |
| Control de volumen de telemetria (MEF-ADR-0038) | n/a | El diff no toca seams de observabilidad ni el callback de Wolverine |
| Tests via ToString/comportamiento | ok | Sin cambio |
| Sin numeros magicos | ok | Sin cambio |
| Condiciones en positivo | ok | Sin cambio |

### Elegancia del codigo

- **Ejecucion del swap**: por reemplazo con frontera de palabra en orden de especificidad
  (`InformacionEmpleado` -> `EmpleadoId` -> plural -> singular), de modo que `EmpleadoIdVacio` y
  `empleadoIdA/B` cayeran solos sin reglas ad hoc.
- **Colision evitada**: `EmpleadoProgramado` (campo de test tipado `ColaboradorProgramado`) habria
  quedado como un campo homonimo de su propio tipo -- legal en C# pero confuso. Renombrado a
  `ColaboradorProgramadoEsperado`, alineado con el `TurnoProgramadoEsperado` contiguo.
- **Legibilidad restaurada**: un identificador 8 caracteres mas largo empujo dos lineas de produccion
  fuera del ancho habitual. Reflui el `return` de `MarcacionRegistrada.Crear`. El repo no declara
  `max_line_length` y ya tenia 445 lineas >110; no reflui el resto para no inflar el diff.
- **Sin deuda nueva**: `dotnet format --verify-no-changes` reporta los **mismos 4** `IDE0005`
  preexistentes que en `main` -- ni uno nuevo. Build con 0 errores y sin warnings nuevos.

### Criticas y hallazgos

**1. Mayor -- la investigacion del issue declaraba a `ObtenerTurnoVigente` libre del termino, y no lo estaba.**
El issue afirma: *"`ObtenerTurnoVigente` no porta el termino (verificado por grep)"*. Es incorrecto:
ese endpoint portaba `{empleadoId}` como **placeholder de ruta** y como parametro de binding.
Corregido (CA-5 lo exige). El riesgo de contrato es nulo y lo verifique antes de aplicarlo: el
placeholder de un segmento de ruta es **posicional**, asi que la URL publica
(`/control-horas/turnos-vigentes/{valor}/{fecha}`) es identica antes y despues. Es lo contrario del
parametro de query string de `ListarTurnosVigentes`, que si es parte del contrato y por eso el issue
si lo declaro.

**2. Mayor -- las narrativas de los comentarios quedaban invertidas por el swap mecanico.**
El reemplazo textual corrompio la memoria historica: `"el nombre anterior era Empleado"` se convirtio
en `"el nombre anterior era Colaborador"`, y `DiaCalculado` llego a decir *"paso de
InformacionColaborador a InformacionColaborador"*. Peor aun, ~8 comentarios afirmaban *"las claves
JSON se conservan hasta #401"* -- una promesa que **este** issue rompe. Reescribi las narrativas de
los 10 archivos afectados para que digan la verdad: que #319/#322/#340 no tocaron el wire y que #401
si lo hace, con la purga (no el mapeo) como mecanismo. CA-5 admite menciones historicas del termino
en comentarios, y aqui son necesarias para que el registro sea veraz.

**3. Mayor -- los tests de serializacion cambiaron de significado, no solo de literal.**
Antes acreditaban **compatibilidad hacia atras** (que un cambio de tipo no alteraba la forma
persistida). Con las claves reescritas ya no acreditan eso: acreditan la **forma canonica hacia
adelante**. Dejar la cabecera vieja habria hecho creer a un lector futuro que el wire sigue intacto
desde #319. Reescribi las cabeceras y renombre el helper
`JsonConFormaPersistidaAntesDelCambioDeTipos` -> `JsonConLaFormaPersistidaEnMtEvents`: su contenido
es hoy la forma **posterior** al cambio, asi que el nombre viejo era activamente enganoso.

**4. Menor -- 3 smoke tests en rojo por causa ambiental, no por defecto.**
Detalle completo en `.claude/pipeline/blockage-report.md`. No los corregi ni los elimine: el codigo
es correcto y los tests son legitimos. **Verificado empiricamente contra dev**, no inferido: un POST
con la clave nueva responde `400` nombrando literalmente `EmpleadoId`, y con la clave vieja responde
`202`. Se resuelven solos con el despliegue que integra el PR, siempre que incluya la purga.

**5. Observacion para el despliegue (no bloqueante).** MEF-ADR-0036 seccion 5 nacio de un incidente
donde el codigo salio y la purga quedo pendiente. Aqui el riesgo es concreto y vale nombrarlo: si se
desplegara sin purgar, la primera rehidratacion de un aggregate preexistente fallaria, porque
`MarcacionRegistrada.Crear` valida su identificador no vacio y el JSON viejo ya no trae la clave que
lo puebla.

### Refactorings aplicados

1. Swap de identificadores en 75 archivos (produccion, tests, `.resx`, comentarios de `.csproj`).
2. `EmpleadoProgramado` -> `ColaboradorProgramadoEsperado`, para no crear un campo homonimo de su tipo.
3. Reescritura de las narrativas historicas en 10 archivos de produccion y 3 de test.
4. `JsonConFormaPersistidaAntesDelCambioDeTipos` -> `JsonConLaFormaPersistidaEnMtEvents` (+ los
   nombres de test que lo citaban).
5. Reflujo del `return` de `MarcacionRegistrada.Crear`.

### Cobertura de criterios de aceptacion

| Criterio | Estado | Test(s) |
|---|---|---|
| CA-1: claves de eventos persistidos + tests de serializacion con claves nuevas crudas | cubierto | `ProgramacionTurnoSolicitadaSerializacionTests` (JSON anonimo con `Colaborador`/`CodigoColaborador`), `TurnoDiarioAsignadoSerializacionTests` (JSON literal con `InformacionColaborador`/`CodigoColaborador`), `MarcacionRegistradaSerializacionTests`, `MarcacionAdicionadaSerializacionTests` |
| CA-2: contratos de bus con round-trip por serializador por defecto | cubierto | `ProgramacionTurnoDiarioSolicitadaPortabilidadTests` (`RoundTrip_*_ConSerializadorPorDefectoDelBus`), `DiaCalculadoSerializacionTests` (`RoundTrip_*_ConSerializadorPorDefectoDelPublisher`, `RoundTrip_PreservaCampos_CuandoInformacionColaboradorEsNula`, `Deserializar_TieneExito_ConResolverPorDefectoSinRegistros`), `RegistroDeMarcacionCreadoDeserializacionTests` (clave cruda `codigoColaborador`) |
| CA-3: contratos HTTP, validators y `.resx` | cubierto | `SolicitarProgramacionTurnoValidatorTests`, `RegistrarMarcacionValidatorTests`, `MarcacionRegistradaTests`; `.resx` con clave **y texto** renombrados |
| CA-4: read model, proyeccion y smoke de consulta | cubierto | `TurnoVigenteProjectionTests`, `ListarTurnosVigentes/FunctionEndpointTests`, `ListarTurnosVigentesSmokeTests` (rojo ambiental, ver hallazgo 4) |
| CA-5: cero apariciones en identificadores | cubierto | Verificado por grep: **0** ocurrencias de `Empleado`/`empleado` fuera de comentarios en `src/` y `tests/` |

### Tests agregados

Ninguno, deliberadamente. Un refactor puro no cambia comportamiento, asi que un test nuevo no tendria
canal propio que probar. La cobertura de contratos que exige mi rol (igualdad y round-trip de
serializacion) **ya existia** y quedo intacta: `ColaboradorProgramadoIgualdadTests`,
`DetalleColaboradorIgualdadTests`, `SedeProgramadaIgualdadTests` y los tests de portabilidad citados
en CA-2 -- todos verdes con los identificadores nuevos.

### Estado final

| | Baseline | Final |
|---|---|---|
| Total | 1357 | 1357 |
| Correctos | 1309 | 1306 |
| Errores | 0 | 3 (smoke ambiental) |
| Omitidos | 48 | 48 |

Unitarios: **1174/1174 verdes**. Build: 0 errores, sin warnings nuevos. Formato: sin drift.

</details>

## Commits

8223448 refactor(hu-401): renombra a CodigoColaborador y Colaborador las claves de los contratos

Closes #401