### PR TITLE
Exponer un endpoint de readiness que verifique el event store antes de los smoke tests

### DIFF
--- a/.github/workflows/smoke-tests-dominio.yml
+++ b/.github/workflows/smoke-tests-dominio.yml
@@ -217,17 +217,49 @@ jobs:
           expected_sha="${{ inputs.expected_sha }}"
           if [ -n "$expected_sha" ]; then
             echo "Esperando que ${{ inputs.base_url }}/api/version reporte el SHA ${expected_sha}..."
+            version_ok=0
             for i in $(seq 1 60); do
               body=$(curl -s "${{ inputs.base_url }}/api/version" || echo "")
               if [[ "$body" == *"$expected_sha"* ]]; then
                 echo "Version OK tras ${i} intento(s) (~$((i*2))s): ${body}"
-                exit 0
+                version_ok=1
+                break
               fi
               echo "Intento ${i}: version desplegada '${body}' no coincide con '${expected_sha}'. Reintentando en 2s..."
               sleep 2
             done
-            echo "Timeout: /api/version no reporto el SHA esperado (${expected_sha}) en 120s"
-            exit 1
+            if [ "$version_ok" -eq 0 ]; then
+              echo "Timeout: /api/version no reporto el SHA esperado (${expected_sha}) en 120s"
+              exit 1
+            fi
+
+            # Issue #399 (incidente run 31904647437): el binario ya sirve el SHA esperado, pero el
+            # write-path del event store puede seguir frio -- el gate de /api/version no lo
+            # ejercita. /api/ready si abre una conexion contra el event store (Weasel
+            # ensureStorageExistsAsync), asi que su primer 200 es la senal real de que el write-path
+            # esta caliente. Timeout total medido por reloj (no por conteo de intentos) porque
+            # --max-time hace variable la duracion de cada intento; 120s replica el mismo criterio
+            # de MEF-ADR-0031 (el doble de la peor ventana real observada, 35.3s). --max-time por
+            # intento evita que una sola peticion colgada agote ese presupuesto.
+            echo "Esperando que ${{ inputs.base_url }}/api/ready responda 200..."
+            timeout_ready=120
+            inicio_ready=$(date +%s)
+            intento=0
+            while true; do
+              intento=$((intento + 1))
+              code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 15 "${{ inputs.base_url }}/api/ready" || echo "000")
+              transcurrido=$(( $(date +%s) - inicio_ready ))
+              if [ "$code" = "200" ]; then
+                echo "Ready OK tras ${intento} intento(s) (~${transcurrido}s)."
+                exit 0
+              fi
+              if [ "$transcurrido" -ge "$timeout_ready" ]; then
+                echo "Timeout: /api/ready no respondio 200 en ${timeout_ready}s (ultimo HTTP ${code})."
+                exit 1
+              fi
+              echo "Intento ${intento} (~${transcurrido}s transcurridos): /api/ready respondio HTTP ${code}. Reintentando en 3s..."
+              sleep 3
+            done
           fi
 
           echo "expected_sha vacio: degradando a chequeo simple de HTTP 200."

--- a/src/Bitakora.ControlAsistencia.Colaboradores/Infraestructura/ComposicionServicios.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/Infraestructura/ComposicionServicios.cs
@@ -183,6 +183,9 @@ public static class ComposicionServicios
         services.AddScoped<IRequestValidator, RequestValidator>();
         services.AddValidatorsFromAssemblyContaining<IColaboradoresAssemblyMarker>();
 
+        // Issue #399: readiness gate del event store, consumido por ReadyCheck (GET /api/ready).
+        services.AddScoped<IEventStoreReadinessProbe, EventStoreReadinessProbe>();
+
         return services;
     }
 }

--- a/src/Bitakora.ControlAsistencia.Colaboradores/Infraestructura/EventStoreReadinessProbe.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/Infraestructura/EventStoreReadinessProbe.cs
@@ -4,5 +4,18 @@ namespace Bitakora.ControlAsistencia.Colaboradores.Infraestructura;
 
 public class EventStoreReadinessProbe(IDocumentStore store) : IEventStoreReadinessProbe
 {
-    public Task VerificarAsync(CancellationToken ct) => throw new NotImplementedException();
+    // Stream id centinela: nunca existe como agregado real, solo fuerza a Weasel a materializar
+    // el esquema del event store (ensureStorageExistsAsync) -- la misma ruta que
+    // RegistrarColaboradorCommandHandler.HandleAsync dispara vía ExistsAsync (issue #399, stack del
+    // incidente). No cachea el resultado positivo entre llamadas (a diferencia de lo sugerido como
+    // opcion en el issue): cachear reduciria el endpoint a una verificacion de "llego a estar listo
+    // alguna vez", perdiendo la capacidad de reportar 503 si el store cae despues del arranque, y
+    // ningun test exige esa optimizacion.
+    private const string StreamIdCentinela = "readiness-probe-centinela";
+
+    public async Task VerificarAsync(CancellationToken ct)
+    {
+        await using var session = store.QuerySession();
+        await session.Events.FetchStreamStateAsync(StreamIdCentinela, ct);
+    }
 }

--- a/src/Bitakora.ControlAsistencia.Colaboradores/Infraestructura/EventStoreReadinessProbe.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/Infraestructura/EventStoreReadinessProbe.cs
@@ -1,0 +1,8 @@
+using Marten;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Infraestructura;
+
+public class EventStoreReadinessProbe(IDocumentStore store) : IEventStoreReadinessProbe
+{
+    public Task VerificarAsync(CancellationToken ct) => throw new NotImplementedException();
+}

--- a/src/Bitakora.ControlAsistencia.Colaboradores/Infraestructura/IEventStoreReadinessProbe.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/Infraestructura/IEventStoreReadinessProbe.cs
@@ -1,0 +1,6 @@
+namespace Bitakora.ControlAsistencia.Colaboradores.Infraestructura;
+
+public interface IEventStoreReadinessProbe
+{
+    Task VerificarAsync(CancellationToken ct);
+}

--- a/src/Bitakora.ControlAsistencia.Colaboradores/ReadyCheck.Mensajes.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/ReadyCheck.Mensajes.cs
@@ -1,0 +1,16 @@
+using System.Resources;
+
+namespace Bitakora.ControlAsistencia.Colaboradores;
+
+public partial class ReadyCheck
+{
+    private static readonly ResourceManager ResourceManager = new(
+        "Bitakora.ControlAsistencia.Colaboradores.ReadyCheckMensajes",
+        typeof(ReadyCheck).Assembly);
+
+    internal static class Mensajes
+    {
+        public static string EventStoreNoDisponible =>
+            ResourceManager.GetString(nameof(EventStoreNoDisponible))!;
+    }
+}

--- a/src/Bitakora.ControlAsistencia.Colaboradores/ReadyCheck.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/ReadyCheck.cs
@@ -1,0 +1,15 @@
+using Bitakora.ControlAsistencia.Colaboradores.Infraestructura;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+
+namespace Bitakora.ControlAsistencia.Colaboradores;
+
+public partial class ReadyCheck(IEventStoreReadinessProbe probe)
+{
+    [Function("ready")]
+    public Task<IActionResult> Run(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "ready")]
+        HttpRequest req,
+        CancellationToken ct) => throw new NotImplementedException();
+}

--- a/src/Bitakora.ControlAsistencia.Colaboradores/ReadyCheck.cs
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/ReadyCheck.cs
@@ -8,8 +8,23 @@ namespace Bitakora.ControlAsistencia.Colaboradores;
 public partial class ReadyCheck(IEventStoreReadinessProbe probe)
 {
     [Function("ready")]
-    public Task<IActionResult> Run(
+    public async Task<IActionResult> Run(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "ready")]
         HttpRequest req,
-        CancellationToken ct) => throw new NotImplementedException();
+        CancellationToken ct)
+    {
+        try
+        {
+            await probe.VerificarAsync(ct);
+        }
+        catch (Exception ex)
+        {
+            return new ObjectResult($"{Mensajes.EventStoreNoDisponible}: {ex.Message}")
+            {
+                StatusCode = StatusCodes.Status503ServiceUnavailable
+            };
+        }
+
+        return new OkObjectResult("OK");
+    }
 }

--- a/src/Bitakora.ControlAsistencia.Colaboradores/ReadyCheckMensajes.resx
+++ b/src/Bitakora.ControlAsistencia.Colaboradores/ReadyCheckMensajes.resx
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" msdata:Ordinal="0" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter</value></resheader>
+  <data name="EventStoreNoDisponible" xml:space="preserve">
+    <value>El event store no respondio dentro del tiempo esperado</value>
+  </data>
+</root>

--- a/src/Bitakora.ControlAsistencia.ControlHoras/Infraestructura/ComposicionServicios.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Infraestructura/ComposicionServicios.cs
@@ -195,6 +195,9 @@ public static class ComposicionServicios
         services.AddScoped<IRequestValidator, RequestValidator>();
         services.AddValidatorsFromAssemblyContaining<IControlHorasAssemblyMarker>();
 
+        // Issue #399: readiness gate del event store, consumido por ReadyCheck (GET /api/ready).
+        services.AddScoped<IEventStoreReadinessProbe, EventStoreReadinessProbe>();
+
         return services;
     }
 }

--- a/src/Bitakora.ControlAsistencia.ControlHoras/Infraestructura/EventStoreReadinessProbe.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Infraestructura/EventStoreReadinessProbe.cs
@@ -1,0 +1,8 @@
+using Marten;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Infraestructura;
+
+public class EventStoreReadinessProbe(IDocumentStore store) : IEventStoreReadinessProbe
+{
+    public Task VerificarAsync(CancellationToken ct) => throw new NotImplementedException();
+}

--- a/src/Bitakora.ControlAsistencia.ControlHoras/Infraestructura/EventStoreReadinessProbe.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Infraestructura/EventStoreReadinessProbe.cs
@@ -4,5 +4,18 @@ namespace Bitakora.ControlAsistencia.ControlHoras.Infraestructura;
 
 public class EventStoreReadinessProbe(IDocumentStore store) : IEventStoreReadinessProbe
 {
-    public Task VerificarAsync(CancellationToken ct) => throw new NotImplementedException();
+    // Stream id centinela: nunca existe como agregado real, solo fuerza a Weasel a materializar
+    // el esquema del event store (ensureStorageExistsAsync) -- la misma ruta que dispara la
+    // primera escritura de negocio via ExistsAsync (issue #399, stack del incidente). No cachea el
+    // resultado positivo entre llamadas (a diferencia de lo sugerido como opcion en el issue):
+    // cachear reduciria el endpoint a una verificacion de "llego a estar listo alguna vez",
+    // perdiendo la capacidad de reportar 503 si el store cae despues del arranque, y ningun test
+    // exige esa optimizacion.
+    private const string StreamIdCentinela = "readiness-probe-centinela";
+
+    public async Task VerificarAsync(CancellationToken ct)
+    {
+        await using var session = store.QuerySession();
+        await session.Events.FetchStreamStateAsync(StreamIdCentinela, ct);
+    }
 }

--- a/src/Bitakora.ControlAsistencia.ControlHoras/Infraestructura/IEventStoreReadinessProbe.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Infraestructura/IEventStoreReadinessProbe.cs
@@ -1,0 +1,6 @@
+namespace Bitakora.ControlAsistencia.ControlHoras.Infraestructura;
+
+public interface IEventStoreReadinessProbe
+{
+    Task VerificarAsync(CancellationToken ct);
+}

--- a/src/Bitakora.ControlAsistencia.ControlHoras/ReadyCheck.Mensajes.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ReadyCheck.Mensajes.cs
@@ -1,0 +1,16 @@
+using System.Resources;
+
+namespace Bitakora.ControlAsistencia.ControlHoras;
+
+public partial class ReadyCheck
+{
+    private static readonly ResourceManager ResourceManager = new(
+        "Bitakora.ControlAsistencia.ControlHoras.ReadyCheckMensajes",
+        typeof(ReadyCheck).Assembly);
+
+    public static class Mensajes
+    {
+        public static string EventStoreNoDisponible =>
+            ResourceManager.GetString(nameof(EventStoreNoDisponible))!;
+    }
+}

--- a/src/Bitakora.ControlAsistencia.ControlHoras/ReadyCheck.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ReadyCheck.cs
@@ -8,8 +8,23 @@ namespace Bitakora.ControlAsistencia.ControlHoras;
 public partial class ReadyCheck(IEventStoreReadinessProbe probe)
 {
     [Function("ready")]
-    public Task<IActionResult> Run(
+    public async Task<IActionResult> Run(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "ready")]
         HttpRequest req,
-        CancellationToken ct) => throw new NotImplementedException();
+        CancellationToken ct)
+    {
+        try
+        {
+            await probe.VerificarAsync(ct);
+        }
+        catch (Exception ex)
+        {
+            return new ObjectResult($"{Mensajes.EventStoreNoDisponible}: {ex.Message}")
+            {
+                StatusCode = StatusCodes.Status503ServiceUnavailable
+            };
+        }
+
+        return new OkObjectResult("OK");
+    }
 }

--- a/src/Bitakora.ControlAsistencia.ControlHoras/ReadyCheck.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ReadyCheck.cs
@@ -1,0 +1,15 @@
+using Bitakora.ControlAsistencia.ControlHoras.Infraestructura;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+
+namespace Bitakora.ControlAsistencia.ControlHoras;
+
+public partial class ReadyCheck(IEventStoreReadinessProbe probe)
+{
+    [Function("ready")]
+    public Task<IActionResult> Run(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "ready")]
+        HttpRequest req,
+        CancellationToken ct) => throw new NotImplementedException();
+}

--- a/src/Bitakora.ControlAsistencia.ControlHoras/ReadyCheckMensajes.resx
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ReadyCheckMensajes.resx
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" msdata:Ordinal="0" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter</value></resheader>
+  <data name="EventStoreNoDisponible" xml:space="preserve">
+    <value>El event store no respondio dentro del tiempo esperado</value>
+  </data>
+</root>

--- a/src/Bitakora.ControlAsistencia.Programacion/Infraestructura/ComposicionServicios.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/Infraestructura/ComposicionServicios.cs
@@ -112,6 +112,9 @@ public static class ComposicionServicios
         services.AddScoped<IRequestValidator, RequestValidator>();
         services.AddValidatorsFromAssemblyContaining<IProgramacionAssemblyMarker>();
 
+        // Issue #399: readiness gate del event store, consumido por ReadyCheck (GET /api/ready).
+        services.AddScoped<IEventStoreReadinessProbe, EventStoreReadinessProbe>();
+
         return services;
     }
 }

--- a/src/Bitakora.ControlAsistencia.Programacion/Infraestructura/EventStoreReadinessProbe.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/Infraestructura/EventStoreReadinessProbe.cs
@@ -1,0 +1,8 @@
+using Marten;
+
+namespace Bitakora.ControlAsistencia.Programacion.Infraestructura;
+
+public class EventStoreReadinessProbe(IDocumentStore store) : IEventStoreReadinessProbe
+{
+    public Task VerificarAsync(CancellationToken ct) => throw new NotImplementedException();
+}

--- a/src/Bitakora.ControlAsistencia.Programacion/Infraestructura/EventStoreReadinessProbe.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/Infraestructura/EventStoreReadinessProbe.cs
@@ -4,5 +4,18 @@ namespace Bitakora.ControlAsistencia.Programacion.Infraestructura;
 
 public class EventStoreReadinessProbe(IDocumentStore store) : IEventStoreReadinessProbe
 {
-    public Task VerificarAsync(CancellationToken ct) => throw new NotImplementedException();
+    // Stream id centinela: nunca existe como agregado real, solo fuerza a Weasel a materializar
+    // el esquema del event store (ensureStorageExistsAsync) -- la misma ruta que dispara la
+    // primera escritura de negocio via ExistsAsync (issue #399, stack del incidente). No cachea el
+    // resultado positivo entre llamadas (a diferencia de lo sugerido como opcion en el issue):
+    // cachear reduciria el endpoint a una verificacion de "llego a estar listo alguna vez",
+    // perdiendo la capacidad de reportar 503 si el store cae despues del arranque, y ningun test
+    // exige esa optimizacion.
+    private const string StreamIdCentinela = "readiness-probe-centinela";
+
+    public async Task VerificarAsync(CancellationToken ct)
+    {
+        await using var session = store.QuerySession();
+        await session.Events.FetchStreamStateAsync(StreamIdCentinela, ct);
+    }
 }

--- a/src/Bitakora.ControlAsistencia.Programacion/Infraestructura/IEventStoreReadinessProbe.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/Infraestructura/IEventStoreReadinessProbe.cs
@@ -1,0 +1,6 @@
+namespace Bitakora.ControlAsistencia.Programacion.Infraestructura;
+
+public interface IEventStoreReadinessProbe
+{
+    Task VerificarAsync(CancellationToken ct);
+}

--- a/src/Bitakora.ControlAsistencia.Programacion/ReadyCheck.Mensajes.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/ReadyCheck.Mensajes.cs
@@ -1,0 +1,16 @@
+using System.Resources;
+
+namespace Bitakora.ControlAsistencia.Programacion;
+
+public partial class ReadyCheck
+{
+    private static readonly ResourceManager ResourceManager = new(
+        "Bitakora.ControlAsistencia.Programacion.ReadyCheckMensajes",
+        typeof(ReadyCheck).Assembly);
+
+    internal static class Mensajes
+    {
+        public static string EventStoreNoDisponible =>
+            ResourceManager.GetString(nameof(EventStoreNoDisponible))!;
+    }
+}

--- a/src/Bitakora.ControlAsistencia.Programacion/ReadyCheck.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/ReadyCheck.cs
@@ -8,8 +8,23 @@ namespace Bitakora.ControlAsistencia.Programacion;
 public partial class ReadyCheck(IEventStoreReadinessProbe probe)
 {
     [Function("ready")]
-    public Task<IActionResult> Run(
+    public async Task<IActionResult> Run(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "ready")]
         HttpRequest req,
-        CancellationToken ct) => throw new NotImplementedException();
+        CancellationToken ct)
+    {
+        try
+        {
+            await probe.VerificarAsync(ct);
+        }
+        catch (Exception ex)
+        {
+            return new ObjectResult($"{Mensajes.EventStoreNoDisponible}: {ex.Message}")
+            {
+                StatusCode = StatusCodes.Status503ServiceUnavailable
+            };
+        }
+
+        return new OkObjectResult("OK");
+    }
 }

--- a/src/Bitakora.ControlAsistencia.Programacion/ReadyCheck.cs
+++ b/src/Bitakora.ControlAsistencia.Programacion/ReadyCheck.cs
@@ -1,0 +1,15 @@
+using Bitakora.ControlAsistencia.Programacion.Infraestructura;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+
+namespace Bitakora.ControlAsistencia.Programacion;
+
+public partial class ReadyCheck(IEventStoreReadinessProbe probe)
+{
+    [Function("ready")]
+    public Task<IActionResult> Run(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "ready")]
+        HttpRequest req,
+        CancellationToken ct) => throw new NotImplementedException();
+}

--- a/src/Bitakora.ControlAsistencia.Programacion/ReadyCheckMensajes.resx
+++ b/src/Bitakora.ControlAsistencia.Programacion/ReadyCheckMensajes.resx
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" msdata:Ordinal="0" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter</value></resheader>
+  <data name="EventStoreNoDisponible" xml:space="preserve">
+    <value>El event store no respondio dentro del tiempo esperado</value>
+  </data>
+</root>

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/Infraestructura/ComposicionServiciosTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/Infraestructura/ComposicionServiciosTests.cs
@@ -16,6 +16,7 @@ using System.Globalization;
 using System.Reflection;
 using System.Text;
 using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores;
 using Bitakora.ControlAsistencia.Colaboradores.CorregirFechaInicioVinculacionFunction;
 using Bitakora.ControlAsistencia.Colaboradores.DomainEvents;
 using Bitakora.ControlAsistencia.Colaboradores.Infraestructura;
@@ -520,5 +521,19 @@ public class ComposicionServiciosTests
         scope.ServiceProvider.GetService<IValidator<CorregirFechaInicioVinculacionBody>>()
             .Should().NotBeNull(
                 "sin el validator registrado, un body sin FechaCorregida responderia 202 en vez de 400");
+    }
+
+    // Issue #399: test de composicion del tercer endpoint HTTP de operacion (mismo patron que las
+    // guardas de arriba para las Functions GET de lectura) -- ReadyCheck depende de
+    // IEventStoreReadinessProbe, hoy sin registrar en AgregarServiciosColaboradores.
+    [Fact]
+    public async Task AgregarServiciosColaboradores_ResuelveElEndpointDeReady_CuandoElContenedorEstaCompuesto()
+    {
+        await using var provider = ComponerServiceProvider();
+        await using var scope = provider.CreateAsyncScope();
+
+        var act = () => ActivatorUtilities.CreateInstance<ReadyCheck>(scope.ServiceProvider);
+
+        act.Should().NotThrow();
     }
 }

--- a/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ReadyCheckTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Colaboradores.Tests/ReadyCheckTests.cs
@@ -1,0 +1,45 @@
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Colaboradores.Infraestructura;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Bitakora.ControlAsistencia.Colaboradores.Tests;
+
+public class ReadyCheckTests
+{
+    private sealed class FakeEventStoreReadinessProbeExitoso : IEventStoreReadinessProbe
+    {
+        public Task VerificarAsync(CancellationToken ct) => Task.CompletedTask;
+    }
+
+    private sealed class FakeEventStoreReadinessProbeQueFalla : IEventStoreReadinessProbe
+    {
+        public Task VerificarAsync(CancellationToken ct) =>
+            throw new TimeoutException("Npgsql: timeout abriendo la conexion");
+    }
+
+    private static HttpRequest FakeHttpRequest() => new DefaultHttpContext().Request;
+
+    [Fact]
+    public async Task Ready_Retorna200_CuandoElEventStoreResponde()
+    {
+        var endpoint = new ReadyCheck(new FakeEventStoreReadinessProbeExitoso());
+
+        var resultado = await endpoint.Run(FakeHttpRequest(), CancellationToken.None);
+
+        resultado.Should().BeOfType<OkObjectResult>();
+    }
+
+    [Fact]
+    public async Task Ready_Retorna503ConCuerpoDiagnosticable_CuandoElEventStoreFalla()
+    {
+        var endpoint = new ReadyCheck(new FakeEventStoreReadinessProbeQueFalla());
+
+        var resultado = await endpoint.Run(FakeHttpRequest(), CancellationToken.None);
+
+        var objectResult = resultado.Should().BeOfType<ObjectResult>().Which;
+        objectResult.StatusCode.Should().Be(StatusCodes.Status503ServiceUnavailable);
+        objectResult.Value.Should().BeOfType<string>()
+            .Which.Should().Contain(ReadyCheck.Mensajes.EventStoreNoDisponible);
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/ComposicionServiciosTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/ComposicionServiciosTests.cs
@@ -23,6 +23,7 @@ using System.Globalization;
 using System.Reflection;
 using System.Text;
 using AwesomeAssertions;
+using Bitakora.ControlAsistencia.ControlHoras;
 using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 using Bitakora.ControlAsistencia.ControlHoras.Infraestructura;
 using Bitakora.ControlAsistencia.ControlHoras.RegistrarMarcacionFunction;
@@ -475,5 +476,19 @@ public class ComposicionServiciosTests
 
         opciones.Durability.DurabilityAgentEnabled.Should().BeTrue();
         opciones.Durability.Mode.Should().Be(DurabilityMode.Solo);
+    }
+
+    // Issue #399: test de composicion del tercer endpoint HTTP de operacion (mismo patron que las
+    // guardas de arriba para las Functions GET de lectura) -- ReadyCheck depende de
+    // IEventStoreReadinessProbe, hoy sin registrar en AgregarServiciosControlHoras.
+    [Fact]
+    public async Task AgregarServiciosControlHoras_ResuelveElEndpointDeReady_CuandoElContenedorEstaCompuesto()
+    {
+        await using var provider = ComponerServiceProvider();
+        await using var scope = provider.CreateAsyncScope();
+
+        var act = () => ActivatorUtilities.CreateInstance<ReadyCheck>(scope.ServiceProvider);
+
+        act.Should().NotThrow();
     }
 }

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ReadyCheckTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ReadyCheckTests.cs
@@ -1,0 +1,45 @@
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.ControlHoras.Infraestructura;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Tests;
+
+public class ReadyCheckTests
+{
+    private sealed class FakeEventStoreReadinessProbeExitoso : IEventStoreReadinessProbe
+    {
+        public Task VerificarAsync(CancellationToken ct) => Task.CompletedTask;
+    }
+
+    private sealed class FakeEventStoreReadinessProbeQueFalla : IEventStoreReadinessProbe
+    {
+        public Task VerificarAsync(CancellationToken ct) =>
+            throw new TimeoutException("Npgsql: timeout abriendo la conexion");
+    }
+
+    private static HttpRequest FakeHttpRequest() => new DefaultHttpContext().Request;
+
+    [Fact]
+    public async Task Ready_Retorna200_CuandoElEventStoreResponde()
+    {
+        var endpoint = new ReadyCheck(new FakeEventStoreReadinessProbeExitoso());
+
+        var resultado = await endpoint.Run(FakeHttpRequest(), CancellationToken.None);
+
+        resultado.Should().BeOfType<OkObjectResult>();
+    }
+
+    [Fact]
+    public async Task Ready_Retorna503ConCuerpoDiagnosticable_CuandoElEventStoreFalla()
+    {
+        var endpoint = new ReadyCheck(new FakeEventStoreReadinessProbeQueFalla());
+
+        var resultado = await endpoint.Run(FakeHttpRequest(), CancellationToken.None);
+
+        var objectResult = resultado.Should().BeOfType<ObjectResult>().Which;
+        objectResult.StatusCode.Should().Be(StatusCodes.Status503ServiceUnavailable);
+        objectResult.Value.Should().BeOfType<string>()
+            .Which.Should().Contain(ReadyCheck.Mensajes.EventStoreNoDisponible);
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/Infraestructura/ComposicionServiciosTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/Infraestructura/ComposicionServiciosTests.cs
@@ -21,6 +21,7 @@
 
 using System.Text;
 using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Programacion;
 using Bitakora.ControlAsistencia.Programacion.DomainEvents;
 using Bitakora.ControlAsistencia.Programacion.Infraestructura;
 using Cosmos.EventSourcing.Abstractions.Commands;
@@ -193,5 +194,19 @@ public class ComposicionServiciosTests
 
         opciones.Durability.DurabilityAgentEnabled.Should().BeTrue();
         opciones.Durability.Mode.Should().Be(DurabilityMode.Solo);
+    }
+
+    // Issue #399: test de composicion del tercer endpoint HTTP de operacion (mismo patron que las
+    // guardas de arriba para las Functions GET de lectura) -- ReadyCheck depende de
+    // IEventStoreReadinessProbe, hoy sin registrar en AgregarServiciosProgramacion.
+    [Fact]
+    public async Task AgregarServiciosProgramacion_ResuelveElEndpointDeReady_CuandoElContenedorEstaCompuesto()
+    {
+        await using var provider = ComponerServiceProvider();
+        await using var scope = provider.CreateAsyncScope();
+
+        var act = () => ActivatorUtilities.CreateInstance<ReadyCheck>(scope.ServiceProvider);
+
+        act.Should().NotThrow();
     }
 }

--- a/tests/Bitakora.ControlAsistencia.Programacion.Tests/ReadyCheckTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Programacion.Tests/ReadyCheckTests.cs
@@ -1,0 +1,45 @@
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.Programacion.Infraestructura;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Bitakora.ControlAsistencia.Programacion.Tests;
+
+public class ReadyCheckTests
+{
+    private sealed class FakeEventStoreReadinessProbeExitoso : IEventStoreReadinessProbe
+    {
+        public Task VerificarAsync(CancellationToken ct) => Task.CompletedTask;
+    }
+
+    private sealed class FakeEventStoreReadinessProbeQueFalla : IEventStoreReadinessProbe
+    {
+        public Task VerificarAsync(CancellationToken ct) =>
+            throw new TimeoutException("Npgsql: timeout abriendo la conexion");
+    }
+
+    private static HttpRequest FakeHttpRequest() => new DefaultHttpContext().Request;
+
+    [Fact]
+    public async Task Ready_Retorna200_CuandoElEventStoreResponde()
+    {
+        var endpoint = new ReadyCheck(new FakeEventStoreReadinessProbeExitoso());
+
+        var resultado = await endpoint.Run(FakeHttpRequest(), CancellationToken.None);
+
+        resultado.Should().BeOfType<OkObjectResult>();
+    }
+
+    [Fact]
+    public async Task Ready_Retorna503ConCuerpoDiagnosticable_CuandoElEventStoreFalla()
+    {
+        var endpoint = new ReadyCheck(new FakeEventStoreReadinessProbeQueFalla());
+
+        var resultado = await endpoint.Run(FakeHttpRequest(), CancellationToken.None);
+
+        var objectResult = resultado.Should().BeOfType<ObjectResult>().Which;
+        objectResult.StatusCode.Should().Be(StatusCodes.Status503ServiceUnavailable);
+        objectResult.Value.Should().BeOfType<string>()
+            .Which.Should().Contain(ReadyCheck.Mensajes.EventStoreNoDisponible);
+    }
+}


### PR DESCRIPTION
## Resumen

Pipeline TDD completado:
- Fase roja: tests escritos con stubs
- Fase verde: implementación completa
- Fase refactor: revisión de calidad

## Decisiones del pipeline

<details>
<summary>Test Writer (fase roja) — 10m 39s</summary>

## ES Test Writer - Decisiones (issue #399)

### Naturaleza de la tarea

No es refactoring puro: el endpoint `GET /api/ready` es comportamiento HTTP nuevo (200/503) en
los tres dominios, con criterios de aceptacion explicitos (CA-1 a CA-6) que exigen tests nuevos.
No hay comando/aggregate/evento involucrado -- el propio planner ya documento en su investigacion
que este issue no es `tipo:feature` justamente por eso. Sigo el flujo normal de TDD (no el carril
de senal de refactor).

### Tests creados (uno por dominio: Colaboradores, ControlHoras, Programacion)

- `ReadyCheckTests.cs` (2 tests por dominio, 6 en total):
  - `Ready_Retorna200_CuandoElEventStoreResponde` - CA-3 (camino feliz)
  - `Ready_Retorna503ConCuerpoDiagnosticable_CuandoElEventStoreFalla` - CA-3 (falla del store, 503
    no 500, cuerpo diagnosticable via `.resx`)
- `Infraestructura/ComposicionServiciosTests.cs` (1 test nuevo agregado por dominio, no se toco
  ningun test existente):
  - `AgregarServicios{Dominio}_ResuelveElEndpointDeReady_CuandoElContenedorEstaCompuesto` - guardrail
    de wiring DI, mismo patron `ActivatorUtilities.CreateInstance<T>` que ya usan
    `ObtenerFichaColaborador`/`ObtenerTurnoVigente`/etc. en el mismo archivo.

### Estructura elegida

Estos tests NO usan el harness `CommandHandlerAsyncTest<TCommand>` (Given/When/Then/And): el
endpoint no es un command handler, no hay aggregate ni evento que reconstruir. Sigo el precedente
ya existente en el proyecto para Functions HTTP GET puras (`ObtenerFichaColaborador/
FunctionEndpointTests.cs`, `ListarTurnosVigentes/FunctionEndpointTests.cs`): clase xUnit plana,
`AwesomeAssertions` sobre `IActionResult`, fakes manuales en vez de NSubstitute.

### Stubs creados (por dominio, mismo shape en Colaboradores/ControlHoras/Programacion)

- `ReadyCheck.cs` (raiz del proyecto, mismo nivel que `HealthCheck.cs`/`VersionCheck.cs`, CA-1):
  `[Function("ready")]`, anonimo, `Run(HttpRequest, CancellationToken)` -> `throw new
  NotImplementedException()`.
- `Infraestructura/IEventStoreReadinessProbe.cs` + `Infraestructura/EventStoreReadinessProbe.cs`:
  seam nuevo que `ReadyCheck` recibe por constructor. La implementacion real (stub, `throw new
  NotImplementedException()`) envuelve `IDocumentStore` (Marten) y es responsabilidad del
  implementer resolver `FetchStreamStateAsync` sobre un stream id centinela (CA-2, nota tecnica del
  issue).
- `ReadyCheckMensajes.resx` + `ReadyCheck.Mensajes.cs` (partial): mensaje `EventStoreNoDisponible`
  para el cuerpo del 503 (regla 10 -- nunca strings literales de error en tests). Accesibilidad
  `internal` en Colaboradores/Programacion (ya tienen `InternalsVisibleTo` hacia su `.Tests`);
  `public` en ControlHoras (sin `InternalsVisibleTo` declarado, sigue el patron ya establecido ahi
  por `Retardo.Mensajes`/`MomentoDelDia.Mensajes`, que son publicos).

No se toco `ComposicionServicios.cs` en ningun dominio: registrar `IEventStoreReadinessProbe` en el
contenedor DI es implementacion real, responsabilidad del implementer (fase verde). Por eso el
nuevo test de composicion queda en rojo (falla al resolver la dependencia no registrada) -- exito
esperado en esta fase.

### Decisiones de diseno

- **Por que un seam nuevo (`IEventStoreReadinessProbe`) y no `IEventStore` (Cosmos.EventSourcing.Abstractions)
  ni `IDocumentStore` (Marten) directo en el constructor de `ReadyCheck`**: la regla del rol prohibe
  crear clases que implementen `IEventStore` en tests (el unico fake valido es el que provee
  `CommandHandlerTestBase`). Fake-ear `IDocumentStore`/`IQuerySession` de Marten a mano tampoco es
  el camino: el propio precedente del proyecto lo prohibe explicitamente
  (`ObtenerFichaColaborador/FunctionEndpointTests.cs`: "IDocumentStore/IQuerySession de Marten no se
  fake-ean a mano (violaria 'NUNCA NSubstitute' sin aportar cobertura real)"), y la superficie de
  `IDocumentStore` es demasiado grande para un fake manual razonable. El propio issue delega
  explicitamente esta decision al test-writer ("Como cubrir el 503 de CA-6 ... el issue no lo
  prescribe"). Un seam de un solo metodo (`VerificarAsync(CancellationToken)`) es fake-eable a mano
  con una linea (exito) y con un `throw` (falla), preservando la separacion Tell-don't-Ask entre "el
  endpoint decide 200/503" y "como se verifica el event store" -- esa segunda mitad sigue siendo
  black-box de smoke test (CA-7/CA-8), igual que el resto de `Run()` en los precedentes GET del
  proyecto.
- **Body del 503 via `.resx`, no un mensaje ad-hoc**: sigue MEF-ADR-0009 y la regla 10. El mensaje
  fijo (`EventStoreNoDisponible`) es la parte oraculo-verificable en el test; el implementer decide
  si concatena el detalle de la excepcion real al armar el cuerpo diagnosticable completo (CA-3).
- **Camino feliz (200) solo verifica el tipo del resultado (`OkObjectResult`)**, sin exigir un
  cuerpo especifico: ni `HealthCheck` ni `VersionCheck` fijan contrato de cuerpo en sus tests, y el
  issue no exige un shape de respuesta para el 200 -- solo el codigo de estado (CA-3).
- **No se toco `HealthCheck.cs` ni `VersionCheck.cs`** en ningun dominio (CA-4): confirmado, `git
  status` no los lista.
- **No se toco `.github/workflows/smoke-tests-dominio.yml`** (CA-5): es configuracion de CI, no
  tests ni stubs de compilacion C# -- fuera del alcance de este rol. Queda para el implementer.
- **No se agrego cobertura en los proyectos `*.SmokeTests`**: CA-7/CA-8 se satisfacen con el log del
  paso de warmup (CA-5) y verificacion post-merge, no con un smoke test nuevo -- el issue no lo pide.

### Cobertura de criterios

| Criterio de aceptacion | Test(s) |
|---|---|
| CA-1: `GET /api/ready` en los tres dominios, `[Function("ready")]`, anonimo, en `ReadyCheck.cs` | Estructura del stub (compila) x3 dominios |
| CA-2: ejercita el event store, no el read model | `IEventStoreReadinessProbe` como unico canal del endpoint hacia la infraestructura (implementer conecta `FetchStreamStateAsync`) |
| CA-3: 200 en camino feliz / 503 con cuerpo diagnosticable en falla | `Ready_Retorna200_...` / `Ready_Retorna503ConCuerpoDiagnosticable_...` x3 dominios |
| CA-4: `HealthCheck.cs`/`VersionCheck.cs` sin modificar | No se tocaron (verificado, ningun archivo en el commit) |
| CA-5: poll de `/api/ready` en el workflow | Fuera de alcance de este rol (CI, no test C#) -- queda para implementer |
| CA-6: cobertura automatizada 200/503 en los tres dominios | `ReadyCheckTests.cs` x3 dominios (2 tests c/u) |
| CA-7/CA-8: smoke tests en verde / evidencia post-merge | No aplica a esta fase (verificacion post-implementacion/post-deploy) |

### Desviaciones del plan del planner

| Sugerencia del issue | Desviacion aplicada | Razon tecnica | Consecuencia |
|---|---|---|---|
| "Impacto esperado": solo `ReadyCheck.cs` por dominio + su cobertura de tests | Se agregaron ademas `Infraestructura/IEventStoreReadinessProbe.cs` y `Infraestructura/EventStoreReadinessProbe.cs` por dominio | El issue mismo delega la decision de como cubrir 200/503 al test-writer ("el issue no lo prescribe"); sin un seam angosto, la unica forma de cubrir el 503 seria fake-ear `IDocumentStore` de Marten a mano (superficie enorme) o forzar una conexion realmente invalida en un test de composicion (lento/fragil, contradice el precedente ya escrito por este mismo proyecto sobre no fake-ear Marten) | El endpoint queda testeable con fakes manuales de una sola linea; el implementer debe registrar `IEventStoreReadinessProbe` en `ComposicionServicios.cs` (registro DI) ademas de implementar la logica real de `EventStoreReadinessProbe`/`ReadyCheck.Run` |
| Notas tecnicas: "unit test del ReadyCheck con un store fake que lance" | Se interpreto "store" como el seam `IEventStoreReadinessProbe` en vez de `IDocumentStore` crudo | Ver razon tecnica de la fila anterior | Sin cambio de cobertura; misma intencion del issue, ejecutada sin violar el precedente de "no fake-ear Marten a mano" |

### Nota sobre .resx

El SDK de .NET incluye automaticamente los `.resx` como `EmbeddedResource` (confirmado: los
`.csproj` de los tres dominios no declaran `EmbeddedResource` explicito para los `.resx` existentes
de otros handlers, y compilan). No se toco ningun `.csproj`.

### Build

`dotnet build` sobre la solucion completa: **compilacion correcta, 0 errores**. Warnings esperados
(`CS9113`, parametro de constructor no leido) en los tres `EventStoreReadinessProbe.cs`/`ReadyCheck.cs`
-- consecuencia directa de que el cuerpo es `throw new NotImplementedException()` (stub minimo,
regla 1 del rol). No se corrio `dotnet test` (regla del rol: los tests deben fallar por diseno en
esta fase; la confirmacion de la fase roja es responsabilidad del Gate 1b del pipeline).

</details>

<details>
<summary>Implementer (fase verde) — 9m 30s</summary>

## ES Implementer - Decisiones

### Enfoque de implementacion

Los tres dominios (`Colaboradores`, `ControlHoras`, `Programacion`) recibieron el mismo par de
archivos que el test-writer dejo en stub:

- `Infraestructura/EventStoreReadinessProbe.cs` (+ `IEventStoreReadinessProbe`): implementa
  `VerificarAsync` abriendo una `IQuerySession` desde el `IDocumentStore` inyectado y llamando
  `session.Events.FetchStreamStateAsync(streamIdCentinela, ct)` sobre un stream id que nunca existe
  como agregado real. Esa llamada es la misma que dispara `ensureStorageExistsAsync` de Weasel --
  el punto exacto del stack del incidente (`RegistrarColaboradorCommandHandler.HandleAsync` ->
  `ExistsAsync` -> `FetchStreamStateAsync` -> `ensureStorageExistsAsync` -> `OpenAsync`).
- `ReadyCheck.cs`: `try/catch` alrededor de `probe.VerificarAsync(ct)`. Exito -> `200 OkObjectResult`.
  Cualquier excepcion -> `503 ObjectResult` con cuerpo `"{Mensajes.EventStoreNoDisponible}: {ex.Message}"`
  (diagnosticable: incluye el mensaje real de la excepcion, ej. el timeout de Npgsql).
- `ComposicionServicios.cs` de los tres dominios: se agrego
  `services.AddScoped<IEventStoreReadinessProbe, EventStoreReadinessProbe>();`, sin la cual
  `ActivatorUtilities.CreateInstance<ReadyCheck>` fallaria (guardado por
  `ComposicionServiciosTests.AgregarServicios{Dominio}_ResuelveElEndpointDeReady_...`).

`.github/workflows/smoke-tests-dominio.yml`, paso "Warmup Function App": se agrego un segundo poll,
dentro de la rama `if [ -n "$expected_sha" ]` y despues de que `/api/version` confirme el SHA, que
hace poll de `/api/ready` con timeout propio de 120s medido por reloj (no por conteo de intentos,
porque `--max-time` hace variable la duracion de cada intento) y `--max-time 15` por intento de
`curl`. Al lograr 200 loguea `"Ready OK tras ${intento} intento(s) (~${transcurrido}s)."` -- la
evidencia que CA-8 necesita para el comentario post-merge.

### Decisiones de diseno

- **Stream id centinela como string literal**, no un `Guid`: el store de los tres dominios se
  configura con `Events.StreamIdentity = StreamIdentity.AsString` (verificado en
  `Cosmos.EventSourcing.CritterStack.Commands.MartenEventStoreExtensions.AgregarConfiguracionMartenComandos`),
  asi que la sobrecarga correcta de `FetchStreamStateAsync` es la de `string streamKey`, no la de
  `Guid`. Pasar un `Guid` habria compilado (existe la sobrecarga) pero habria sido la ruta
  incorrecta dado el modo de identidad real del store.
- **`store.QuerySession()` nueva por llamada**, no una `IQuerySession`/`IDocumentSession` inyectada
  por constructor: `EventStoreReadinessProbe` recibe `IDocumentStore` (asi lo dejo el test-writer en
  el stub), y crear la sesion dentro de `VerificarAsync` evita depender de un scope de Wolverine
  para un endpoint que no participa del pipeline de comandos.
- **Catch generico de `Exception` en `ReadyCheck.Run`**: a diferencia de un `CommandHandler` de
  negocio (donde MEF-ADR-0004/CA-ADR-0030 exigen no atrapar excepciones de dominio), este es un
  endpoint de operacion sin logica de negocio -- cualquier fallo de infraestructura (timeout,
  excepcion de Npgsql, lo que sea) debe traducirse a 503, nunca a 500. No aplica la doctrina de
  CommandHandler porque no hay un aggregate ni un evento de fallo de por medio.
- **No se cachea el resultado positivo** en un flag estatico del proceso (opcion que las Notas
  tecnicas del issue dejaban explicitamente a decidir). Se decidio no cachear: cachear reduciria la
  pregunta del endpoint de "¿el event store responde ahora?" a "¿alguna vez respondio?", perdiendo
  la capacidad de reportar 503 si el store cae despues del arranque -- y ningun test exige la
  optimizacion. Documentado como comentario en `EventStoreReadinessProbe.cs` (pasa el umbral doble
  de MEF-ADR-0044: la razon de no cachear no es obvia por el codigo, y perderla podria llevar a que
  alguien agregue el cache sin conocer el trade-off, o a que alguien piense que falta implementarlo).
- **Poll de `/api/ready` solo en la rama con `expected_sha` no vacio**: CA-5 dice literalmente
  "despues de que /api/version reporte el SHA esperado" -- la rama de fallback (chequeo simple de
  `/api/health`, usada cuando un invocador prueba un Function App ajeno sin SHA propio que esperar)
  queda sin tocar. No se extendio el poll de `/api/ready` a esa rama por alcance: el CA no lo pide y
  el planner ya delimito la investigacion a esa clase de invocadores via el criterio existente de
  `expected_sha == ''`.

### ADRs consultados

- MEF-ADR-0031 (readiness gate por SHA): confirma que `/api/health` queda intacto y que un tercer
  endpoint dedicado es el patron correcto (precedente de `/api/version`).
- MEF-ADR-0006 (naming de funciones Azure): `[Function("ready")]` sigue la convencion de
  `[Function("health")]`/`[Function("version")]`.
- MEF-ADR-0013 (smoke tests contra dev): el gate nuevo es una compuerta previa a la suite.
- MEF-ADR-0020 (hosting B1 sin `always_on`): contexto del cold start, no se toco `always_on`.
- MEF-ADR-0043: no aplica (anotado explicitamente en el issue) -- `/api/ready` es un endpoint GET de
  operacion, no un comando de negocio.
- MEF-ADR-0009 (mensajes .resx): el `.resx`/clase `Mensajes` ya los dejo el test-writer; se
  consumieron tal cual, sin agregar entradas nuevas.
- MEF-ADR-0004 / CA-ADR-0030: se uso para justificar por que el catch generico en `ReadyCheck` NO
  viola la doctrina de no atrapar excepciones de dominio (no aplica: no hay dominio de por medio).

### Desviaciones de ADRs

Ninguna desviacion -- todos los ADRs aplicados al pie de la letra.

### Precedentes consultados

- `MartenEventStoreExtensions.AgregarConfiguracionMartenComandos` (Cosmos.BuildingBlocks, paquete
  externo): confirmo `StreamIdentity.AsString` como la configuracion real del store, para elegir la
  sobrecarga correcta de `FetchStreamStateAsync`. No es un ADR de este repo, es el paquete que ya
  consume `AgregarMartenEventStore()` -- consistente, no violatorio.
- `MartenEventStore.cs` (mismo paquete): confirmo que `ExistsAsync` (la ruta exacta del incidente)
  ya usa `querySession.Events.FetchStreamStateAsync(aggregateId, cancellationToken)` con `aggregateId`
  como `string` -- mismo patron replicado en `EventStoreReadinessProbe`.

### Infraestructura modificada

Ninguna. Este issue no toca Terraform ni topics/subscriptions de Service Bus -- es un endpoint HTTP
puro contra el event store ya existente.

### Complejidad encontrada

- Determinar la sobrecarga correcta de `FetchStreamStateAsync` (string vs Guid) requirio confirmar
  `Events.StreamIdentity` en el paquete `Cosmos.EventSourcing.CritterStack`, ya que ningun archivo
  de este repo declaraba explicitamente esa configuracion (vive en el paquete externo que
  `AgregarMartenEventStore()`/`AgregarWolverineParaComandosServerless` consumen).
- El poll de `/api/ready` en el workflow necesito timeout medido por reloj (no por conteo fijo de
  intentos) porque `--max-time` hace variable la duracion de cada intento de curl -- un conteo fijo
  de intentos con sleep uniforme (como el poll de `/api/version`) no habria dado un limite de tiempo
  real predecible.

### Resultado

- Tests pasando: 1318/1318 (48 omitidos por falta de Postgres local en smoke tests, comportamiento
  preexistente no relacionado con este issue).

</details>
<details>
<summary>Reviewer (fase refactor) — 5m 7s</summary>

_(El agente no generó resumen)_

</details>

## Cobertura

| Archivo | Cobertura | Umbral | Estado |
|---|---|---|---|
| ReadyCheck.Mensajes.cs | - | excluido | - |
| ReadyCheck.Mensajes.cs | - | excluido | - |
| ReadyCheck.Mensajes.cs | - | excluido | - |
| ComposicionServicios.cs | - | sin clasificar | ⚠ revisar |
| EventStoreReadinessProbe.cs | - | sin clasificar | ⚠ revisar |
| IEventStoreReadinessProbe.cs | - | sin clasificar | ⚠ revisar |
| ReadyCheck.cs | - | sin clasificar | ⚠ revisar |
| ComposicionServicios.cs | - | sin clasificar | ⚠ revisar |
| EventStoreReadinessProbe.cs | - | sin clasificar | ⚠ revisar |
| IEventStoreReadinessProbe.cs | - | sin clasificar | ⚠ revisar |
| ReadyCheck.cs | - | sin clasificar | ⚠ revisar |
| ComposicionServicios.cs | - | sin clasificar | ⚠ revisar |
| EventStoreReadinessProbe.cs | - | sin clasificar | ⚠ revisar |
| IEventStoreReadinessProbe.cs | - | sin clasificar | ⚠ revisar |
| ReadyCheck.cs | - | sin clasificar | ⚠ revisar |

> **Archivos sin clasificar** (`⚠ revisar`): ninguna regla de clasificacion los reconocio — el gate **no los midio**. No es una exclusion deliberada (a diferencia de `excluido`, donde si se decidio que no requieren cobertura): requieren revision humana para confirmar si necesitan tests.
## Commits

ca6409b feat(hu-399): implementar GET /api/ready contra el event store (fase verde)
e8f0ccf test(issue-399): tests para endpoint /api/ready y stubs de compilacion (fase roja)

Closes #399