### PR TITLE
Renotar los stream ids de RegistroDeMarcacion a rdm:

### DIFF
--- a/src/Bitakora.ControlAsistencia.ControlHoras/Entities/RegistroDeMarcacionAggregateRoot.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Entities/RegistroDeMarcacionAggregateRoot.cs
@@ -17,21 +17,28 @@ public partial class RegistroDeMarcacionAggregateRoot : AggregateRoot
     public string? TipoMarcacion { get; private set; }
     public string? DispositivoId { get; private set; }
 
-    // CA-5: stream ID determinista: "{CodigoColaborador}:{Timestamp:yyyy-MM-ddTHH:mm:ss}"
-    // Cambiar el separador invalidaria la identidad de todos los streams ya escritos, por eso vive
-    // como constante privada: nadie lo compone a mano desde afuera.
+    // Issue #419 / CA-ADR-0031 seccion 2: stream ID determinista con prefijo de tipo, notacion
+    // "rdm:{CodigoColaborador}:{Timestamp:yyyyMMddTHHmmss}" -- prefijo (iniciales del aggregate) y
+    // timestamp en ISO 8601 basico (solo [0-9] y 'T', sin ':' propios) para que el separador quede
+    // libre exclusivamente entre los tres componentes: clave.Split(':') siempre devuelve 3 partes
+    // (paso 5 de la heuristica). Cambiar el prefijo o el separador invalidaria la identidad de todos
+    // los streams ya escritos, por eso viven como constantes privadas: nadie los compone a mano
+    // desde afuera.
+    // El Timestamp llega sin offset y se interpreta como hora local de Colombia (UTC-5, sin DST).
+    private const string PrefijoStreamId = "rdm";
     private const char SeparadorStreamId = ':';
 
     public static string ComputarStreamId(string codigoColaborador, DateTime timestamp) =>
-        $"{codigoColaborador}{SeparadorStreamId}{timestamp:yyyy-MM-ddTHH:mm:ss}";
+        $"{PrefijoStreamId}{SeparadorStreamId}{codigoColaborador}{SeparadorStreamId}{timestamp:yyyyMMddTHHmmss}";
 
     // Issue #279 CA-3: un CodigoColaborador que contenga el separador vuelve ambigua la composicion del
     // stream ID -- dos combinaciones distintas de colaborador y timestamp pueden producir el mismo id, y
     // como la idempotencia se decide por existencia del stream, una marcacion legitima se descartaria
     // como "duplicado exacto". La regla vive junto al formato que la origina (MEF-ADR-0012,
     // Tell-don't-Ask): el validator del borde la invoca en vez de repetir el literal del separador.
-    // ControlDiarioAggregateRoot compone su stream ID con el mismo separador, asi que rechazarlo en el
-    // borde protege ambos streams; unificar el separador entre ambos aggregates queda pendiente.
+    // ControlDiarioAggregateRoot compone su stream ID con el mismo separador; el prefijo de cada
+    // aggregate (distinto por CA-ADR-0031) es lo que disjunta ambos streams dentro del mismo store,
+    // asi que rechazar ':' en el borde sigue protegiendo la composicion de ambos.
     public static bool EsComponenteValidoDeStreamId(string codigoColaborador) =>
         !codigoColaborador.Contains(SeparadorStreamId);
 

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/RegistrarMarcacionFunction/RegistrarMarcacionSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/RegistrarMarcacionFunction/RegistrarMarcacionSmokeTests.cs
@@ -51,10 +51,11 @@ public class RegistrarMarcacionSmokeTests(
     // fecha; asi el 400 esperado solo puede venir de la regla bajo prueba.
     private static readonly DateTime TimestampValido = new(2026, 4, 20, 8, 0, 0, DateTimeKind.Utc);
 
-    // CA-5: stream ID determinista = "{CodigoColaborador}:{Timestamp:yyyy-MM-ddTHH:mm:ss}"
-    // El timestamp que se usa para el stream ID es el crudo (antes de normalizar al minuto).
+    // Issue #419 CA-6: stream ID determinista = "rdm:{CodigoColaborador}:{Timestamp:yyyyMMddTHHmmss}",
+    // en sync con RegistroDeMarcacionAggregateRoot.ComputarStreamId. El timestamp que se usa para el
+    // stream ID es el crudo (antes de normalizar al minuto).
     private static string ComputarStreamId(string codigoColaborador, DateTime timestampCrudo) =>
-        $"{codigoColaborador}:{timestampCrudo:yyyy-MM-ddTHH:mm:ss}";
+        $"rdm:{codigoColaborador}:{timestampCrudo:yyyyMMddTHHmmss}";
 
     // Issue #279: los casos de rechazo por forma solo varian en CodigoColaborador o Timestamp; el resto del
     // payload es identico. Se envia el timestamp con el mismo formato que el resto del archivo.

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/RegistroDeMarcacionAggregateRootTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/RegistroDeMarcacionAggregateRootTests.cs
@@ -1,0 +1,56 @@
+// Issue #419: renotacion del stream ID de RegistroDeMarcacionAggregateRoot a "rdm:{codigo}:{timestamp}",
+// aplicando la heuristica de anatomia de CA-ADR-0031 seccion 2. Tests directos sobre los dos metodos
+// estaticos puros del aggregate -- sin harness de event sourcing, porque ninguno de los dos requiere
+// stream ni evento.
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.ControlHoras.Entities;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Tests.Entities;
+
+public class RegistroDeMarcacionAggregateRootTests
+{
+    // CA-1: ejemplo exacto del issue.
+    [Fact]
+    public void ComputarStreamId_ProduceNotacionConPrefijoRdmYTimestampBasico()
+    {
+        var streamId = RegistroDeMarcacionAggregateRoot.ComputarStreamId(
+            "ABC123", new DateTime(2026, 8, 19, 14, 30, 5));
+
+        streamId.Should().Be("rdm:ABC123:20260819T143005");
+    }
+
+    // CA-2 / CA-ADR-0031 seccion 2 paso 5: la clave vigente (ISO extendido) falla este test porque la
+    // hora aporta sus propios ':'; la notacion objetivo (ISO basico) lo pasa por construccion.
+    [Fact]
+    public void ComputarStreamId_ProduceClaveDivisibleEnTresPartes_AlHacerSplitPorElSeparador()
+    {
+        var streamId = RegistroDeMarcacionAggregateRoot.ComputarStreamId(
+            "EMP-001", new DateTime(2026, 3, 15, 8, 9, 0));
+
+        var partes = streamId.Split(':');
+
+        partes.Should().HaveCount(3);
+        partes[0].Should().Be("rdm");
+        partes[1].Should().Be("EMP-001");
+        partes[2].Should().Be("20260315T080900");
+    }
+
+    // CA-3: el comportamiento de EsComponenteValidoDeStreamId no cambia con la renotacion -- sigue
+    // rechazando codigos que contengan ':', el separador vigente.
+    [Fact]
+    public void EsComponenteValidoDeStreamId_Rechaza_CuandoCodigoContieneSeparador()
+    {
+        var esValido = RegistroDeMarcacionAggregateRoot.EsComponenteValidoDeStreamId("EMP:001");
+
+        esValido.Should().BeFalse();
+    }
+
+    [Fact]
+    public void EsComponenteValidoDeStreamId_Acepta_CuandoCodigoNoContieneSeparador()
+    {
+        var esValido = RegistroDeMarcacionAggregateRoot.EsComponenteValidoDeStreamId("EMP-001");
+
+        esValido.Should().BeTrue();
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/RegistrarMarcacionFunction/RegistrarMarcacionCommandHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/RegistrarMarcacionFunction/RegistrarMarcacionCommandHandlerTests.cs
@@ -30,12 +30,14 @@ public class RegistrarMarcacionCommandHandlerTests : CommandHandlerAsyncTest<Reg
     // CA-2: 08:09:59 truncado al minuto -> 08:09:00
     private static readonly DateTime TimestampNormalizado = new DateTime(2026, 3, 15, 8, 9, 0);
 
-    // CA-5: stream ID determinista {CodigoColaborador}:{Timestamp:yyyy-MM-ddTHH:mm:ss}
-    private static readonly string StreamId = $"{CodigoColaborador}:{Timestamp:yyyy-MM-ddTHH:mm:ss}";
+    // Issue #419 CA-1/CA-2: stream ID determinista "rdm:{CodigoColaborador}:{Timestamp:yyyyMMddTHHmmss}"
+    // -- armado a mano (no via ComputarStreamId) para que el test siga siendo un oraculo independiente
+    // de la logica bajo prueba (regla 20).
+    private static readonly string StreamId = $"rdm:{CodigoColaborador}:{Timestamp:yyyyMMddTHHmmss}";
 
     // Issue #275: el stream que el handler habria abierto si el factory no hubiera rechazado el
     // CodigoColaborador vacio -- se afirma vacio para probar que el throw precede a cualquier escritura.
-    private static readonly string StreamIdSinColaborador = $":{Timestamp:yyyy-MM-ddTHH:mm:ss}";
+    private static readonly string StreamIdSinColaborador = $"rdm::{Timestamp:yyyyMMddTHHmmss}";
 
     protected override ICommandHandlerAsync<RegistrarMarcacion> Handler =>
         new RegistrarMarcacionCommandHandler(EventStore, PrivateEventSender);

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/RegistrarMarcacionFunction/RegistrarMarcacionValidatorTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/RegistrarMarcacionFunction/RegistrarMarcacionValidatorTests.cs
@@ -70,10 +70,10 @@ public class RegistrarMarcacionValidatorTests
     }
 
     // CA-3: CodigoColaborador que contiene ':' produce 400 - cierra la colision de stream ID descrita
-    // en el Contexto del issue (ComputarStreamId usa ':' como separador entre CodigoColaborador y
-    // Timestamp; un CodigoColaborador con ':' puede fabricar el mismo stream ID que otra combinacion
-    // legitima). El valor no esta vacio, asi que el unico error posible proviene de la regla del
-    // separador y no de NotEmpty.
+    // en el Contexto del issue (ComputarStreamId usa ':' como separador entre el prefijo "rdm", el
+    // CodigoColaborador y el Timestamp, issue #419; un CodigoColaborador con ':' puede fabricar el
+    // mismo stream ID que otra combinacion legitima). El valor no esta vacio, asi que el unico error
+    // posible proviene de la regla del separador y no de NotEmpty.
     [Fact]
     public async Task Validar_RechazaCodigoColaborador_CuandoContieneDosPuntos()
     {


### PR DESCRIPTION
## Resumen

Pipeline TDD completado:
- Fase roja: tests escritos con stubs
- Fase verde: implementación completa
- Fase refactor: revisión de calidad

## Decisiones del pipeline

<details>
<summary>Test Writer (fase roja) — 4m 24s</summary>

## ES Test Writer - Decisiones

### Tipo de tarea
No es refactoring puro: el issue cambia el comportamiento observable de `ComputarStreamId`
(el string que produce), con criterios de aceptacion que definen esa salida (CA-1, CA-2) y
existe un carril TDD normal (los tests nuevos/actualizados compilan y fallan hoy porque la
produccion todavia produce la notacion vieja). Flujo normal, no carril de senal de refactor.

### Tests creados
- `RegistroDeMarcacionAggregateRootTests.cs` (nuevo, `tests/.../Entities/`): 4 tests
  - `ComputarStreamId_ProduceNotacionConPrefijoRdmYTimestampBasico` - CA-1, ejemplo exacto del issue
  - `ComputarStreamId_ProduceClaveDivisibleEnTresPartes_AlHacerSplitPorElSeparador` - CA-2, test de
    split de CA-ADR-0031 seccion 2 paso 5
  - `EsComponenteValidoDeStreamId_Rechaza_CuandoCodigoContieneSeparador` - CA-3 (comportamiento
    invariante)
  - `EsComponenteValidoDeStreamId_Acepta_CuandoCodigoNoContieneSeparador` - complemento del camino feliz

### Tests actualizados
- `RegistrarMarcacionCommandHandlerTests.cs`: constantes `StreamId` y `StreamIdSinColaborador`
  actualizadas a la nueva notacion `rdm:{codigo}:{yyyyMMddTHHmmss}`, armadas a mano (interpolacion
  de string), no via `ComputarStreamId` -- se preserva el oraculo independiente (regla 20) que ya
  tenia el archivo antes de este issue. CA-4.
- `RegistrarMarcacionValidatorTests.cs`: solo el comentario de
  `Validar_RechazaCodigoColaborador_CuandoContieneDosPuntos` que citaba el formato viejo; ninguna
  logica de test cambio (CA-3: `EsComponenteValidoDeStreamId` no altera su comportamiento).

### Estructura elegida
- Test nuevo del aggregate en `Entities/` (espejo de `src/.../Entities/RegistroDeMarcacionAggregateRoot.cs`),
  siguiendo el patron ya usado ahi para logica pura sin harness de event sourcing (ver
  `ClasificadorTrabajoTests.cs`): clase simple con AwesomeAssertions directo, sin
  `CommandHandlerAsyncTest<T>` -- `ComputarStreamId` y `EsComponenteValidoDeStreamId` son metodos
  estaticos puros, no comandos.
- El test de split (CA-2) invoca `ComputarStreamId` (metodo bajo prueba) porque la asercion es
  estructural (`partes.Should().HaveCount(3)` + contenido armado a mano de cada parte), no un
  valor derivado de la misma logica -- no es tautologico bajo regla 20.

### Stubs creados
Ninguno. Todos los tipos referenciados (`RegistroDeMarcacionAggregateRoot`, `RegistrarMarcacion`,
`MarcacionRegistrada`, `RegistrarMarcacionCommandHandler`, `RegistrarMarcacionValidator`) ya
existen en produccion; este issue solo cambia el comportamiento de un metodo estatico ya presente.

### Decisiones de diseno
- No se toca `src/` en absoluto (ni el formato de `ComputarStreamId`, ni la constante de prefijo,
  ni los comentarios de zona horaria/resolucion del pendiente de #279 que pide CA-5) -- es
  responsabilidad exclusiva del implementer (fase verde).
- El archivo nuevo del aggregate no estaba en la lista "Impacto / Modifica" del issue (que solo
  anticipaba tests de handler/validator/smoke). Se agrego porque CA-1 y CA-2 exigen verificar
  `ComputarStreamId` y el test de split directamente sobre el metodo, no solo indirectamente via
  el command handler test (que solo ejercita el streamId como clave de busqueda, no como valor
  bajo prueba). Ver "Desviaciones del plan del planner".

### Cobertura de criterios
| Criterio de aceptacion | Test(s) |
|---|---|
| CA-1: `ComputarStreamId` produce `rdm:{codigo}:{timestamp basico}` | `ComputarStreamId_ProduceNotacionConPrefijoRdmYTimestampBasico` |
| CA-2: `clave.Split(':')` devuelve exactamente 3 partes | `ComputarStreamId_ProduceClaveDivisibleEnTresPartes_AlHacerSplitPorElSeparador` |
| CA-3: `EsComponenteValidoDeStreamId` no cambia de comportamiento | `EsComponenteValidoDeStreamId_Rechaza_CuandoCodigoContieneSeparador`, `EsComponenteValidoDeStreamId_Acepta_CuandoCodigoNoContieneSeparador`, tests existentes de `RegistrarMarcacionValidatorTests.cs` (sin modificacion de logica) |
| CA-4: idempotencia por duplicado exacto con la nueva notacion | `RegistrarMarcacion_NoPersisteNiPublica_CuandoStreamYaExiste` (constantes `StreamId`/`StreamIdSinColaborador` actualizadas) |
| CA-5: comentario de zona horaria junto a `ComputarStreamId` | No testeable por xUnit; corresponde al implementer (comentario en `src/`) |
| CA-6: helper de smoke tests en sync con la nueva notacion | Fuera de alcance de este agente (ver desviacion) |

### Desviaciones del plan del planner

| Sugerencia del issue | Desviacion aplicada | Razon tecnica | Consecuencia |
|---|---|---|---|
| Impacto/Modifica no lista un archivo de test dedicado al aggregate | Se creo `RegistroDeMarcacionAggregateRootTests.cs` (nuevo) | CA-1 y CA-2 verifican el comportamiento de `ComputarStreamId`/`EsComponenteValidoDeStreamId` en si mismos; el command handler test solo usa el streamId como clave de busqueda (oraculo armado a mano), no verifica el formato producido por el metodo de produccion | Cobertura directa de CA-1/CA-2 sin depender de un efecto indirecto en el handler test |
| Impacto/Modifica lista `RegistrarMarcacionSmokeTests.cs` (CA-6) | No se modifico | Los smoke tests contra el entorno desplegado son responsabilidad de `smoke-test-writer` (agente dedicado, catalogo de agentes de `CLAUDE.md`), no del test-writer de event sourcing, cuya unica responsabilidad son tests de command handlers y sus stubs | CA-6 queda pendiente de la etapa de smoke tests del pipeline, no de esta etapa |
| CA-5 (comentario de zona horaria en `src/`) | No se creo ningun artefacto de test para este CA | Un comentario en codigo de produccion no es observable por un test xUnit; y el test-writer no toca `src/` | El implementer debe agregar el comentario como parte de su fase verde; el reviewer puede verificarlo por lectura |

### Verificacion
`dotnet build tests/Bitakora.ControlAsistencia.ControlHoras.Tests/` compila sin errores. Los
tests nuevos/actualizados fallan hoy (fase roja esperada) porque `ComputarStreamId` todavia
produce la notacion legada `{codigo}:{yyyy-MM-ddTHH:mm:ss}`.

</details>

<details>
<summary>Implementer (fase verde) — 4m 25s</summary>

## ES Implementer - Decisiones

### Enfoque de implementacion
Cambio puntual y acotado en `RegistroDeMarcacionAggregateRoot.ComputarStreamId`: se agrega la
constante `PrefijoStreamId = "rdm"` y se cambia el formato del componente temporal de
`yyyy-MM-ddTHH:mm:ss` (ISO extendido) a `yyyyMMddTHHmmss` (ISO basico), interpolando
`{prefijo}{sep}{codigo}{sep}{timestamp}`. `EsComponenteValidoDeStreamId` no cambio de logica (sigue
rechazando `:` en el codigo) -- solo se actualizo su comentario para reflejar que el prefijo, no ya
el separador compartido, es lo que disjunta `RegistroDeMarcacion` de `ControlDiario` dentro del
mismo store (CA-ADR-0031). El validator (`RegistrarMarcacionValidator`) y el command handler
(`RegistrarMarcacionCommandHandler`) no requirieron cambios: ambos consumen el punto unico de
conversion (`ComputarStreamId`/`EsComponenteValidoDeStreamId`) sin recomponer la clave por su
cuenta, tal como exige MEF-ADR-0037 seccion 1.

### Decisiones de diseno
- Prefijo y separador quedan como constantes privadas junto al metodo que las compone
  (`ComputarStreamId`), consistente con el patron ya vigente en el archivo.
- Se agrego el comentario de zona horaria pedido por CA-5 (el `DateTime` llega sin offset y se
  interpreta como hora local de Colombia, UTC-5 sin DST), junto al bloque de constantes que ya
  documenta la anatomia del stream ID.
- Se resolvio el comentario pendiente de #279 ("unificar el separador entre ambos aggregates"):
  ya no queda pendiente -- el separador `:` se mantiene compartido entre `RegistroDeMarcacion` y
  `ControlDiario`, y es el prefijo de tipo (`rdm:`/`cd:`, este ultimo objeto de #420) el que disjunta
  ambos aggregates dentro del schema `control_horas`, siguiendo CA-ADR-0031 seccion 2 paso 2.

### ADRs consultados
- CA-ADR-0031 (identidad de streams por store, heuristica de anatomia): fuente de la notacion
  `rdm:{codigo}:{timestamp basico}` aplicada.
- MEF-ADR-0037 (identidad de stream como string, punto unico de conversion): verificado que
  `ComputarStreamId` sigue siendo el unico punto de composicion; ningun CommandHandler/Validator
  reconstruye la clave por su cuenta.
- MEF-ADR-0036 (identidad de eventos persistidos): no aplica su protocolo de dos despliegues (no se
  mueve ni renombra ningun tipo de evento); su disciplina de purga en la misma ventana es el
  precedente que ampara la ventana operativa manual descrita en el issue (no ejecutada por este
  agente).
- MEF-ADR-0012 (Tell-don't-Ask): `EsComponenteValidoDeStreamId` sigue viviendo junto al formato que
  la origina, sin exponerse mas alla de lo necesario.
- MEF-ADR-0016 (naming de tests): no se crearon tests nuevos (responsabilidad del test-writer); se
  verifico que los ya escritos siguen esa convencion.

### Desviaciones de ADRs
Ninguna desviacion -- todos los ADRs aplicados al pie de la letra.

### Desviaciones del plan del planner
Ninguna desviacion respecto al plan del planner. El archivo
`RegistrarMarcacionValidatorTests.cs` que el planner anticipaba modificar (solo el comentario que
cita el formato viejo) ya llego actualizado por el test-writer con el comentario correcto -- no
requirio ningun cambio adicional de mi parte, ni en el comentario ni en la logica.

### Precedentes consultados
Ninguno replicado: el unico patron seguido fue el ya vigente en el propio archivo
(`RegistroDeMarcacionAggregateRoot.cs`), que ya cumple MEF-ADR-0012/MEF-ADR-0037.

### Infraestructura modificada
Ninguna. Este issue no introduce ni modifica ningun topic/subscription de Service Bus: el cambio es
puramente de notacion de la clave de stream, interna al aggregate, y no altera ningun contrato de
bus (`RegistroDeMarcacionCreado` sigue igual). Tampoco hay contrato HTTP nuevo o modificado (el
issue lo declara explicitamente fuera de alcance).

### Nota sobre el helper duplicado de los smoke tests
El archivo `tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/RegistrarMarcacionFunction/RegistrarMarcacionSmokeTests.cs`
no fue tocado por el test-writer (no aparece en su lista de archivos modificados), pero el CA-6 del
issue lo pide explicitamente ("el helper duplicado de los smoke tests computa la nueva notacion") y
el planner lo anticipa en "Impacto en archivos". Se trata de un helper privado que solo compone la
clave para consultar Postgres directamente -- no una asercion de negocio -- asi que se actualizo
`ComputarStreamId` (helper local) a la nueva notacion `rdm:{codigo}:{timestamp}` para que los smoke
tests sigan encontrando el stream tras el despliegue de este cambio. No se toco ninguna asercion ni
la logica de ningun test; solo el calculo derivado que ya existia. Documentado aqui por ser una
desviacion de la regla general "nunca modificas tests", justificada por ser un helper de
sincronizacion (no de asercion) explicitamente pedido por un criterio de aceptacion del issue.

### Complejidad encontrada
Ninguna. Cambio de una sola linea de logica (formato de `ComputarStreamId`) mas actualizacion de
comentarios; los tests del test-writer ya quedaron en verde con ese unico cambio, sin iteracion.

### Resultado
- Tests pasando: 449/449 en `Bitakora.ControlAsistencia.ControlHoras.Tests` (los 3 archivos de test
  del test-writer incluidos).
- Suite completa del repo: 1322 correctos, 0 errores, 48 omitidos (Postgres/ServiceBus no
  configurados localmente -- esperado en smoke tests).

</details>
<details>
<summary>Reviewer (fase refactor) — 3m 39s</summary>

_(El agente no generó resumen)_

</details>

## Cobertura

| Archivo | Cobertura | Umbral | Estado |
|---|---|---|---|
| RegistroDeMarcacionAggregateRoot.cs | 100.0% | 95% | ok |
## Commits

3f9fd88 feat(issue-419): renotar stream ids de RegistroDeMarcacion a rdm: (fase verde)
df7b52a test(issue-419): tests para renotacion de stream ids de RegistroDeMarcacion a rdm: (fase roja)

Closes #419