### PR TITLE
infra(dev): #398 Alertar el spike de excepciones del worker de proyecciones

### DIFF
--- a/docs/adr/ca-adr-0009-control-costos-application-insights.md
+++ b/docs/adr/ca-adr-0009-control-costos-application-insights.md
@@ -273,3 +273,56 @@ que duplicaria la topologia de eventos solo para observabilidad. Si en el futuro
 como red de seguridad de ultimo recurso, la decision de topologia va antes que la alerta.
 
 Capas 1, 2 y 3 sin cambios.
+
+## Actualizacion (2026-08-17, issue #398): la Capa 4 suma una tercera alerta para el worker de proyecciones
+
+Acotar la alerta de excepciones al borde HTTP (seccion anterior) dejo un hueco: el worker de
+proyecciones (`Bitakora.ControlAsistencia.Projections`) no atiende HTTP -- no genera `requests` con
+`resultCode == "500"` -- y sus operaciones no son un trigger no-HTTP de Azure Functions (la segunda
+alerta mira `requests` fallidos de un host de Functions; el daemon HotCold de Marten corre spans
+internos que van a `dependencies`/`exceptions`, no a `requests`). Antes de acotar la Capa 4 por
+borde, sus excepciones al menos contaban en la alerta generica de spike; despues, un worker en loop
+de errores no despertaba a nadie -- exactamente el patron que motivo este ADR.
+
+La Capa 4 pasa a tener **tres** alertas de spike, una por borde:
+
+| Alerta | Cubre | Filtro |
+|---|---|---|
+| `<prefijo>-exception-spike` | Borde HTTP | excepciones correlacionadas a un request con `resultCode == "500"` |
+| `<prefijo>-non-http-failure-spike` | Triggers no-HTTP | invocaciones con `success == false` cuyo `resultCode` no es un status HTTP |
+| `<prefijo>-projections-exception-spike` | Worker de proyecciones | excepciones con `cloud_RoleName == "Bitakora.ControlAsistencia.Projections"` |
+
+Umbral (>50), frecuencia (PT5M), ventana (PT5M), severidad (1) y action group: iguales en las tres.
+
+```kql
+exceptions
+| where timestamp > ago(5m)
+| where cloud_RoleName == "Bitakora.ControlAsistencia.Projections"
+| summarize ExceptionCount = count()
+| where ExceptionCount > 50
+```
+
+**Por que filtrar por `cloud_RoleName` y no correlacionar con `requests` (como la alerta del borde
+HTTP).** El worker no es un host de Azure Functions -- no tiene requests que correlacionar. El valor
+exacto (`"Bitakora.ControlAsistencia.Projections"`) es la constante `NombreServicio` de
+`ConfiguracionObservabilidadProjections.cs`, fijada por guardrail de test (issue #263): un cambio de
+ese string sin actualizar la alerta la deja evaluando un `cloud_RoleName` que ya no existe, silenciosa
+sin ningun error visible. No se generaliza a un filtro que cubra "cualquier worker no-HTTP" (MEF-ADR-0018,
+Rule of Three): `Projections` es hoy el unico proceso que no es ni borde HTTP ni trigger de Azure
+Functions.
+
+**Por que esta alerta no excluye trafico de smoke tests (a diferencia de nada -- nunca hubo lista de
+exclusion que quitarle).** Los smoke tests publican eventos validos: sus propias aserciones exigen
+cero dead letters, asi que no pueden inducir errores en el worker. Toda excepcion del worker es senal
+real y accionable, venga de un evento de negocio o de un evento publicado por un smoke test -- a
+diferencia de la segunda alerta (seccion anterior), que si necesita descartar la subscription
+`smoke-tests` porque esa si comparte `EntityName` con subscriptions de negocio en la metrica de DLQ.
+Aqui no aplica esa limitacion: la fuente es `exceptions` filtrada por rol de servicio, no una metrica
+por `EntityName`.
+
+**Limitacion conocida: el sampling head-based tambien recorta esta alerta.** Misma limitacion que las
+dos alertas hermanas: opera sobre telemetria muestreada al ratio de la Capa 2 (`TELEMETRY_SAMPLING_RATIO`,
+0.2 por defecto), asi que el conteo observado es una fraccion del real. No bajar el ratio sin
+recalibrar el umbral de las tres alertas.
+
+Capas 1, 2 y 3 sin cambios.

--- a/infra/modules/monitoring/main.tf
+++ b/infra/modules/monitoring/main.tf
@@ -205,6 +205,48 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "non_http_failure_spik
   tags = var.tags
 }
 
+# Alerta 4: pico de excepciones >50 en 5 minutos en el worker de proyecciones
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "projections_exception_spike" {
+  name                = "${var.name}-projections-exception-spike"
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  description         = "Pico de excepciones en el worker de proyecciones - posible proyeccion atascada en loop de reintentos generando costos"
+  severity            = 1
+  enabled             = true
+
+  scopes               = [azurerm_application_insights.this.id]
+  evaluation_frequency = "PT5M"
+  window_duration      = "PT5M"
+
+  criteria {
+    # cloud_RoleName fijo a "Bitakora.ControlAsistencia.Projections" (constante
+    # NombreServicio, guardrail issue #263). No filtra trafico de smoke tests: ver
+    # CA-ADR-0009.
+    query = <<-QUERY
+      exceptions
+      | where timestamp > ago(5m)
+      | where cloud_RoleName == "Bitakora.ControlAsistencia.Projections"
+      | summarize ExceptionCount = count()
+      | where ExceptionCount > 50
+    QUERY
+
+    time_aggregation_method = "Count"
+    operator                = "GreaterThan"
+    threshold               = 0
+
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
+  }
+
+  action {
+    action_groups = [azurerm_monitor_action_group.cost_alerts.id]
+  }
+
+  tags = var.tags
+}
+
 output "connection_string" {
   value     = azurerm_application_insights.this.connection_string
   sensitive = true


### PR DESCRIPTION
## Infraestructura

Implementa los cambios de infraestructura del issue #398.

- **Ambiente**: dev
- **Estado**: HCL escrito y revisado localmente (sin plan ni apply local); pendiente de aplicar por CI
- **Pipeline**: iac-pipeline.sh

## Decisiones del pipeline

<details>
<summary>infra-writer -- 1m 44s</summary>

_(El agente no genero resumen)_

</details>

<details>
<summary>infra-reviewer -- 1m 55s</summary>

_(El agente no genero resumen)_

</details>

## Cambios Terraform

 infra/modules/monitoring/main.tf | 42 ++++++++++++++++++++++++++++++++++++++++
 1 file changed, 42 insertions(+)

## Commits

c408a19 infra(dev): agregar alerta de spike de excepciones para el worker de proyecciones

> **Apply pendiente en CI**: este PR no cierra el issue #398. El `terraform apply` lo ejecuta el workflow **Infra CD** al mergear este PR a `main` (MEF-ADR-0022); el issue se cierra automaticamente cuando ese apply termine exitosamente.