### PR TITLE
docs(bitacora): entradas hasta el 2026-08-17

### DIFF
--- a/docs/bitacora/2026-08-14.md
+++ b/docs/bitacora/2026-08-14.md
@@ -1,6 +1,6 @@
 # 2026-08-14 - El Guion que Cambia (y Arregla) la Identidad de Colaborador
 
-> El día que un solo cambio de carácter — el separador de la llave de stream de Colaborador, de `:` a `-` — obligó a limpiar el número de identificación a alfanumérico para que ese guion siguiera siendo inequívoco. Se implementó y mergeó el mismo día, y de paso terminaron de aterrizar tres PRs que llevaban días en cola.
+> El día que un solo cambio de carácter — el separador de la llave de stream de Colaborador, de `:` a `-` — obligó a limpiar el número de identificación a alfanumérico para que ese guion siguiera siendo inequívoco. Se implementó y mergeó el mismo día, terminaron de aterrizar tres PRs que llevaban días en cola, y la noche cerró con la doctrina HTTP del día anterior aplicada issue por issue sobre toda la saga de Colaboradores.
 
 ## Lo que se logró
 
@@ -10,11 +10,19 @@
 
 **Revisión post-merge del backlog completo por divergencias.** Con #381 ya en `main`, se repasaron los issues que dependían de la forma vieja de la llave: #373 (su dependencia de #356 quedó satisfecha, y el `Id` de `FichaColaborador` ya nació con el contrato nuevo — el cursor keyset resultó agnóstico al formato del separador); #376 (la pregunta abierta desde el 13 de agosto sobre la forma URL-safe de `Identificacion` quedó resuelta por el propio #381: el `{id}` de ruta ES `Identificacion.ToString()`, vía el punto único de conversión de MEF-ADR-0037); #377-#379 heredan la resolución sin necesitar edición propia.
 
+**La doctrina HTTP del día anterior (draft #621) se aplicó por primera vez, issue por issue, sobre toda la saga de Colaboradores.** Sesión de refinamiento completa bajo MEF-ADR-0043 (ya aceptado, con su test de precedencia de 5 pasos, kebab-case y contrato HTTP como campo crítico del DoR): #376, #377, #378 y #379 quedaron refinados a `estado:listo`; #386 (GET de la ficha por `{id}` único) y #387 (código de vinculación URL-safe) se crearon directamente en `estado:listo` para cerrar huecos que la doctrina expuso. Plan de implementación fijado: `/mefisto:sequential 376 387 377 386 378 379` — secuencial puro, con #387 antes de #378 (comparten validator) y #379 al final (aggregate + gate empírico del literal `:`). La sesión no se quedó en el papel: esa misma noche arrancaron las fases roja/verde de #376 (23:05-23:32) y de #387 (23:43-23:53), que terminarían de mergearse ya entrada la madrugada del 15.
+
+**Draft #631 abierto en el harness**: doctrina de aceptación de ids/códigos destinados a URI (charset unreserved RFC 3986 + criterio "dueño del dato" + el momento del issue en que debe decidirse), generalizando lo que #387 resolvió puntualmente.
+
 ## Problemas encontrados
 
 **Dos peticiones que parecían independientes eran, en realidad, un solo contrato de identidad.** Cambiar el separador sin limpiar el número habría dejado la llave ambigua: hoy `"AB-123"` es un número de documento legal (pasaporte), así que `"CC-AB-123"` sería indistinguible de una identificación con separador propio dentro del número. Tratarlas como dos issues separados habría entregado una mitad rota — el guion solo es un separador inequívoco *porque* la limpieza garantiza que el número nunca contiene uno.
 
 **El separador viejo (`:`) era, hasta este día, el mismo carácter que la sesión del día anterior había identificado como el que hay que reservar exclusivamente para acciones HTTP (`:verbo`).** El cambio de separador de la llave de stream resulta, en la práctica, un prerequisito silencioso de la migración de rutas que #378/#379 venían proponiendo — sin que ninguna de las dos sesiones lo hubiera anticipado como dependencia explícita.
+
+**`CodigoColaborador` no era URL-safe, y el usuario no lo creyó al principio.** Solo tenía la validación `NotEmpty()`; un código con `:` volvería inparseable la ruta `{codigo}:terminar` que #379 venía proponiendo — el mismo patrón que #381 ya había descubierto esa misma tarde con el número de identificación. La confusión inicial fue entre dos salvaguardas parecidas (la de `Identificacion`, ya resuelta, y la de `CodigoColaborador`, todavía abierta); se resolvió mostrando la evidencia del flujo crudo — validator → handler → evento plano — en vez de apelar a la autoridad del hallazgo. Terminó en #387, creado directamente `estado:listo`.
+
+**El guardrail anti-sinónimos, recién destilado el día anterior, atrapó un tercer nombre en su primer uso real.** #380 proponía renombrar la ruta a `solicitudes-de-turno`, pero el aggregate ya se llama `SolicitudProgramacionAggregateRoot` y la URL `programacion/solicitudes`, leída completa, ya dice lo mismo — "solicitud de turno" además sugiere pedir la plantilla, no programarla. Se cerró `not planned` la misma noche.
 
 ## Lo que descartamos
 
@@ -26,21 +34,30 @@
 
 **Purgar los streams huérfanos que deja el cambio de separador en dev.** Se toleran sin protocolo de migración: no hay producción todavía, y los datos existentes son de smoke tests, no de negocio real.
 
+**#380 (rename de la ruta de solicitudes a `solicitudes-de-turno`).** Not planned — acuñaba un sinónimo que el guardrail anti-sinónimos ya prohibía.
+
+**Código de vinculación viajando en el body en vez de en la ruta (#379, opción b).** Perdía el direccionamiento explícito que la doctrina de #621 exige para las acciones `POST {recurso}:{verbo}`.
+
+**Partir #379 en un issue por comando.** Habría triplicado el gate empírico del literal `:` en rutas del worker aislado sin ganar claridad — los siete criterios de aceptación resultaron homogéneos entre sí.
+
 ## Aprendizajes
 
 1. **Dos peticiones que suenan a features distintas pueden ser, en el fondo, un único contrato de identidad.** Separar "cambiar el separador" de "limpiar el número" en dos issues habría entregado una mitad inconsistente — la unidad del cambio solo se ve al preguntar qué hace al guion inequívoco.
 2. **Un cambio de invariante en un VO de identidad exige revisar de inmediato todo el backlog que depende de su forma anterior.** La revisión post-merge encontró que una pregunta abierta desde el día anterior (la forma URL-safe de `Identificacion`) ya había quedado resuelta como efecto colateral del propio cambio, sin que nadie lo hubiera planeado así.
 3. **Tolerar streams huérfanos en un ambiente sin producción es una decisión legítima y explícita, no negligencia.** La condición que la hace válida — sin usuarios reales, datos de smoke tests — es la que hay que verificar antes de aplicar el mismo criterio en cualquier otro ambiente.
+4. **Una doctrina recién aceptada no se aplica sola.** Hizo falta una sesión completa de refinamiento, issue por issue, para bajar #621 a la saga de Colaboradores — y en el proceso destapó una divergencia (query vs. comando en la identidad) y un vacío (la URL-safety de un segundo VO) que el draft original no había anticipado.
+5. **La resistencia inicial ante un hallazgo correcto se resuelve con evidencia del flujo, no con autoridad.** La confusión entre dos salvaguardas similares (`Identificacion` vs. `CodigoColaborador`) es fácil de cometer; mostrar el camino crudo validator → handler → evento convenció donde la sola afirmación no lo había hecho.
 
 ## Números del día
 
 | Métrica | Valor |
 |---|---|
-| Field notes | 1 (planner) |
-| Commits | 12 |
+| Field notes | 2 (planner) |
+| Commits | 19 |
 | PRs mergeados | 4 (#375, #382, #383, #384) |
-| Issues cerrados | 4 (#356, #357, #373, #381) |
+| Issues cerrados | 5 (#356, #357, #373, #380, #381) |
+| Issues creados | 2 (#386, #387) |
 | ADRs creados | 0 |
-| Archivos cambiados | 68 |
-| Líneas agregadas | ~2286 |
-| Líneas eliminadas | 221 |
+| Archivos cambiados | 86 |
+| Líneas agregadas | ~2651 |
+| Líneas eliminadas | 234 |

--- a/docs/bitacora/2026-08-15.md
+++ b/docs/bitacora/2026-08-15.md
@@ -1,0 +1,54 @@
+# 2026-08-15 - Seis Merges, un Timeout de 35 Segundos y una Herramienta que Mentía en Silencio
+
+> El día en que la doctrina HTTP del 13 y el refinamiento del 14 se convirtieron en código — seis issues de la saga de Colaboradores implementados y mergeados entre la medianoche y las 8 de la mañana — y en que, horas después, un deploy real casi pasó una regresión de disponibilidad de 74 segundos porque la herramienta de diagnóstico devolvía "todo OK" cuando en realidad no había consultado nada.
+
+## Lo que se logró
+
+**La cadena secuencial planeada la noche anterior corrió de punta a punta.** `/mefisto:sequential 376 387 377 386 378 379` cerró seis issues con sus PRs entre las 00:05 y las 08:18: #387 (PR #389, código de vinculación URL-safe), #377 (PR #390, `CorregirNombres` como PUT), #386 (PR #391, GET de la ficha por `{id}` único), #378 (PR #392, reingreso absorbido como creación canónica de vinculación) y #379 (PR #394, acciones de la vinculación con verbo explícito — el gate empírico del literal `:` en rutas del worker aislado, pendiente desde el 13, resultó viable). #376 (verbos canónicos en etiquetas, PR #388) cerró más tarde, a las 14:41, tras resolver en main un conflicto real contra el propio #379.
+
+**El hueco que #379 dejó en dos endpoints se encontró y se cerró el mismo día.** Field note de las 12:07: la centralización del parseo del `{id}` de ruta (helper `IdentificacionDeRuta.TryParsear`, nacido en #379) llegó a `main` después de que la rama de #376 (PR #388) ya existiera; al resolver el conflicto se preservó la forma vieja en los dos endpoints de etiquetas, dejando dos patrones convivendo en el mismo borde HTTP. Se verificó que en realidad eran *seis* los endpoints que debían usar el helper, no cinco — `TerminarVinculacionFunction` también. Issue #395 creado y cerrado el mismo día (PR #397, 14:58): refactor puro, los `FunctionEndpointTests` de ambos endpoints afirman el tipo de respuesta, no el texto.
+
+**Las alertas de spike de Application Insights se acotaron por borde de entrada.** Una sesión corta fuera del flujo Mefisto (commits `e92ecb9`/`4004c74`, 07:10-07:18) partió la alerta única de excepciones en dos: `exception-spike` correlacionada por `operation_Id` a requests con `resultCode == "500"` (borde HTTP), y una alerta nueva para los consumidores de Service Bus, que nunca entran por ese filtro porque reportan `resultCode "0"`. El trabajo se regularizó horas más tarde con el issue #396, documentando retroactivamente el PR #393.
+
+**Refinamiento de #340: "Empleado" no fue liberado, fue proscrito.** El borrador original asumía que el nombre "Empleado" quedaba libre tras el cierre de #330 con el maestro llamado `Colaborador`; el usuario corrigió el marco — "Empleado" se proscribió del lenguaje ubicuo para dar cabida a contratistas, y un término proscrito no puede aparecer en ningún artefacto. Se identificaron tres niveles de costo (tipos anidados de eventos, tipos de contratos de bus, claves persistidas/bus/HTTP/read model) y se decidió corregir los tres, sin mapeo, purgando en el mismo despliegue del cambio de claves (dev es desechable). Se partió en dos por perfil de riesgo: #340 (tipos, tests de serialización intactos como prueba de seguridad) y #401 (claves + purga, bloqueado por #340, tests reescritos).
+
+## Problemas encontrados
+
+**Un HTTP 500 real en producción-dev, 74 segundos de indisponibilidad del write-path, tras el deploy del PR #388.** El smoke test `ObtenerFichaColaborador_Retorna200ConLaMismaFicha_CuandoElIdDeRutaViajaEnMinusculas` falló en el *arrange*: `RegistrarColaborador` devolvió 500 en vez de 202. La causa raíz, con evidencia convergente: un `TimeoutException` de Npgsql abriendo la conexión para la migración de esquema de Marten (`ensureStorageExistsAsync`, disparada por la primera operación contra el event store tras un cold start), compitiendo por el único core del plan B1 mientras dos instancias del Function App convivían y el worker nuevo hacía JIT + codegen de Wolverine. El servidor PostgreSQL estaba sano (8% CPU, `connections_failed = 0`); el cuello de botella estaba enteramente del lado del Function App (CPU al 62-92% durante la ventana). El deploy *siguiente* reprodujo el patrón como *near miss*: 24.2s contra un umbral de ~35s. El commit del PR #388 no tocaba ni el handler ni `ComposicionServicios.cs` — no era un bug de lógica.
+
+**La herramienta de diagnóstico devolvía "todo OK" en falso.** `scripts/appinsights-query.sh` usaba `az monitor app-insights query --output table`, que en `azure-cli 2.82.0` + extensión `application-insights 1.2.3` no renderiza absolutamente nada — ni siquiera para `print x=1`. Toda query predefinida (`exceptions`, `function-errors`, `health-summary`) devolvía vacío en silencio. Sin descubrir esto primero, la investigación del timeout habría concluido "no hay evidencia en App Insights" y el incidente habría quedado sin diagnóstico. Toda la investigación se rehízo con `-o json` + formateo propio.
+
+**El gate de readiness del workflow confirma el binario, no el event store.** `/api/version` abre el gate en cuanto reporta el SHA nuevo, y `/api/health` responde `OkObjectResult("OK")` sin tocar Postgres ni Marten. Los smoke tests entraron ~13 segundos antes de que el write-path pudiera responder. Tres issues cerrados en el pasado (#119, #166, #224) ya habían tocado variantes de este problema — ninguno cubría el write-path HTTP + Marten de Colaboradores.
+
+## Lo que descartamos
+
+**Crear issues inmediatos para las tres acciones propuestas tras la investigación del bug.** Se dejaron como propuestas, pendientes de confirmación del usuario, documentadas en la field note. Dos de las tres (endpoint de readiness y `always_on`) se convirtieron en issues (#399, #400) apenas minutos después de escrita la nota; la tercera — reparar `scripts/appinsights-query.sh` — quedó sin issue: es el hallazgo de mayor impacto transversal (envenena cualquier investigación futura) y sigue como cabo suelto al cierre del día.
+
+**Mapear `EmpleadoId`/`Empleado` con `JsonPropertyName` o upcasters, en vez de renombrar sin mapeo.** El primero deja el término proscrito en el wire; el segundo es maquinaria permanente para datos que son desechables (smoke tests en dev). CA-ADR-0029 decisión #6 ya proscribe `MapEventType`.
+
+**Un solo issue para tipos y claves del rename de "Empleado".** Habría mezclado dos perfiles de verificación distintos (serialización intacta vs. tests reescritos) en una sola revisión turbia. Se partió en #340 y #401.
+
+**Nombre puro `Colaborador` para los tipos nuevos y `EmpleadoProgramado`.** El primero hace *squatting* del nombre reservado al concepto rico del dominio; el segundo conserva el término proscrito. Se optó por `ColaboradorProgramado`, `InformacionColaborador` y `DetalleColaborador`.
+
+## Aprendizajes
+
+1. **Una doctrina recién aceptada, una vez aplicada issue por issue, expone huecos que el refinamiento original no vio.** La centralización del parseo de `{id}` en #379 llegó a `main` a mitad de camino de otra rama en vuelo (#376); la resolución de conflictos, hecha sin mala intención, dejó dos patrones convivendo en el mismo borde — el tipo de deriva que solo un repaso posterior detecta.
+2. **Verificar la herramienta de diagnóstico antes de confiar en su silencio.** Un "sin hallazgos" de una query KQL puede significar dos cosas radicalmente distintas: que no hay evidencia, o que la herramienta nunca llegó a consultar nada. El caso trivial (`print x=1` devolviendo vacío) fue lo que destapó la segunda.
+3. **Un cold start no es solo lento: puede ser indistinguible de un fallo real bajo un gate de readiness insuficiente.** El binario puede estar listo (`/api/version`, `/api/health`) mientras la dependencia que la primera request de negocio necesita (migración de esquema de Marten) todavía está compitiendo por CPU. La brecha entre "el proceso arrancó" y "el write-path puede responder" es exactamente lo que un smoke test corriendo 13 segundos demasiado pronto no puede ver.
+4. **Un *near miss* es tan valioso como un fallo para dimensionar el riesgo.** El deploy siguiente tardó 24.2s contra un umbral de ~35s — sin el incidente de hoy, ese dato habría pasado desapercibido como una latencia alta cualquiera.
+5. **Partir un rename en niveles de costo distintos (tipos vs. claves) permite avanzar sin exponerse al riesgo completo de una sola vez.** Los tipos se pueden renombrar con los tests de serialización como red de seguridad; las claves en el wire exigen reescribir esos mismos tests — perfiles de verificación distintos que no conviene mezclar en una sola revisión.
+
+## Números del día
+
+| Métrica | Valor |
+|---|---|
+| Field notes | 3 (2 planner, 1 bug-investigation) |
+| Commits | 19 |
+| PRs mergeados | 7 (#388, #389, #390, #391, #392, #394, #397) |
+| Issues cerrados | 7 (#376, #377, #378, #379, #386, #387, #395) |
+| Issues creados | 6 (#395, #396, #398, #399, #400, #401) |
+| ADRs modificados | 1 (CA-ADR-0009, Capa 4 partida por borde de entrada) |
+| ADRs creados | 0 |
+| Archivos cambiados | 113 |
+| Líneas agregadas | ~4462 |
+| Líneas eliminadas | ~3190 |

--- a/docs/bitacora/2026-08-16.md
+++ b/docs/bitacora/2026-08-16.md
@@ -1,0 +1,49 @@
+# 2026-08-16 - "Empleado" Desaparece del Código, y el Issue que no Cerró Solo
+
+> El día en que el término proscrito "Empleado" terminó de borrarse del código en sus dos niveles restantes (tipos y claves), `always_on` llegó a los tres Function Apps de dev cerrando además toda la deriva del módulo `service-plan` — y en que cerrar ese mismo issue de infra a mano, porque la automatización prometida no corrió, sembró el bug que se refinaría al día siguiente.
+
+## Lo que se logró
+
+**`always_on` encendido en los tres Function Apps de dev, con toda la deriva del módulo `service-plan` corregida de una vez.** Field note de las 17:21: el borrador #400 era factualmente sólido, pero el usuario amplió el alcance — no solo `always_on`, sino también `os_type` (default `Linux`) y `worker_count` (default `1`), cerrando la deriva completa del contrato de MEF-ADR-0020 en un solo cambio. HCL escrito y revisado en cinco minutos (`dae592b` a las 17:25, `027fbc2` a las 17:26) y mergeado a las 17:30 (PR #402) — el turnaround más rápido de infra de la semana.
+
+**El rename de "Empleado" cerró sus dos niveles restantes.** #340 (PR #404, 18:54): los tipos de payload que portaban el término proscrito se renombraron en los tres ensamblados de eventos — `ColaboradorProgramado`, `InformacionColaborador`, `DetalleColaborador` — con las claves todavía intactas como red de seguridad. #401 (PR #405, 19:18), ya destrabado por el merge de #340: las claves `EmpleadoId`/`Empleado` de los contratos persistidos, de bus y HTTP se renombraron a `CodigoColaborador`/`Colaborador`, sin mapeo, con purga de los streams de dev (smoke tests, desechables).
+
+**Las alertas de spike de Application Insights, regularizadas y corregidas tras revisión manual.** El PR #393 —nacido fuera del flujo Mefisto, sin issue, sin DoR, sin etapa `infra-reviewer`— recibió una revisión completa del usuario a mano el día anterior, dejada como comentario único del PR. Dos correcciones aplicadas en el commit `739d438` (17:47): la alerta `service_bus_failure_spike` se renombró a `non_http_failure_spike` (su filtro cubre cualquier trigger no-HTTP, no solo Service Bus) — gratis porque el recurso aún no existía en Azure, verificado contra el plan de CI antes de tocarlo; y los comentarios HCL se comprimieron de ~24 a 8 líneas según MEF-ADR-0044, verificando primero que todo lo removido ya vivía en CA-ADR-0009. El PR mergeó a las 18:07 (issue #396 cerrado).
+
+**Refinamiento de #399 (endpoint `/api/ready`), con el reetiquetado correcto para no chocar con el pipeline.** Field note de las 19:45: `tipo:tooling` habría enrutado a `tooling-pipeline.sh`, cuya allowlist prohíbe `src/` desde una enmienda del harness (issue #448, posterior al precedente que el borrador citaba); se corrigió a `tipo:refactor` + los tres dominios reales. El criterio de aceptación "sin evidencia el issue no se cierra" se reformuló porque contradecía el propio `Closes #399` del PR — la verificación real de un deploy en producción solo puede ocurrir post-merge. Implementación arrancada la misma noche: fase roja (`e8f0ccf`, 19:58) y verde (`ca6409b`, 20:08) — el PR (#406) mergearía a la mañana siguiente.
+
+## Problemas encontrados
+
+**El issue #400 no se cerró solo, y hubo que cerrarlo a mano.** MEF-ADR-0022 promete que el workflow `infra-cd.yml` cierra el issue de infra al terminar el `terraform apply`; no ocurrió. El PR #402 fue explícito al respecto ("este PR no cierra el issue #400... el issue se cierra automáticamente cuando ese apply termine exitosamente") — y aun así, el issue quedó abierto tras el run exitoso 31976506428. Se cerró a mano un minuto antes de que naciera el issue #403 para reparar la causa: el `infra-base-scaffolder` del harness (v0.23.0) ya genera el step de cierre completo con los permisos correctos, así que el fix es transcripción, no diseño — la brecha es que este consumidor nunca lo adoptó.
+
+**Dos gaps de agentes identificados en la revisión del PR #393, y el usuario decidió deliberadamente no enrutarlos como draft.** `infra-writer` no tiene la doctrina de comentarios de MEF-ADR-0044 (el propio ADR sub-especificó su alcance de propagación, nombrando solo a los tres escritores de `.cs` y omitiendo al único agente que escribe HCL); `infra-reviewer` valida que un nombre de alerta tenga la forma correcta, pero no que corresponda a lo que el filtro realmente captura — el gap que dejó pasar `servicebus-failure-spike` describiendo solo un subconjunto de lo que cubría. Quedan registrados en la field note por si reaparecen, sin acción tomada.
+
+## Lo que descartamos
+
+**Sincronizar todo el drift del workflow `infra-cd.yml` del consumidor contra el canon del harness, no solo el step de cierre.** Había más diferencias (siembra de secretos KV, reciclado de Function Apps, estructura de jobs, pin de Terraform) pero ninguna aplicaba a este proyecto o eran decisiones locales deliberadas — se excluyeron del alcance de #403 con justificación explícita en el issue, dejando solo permisos + step de cierre.
+
+**Alcance mínimo para #400 (solo `always_on`).** El usuario prefirió cerrar la deriva completa del contrato de `service-plan` de una vez, en vez de volver sobre el mismo módulo por cada default no alineado.
+
+**Prescribir el mecanismo exacto (service-plan output vs. variable directa) por el que `always_on` llega al `site_config`.** El ADR fija los inputs del módulo pero no ese mecanismo — se marcó como propuesta revisable del `infra-writer`, no como contrato, y quedó un draft de seguimiento en el harness (#652) para corregirlo junto con el fundamento de costo de MEF-ADR-0020.
+
+## Aprendizajes
+
+1. **Una promesa documentada en un ADR (MEF-ADR-0022) no garantiza que el mecanismo esté conectado en cada consumidor.** El scaffolder del harness ya resolvió esto correctamente desde v0.23.0; el proyecto simplemente nunca absorbió esa versión del canon en su workflow generado.
+2. **Un fix gratis tiene fecha de vencimiento.** Renombrar un recurso Terraform que el `plan` todavía muestra como `will be created` cuesta cero; después del merge, cuesta un destroy + create. Verificarlo contra el plan de CI antes de decidir, no asumirlo, fue lo que permitió capturar esa ventana.
+3. **Comprimir un comentario de código exige verificar que su contenido ya vive en otro lado, no solo que "suena redundante".** La poda según MEF-ADR-0044 es segura solo si lo removido está verificadamente documentado en el ADR citado.
+4. **Identificar un gap de agente no obliga a repararlo de inmediato.** Dejar el hallazgo registrado en la field note, con su causa raíz diagnosticada, es una opción legítima cuando el costo de la reparación no se justifica todavía — la trazabilidad del "por qué no" importa tanto como la del "qué se arregló".
+
+## Números del día
+
+| Métrica | Valor |
+|---|---|
+| Field notes | 3 (2 planner, 1 review de PR) |
+| Commits | 7 |
+| PRs mergeados | 4 (#393, #402, #404, #405) |
+| Issues cerrados | 4 (#340, #396, #400, #401) |
+| Issues creados | 1 (#403) |
+| ADRs modificados | 1 (CA-ADR-0009, corrección post-revisión) |
+| ADRs creados | 0 |
+| Archivos cambiados | 121 |
+| Líneas agregadas | ~1845 |
+| Líneas eliminadas | ~989 |

--- a/docs/bitacora/2026-08-17.md
+++ b/docs/bitacora/2026-08-17.md
@@ -1,0 +1,41 @@
+# 2026-08-17 - El Círculo se Cierra: del Timeout de Npgsql al Endpoint de Readiness
+
+> Un día corto que cierra dos arcos abiertos en la semana: el endpoint `/api/ready` que nació de la investigación del cold start del 15 llegó a los tres dominios, y el dolor de cerrar un issue de infra a mano el día anterior se convirtió en un fix concreto y transcrito, no diseñado desde cero.
+
+## Lo que se logró
+
+**El endpoint `/api/ready` mergeado en los tres dominios (PR #406, 07:35), cerrando el issue #399.** Directamente heredado de la investigación del bug del 15 de agosto: un endpoint de readiness que verifica el event store antes de que el gate de los smoke tests se abra, en vez de confiar únicamente en `/api/version` y `/api/health` como indicadores de que el binario cargó. El workflow `smoke-tests-dominio.yml`, reusable por los tres dominios, exigía que los tres lo expusieran a la vez — la razón dura por la que el issue no se partió por dominio el día anterior.
+
+**#403 refinado a `estado:listo`: el cierre automático del issue de infra al terminar el `terraform apply`.** Field note de las 07:40: el `infra-base-scaffolder` del harness (v0.23.0) ya genera el step completo — permisos `issues: write` + `pull-requests: read`, resolución del PR vía `commits/{sha}/pulls` (robusta ante squash-merge) — así que el fix del workflow de este consumidor es transcripción del canon, no diseño nuevo. Se verificó que no hay backlog de issues de infra zombis por limpiar: solo un PR había mergeado con rama `infra-issue-*` antes de hoy (#402/#400), y ya se había cerrado a mano. La verificación empírica queda diferida al próximo `tipo:infra` real (#398, candidato).
+
+**Issue #407 creado**: mover el glosario de lenguaje ubicuo de `docs/eda/` a `docs/ddd/` (MEF-ADR-0040) — la pregunta abierta que venía repitiéndose sin resolver desde la field note del 14 de agosto, capturada finalmente como trabajo concreto en vez de quedar como nota al margen.
+
+**Consolidación del modelo de dominio de Colaboradores.** Commit `80b2325`: el glosario en `docs/eda/` se actualiza para reflejar la proscripción operativa de "Empleado" que se ejecutó en código los dos días anteriores (#340, #401).
+
+## Problemas encontrados
+
+**Drift adicional detectado entre el workflow del consumidor y el canon del scaffolder, más allá del step de cierre.** Al comparar en detalle para refinar #403: siembra de secretos de Key Vault y reciclado de Function Apps (no aplican — `harness.config.json` sin `secrets[]`), estructura de dos jobs vs. dos archivos, `azure/login` vs. `ARM_USE_OIDC` directo, y el pin de Terraform 1.15.8 (ya resuelto en #303). Ninguno se llevó al alcance de #403 — decisiones locales deliberadas que no ameritan sincronizarse solo porque el canon evolucionó en otro punto.
+
+## Lo que descartamos
+
+**Quitar la promesa de cierre automático (`CLOSES_LINE` en `iac-pipeline.sh`) y aceptar el cierre manual como forma normal de operar.** Dejaría el hueco abierto permanentemente, y además exigiría un cambio en el repo del harness (fuera del alcance de este proyecto) en vez de corregir la transcripción faltante en el workflow del consumidor.
+
+## Aprendizajes
+
+1. **Un fix "de transcripción" sigue mereciendo un issue propio con su propia verificación.** Que el canon ya resuelva el problema en el scaffolder no vuelve automática la adopción en cada consumidor existente — alguien tiene que notar la brecha, como pasó ayer con el cierre manual de #400.
+2. **Un drift detectado no siempre justifica una sincronización completa.** Cuando el canon evolucionó en un eje (el step de cierre) mientras el consumidor tomó decisiones deliberadas en otros ejes (autenticación, estructura de jobs), sincronizar todo de una vez mezclaría una corrección puntual con un rediseño no solicitado.
+3. **Una pregunta abierta que se repite en varias field notes sin resolverse merece convertirse en trabajo concreto, no seguir pospuesta.** El `git mv` del glosario a `docs/ddd/` apareció como nota al margen los días 14, 15 y 16 antes de capturarse como issue #407 hoy.
+
+## Números del día
+
+| Métrica | Valor |
+|---|---|
+| Field notes | 1 (planner) |
+| Commits | 2 |
+| PRs mergeados | 1 (#406) |
+| Issues cerrados | 1 (#399) |
+| Issues creados | 1 (#407) |
+| ADRs creados | 0 |
+| Archivos cambiados | 29 |
+| Líneas agregadas | ~933 |
+| Líneas eliminadas | ~35 |

--- a/docs/bitacora/field-notes/procesadas/2026-08-14-2252-planner.md
+++ b/docs/bitacora/field-notes/procesadas/2026-08-14-2252-planner.md
@@ -1,0 +1,77 @@
+---
+fecha: 2026-08-14
+hora: 22:52
+sesion: planner
+tema: Refinamiento de la saga HTTP de Colaboradores bajo MEF-ADR-0043
+---
+
+## Contexto
+Revision de "que esta listo para implementar" que se convirtio en el refinamiento completo de la
+saga HTTP de Colaboradores. El bloqueador doctrinal (harness#621) habia cerrado con MEF-ADR-0043
+aceptado (test de precedencia de 5 pasos, kebab-case, contrato HTTP como campo critico del DoR),
+lo que destrabo los borradores #376-#380. El main local estaba 26 commits detras de origin
+(PRs #382 y #384 ya mergeados) -- se sincronizo antes de leer codigo: leccion recurrente de
+"verificar el estado del entorno, no asumirlo".
+
+## Descubrimientos
+- **Divergencia query/comando en la identidad del colaborador**: el GET ObtenerFichaColaborador
+  (#356) direcciona con dos segmentos `{tipo}/{numero}`; los comandos de #376 fijaron un segmento
+  `{id}` = llave del stream (`CC-79543210`). Se acepto la divergencia (MEF-ADR-0043 seccion 7) y
+  se capturo #386 para alinearla.
+- **El guardrail anti-sinonimos atrapo un tercer nombre**: #380 queria renombrar la ruta a
+  `solicitudes-de-turno`, pero el aggregate es SolicitudProgramacionAggregateRoot y la URL
+  `programacion/solicitudes` leida completa ya dice lo mismo. "Solicitud de turno" ademas sugiere
+  pedir la plantilla, no programarla. #380 se cerro not planned.
+- **CodigoColaborador no era URL-safe**: solo `NotEmpty()`; un codigo con `:` haria inparseable la
+  ruta `{codigo}:terminar` de #379. Mismo patron que #381 descubrio con el numero de la
+  identificacion. El usuario inicialmente no lo creyo (confundia la salvaguarda de Identificacion
+  con el codigo) -- la evidencia del flujo crudo (validator -> handler -> evento plano) lo
+  resolvio.
+- **Criterio rechazar-vs-normalizar segun dueno del dato**: la identidad que el dominio unifica se
+  normaliza (#381); el identificador asignado por un tercero se rechaza con 400 (#387) porque
+  alterarlo en silencio cambiaria un dato ajeno. Elevado a draft del harness (#631).
+- El aggregate ya rastrea `_codigoVinculacionVigente`: la salvaguarda de concurrencia optimista de
+  #379 es una comparacion, sin estado nuevo.
+
+## Decisiones
+- **#376 refinado a listo**: PUT/DELETE de etiquetas con `{id}` unico; `Identificacion.Parsear`
+  como inverso de `ToString()` en el VO (punto unico de conversion). Opcion "dos segmentos"
+  evaluada y descartada (pierde round-trip con FichaColaborador.Id).
+- **#377 refinado a listo**: PUT colaboradores/{id}/nombres (paso 2 de manual; la idempotencia ya
+  existia en el aggregate). PATCH descartado con el argumento concreto de los opcionales
+  (trampa del null de RFC 7386).
+- **#378 refinado a listo**: ReingresarColaborador -> IniciarVinculacion con simetria COMPLETA
+  (metodo del aggregate y enum incluidos, decidido en sesion); POST colaboradores/{id}/vinculaciones
+  (paso 1: create disfrazado); casing de RegistrarColaborador de pasada.
+- **#379 refinado a listo**: tres acciones `POST .../vinculaciones/{codigo}:verbo` (paso 4);
+  CodigoNoCorresponde -> 409 evaluado primero, en el aggregate; gate empirico del complex segment
+  como CA-1 obligatorio con reporte al harness.
+- **#387 creado listo**: codigo URL-safe por RECHAZO (400), charset unreserved RFC 3986, `:` fuera;
+  sin normalizacion (menos estricto que #381, decision del usuario).
+- **#386 creado listo**: GET ficha por `{id}` unico; alternativa LoadAsync directo descartada
+  (pierde 400 y normalizacion de minusculas).
+- **#380 cerrado not planned**: la ruta ya cumplia; renombrar acunaba un sinonimo.
+- **Draft harness #631**: doctrina de aceptacion de ids/codigos destinados a URI (charset +
+  criterio dueno-del-dato + momento del issue previo).
+- **Plan de implementacion**: `/mefisto:sequential 376 387 377 386 378 379` -- secuencial puro por
+  decision del usuario; #387 antes de #378 (validator compartido); #379 ultimo (aggregate + gate).
+
+## Descartado
+- #380 (rename de ruta de solicitudes) -- not planned, ver arriba.
+- Opcion (b) para #379 (codigo en body como expectativa): perdia el direccionamiento explicito.
+- Split de #379 por comando: triplicaba el gate empirico sin ganar claridad (7 CAs homogeneos).
+
+## Preguntas abiertas
+- Resultado del gate empirico `{codigo}:verbo` en Azure Functions worker aislado (CA-1 de #379):
+  si falla, fallback `/{codigo}/terminar` a decidir con el harness.
+- Streams de dev con codigos no conformes a #387: quedarian inalcanzables por codigo en #379
+  (409 permanente). Dev es desechable; anotado en #387, sin migracion.
+- El glosario sigue en la ruta vieja `docs/eda/` -- pendiente `git mv` a `docs/ddd/` (sugerido al
+  usuario, no ejecutado).
+
+## Referencias
+Issues creados: #386, #387 (consumidor); #631 (draft en el harness)
+Issues refinados a listo: #376, #377, #378, #379
+Issues cerrados: #380 (not planned)
+Glosario: Vinculacion (nota actualizada), CodigoColaborador (invariante URL-safe),
+Solicitud de Programacion (termino nuevo con sinonimo rechazado "solicitud de turno")

--- a/docs/bitacora/field-notes/procesadas/2026-08-15-1207-planner.md
+++ b/docs/bitacora/field-notes/procesadas/2026-08-15-1207-planner.md
@@ -1,0 +1,26 @@
+---
+fecha: 2026-08-15
+hora: 12:07
+sesion: planner
+tema: inconsistencia en el parseo del {id} de ruta en los endpoints de etiquetas
+---
+
+## Contexto
+La centralizacion del parseo del `{id}` de ruta (#379, helper `IdentificacionDeRuta.TryParsear`) llego a `main` despues de que naciera la rama del PR #388 (issue #376); los conflictos se resolvieron preservando la forma vieja de los dos endpoints de etiquetas, dejando dos patrones conviviendo en el mismo borde HTTP.
+
+## Descubrimientos
+- En `main` son seis (no cinco) los endpoints que usan el helper: tambien `TerminarVinculacionFunction`.
+- MEF-ADR-0009 (.resx) no cubre literales del borde HTTP: su alcance es aggregate/handler/FluentValidation. El precedente aceptado en #379 es el literal inline dentro del helper, en un unico sitio.
+- Los `FunctionEndpointTests` de ambos endpoints afirman el tipo `BadRequestObjectResult`, no el texto: la migracion es refactor puro, tests intactos.
+
+## Decisiones
+- Issue #395 creado (`tipo:refactor`, `dom:colaboradores`, `estado:listo`, `bloqueado`): migrar los dos endpoints de etiquetas a `IdentificacionDeRuta.TryParsear`, preservando la guarda de `{categoria}` en blanco y el contrato HTTP observable. Depende de #376 / PR #388.
+
+## Descartado
+- Mover el mensaje del 400 a `.resx` (fuera del alcance de MEF-ADR-0009).
+
+## Preguntas abiertas
+Ninguna.
+
+## Referencias
+Issues creados: #395

--- a/docs/bitacora/field-notes/procesadas/2026-08-15-1513-bug-investigation.md
+++ b/docs/bitacora/field-notes/procesadas/2026-08-15-1513-bug-investigation.md
@@ -1,0 +1,241 @@
+---
+fecha: 2026-08-15
+hora: 15:13
+sesion: bug-investigator
+tema: HTTP 500 en RegistrarColaborador tras deploy (run 31904647437) — timeout de Npgsql durante migracion de esquema de Marten en cold start
+---
+
+## Sintoma reportado
+
+El workflow "Deploy Colaboradores" run 31904647437 (merge del PR #388, issue #376 "Adoptar verbos
+canonicos en los endpoints de etiquetas", commit 25cad4ac) fallo en el job `smoke-tests`.
+
+Fallo 1 test: `ObtenerFichaColaborador_Retorna200ConLaMismaFicha_CuandoElIdDeRutaViajaEnMinusculas`.
+El fallo fue en el **arrange**: la llamada a `RegistrarColaborador` devolvio HTTP 500 en vez de 202,
+tras 1m02s de espera. Ventana: 2026-08-15 entre 19:44 y 19:49 UTC.
+
+Los smoke tests locales contra el mismo dev pasan 103/103.
+
+## Investigacion
+
+### Obstaculo de tooling encontrado primero (bloqueante)
+
+`scripts/appinsights-query.sh` devolvio **vacio** para `exceptions`, `function-errors` y
+`health-summary` — un falso "todo OK". Causa: `az monitor app-insights query --output table` no
+renderiza nada en `azure-cli 2.82.0` + extension `application-insights 1.2.3`. Verificado con el
+caso trivial:
+
+```bash
+az monitor app-insights query --app controlasistencias-dev-ai -g rg-controlasistencias-dev \
+  --analytics-query "print x=1" -o table   # -> vacio
+az monitor app-insights query ... -o json  # -> {"tables":[{... "rows":[[1]]}]}
+```
+
+Toda la investigacion se rehizo con `-o json` + formateador propio. Sin esto, la sesion habria
+concluido "no hay evidencia en App Insights".
+
+### Recoleccion (queries KQL, todas con `-o json`)
+
+1. Volumen de telemetria 4h por `itemType` -> si habia datos (137 excepciones en el bin 19:30-20:00).
+2. `requests | summarize by cloud_RoleName, name, resultCode` (4h) -> **exactamente 1 request 500**.
+3. Detalle de la request 500 -> `operation_Id`, instancia, duracion.
+4. `exceptions | where operation_Id == '...'` con `details` -> stack trace completo.
+5. Historico 14d de 500s y de timeouts -> evento unico.
+6. `traces` en la ventana 19:40-19:50 -> reconstruccion de la linea de tiempo por `cloud_RoleInstance`.
+7. `dependencies` en la ventana -> duracion de la invocacion y de las dependencias postgresql.
+8. Ventana del deploy siguiente (19:55-20:10) -> el *near miss*.
+
+Metricas de Azure Monitor (fuera de App Insights): `psql-asist-dev` (cpu_percent, memory_percent,
+active_connections, connections_failed, connections_succeeded) y `asp-asist-dev-colaboradores`
+(CpuPercentage, MemoryPercentage), intervalo PT1M.
+
+### La request 500
+
+| Campo | Valor |
+|---|---|
+| timestamp | 2026-08-15T19:45:39.6590067Z |
+| name | `POST api/colaboradores` |
+| duration | **35261.96 ms (35.3 s)** |
+| resultCode | 500 |
+| operation_Id | `bc65ea2c90831abcf8af8c81c4735bae` |
+| cloud_RoleInstance | `786e5bc5230b` |
+
+### La excepcion
+
+`System.TimeoutException: "The operation has timed out."` (Npgsql 9.0.4.0), envuelta por
+`Microsoft.Azure.WebJobs.Script.Workers.Rpc.RpcException` a las 19:46:14.95 -> HTTP 500.
+
+Cadena del stack (de adentro hacia afuera):
+
+```
+Npgsql.TaskTimeoutAndCancellation.ExecuteAsync
+  <- Npgsql.Internal.NpgsqlConnector.ConnectAsync
+  <- Npgsql.Internal.NpgsqlConnector.RawOpen
+  <- Npgsql.PoolingDataSource.OpenNewConnector
+  <- Npgsql.NpgsqlConnection.OpenAsync
+  <- Weasel.Core.Migrations.DatabaseBase.executeMigration        (DatabaseBase.cs:516/528)
+  <- Weasel.Core.Migrations.DatabaseBase.generateOrUpdateFeature (DatabaseBase.cs:507)
+  <- Weasel.Core.Migrations.DatabaseBase.ensureStorageExistsAsync(DatabaseBase.cs:471/468)
+  <- Marten.Events.QueryEventStore.FetchStreamStateAsync         (QueryEventStore.cs:224)
+  <- Cosmos.EventSourcing.CritterStack.TaskAggregateRootExtensions.Map
+  <- RegistrarColaboradorCommandHandler.HandleAsync             (linea 28)
+  <- Wolverine Executor.InvokeAsync / InvokeInlineAsync
+  <- RegistrarColaboradorFunction.FunctionEndpoint.Run          (linea 34)
+```
+
+El timeout NO ocurre ejecutando una consulta de negocio: ocurre **abriendo la conexion** que Weasel
+necesita para correr la **migracion de esquema** de Marten (`AutoCreate = CreateOrUpdate`, el default,
+confirmado en los comentarios de `ComposicionServicios.cs`), disparada por `ensureStorageExistsAsync`
+en la primera operacion contra el event store tras el arranque del worker.
+
+Correlacion con el codigo (ambas lineas coinciden exactamente):
+- `RegistrarColaboradorCommandHandler.cs:28` = `await _eventStore.ExistsAsync<ColaboradorAggregateRoot>(streamId, ct)` -> `FetchStreamStateAsync`.
+- `FunctionEndpoint.cs:34` = `await commandRouter.InvokeAsync(comando!, ct)`.
+
+### Linea de tiempo (traces por `cloud_RoleInstance`)
+
+| Hora UTC | Instancia | Evento |
+|---|---|---|
+| 19:44:37 - 19:45:23 | `b5bfc2585ca2` (vieja) | 21x `GET /api/version` cada ~2.1s — el gate del workflow esperando el SHA |
+| 19:45:26.22 | **`786e5bc5230b` (nueva)** | primera aparicion: responde `/api/version` con el SHA nuevo -> **gate abierto** |
+| 19:45:38.85 | nueva | `GET /api/health` -> 200 |
+| 19:45:39.52 | nueva | `GET /api/colaboradores/fichas/...` |
+| **19:45:39.688** | nueva | **`POST /api/Colaboradores`** — primera escritura contra el proceso recien arrancado |
+| 19:46:13.83 - 19:46:39.13 | nueva | 13 `TimeoutException` de Npgsql, en pares, reintentos cada ~5s |
+| 19:46:14.95 | nueva | `RpcException` -> HTTP 500 -> el smoke test falla |
+| 19:46:41.81 | nueva | siguiente `POST /api/Colaboradores` -> **202**; a partir de aqui todo normal |
+
+Ventana de indisponibilidad del write-path: ~19:45:26 -> ~19:46:40 (**~74 s**).
+
+### El servidor PostgreSQL estaba sano
+
+`psql-asist-dev` (Standard_B1ms, Burstable, PG 17), ventana 19:35-20:00, intervalo 1m:
+
+- `cpu_percent`: 8.0 - 11.3 % (sin pico alguno; 8.85 % a las 19:45, 8.22 % a las 19:46)
+- `memory_percent`: ~58-61 % estable
+- `active_connections`: 14-19 (limite de B1ms ~35)
+- **`connections_failed`: 0.0 en TODOS los minutos de la ventana**
+- `connections_succeeded`: 1.0 constante
+
+El servidor no rechazo ninguna conexion ni estaba saturado. Descarta agotamiento de `max_connections`
+y descarta throttling de Postgres.
+
+### El cuello de botella estaba en el lado del Function App
+
+`asp-asist-dev-colaboradores` (**B1 Basic, 1 core, capacity 1, plan dedicado** — MEF-ADR-0020 OK,
+cada dominio tiene su propio plan):
+
+| Minuto UTC | CpuPercentage | MemoryPercentage |
+|---|---|---|
+| 19:44 | 13 % | 76 % |
+| **19:45** | **62 %** | 81 % |
+| **19:46** | **80 %** | 81 % |
+| 19:47 | 60 % | 84 % |
+| 19:48 | 92 % | 91 % |
+
+Durante 19:45:26 - 19:45:23 convivieron **dos instancias** (`b5bfc2585ca2` saliendo y `786e5bc5230b`
+arrancando) sobre **un solo core**, mientras el worker nuevo hacia JIT + codegen de Wolverine +
+descubrimiento/migracion de esquema de Marten.
+
+Config del Function App: `alwaysOn: false`, `healthCheckPath: null`, `numberOfWorkers: 1`,
+`preWarmedInstanceCount: 0`.
+
+### El deploy siguiente reprodujo el patron (near miss)
+
+Run 31905426735 (PR #397, **exitoso**): instancia nueva `ea7384eb4056` aparece a las 20:03 y su
+primera escritura tardo **24191.18 ms (24.2 s)** — devolvio 202, pero se quedo justo por debajo del
+umbral. Mismo patron, distinto lado del filo.
+
+Comparativa de duraciones de `POST api/colaboradores` (4h):
+
+| Poblacion | n | valor |
+|---|---|---|
+| 500 (la fallida) | 1 | 35261.96 ms |
+| 202 exitosas — p50 | 299 | **111.65 ms** |
+| 202 exitosas — max (primera tras cold start del deploy siguiente) | 1 | 24191.18 ms |
+
+Ratio: la request fallida tardo **~316x** el p50 normal.
+
+### Descarte del bug de logica
+
+`git show --stat 25cad4ac` — el commit toca **unicamente**:
+`AsignarEtiquetaFunction/` (4 archivos), `RetirarEtiquetaFunction/` (3), smoke tests de etiquetas y
+fichas, tests unitarios de endpoints y `IdentificacionTests.cs`.
+
+**No toca `RegistrarColaboradorFunction/`** ni el handler ni `ComposicionServicios.cs`. Ninguno de
+los archivos del stack trace fue modificado por el PR.
+
+### Alcance temporal
+
+- `requests` del rol `func-asist-dev-colaboradores`, ultimos 14 dias, agrupado por dia:
+  **1427 requests, 1 sola con resultCode 500** (la investigada).
+- `exceptions` de tipo timeout en 14 dias: **13, todas en la hora 19:00 del 2026-08-15**, todas en la
+  instancia `786e5bc5230b`.
+- App Insights: retencion 90 dias, sampling 100 %, daily cap 0.5 GB (reset 21:00).
+  Nota: la telemetria de este rol solo aparece a partir de hoy — verificar si es por antiguedad del
+  dominio o por perdida de ingesta.
+
+### Terreno previo relacionado
+
+- **#119** "Endurecer smoke tests ante cold start de Function Apps" (cerrado, `dom:control-horas`).
+- **#166** "Calentar la cadena Service Bus con un warm-up funcional en el fixture de smoke tests"
+  (cerrado, `bug`, `tipo:tooling`) — establece el precedente del **warm-up funcional**, aplicado al
+  listener de Service Bus de ControlHoras.
+- **#224** "Condicionar el smoke al SHA desplegado via endpoint /api/version" (cerrado) — introdujo
+  el gate que aqui se muestra insuficiente para el write-path.
+
+Ninguno cubre el write-path HTTP + Marten de Colaboradores: los fixtures de
+`Bitakora.ControlAsistencia.Colaboradores.SmokeTests/Fixtures/` tienen `Polling` (esperas de
+resultado) pero **ningun warm-up funcional** del event store.
+
+## Diagnostico
+
+**Causa raiz (confianza alta, evidencia convergente): timeout de conexion de Npgsql durante la
+migracion de esquema de Marten (`ensureStorageExistsAsync`), disparada por la primera operacion
+contra el event store en un worker recien arrancado, bajo saturacion de CPU del plan B1 de 1 core.**
+
+No es un bug de logica del PR #388: el commit no toca ninguno de los archivos del stack.
+No es un fallo de PostgreSQL: el servidor estaba al 8 % de CPU con `connections_failed = 0`.
+No es noisy neighbor por plan compartido (MEF-ADR-0020): el plan es dedicado, `numberOfSites` = 1.
+
+El mecanismo: con `alwaysOn = false` y `AutoCreate = CreateOrUpdate`, cada deploy produce un worker
+frio que paga el descubrimiento/migracion de esquema de Marten **en la primera request de negocio**,
+no en el arranque. Esa primera request compite por el unico core con el JIT, el codegen de Wolverine
+y la instancia saliente, y el handshake de conexion de Npgsql vence su timeout antes de completarse.
+
+**Fallo secundario que lo convierte en fallo de CI**: el gate de readiness del workflow
+(`smoke-tests-dominio.yml`) abre en cuanto `/api/version` reporta el SHA, y `/api/health` devuelve
+`OkObjectResult("OK")` **sin tocar Postgres ni Marten**. Ambos endpoints confirman "el binario nuevo
+esta cargado", ninguno confirma "el event store esta listo". Los smoke tests entran ~13 s antes de
+que el write-path pueda responder.
+
+## Acciones
+
+Ninguna ejecutada. **No se crearon issues** (pendiente de confirmacion del usuario). Propuestas:
+
+1. **`bug, tipo:tooling, dom:tooling`** — Reparar `scripts/appinsights-query.sh`: cambiar
+   `--output table` por `-o json` con formateo propio. Hoy todas las queries predefinidas devuelven
+   vacio silenciosamente con az-cli 2.82.0 / app-insights 1.2.3, produciendo falsos "sin hallazgos".
+   Es el hallazgo de mayor impacto transversal: envenena cualquier investigacion futura.
+2. **`bug, tipo:tooling, dom:colaboradores`** — Warm-up funcional del write-path en el gate de
+   readiness o en el fixture de smoke (precedente #166): tras confirmar el SHA en `/api/version`,
+   ejercitar una operacion que toque el event store y esperar a que responda, antes de soltar la
+   suite. Alternativa complementaria: que `/api/health` verifique realmente la conexion a Marten.
+3. **`tipo:infra`** — Evaluar `always_on = true` en `asp-asist-dev-colaboradores` (y/o
+   `ApplyAllDatabaseChangesOnStartup` para mover la migracion al arranque). Ambas opciones tienen
+   coste y fueron descartadas antes por precio (#166 lo documenta); decision del usuario.
+
+## Preguntas abiertas
+
+- **Timeout efectivo de Npgsql**: el default es 15 s y la request duro 35.3 s (≈2 intentos + retry de
+  Weasel). No se inspecciono el connection string (esta en Key Vault, CA-ADR-0026) para confirmar si
+  `Timeout`/`Command Timeout` estan personalizados. Verificar antes de proponer ajustes de valores.
+- **Por que los timeouts vienen en pares** (19:46:13.83/13.84, 14.58/14.62, 18.45/18.46, 23.98/23.98,
+  28.44/28.45): sugiere dos rutas de migracion concurrentes o dos schemas. No confirmado.
+- **Telemetria de solo un dia** para este rol con retencion de 90 d y sampling 100 %: verificar si es
+  por antiguedad del dominio o por agotamiento del daily cap de 0.5 GB (CA-ADR-0009).
+- **Recurrencia**: 1 fallo de 2 deploys consecutivos, con el segundo a 24.2 s de un umbral de ~35 s.
+  Sin cambio, la probabilidad de repeticion por deploy es alta. Monitorear `maxDur` de la primera
+  escritura tras cada deploy como indicador adelantado.
+- ¿Conviene un ADR sobre readiness real del write-path tras deploy (vs. readiness de binario), dado
+  que ya hay tres issues cerrados orbitando el mismo tema (#119, #166, #224)?

--- a/docs/bitacora/field-notes/procesadas/2026-08-15-1610-planner.md
+++ b/docs/bitacora/field-notes/procesadas/2026-08-15-1610-planner.md
@@ -1,0 +1,33 @@
+---
+fecha: 2026-08-15
+hora: 16:10
+sesion: planner
+tema: Refinamiento de #340 -- proscripcion operativa de "Empleado" en todos los niveles
+---
+
+## Contexto
+Refinar el borrador #340 ("renombrar los payloads Empleado para liberar el nombre del concepto rico"). La sesion se condujo paso a paso por pedido del usuario.
+
+## Descubrimientos
+- La premisa del borrador quedo obsoleta: #330 cerro con el maestro llamado `Colaborador`. El usuario preciso el marco correcto: "Empleado" no fue liberado sino **proscrito** del lenguaje ubicuo (concepto mas amplio para dar cabida a contratistas). Un termino proscrito no aparece en ningun artefacto.
+- El termino vive en tres niveles con costos distintos: (A) tipos anidados de eventos persistidos (barato: sin $type, sin alias), (B) tipos de contratos de bus (barato como tipo), (C) claves de propiedad persistidas/bus/HTTP/read model (caro: wire).
+- Los renames previos (#319/#322) nunca maparon nada: evitaron tocar claves. En src/ hay cero `JsonPropertyName`/`Upcast`/`MapEventType`; CA-ADR-0029 decision #6 proscribe `MapEventType`.
+
+## Decisiones
+- **Corregir los tres niveles** (usuario). Los datos dev son de smoke tests: desechables.
+- **Sin mapeo, con purga** en el mismo despliegue que el cambio de claves (MEF-ADR-0036 seccion 5); no aplica protocolo de dos despliegues (ningun tipo de EVENTO se renombra).
+- **`EmpleadoId` ES `CodigoColaborador`** (usuario): unificado con el codigo aplanado que exporta el maestro. Los downstream lo reciben como string plano; el invariante URL-safe queda en el VO del maestro.
+- **Nombres**: `ColaboradorProgramado` (gemelos en ambas islas, patron SedeProgramada), `InformacionColaborador` (+ carpeta `Colaboradores/` en PublicEvents), `DetalleColaborador` (PrivateEvents). Nombre puro `Colaborador` reservado al concepto rico (anti-squatting).
+- **Constancia del criterio en glosario + remarks, sin ADR** (usuario).
+- **Partir en dos por perfil de riesgo** (usuario): #340 = tipos (claves intactas; tests de serializacion inmutables como prueba de seguridad); #401 = claves + purga (tests reescritos). Secuencial: #401 nace `bloqueado`.
+
+## Descartado
+- `EmpleadoProgramado` (conserva el termino proscrito), `Colaborador` puro (squatting), mapeo con `JsonPropertyName` (deja el termino en el wire) o upcasters (maquinaria permanente para datos desechables), corte por dominio (los ensamblados de eventos acoplan en compilacion), issue unico (revision turbia: mezcla los dos perfiles de verificacion).
+
+## Preguntas abiertas
+- Menciones en prosa de "empleado" en entradas viejas del glosario (Marcacion, Supervisor): limpieza pendiente en una futura pasada de glosario.
+- El glosario sigue en la ruta vieja `docs/eda/`; pendiente `git mv` a `docs/ddd/` (sugerido al usuario).
+
+## Referencias
+Issues: #340 reescrito y refinado a `estado:listo` (tipos); #401 creado `estado:listo` + `bloqueado` (claves + purga, depende de #340).
+Glosario actualizado: proscripcion operativa en entrada Colaborador, Registro de Marcacion (CodigoColaborador), actor renombrado a "Colaborador (actor)" con pregunta resuelta.

--- a/docs/bitacora/field-notes/procesadas/2026-08-16-1721-planner.md
+++ b/docs/bitacora/field-notes/procesadas/2026-08-16-1721-planner.md
@@ -1,0 +1,32 @@
+---
+fecha: 2026-08-16
+hora: 17:21
+sesion: planner
+tema: Refinamiento de #400 -- encender always_on en los tres Function Apps de dev
+---
+
+## Contexto
+Refinar el borrador #400 (always_on en dev). Sesion paso a paso por pedido del usuario.
+
+## Descubrimientos
+- El borrador era factualmente solido: todas sus afirmaciones sobre modulos, comentario de deriva y MEF-ADR-0020 se verificaron contra el codigo y el ADR.
+- Una sobreafirmacion corregida: el ADR define los INPUTS del modulo service-plan pero NO fija el mecanismo por el que always_on llega al site_config (el "output" que el borrador presentaba como contrato es una interpretacion). Se marco como propuesta revisable del infra-writer.
+- Dato extra para el harness: el contrato del ADR tambien fija el default `false (dev)` (linea 67), no solo la prosa de costo (lineas 54 y 110).
+
+## Decisiones
+- **Alcance (b), decision del usuario**: cerrar TODA la deriva del modulo service-plan (os_type default Linux, worker_count default 1, always_on default false), no solo always_on. Defaults replican el comportamiento actual; os_type es ForceNew, por eso el default calca el hardcode.
+- CA-2 y CA-5 fusionados (verificaban lo mismo): quedan 6 CAs de un solo eje.
+- Seccion `## Ambiente: dev` agregada (gap de DoR para tipo:infra).
+- Labels: fuera `dom:tooling` (pseudo-dominio, proscrito); entran los tres reales (programacion, control-horas, colaboradores), precedente #253.
+- Draft de seguimiento creado en el harness: eda-evsourcing-azure-harness#652 (corregir fundamento de costo, default del contrato y default de scaffolders en MEF-ADR-0020). No bloquea a #400.
+
+## Descartado
+- Alcance minimo (solo always_on): el usuario prefirio cerrar la deriva completa del contrato.
+- Prescribir el mecanismo input+output como contrato: el ADR no lo fija; queda como recomendacion revisable.
+
+## Preguntas abiertas
+- #399 (readiness) arrastra el mismo `dom:tooling` -- corregir cuando se refine.
+- El mecanismo canonico de always_on (service-plan output vs variable directa en function-app) lo fijara el harness en #652.
+
+## Referencias
+Issues: #400 refinado a `estado:listo` (tipo:infra, 3 dom reales); draft harness #652 creado.

--- a/docs/bitacora/field-notes/procesadas/2026-08-16-1945-planner.md
+++ b/docs/bitacora/field-notes/procesadas/2026-08-16-1945-planner.md
@@ -1,0 +1,31 @@
+---
+fecha: 2026-08-16
+hora: 19:45
+sesion: planner
+tema: refinamiento del issue #399 (endpoint /api/ready contra el event store)
+---
+
+## Contexto
+Refinar el borrador #399: endpoint de readiness que verifique el event store antes de los smoke tests (incidente del deploy de PR #388, timeout de Npgsql en el primer POST frio).
+
+## Descubrimientos
+- La allowlist de `tooling-pipeline.sh` (plugin v0.25.0) prohibe `src/`; el precedente #224 (VersionCheck.cs como `tipo:tooling` tocando `src/`, 2026-07-19) es anterior a la enmienda del harness que cerro esa puerta (issue #448 del harness, 2026-07-29, MEF-ADR-0011). El etiquetado original del #399 (`tipo:tooling`) habria chocado contra el pipeline.
+- `smoke-tests-dominio.yml` es reusable por los tres dominios: un gate que pollee `/api/ready` exige que los tres lo expongan a la vez -- razon dura para NO partir el issue por dominio.
+- CA-8 original ("sin evidencia el issue no se cierra") contradice el `Closes #399` del PR: el deploy real solo ocurre post-merge.
+
+## Decisiones
+- Reetiquetado: `tipo:tooling` -> `tipo:refactor` (enruta a tdd-pipeline, que si escribe en `src/` y no restringe `.github/workflows/`); `dom:tooling` -> `dom:colaboradores` + `dom:control-horas` + `dom:programacion` (multiples dom: reales, doctrina MEF-ADR-0011, precedente #253).
+- CA-8 reformulado: la evidencia es el log de duracion del poll (CA-5); la verificacion del primer deploy real se documenta como comentario en el PR post-merge; el issue de seguimiento del harness es quien exige la evidencia antes de propagar.
+- 8 CAs justificados sin partir: CA-4/CA-7 son guardas, CA-8 es verificacion logueada; el trabajo real es un endpoint homogeneo x3 + gate acoplado (partir dejaria huerfanos o romperia el workflow compartido).
+- Anotado en el issue que MEF-ADR-0043 no aplica (GET de operacion, no comando).
+
+## Descartado
+- Partir por dominio o por endpoint/gate (corte cosmetico + huerfanos + workflow reusable).
+- `tipo:feature` (no hay modelo de eventos; el gate de /implement exigiria la seccion).
+
+## Preguntas abiertas
+- `harness.config.json` -> `domainLabels` desactualizado: no lista `colaboradores`; lista `asistencia` y `contracts` que ya no son dominios en `src/`. Conviene corregirlo (no bloqueo este issue).
+- Glosario sigue en la ruta vieja `docs/eda/ubiquitous-language.yaml`: pendiente `git mv` a `docs/ddd/ubiquitous-language.yaml` (MEF-ADR-0040).
+
+## Referencias
+Issues refinados: #399 (estado:listo)

--- a/docs/bitacora/field-notes/procesadas/2026-08-17-0740-planner.md
+++ b/docs/bitacora/field-notes/procesadas/2026-08-17-0740-planner.md
@@ -1,0 +1,31 @@
+---
+fecha: 2026-08-17
+hora: 07:40
+sesion: planner
+tema: refinamiento del issue #403 (cierre automatico del issue de infra tras el apply)
+---
+
+## Contexto
+Refinar el borrador #403: el workflow `infra-cd.yml` no cumple la promesa del PR de `/infra` de cerrar el issue al terminar el `terraform apply` (MEF-ADR-0022). El issue #400 quedo abierto tras el run exitoso 31976506428 y hubo que cerrarlo a mano.
+
+## Descubrimientos
+- El canon del `infra-base-scaffolder` (mefisto v0.23.0) ya genera el step de cierre completo, con permisos `issues: write` + `pull-requests: read` y resolucion del PR via `commits/{sha}/pulls` (robusto ante squash-merge). El fix es transcripcion, no diseno.
+- Drift adicional entre el workflow del consumidor y el canon: siembra de secretos KV y reciclado de Function Apps (no aplican: `harness.config.json` sin `secrets[]`), estructura de dos jobs vs dos archivos, `azure/login` vs `ARM_USE_OIDC` directo, pin de Terraform 1.15.8 (#303). Todo excluido del alcance con justificacion en el issue.
+- Solo un PR mergeado con rama `infra-issue-*` (el #402 / issue #400, ya cerrado a mano): no hay backlog de issues de infra zombis por limpiar.
+- Verificacion empirica diferida: el proximo `tipo:infra` por `/infra` (candidato #398, hoy `estado:listo`) sera el primer verificador real del cierre automatico.
+
+## Decisiones
+- Alcance quirurgico: solo permisos + step de cierre; no sincronizar el resto del canon (decisiones locales deliberadas se respetan).
+- Tipo confirmado `tipo:tooling` + `bug` (toca `.github/workflows/` del consumidor, no `infra/**` ni `src/`); sin `dom:`.
+- #403 pasa Revision de complejidad (1 eje, 1 archivo, 5 CAs) y DoR de tooling -> `estado:listo`.
+
+## Descartado
+- Quitar la promesa (`CLOSES_LINE`) de `iac-pipeline.sh` y aceptar cierre manual: deja el hueco y ademas seria cambio en el repo de Mefisto.
+
+## Preguntas abiertas
+- ¿Vale un draft cross-repo en Mefisto sobre "drift management": mecanismo para re-sincronizar workflows generados por el scaffolder cuando el canon evoluciona? Hoy la deteccion es artesanal (este bug lo prueba). Pendiente de decision del usuario.
+- ~~El glosario sigue solo en la ruta vieja~~ -> capturado como issue #407 (git mv a docs/ddd/, referencias vivas, sin tocar bitacora). Prerequisito operativo anotado: commitear los cambios locales de docs/eda/*.yaml antes de correr el pipeline.
+
+## Referencias
+Issues refinados: #403 (borrador -> listo)
+Issues creados: #407 (mover el glosario a docs/ddd/, estado:listo)

--- a/docs/bitacora/field-notes/procesadas/review-pr-393.md
+++ b/docs/bitacora/field-notes/procesadas/review-pr-393.md
@@ -1,0 +1,107 @@
+# Field Note: Review del PR #393
+
+**Fecha**: 2026-08-16
+**PR**: https://github.com/augusto-romero-arango/Bitakora.ControlAsistencia/pull/393
+**Issue**: #396
+
+## Contexto
+
+El PR nacio fuera del flujo Mefisto -- sin issue, sin DoR -- y se salto la etapa `infra-reviewer`.
+Se regularizo despues con el issue #396. La revision la hizo el usuario a mano el 2026-08-15,
+haciendo las veces de esa etapa saltada, y dejo las observaciones en el **body de la review**
+(`PRR_kwDOR3ZjV88AAAABJriSSQ`) en vez de como comentarios inline. Eso importa para la mecanica de
+respuesta: sin comentarios inline no hay `in_reply_to`, asi que las respuestas van como un
+comentario unico del PR.
+
+## Comentarios del review
+
+| # | Categoria  | Resumen |
+|---|------------|---------|
+| 1 | corregir   | La alerta 3 (`servicebus-failure-spike`) tiene un nombre mas estrecho que su semantica: el filtro cubre cualquier trigger no-HTTP, no solo Service Bus |
+| 2 | corregir   | Los comentarios HCL duplican extensamente CA-ADR-0009; comprimir segun MEF-ADR-0044 |
+| 3 | sin accion | `resultCode == "500"` exacto (no 5xx): decision deliberada ya documentada en el ADR con su linea de escape |
+
+## Correcciones aplicadas
+
+Commit `739d438` (2 archivos, +12/-36).
+
+**C1 -- rename.** `service_bus_failure_spike` -> `non_http_failure_spike` en el recurso Terraform,
+su atributo `name`, su `description`, y la fila de la tabla de CA-ADR-0009 (donde la columna "Cubre"
+paso de "Consumidores de eventos" a "Triggers no-HTTP", para que la tabla no reintrodujera por la
+columna el sesgo que el rename le quita al nombre).
+
+El rename era gratis y se verifico antes de hacerlo, no se asumio: el plan de CI reportaba
+`service_bus_failure_spike will be created` con `1 to add, 1 to change, 0 to destroy` -- el recurso
+no existia en Azure. Despues del merge habria costado destroy + create. Se verifico ademas que el
+rename estaba contenido: 3 referencias en todo el repo, ningun `output` del modulo expone la alerta,
+ningun otro modulo la consume.
+
+**C2 -- compresion de comentarios.** De ~24 lineas a 8. Se conservo, con su cita a CA-ADR-0009, lo
+que es restriccion local activa: que `exceptions` no expone el status code (vive en `requests`, de
+ahi el join por `operation_Id`), y que los triggers no-HTTP reportan `resultCode "0"` -- valor no
+contractual -- por lo que se descarta lo que si es un status HTTP (`100..599`). Se podo el racional
+de `DeadletteredMessages`/`EntityName`, el detalle de la subscription `smoke-tests` y la ventaja de
+deteccion temprana; los tres se verificaron presentes en CA-ADR-0009 antes de removerlos, para que
+la poda no dejara nada huerfano. Los headers de recurso quedaron en una linea, replicando el estilo
+que ya tenia la alerta 1 en el mismo archivo.
+
+## Verificacion
+
+El diff es solo HCL y Markdown -- no toca un solo `.cs` --, asi que `dotnet build`/`dotnet test` no
+ejercitan nada de el. Se corrio la estatica de Terraform, que es la que aplica (y la misma que corre
+`infra-reviewer`):
+
+| Check | Resultado |
+|---|---|
+| `terraform fmt -check` (modulo monitoring) | exit 0 |
+| `terraform init -backend=false` + `validate` (dev) | `Success! The configuration is valid.` |
+| `terraform-plan` en CI tras el push | pass -- `non_http_failure_spike will be created`, `1 to add, 1 to change, 0 to destroy` |
+| Referencias al nombre anterior | 0 |
+| Referencias al nombre nuevo | 3 (las esperadas) |
+
+## Mejoras a agentes
+
+Se identificaron dos gaps del harness, ambos verificados empiricamente contra el cache del plugin
+(version 0.24.0). **El usuario decidio no enrutar ninguno como draft.** Se dejan registrados aqui
+por si reaparecen.
+
+| Agente | Gap | Destino | Ajuste aplicado |
+|---|---|---|---|
+| `infra-writer` | regla faltante | (no enrutado) | Ninguno -- decision del usuario |
+| `infra-reviewer` | regla faltante | (no enrutado) | Ninguno -- decision del usuario |
+
+**Gap 1 -- `infra-writer` sin la doctrina de MEF-ADR-0044.** `test-writer`, `implementer`,
+`smoke-test-writer` y `reviewer` tienen su seccion `## Doctrina de comentarios (MEF-ADR-0044)`;
+`infra-writer` no tiene ninguna coincidencia con `0044`/`Context Delta`/`Decision Delta`. La causa
+raiz esta en el propio ADR: su linea de alcance nombra como objetivos de propagacion a los tres
+escritores de `.cs`, y el issue de propagacion (harness #635, cerrado) siguio esa lista -- pero la
+§5 del ADR **si pone HCL en alcance del umbral de escritura**. El ADR sub-especifico su propio
+conjunto de propagacion, omitiendo al unico agente que escribe HCL.
+
+**Gap 2 -- `infra-reviewer` valida la forma del nombre, no su correspondencia con la semantica.** Su
+checklist de Calidad tiene una sola regla de nombres: que sigan el patron
+`<tipo>-<proyecto>-<ambiente>`. `servicebus-failure-spike` la pasaba -- esta bien formado, solo que
+describe un subconjunto de lo que su filtro captura. No existe regla que compare el nombre contra lo
+que la configuracion del recurso realmente hace. Para una alerta el costo es mayor que para otros
+recursos: el nombre es la carga util que recibe el humano de guardia. Nota honesta de alcance: este
+ajuste no habria prevenido este caso, porque el PR se salto `infra-reviewer` por completo.
+
+## Lecciones
+
+- **Un nombre de alerta es interfaz de usuario, no etiqueta interna.** Lo lee un humano en el peor
+  momento posible. Cuando el nombre es mas estrecho que el filtro, el error no es cosmetico: produce
+  un diagnostico equivocado. El costo de arreglarlo tiene fecha de vencimiento -- gratis mientras el
+  `plan` diga `will be created`, destroy + create despues del merge --, asi que conviene revisar
+  nombres de recursos que aun no existen antes de mergear, no despues.
+- **Comprimir un comentario exige verificar que su contenido ya vive en otro lado.** La poda de
+  MEF-ADR-0044 es segura solo si lo removido esta verificadamente en el ADR. HCL es hogar canonico
+  de doctrina (MEF-ADR-0027, MEF-ADR-0032 B6) y por eso el ADR lo excluye del modo limpieza; aqui
+  aplico el umbral de escritura -- no el de limpieza -- porque los comentarios se estaban
+  introduciendo en un PR sin mergear.
+- **La verificacion se elige por el diff, no por el runbook.** El pipeline manda `dotnet build` +
+  `dotnet test`, pero un diff de solo HCL y Markdown no ejercita nada de eso: correrlos habria dado
+  un verde que no significa nada. La verificacion real era `fmt -check` + `validate` + el `plan` de
+  CI.
+- **Saltarse una etapa del flujo desplaza el trabajo, no lo elimina.** Las dos observaciones son
+  exactamente lo que `infra-reviewer` existe para atrapar (una de ellas, el gap 2, ni siquiera esta
+  hoy en su checklist). El costo del atajo se pago despues, en revision manual.


### PR DESCRIPTION
Pone al dia la bitacora con el backlog completo de field notes acumuladas desde el 14 hasta el 17 de agosto de 2026: 3 entradas nuevas y 1 extendida, 8 field notes movidas a `procesadas/`.

## Entradas

- **2026-08-14** (extendida) — El Guion que Cambia (y Arregla) la Identidad de Colaborador: se agrega la sesion de refinamiento que aplico la doctrina HTTP (MEF-ADR-0043) a toda la saga de Colaboradores, con el hallazgo de que `CodigoColaborador` tampoco era URL-safe.
- **2026-08-15** — Seis Merges, un Timeout de 35 Segundos y una Herramienta que Mentia en Silencio: la cadena secuencial de 6 issues cerro de madrugada, y una investigacion de bug destapo un cold-start real en produccion-dev y una herramienta de diagnostico que devolvia falsos negativos.
- **2026-08-16** — "Empleado" Desaparece del Codigo, y el Issue que no Cerro Solo: cierre de los dos niveles restantes del rename de "Empleado", `always_on` en los tres Function Apps de dev, y el issue de infra que hubo que cerrar a mano.
- **2026-08-17** — El Circulo se Cierra: del Timeout de Npgsql al Endpoint de Readiness: el endpoint `/api/ready` llega a los tres dominios y se refina el fix del cierre automatico de issues de infra.

## Test plan

- [x] Cada entrada cita commits/PRs/issues verificados contra `git log` y `gh issue/pr view`.
- [x] Los numeros de cada tabla se acotan al dia calendario correspondiente (UTC-5), no al dia de ejecucion del historiador.
- [x] Las 8 field notes del backlog quedaron movidas a `docs/bitacora/field-notes/procesadas/`, ninguna se descarto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)