### PR TITLE
Cerrar el issue de infra al terminar el apply en Infra CD

### DIFF
--- a/.github/workflows/infra-cd.yml
+++ b/.github/workflows/infra-cd.yml
@@ -17,6 +17,8 @@ permissions:
   # azure/login: Terraform lee por su cuenta ACTIONS_ID_TOKEN_REQUEST_URL/TOKEN, que este
   # scope habilita. Va a nivel de workflow porque el archivo tiene un unico job.
   id-token: write
+  issues: write        # requerido para cerrar el issue de infra tras el apply exitoso
+  pull-requests: read  # requerido por 'gh api commits/{sha}/pulls' y 'pulls/{num}' (deriva el issue)
 
 jobs:
   terraform-apply:
@@ -61,3 +63,27 @@ jobs:
       - name: Terraform Apply
         working-directory: infra/environments/dev
         run: terraform apply -auto-approve -lock-timeout=5m
+
+      - name: Cerrar el issue de infra tras el apply exitoso
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # El PR del pipeline IaC NO lleva 'Closes #N' (MEF-ADR-0022, "Cierre del issue de
+          # infra: al aplicar en CI, no al mergear el PR"): el issue representa "infra
+          # aplicada", no "infra mergeada". El numero de issue se deriva de la rama
+          # infra-issue-<num>-<slug> (scripts/iac-pipeline.sh) del PR que se acaba de
+          # mergear, via la API de PRs asociados al commit de merge -- funciona con
+          # squash, merge o rebase, a diferencia de parsear el mensaje del commit.
+          PR_NUM=$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" --jq '.[0].number // empty')
+          if [ -z "$PR_NUM" ]; then
+            echo "No se encontro un PR asociado al commit ${{ github.sha }}; no se cierra ningun issue."
+            exit 0
+          fi
+          BRANCH=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUM}" --jq '.head.ref // empty')
+          ISSUE_NUM=$(echo "$BRANCH" | grep -oE 'infra-issue-[0-9]+' | grep -oE '[0-9]+' || true)
+          if [ -z "$ISSUE_NUM" ]; then
+            echo "La rama '$BRANCH' del PR #$PR_NUM no sigue el patron infra-issue-<num>-*; no se cierra ningun issue."
+            exit 0
+          fi
+          gh issue close "$ISSUE_NUM" \
+            --comment "Infraestructura aplicada por CI (workflow **Infra CD**, run ${{ github.run_id }}, commit ${{ github.sha }})."


### PR DESCRIPTION
## Resumen

Pipeline tooling completado:
- Writer: implementacion de la tarea
- Reviewer: revision de calidad

## Decisiones del pipeline

<details>
<summary>Writer -- 2m 11s</summary>

# Stage 1 (writer) — Issue #403

## Que se hizo

Se sincronizo `.github/workflows/infra-cd.yml` con el canon de `infra-base-scaffolder.md`
(mefisto v0.26.0, confirmado como version activa en `.claude/plugins/cache/.../0.26.0`,
`autoUpdate: true`), solo en el mecanismo de cierre del issue de infra:

1. **Permisos** (bloque `permissions` a nivel workflow, unico job del archivo):
   agregados `issues: write` y `pull-requests: read`, cada uno con comentario de proposito
   copiado del canon (linea 20-21 del archivo).
2. **Step final** "Cerrar el issue de infra tras el apply exitoso", despues de
   `Terraform Apply` (linea 67-89). Logica transcrita casi literal del canon (lineas
   2203-2225 de `agents/infra-base-scaffolder.md`, sin placeholders que sustituir):
   - Resuelve el PR via `gh api repos/.../commits/{sha}/pulls`.
   - Extrae el numero de issue de la rama del PR con
     `grep -oE 'infra-issue-[0-9]+' | grep -oE '[0-9]+'`.
   - Cierra el issue con `gh issue close` + comentario que referencia el workflow, run id
     y commit.
   - Degrada con `exit 0` (sin fallar el workflow) si no hay PR asociado o la rama no
     sigue el patron `infra-issue-<num>-*`.
   - `env: GH_TOKEN: ${{ github.token }}`.

## Decisiones

- Permisos a nivel de workflow (no de job): mismo criterio que el comentario ya existente
  sobre `id-token: write` — este archivo tiene un unico job. No se movieron a nivel de job
  (la nota tecnica del issue lo dejaba como eleccion equivalente).
- No se agrego `if:` al step nuevo: corre despues de `Terraform Apply` por la semantica
  secuencial de steps de GitHub Actions (si el apply falla, el job se detiene ahi).
- No se toco `azure/login`, el pin de `terraform_version: "1.15.8"`, la siembra de
  secretos de Key Vault ni el reciclado de Function Apps — confirmado explicitamente como
  fuera de alcance en el issue.

## Verificacion

- `python3 -c "import yaml; yaml.safe_load(open(...))"` → YAML valido.
- `actionlint .github/workflows/infra-cd.yml` → sin hallazgos.
- Diff acotado a las 26 lineas agregadas (2 permisos + 1 step); ningun otro step,
  permiso o pin se modifico (`git diff --stat`: 1 archivo, +26/-0).

## Verificacion diferida (CA-5, no bloquea el PR)

No hay forma de ejercitar el cierre end-to-end en este PR (el workflow solo corre en push
a `main` con cambios en `infra/**`). El primer verificador real sera el proximo issue
`tipo:infra` que pase por `/infra` (candidato: #398, `estado:listo` al momento de escribir
el issue).

## Fuera de alcance / no se creo draft en el harness

Ninguna parte de esta tarea requirio modificar el plugin Mefisto: el step y los permisos
ya existen en su canon (`infra-base-scaffolder.md`); el trabajo fue estrictamente
transcribirlos a este repo consumidor. No se creo ningun issue de borrador en
`eda-evsourcing-azure-harness`.

</details>

<details>
<summary>Reviewer -- 3m 52s</summary>

# Stage 2 (reviewer) — Issue #403

## Veredicto

**Aprobado sin correcciones.** El cambio del writer es una transcripcion fiel del canon,
acotada al mecanismo de cierre del issue. No se modifico ningun archivo en esta etapa
salvo este resumen.

## Verificacion de criterios de aceptacion

| CA | Estado | Evidencia |
|---|---|---|
| CA-1 permisos | ✅ | `permissions` = `contents: read`, `id-token: write`, `issues: write`, `pull-requests: read`, cada nuevo scope con su comentario de proposito. Comparado contra `HEAD~1`: **ningun scope removido**, solo dos agregados. |
| CA-2 step de cierre | ✅ | Ultimo step, inmediatamente despues de `Terraform Apply`. Orden confirmado parseando el YAML: `[Checkout, Setup Terraform, Init, Plan, Apply, Cerrar el issue...]`. |
| CA-3 degradacion benigna | ✅ | **Verificado ejecutando la logica**, no solo leyendola (ver abajo). |
| CA-4 YAML valido + nada mas alterado | ✅ | `actionlint` → 0 hallazgos. `git diff --numstat` → `26 0` (26 adiciones, **0 deleciones**), un solo archivo. Pin `terraform_version: "1.15.8"` intacto; `infra-ci.yml` sin tocar. |
| CA-5 cierre real end-to-end | ⏸️ Diferido por diseno | El workflow solo corre en push a `main` con cambios en `infra/**`. Primer verificador: proximo issue `tipo:infra` via `/infra` (candidato #398). |

## Fidelidad al canon

`diff` byte a byte del step (lineas 67-89 del workflow) contra el canon
(`agents/infra-base-scaffolder.md`, lineas 2203-2225 de mefisto **v0.26.0**): **identico**.
Los comentarios de los dos permisos nuevos tambien son literales del canon (lineas 2015-2016).

- El issue citaba v0.23.0; la version activa es v0.26.0. Verifique que el step es
  **identico en 0.25.0 y 0.26.0** → el canon esta estable, la transcripcion esta al dia.
- Patron de rama confirmado en la fuente: `iac-pipeline.sh:225` construye
  `BRANCH_NAME="infra-issue-${ISSUE_NUM}-${SLUG}"`.
- La promesa que este fix cumple existe en `iac-pipeline.sh:495` (`CLOSES_LINE`). El texto
  del comentario del step dice "workflow **Infra CD**", igual que esa promesa — se mantiene
  asi a proposito aunque el `name:` del workflow sea "Infra CD - Terraform Apply".

## Verificacion adicional que aporto esta etapa

El writer valido YAML y `actionlint` (analisis estatico). Como CA-5 queda diferido, **ejecute
la logica del step** con un `gh` mockeado, bajo `bash -e` (el shell por defecto de Actions en
Linux, que hace que un fallo de comando aborte el step):

| Escenario | Resultado |
|---|---|
| Rama real del PR #402 (`infra-issue-400-encender-alwayson-...`) | cierra issue **400** ✅ |
| Slug con digitos (`infra-issue-400-subir-a-3-apps-v2`) | cierra **400**, no `3` ni `2` — el grep en dos etapas funciona ✅ |
| Commit sin PR asociado | mensaje + `exit 0` ✅ |
| Rama fuera de patron (`hotfix/parche-directo`) | mensaje + `exit 0` ✅ |

Ademas: `shellcheck` **si** esta instalado, por lo que el pase limpio de `actionlint` sobre
`infra-cd.yml` incluyo el analisis shellcheck del bloque `run:` — 0 hallazgos.

Chequeo de correctitud clave: el job `terraform-apply` **no declara su propio bloque
`permissions:`**, por lo que hereda el de nivel workflow. Si lo declarara, los dos scopes
nuevos se ignorarian silenciosamente y el step fallaria con 403 en produccion.

## Observaciones (sin accion, documentadas)

1. **Error genuino de API falla el step.** Si `gh api` devuelve 403/404/error de red, bajo
   `bash -e` el step sale con codigo 1 y el run queda rojo *despues* de un apply exitoso.
   Esto es mas estricto que la prosa del issue ("nunca falla el workflow"), pero **es el
   comportamiento correcto y se deja igual**: (a) CA-3 acota la degradacion benigna a dos
   casos concretos, ambos verificados; (b) es fidelidad literal al canon — divergir
   reintroduce el drift que este issue justamente cura; (c) fallar ruidosamente avisa que el
   mecanismo de cierre se rompio, en vez de recrear el hueco invisible del issue #400.
2. **`.[0]` toma el primer PR asociado al commit.** Suficiente para un merge commit en
   `main`; es comportamiento del canon. Sin cambio.
3. **Hallazgos preexistentes de actionlint en otros workflows**, fuera del alcance de este
   issue y **no introducidos por el writer** (confirmado corriendo actionlint sobre
   `HEAD~1`): `ci.yml` SC2129, `smoke-tests.yml` SC2086, `smoke-tests-dominio.yml` clave
   `queue: max` no valida en `concurrency`. Esta ultima merece un `/draft` propio: GitHub
   ignora esa clave, asi que la serializacion que aparenta configurar no existe.

## Alcance

Solo se modifico `.github/workflows/infra-cd.yml` (por el writer) y este resumen. **Ninguna
ruta prohibida fue tocada** — sin cambios en `commands/`, `skills/`, `agents/`, `hooks/`,
`.claude-plugin/`, `docs/adr/mef-adr-*` ni `src/`.

</details>

## Commits

8fc7426 fix(ci): cierra el issue de infra al terminar el apply en Infra CD

Closes #403