### PR TITLE
docs(adr): registrar la verificacion empirica de la alerta del worker de proyecciones

### DIFF
--- a/docs/adr/ca-adr-0009-control-costos-application-insights.md
+++ b/docs/adr/ca-adr-0009-control-costos-application-insights.md
@@ -325,4 +325,96 @@ dos alertas hermanas: opera sobre telemetria muestreada al ratio de la Capa 2 (`
 0.2 por defecto), asi que el conteo observado es una fraccion del real. No bajar el ratio sin
 recalibrar el umbral de las tres alertas.
 
+> **Corregido por la actualizacion (2026-08-17, issue #412) al final de este ADR.** El experimento de
+> falla inducida midio que el ratio 0.2 **no** recorta esta alerta: las excepciones del daemon viajan
+> por la senal de logs con `SpanId == default` y pasan enteras (87 de 87, 1:1). El recorte real es
+> binario y de otro origen -- el sampler del issue #308 suprime al 100% una familia de errores del
+> daemon. El parrafo de arriba se conserva por trazabilidad; la seccion final manda.
+
 Capas 1, 2 y 3 sin cambios.
+
+## Actualizacion (2026-08-17, issue #412): verificacion empirica de la alerta del worker
+
+La alerta de la seccion anterior se desplego con ruido cero verificado (sin falsos positivos), pero
+nunca se comprobo su **capacidad de deteccion**: la tabla `exceptions` estaba vacia para el worker en
+los 30 dias de retencion, y la cadena "daemon falla -> excepcion visible en la alerta" era doctrina
+asumida. Se ejecuto una falla inducida sobre dev en sesion supervisada.
+
+**Protocolo.** `az postgres flexible-server stop` sobre `psql-asist-dev` (17:02:18Z, `Stopped` a las
+17:06:27Z) y `start` (17:12:14Z, `Ready` a las 17:20:28Z). Se eligio detener el servidor y no romper la
+connection string del Container App: el provider `azurerm` no modela el power state, asi que no hay
+drift de Terraform, y el worker no re-arranca -- el proceso vivo pierde la conexion y el daemon entra
+en reintentos, que es la cadena a verificar. `TELEMETRY_SAMPLING_RATIO` no se toco (ausente en el
+Container App, o sea el default 0.2 real).
+
+**Resultado 1 -- la alerta detecta, pero su umbral es inalcanzable.** La query exacta de la alerta
+devolvio 88 filas sobre la ventana de falla: el filtro por `cloud_RoleName` funciona y la alerta no es
+ciega. Pero evaluada en bins de 5 minutos -- que es su ventana real -- el maximo fue **30**, contra un
+umbral de `>50`:
+
+| Ventana (UTC) | Excepciones del worker | Supera >50 |
+|---|---|---|
+| 17:00 | 7 | no |
+| 17:05 | 26 | no |
+| 17:10 | 25 | no |
+| 17:15 | 30 | no |
+
+Una caida total de Postgres de ~14 minutos -- el peor caso realista para el worker -- **no dispara la
+alerta**. El ritmo del daemon esta acotado por su backoff de reintentos y por el numero de shards (hoy
+3: `FichaColaborador:All`, `CategoriaDeEtiquetas:All`, `TurnoVigente:All`), no por la gravedad del
+fallo. El umbral >50 se heredo de las alertas de borde HTTP, donde un loop de reintentos si produce
+cientos de eventos por minuto; el daemon no tiene ese perfil. Recalibrar es un issue aparte.
+
+**Resultado 2 -- la via es la senal de logs, y el ratio 0.2 no la recorta.** Evidencia por fila en
+`exceptions`: `customDimensions.CategoryName == "Marten.Events.Daemon.Coordination.ProjectionCoordinator"`
+y `customDimensions.OriginalFormat` con la plantilla del log -- ambos campos solo existen si el item
+nacio de un `LogRecord` de `ILogger`, no de un span event. Ademas `operation_Id` **vacio** en las 88
+filas: el `LogError` del daemon ocurre fuera de un span activo (`SpanId == default`). Eso es lo que
+neutraliza el recorte: `AzureMonitorExporterOptions.EnableTraceBasedLogsSampler` viene en `true` por
+defecto (exporter 1.8.1) e instala un `LogFilteringProcessor` que descarta el LogRecord solo si tiene
+`SpanId` y su span no fue muestreado; sin `SpanId` pasa siempre. Sin sampling de ingestion tampoco
+(`itemCount == 1` en las 88 filas, `samplingPercentage == 100`).
+
+Contraste consola vs `exceptions` sobre la ventana completa, por familia de mensaje:
+
+| Familia de error del daemon | Consola | `exceptions` | Ratio |
+|---|---|---|---|
+| `Error trying to attain a lock for set {Name}...` | 87 | 87 | **1:1** |
+| `Failed while trying to detect high water statistics...` | 35 | 0 | **0%** |
+
+**Resultado 3 (hallazgo no buscado) -- el sampler del issue #308 ciega una familia entera de errores.**
+El split no es fraccional, es binario, y tiene una causa exacta. `SamplerQueDescartaPollingDelDaemon`
+devuelve `SamplingDecision.Drop` para el span `marten.daemon.highwatermark`; el `HighWaterAgent` de
+JasperFx emite sus `LogError` **dentro** de ese span, con `SpanId` poblado y `TraceFlags != Recorded`.
+El `LogFilteringProcessor` los descarta. Los 35 errores de high water llevaban excepcion con stack
+trace completo -- eran candidatos legitimos a `exceptions` -- y no llegaron a ninguna tabla.
+
+El sampler se escribio para recortar **costos de trazas** (95% de los spans Postgres del worker cuelgan
+de ese polling). El efecto colateral es que suprime tambien los **logs de error** emitidos bajo ese
+span, que era justo lo que no se queria perder. Es el mismo modo de falla que el issue #308 corrigio
+--- wiring a medio terminar, silencioso --- reaparecido un nivel mas abajo. El desacople existe y no
+cuesta trazas: `.UseAzureMonitorExporter(o => o.EnableTraceBasedLogsSampler = false)`.
+
+**Correccion a la seccion anterior.** La afirmacion "el sampling head-based tambien recorta esta
+alerta" es **incorrecta** para el worker en su mecanismo y en su magnitud: no hay recorte proporcional
+al ratio 0.2 sobre las excepciones del daemon. Hay paso integro (1:1) para los errores sin contexto de
+span y supresion total (0%) para los emitidos bajo el span de polling. La consecuencia practica se
+invierte: bajar `TELEMETRY_SAMPLING_RATIO` no vuelve mas insensible esta alerta, y subirlo no la
+arregla.
+
+**Efecto colateral observado en las alertas hermanas.** Durante la ventana, `func-asist-dev-colaboradores`
+y `func-asist-dev-control-horas` generaron 810 excepciones de `Wolverine.RDBMS.DurabilityAgent` e
+`IAgentCommand` (116-120 por ventana de 5 min, holgadamente sobre 50, tambien con `operation_Id` vacio).
+Ninguna alerta disparo: hubo **cero `requests`** en toda la ventana, y las dos alertas de borde se
+condicionan a `requests` (500 HTTP / invocaciones no-HTTP fallidas). Un fallo en un agente de fondo no
+produce requests, asi que esas dos alertas son estructuralmente ciegas a este modo de falla. Total del
+incidente: ~1000 excepciones en tres roles, **cero alertas disparadas** (verificado contra
+`Microsoft.AlertsManagement/alerts`).
+
+**Reversion (verificada).** Postgres `Ready`; la replica del worker
+(`ca-asist-dev--0000033-84b48c4f4b-xwtpq`, creada 00:20:28Z) nunca re-arranco, confirmando la premisa
+del mecanismo elegido; post-recuperacion 3 dependencias Npgsql exitosas y 0 excepciones; las tres
+Function Apps `Running`.
+
+Capas 1, 2 y 3 sin cambios. La Capa 4 conserva sus tres alertas; lo que cambia es lo que se sabe de
+ellas.

--- a/docs/bitacora/field-notes/2026-08-17-1141-planner.md
+++ b/docs/bitacora/field-notes/2026-08-17-1141-planner.md
@@ -1,0 +1,62 @@
+---
+fecha: 2026-08-17
+hora: 11:41
+sesion: planner
+tema: revision del backlog y verificacion post-implementacion de la alerta del worker (#398)
+---
+
+## Contexto
+
+Revision de backlog (6 issues abiertos: 2 listos, 4 borradores). El usuario pregunto si #398
+(alerta de spike de excepciones del worker de proyecciones) ya estaba representado en Mefisto;
+antes de subirlo al canon, se reviso la correccion de la implementacion en ControlAsistencia.
+Durante la sesion, #398 y #403 se implementaron y cerraron (PRs #410 y #411).
+
+## Descubrimientos
+
+- **#398 no estaba representado en Mefisto**: lo mas cercano es harness#457 (seam de
+  observabilidad del worker), que emite telemetria pero no la vigila. El canon genera un worker
+  observable pero ciego para alertas.
+- **cloud_RoleName verificado**: la query de la alerta usa exactamente la constante
+  `NombreServicio` de `ConfiguracionObservabilidadProjections.cs` (guardrail de test, issue #263);
+  confirmado empiricamente contra App Insights dev.
+- **La senal de logs del worker esta viva**: `UseAzureMonitorExporter()` exporta tambien
+  LogRecords (filas `trace` en dev), no solo spans. Consecuencia: la afirmacion nueva de
+  CA-ADR-0009 ("el sampling head-based tambien recorta esta alerta, misma limitacion que las
+  hermanas") es probablemente incorrecta -- el trace sampler no toca los logs. No inocua:
+  recalibrar el umbral asumiendo recorte 0.2 inexistente dejaria la alerta 5x mas sensible.
+- **Gate de deteccion NO VERIFICADO**: la tabla `exceptions` esta vacia para todos los roles en
+  los 30 dias de retencion; nunca se ha observado una excepcion del worker. CA-4 probo falsos
+  positivos (ruido cero), nadie probo la deteccion. Mismo patron que el readiness gate (#399).
+- **Primer cierre automatico de issue de infra**: el step que agrego #403 (PR #410, merge 16:22)
+  cerro #398 automaticamente al terminar el apply (16:34). El mecanismo funciono en su primera
+  ejecucion real.
+- **CA-4 de #398 ejecutado y verificado en esta sesion**: las 3 queries de alerta devuelven 0
+  filas sobre la ventana post-smoke-tests (16:30Z en adelante) con trafico real confirmado
+  (66+74+31 items por rol).
+
+## Decisiones
+
+- Crear #412 (borrador) en ControlAsistencia: experimento de falla inducida en dev que cierra
+  ambos puntos (deteccion + via logs-vs-spans frente al sampler), con correccion condicional de
+  CA-ADR-0009.
+- Crear draft harness#679 en Mefisto: propagar la alerta del worker al canon (projections-scaffolder
+  o modulo monitoring del infra-base-scaffolder), declarando el gate de deteccion.
+
+## Descartado
+
+- Enmendar #398 antes de implementarlo: quedo obsoleto, el pipeline lo implemento durante la
+  sesion. Los dos puntos de la enmienda se movieron a #412.
+
+## Preguntas abiertas
+
+- Tipo/pipeline de #412: experimento manual sobre el entorno + edicion de ADR, no encaja limpio
+  en /implement ni /infra. Decidir en el refinamiento.
+- Mecanismo exacto de la falla inducida y su reversion garantizada.
+- Backlog pendiente: borradores #339 y #338 con mas de 7 dias sin refinar; #359 candidato a
+  tipo:projection; #358 suena a sesion de modo analizar, no a issue implementable.
+
+## Referencias
+
+Issues creados: #412 (ControlAsistencia, borrador), harness#679 (Mefisto, draft).
+Issues cerrados durante la sesion (por pipelines, no por el planner): #398, #403.

--- a/docs/bitacora/field-notes/2026-08-17-1152-planner.md
+++ b/docs/bitacora/field-notes/2026-08-17-1152-planner.md
@@ -1,0 +1,47 @@
+---
+fecha: 2026-08-17
+hora: "11:52"
+sesion: planner
+tema: refinamiento del issue 412 (verificacion empirica de la alerta de excepciones del worker)
+---
+
+## Contexto
+Refinar el borrador #412: verificar empiricamente que la alerta `projections-exception-spike`
+(desplegada por #398 / PR #411) detecta excepciones del worker, y si el sampling head-based
+realmente las recorta como afirma CA-ADR-0009 (actualizacion 2026-08-17).
+
+## Descubrimientos
+- La copia local de main estaba detras del merge del PR #411; se hizo `git pull --ff-only`
+  para trabajar sobre el ADR y el Terraform reales.
+- Confirmado en `ConfiguracionObservabilidadProjections.cs`: el `SetSampler` aplica solo a la
+  senal de trazas; los LogRecords no pasan por el. La afirmacion de sampling del ADR es
+  plausiblemente incorrecta para el worker -- exactamente lo que el experimento decide.
+- Riesgo de calibracion nuevo, detectado durante el refinamiento: si el backoff del daemon de
+  Marten genera pocas excepciones por ventana de 5 min, el umbral >50 podria ser inalcanzable
+  para el patron "worker en loop". Se agrego como CA-4.
+
+## Decisiones
+- Tipo: `tipo:tooling` (deliverable documental: actualizar CA-ADR-0009 + field notes), con
+  modalidad de **sesion manual supervisada** -- prohibido lanzar con `/tooling` autonomo, porque
+  la operacion central rompe y revierte infra viva y exige humano presente.
+- Mecanismo de falla: `az postgres flexible-server stop` + `start` (~5 min de ventana). Descartado
+  romper la connection string del Container App: genera drift de Terraform, fuerza revision nueva
+  y un crash de arranque podria matar al exporter antes de enviar telemetria (falso "alerta ciega").
+- Condicion del experimento: NO subir `TELEMETRY_SAMPLING_RATIO` (mediria un comportamiento que
+  no es el de produccion). Fuente de verdad del conteo real: logs de consola del Container App.
+- Issue marcado `estado:listo` tras pasar Revision de complejidad (6 CAs, un solo eje, no
+  partible) y DoR de tooling.
+
+## Descartado
+- `tipo:projection`: el issue no escribe `src/...Projections/`, solo observa su entorno.
+- `tipo:infra`: no cambia Terraform.
+- Falla via config rota del Container App (razones arriba).
+
+## Preguntas abiertas
+- Resultado del experimento (deteccion si/no; via logs vs spans; ritmo vs umbral) -- lo responde
+  la sesion de ejecucion. Segun resultado: issue de correccion local y/o recalibracion, y draft
+  cross-repo a Mefisto para el canon (projections-scaffolder / modulo monitoring).
+
+## Referencias
+Issues refinados: #412 (borrador -> listo, tipo:tooling).
+Relacionados: #398, PR #411, #396, #263, #308, CA-ADR-0009, harness#671 (precedente readiness gate).

--- a/docs/bitacora/field-notes/2026-08-17-1202-experimento.md
+++ b/docs/bitacora/field-notes/2026-08-17-1202-experimento.md
@@ -1,0 +1,91 @@
+---
+fecha: 2026-08-17
+hora: "12:02"
+sesion: experimento
+tema: falla inducida en dev para verificar la deteccion de la alerta de excepciones del worker (issue 412)
+---
+
+## Contexto
+Ejecutar el issue #412 en sesion supervisada: detener Postgres de dev para inducir fallos reales en
+el daemon de Marten y medir si la alerta `controlasistencias-dev-projections-exception-spike`
+(desplegada por #398 / PR #411) realmente los detecta, y por que via viaja la telemetria.
+
+## Protocolo ejecutado
+- Estado previo: `psql-asist-dev` Ready; replica `ca-asist-dev--0000033-84b48c4f4b-xwtpq` Running
+  desde 00:20:28Z; daemon procesando (ultimo rango 12677); `TELEMETRY_SAMPLING_RATIO` **ausente**
+  del Container App -> default 0.2 real, no se toco.
+- `stop` 17:02:18Z -> `Stopped` 17:06:27Z. `start` 17:12:14Z -> `Ready` 17:20:28Z.
+- Errores del daemon observados 17:03:47Z - 17:19:38Z. Colector de logs de consola en paralelo
+  (`az containerapp logs show --follow`), mas conteo de contraste en Log Analytics.
+
+## Descubrimientos
+
+### La alerta detecta, pero su umbral es inalcanzable (CA-2 + CA-4)
+La query exacta de la alerta devolvio **88 filas**: el filtro por `cloud_RoleName` funciona, la
+alerta no es ciega. Pero en bins de 5 min -- su ventana real -- el maximo fue **30**, contra umbral
+`>50`. Bins: 7 / 26 / 25 / 30. Una caida total de Postgres de ~14 min no la dispara.
+El ritmo del daemon lo acota su backoff y el numero de shards (hoy 3), no la gravedad del fallo.
+El umbral >50 se heredo de las alertas de borde HTTP, donde un loop si produce cientos por minuto.
+
+### La via es logs, y el ratio 0.2 no recorta nada (CA-3)
+Evidencia por fila: `CategoryName == "Marten.Events.Daemon.Coordination.ProjectionCoordinator"` y
+`OriginalFormat` con la plantilla del log -> nacieron de `LogRecord` de `ILogger`, no de span events.
+`operation_Id` **vacio** en las 88 -> `SpanId == default`. Sin sampling de ingestion tampoco
+(`itemCount == 1`, `samplingPercentage == 100`).
+
+El mecanismo que hace irrelevante al sampler: `EnableTraceBasedLogsSampler` viene `true` por defecto
+(exporter 1.8.1) e instala un `LogFilteringProcessor` que descarta el LogRecord **solo** si tiene
+`SpanId` y su span no fue muestreado. Sin `SpanId`, pasa siempre.
+
+### El sampler del #308 ciega una familia entera de errores (hallazgo no buscado)
+El contraste consola vs `exceptions` no dio un ratio fraccional sino un split binario:
+
+| Familia | Consola | `exceptions` | Ratio |
+|---|---|---|---|
+| `Error trying to attain a lock for set {Name}...` | 87 | 87 | 1:1 |
+| `Failed while trying to detect high water statistics...` | 35 | 0 | 0% |
+
+Causa exacta: `SamplerQueDescartaPollingDelDaemon` hace `Drop` del span
+`marten.daemon.highwatermark`; el `HighWaterAgent` emite sus `LogError` **dentro** de ese span
+(`SpanId` poblado, `TraceFlags != Recorded`), asi que el `LogFilteringProcessor` los descarta. Los 35
+llevaban excepcion con stack trace completo y no llegaron a ninguna tabla.
+
+El sampler se escribio para recortar **costos de trazas**; termino suprimiendo **logs de error**
+bajo ese span. Mismo modo de falla que el #308 corrigio -- wiring silencioso a medio terminar --
+un nivel mas abajo. Desacople disponible sin costo en trazas:
+`.UseAzureMonitorExporter(o => o.EnableTraceBasedLogsSampler = false)`.
+
+### Las dos alertas hermanas son estructuralmente ciegas a este modo de falla
+`func-asist-dev-colaboradores` y `func-asist-dev-control-horas` generaron 810 excepciones de
+`Wolverine.RDBMS.DurabilityAgent` / `IAgentCommand` (116-120 por ventana de 5 min, holgadamente sobre
+50). Ninguna alerta disparo: hubo **cero `requests`** en toda la ventana y las dos alertas de borde
+se condicionan a `requests`. Un fallo en un agente de fondo no produce requests.
+
+**Total del incidente: ~1000 excepciones en tres roles, cero alertas disparadas** (verificado contra
+`Microsoft.AlertsManagement/alerts`).
+
+## Correcciones a creencias previas
+- La premisa del issue ("la senal de logs esta viva -- filas `trace` exportandose") leia mal la
+  tabla: los `traces` del worker son span events `received-first-response` de Npgsql. Los `LogError`
+  con excepcion nunca van a `traces` -- van a `exceptions` directo. La conclusion del issue (via
+  logs) resulto correcta, pero por evidencia distinta a la que invocaba.
+- Mi hipotesis inicial durante la sesion (que el worker no cableaba la senal de logs, porque el seam
+  solo llama `.WithTracing`) era falsa: `UseAzureMonitorExporter()` hace
+  `builder.WithLogging().WithMetrics().WithTracing()` internamente (verificado contra el codigo del
+  tag `Azure.Monitor.OpenTelemetry.Exporter_1.8.1`).
+- La afirmacion de CA-ADR-0009 "el sampling head-based tambien recorta esta alerta" es incorrecta en
+  mecanismo y magnitud. Corregida en el ADR.
+
+## Reversion (verificada)
+Postgres `Ready`; la replica del worker **nunca re-arranco** (misma, creada 00:20:28Z), confirmando
+la premisa del mecanismo elegido frente a romper la connection string; post-recuperacion 3
+dependencias Npgsql exitosas y 0 excepciones; las tres Function Apps `Running`.
+
+## Pendientes
+- Issue de recalibracion del umbral de `projections-exception-spike` (CA-4 lo exige, el #412 lo
+  excluye de su alcance).
+- Issue por el hallazgo del `EnableTraceBasedLogsSampler` (supresion de logs de error bajo el span
+  de polling).
+- Issue por la ceguera de las dos alertas hermanas ante fallos de agentes de fondo sin `requests`.
+- Draft en el repo de Mefisto: el canon de la alerta del worker (projections-scaffolder / modulo
+  monitoring) arrastra el mismo umbral heredado y el mismo default del exporter.


### PR DESCRIPTION
Ejecuta el issue #412 en sesion manual supervisada: falla inducida sobre el entorno dev
(`az postgres flexible-server stop` + `start` sobre `psql-asist-dev`) para verificar la **capacidad de
deteccion** de la alerta `controlasistencias-dev-projections-exception-spike`, que se habia desplegado
(#398 / PR #411) con ruido cero verificado pero sin ninguna prueba de que detecte algo.

Entregable documental: nueva seccion fechada en CA-ADR-0009 + field notes de la sesion.
No toca `src/` ni `infra/` -- la intervencion fue via az CLI, reversible, sin cambios de codigo.

## Resultados

**CA-1 -- Falla inducida y revertida.** `stop` 17:02:18Z (`Stopped` 17:06:27Z), `start` 17:12:14Z
(`Ready` 17:20:28Z). La replica del worker nunca re-arranco, confirmando la premisa del mecanismo
elegido frente a romper la connection string. Post-recuperacion: 26 dependencias Npgsql exitosas,
0 excepciones, tres Function Apps `Running`.

**CA-2 -- La alerta detecta.** La query exacta devolvio 88 filas sobre la ventana: el filtro por
`cloud_RoleName` funciona, la alerta no es ciega.

**CA-4 -- Pero su umbral es inalcanzable.** En bins de 5 min (su ventana real) el maximo fue **30**
contra `>50`: 7 / 26 / 25 / 30. Una caida **total** de Postgres de ~14 min no la dispara. El ritmo del
daemon lo acota su backoff y el numero de shards, no la gravedad del fallo; el umbral se heredo de las
alertas de borde HTTP, que tienen otro perfil de volumen.

**CA-3 -- La via es logs, y el ratio 0.2 no recorta.** `CategoryName` y `OriginalFormat` poblados
prueban origen `ILogger`; `operation_Id` vacio (`SpanId == default`) neutraliza el
`LogFilteringProcessor`. Sin sampling de ingestion (`itemCount == 1`, `samplingPercentage == 100`).

El contraste consola vs `exceptions` no dio un ratio fraccional sino un split binario:

| Familia de error del daemon | Consola | `exceptions` | Ratio |
|---|---|---|---|
| `Error trying to attain a lock for set {Name}...` | 87 | 87 | **1:1** |
| `Failed while trying to detect high water statistics...` | 35 | **0** | **0%** |

**Hallazgo no buscado.** `SamplerQueDescartaPollingDelDaemon` hace `Drop` del span
`marten.daemon.highwatermark`; el `HighWaterAgent` emite sus `LogError` **dentro** de ese span, y como
`EnableTraceBasedLogsSampler` viene `true` por defecto, el `LogFilteringProcessor` los descarta. 35
errores con stack trace completo no llegaron a ninguna tabla. El sampler se escribio para recortar
costos de **trazas**; termina suprimiendo **logs de error**.

**Efecto colateral medido.** Las dos alertas hermanas se condicionan a `requests`; hubo **cero
`requests`** en la ventana pese a 810 excepciones de `Wolverine.RDBMS.DurabilityAgent` en dos Function
Apps (116-120 por ventana, holgadamente sobre 50). Total del incidente: **~1000 excepciones en tres
roles, cero alertas disparadas**.

**CA-5 -- Correccion al ADR.** La afirmacion "el sampling head-based tambien recorta esta alerta" de la
actualizacion 2026-08-17 queda corregida: es incorrecta en mecanismo y magnitud. El parrafo original se
conserva con una nota de superado, por trazabilidad.

**CA-6 -- Seguimientos abiertos.** #413 (recalibrar el umbral), #414 (desacoplar el muestreo de logs
del de trazas), #415 (ceguera de las alertas hermanas ante agentes de fondo),
harness#680 (canon del marco: mismo umbral heredado y mismo default del exporter).

## Nota de metodo

La alerta se habia verificado contra falsos positivos pero nunca contra falsos negativos.
Desplegado != probado -- el mismo patron que el readiness gate (#399).

Closes #412

🤖 Generated with [Claude Code](https://claude.com/claude-code)
