### PR TITLE
Renotar los stream ids de ControlDiario a cd:

### DIFF
--- a/docs/adr/ca-adr-0031-identidad-de-streams-por-store.md
+++ b/docs/adr/ca-adr-0031-identidad-de-streams-por-store.md
@@ -153,8 +153,8 @@ evento.
 
 | Store (schema) | Aggregate | Anatomia vigente | Anatomia objetivo | Notas |
 |---|---|---|---|---|
-| `control_horas` | `RegistroDeMarcacionAggregateRoot` | `{codigo}:{yyyy-MM-ddTHH:mm:ss}` -- ISO **extendido**, sin prefijo (legado, `RegistroDeMarcacionAggregateRoot.cs:25-26`) | `rdm:{codigo}:{yyyyMMddTHHmmss}` | Objetivo del issue #419. Cambian **dos** cosas, no solo el prefijo: tambien la notacion del timestamp (extendido -> basico). Es la unica fila del registro cuya forma vigente **falla el paso 5**: la hora extendida aporta dos `:` propios, asi que `Split(':')` devuelve 4 partes en vez de 2 (verificado en .NET 10). La forma legada queda registrada como legado hasta que #419 ejecute su migracion (protocolo MEF-ADR-0036 seccion 5). |
-| `control_horas` | `ControlDiarioAggregateRoot` | `{codigo}:{yyyy-MM-dd}` -- ISO **extendido**, sin prefijo (legado, `ControlDiarioAggregateRoot.cs:74-75`) | `cd:{codigo}:{yyyyMMdd}` | Objetivo del issue #420. Igual que la fila anterior, #420 cambia prefijo **y** notacion de fecha. A diferencia de aquella, la forma vigente si pasa el paso 5 (una fecha extendida no aporta `:`), asi que aqui la renotacion la motiva unicamente el prefijo. Misma disciplina de migracion. |
+| `control_horas` | `RegistroDeMarcacionAggregateRoot` | `rdm:{codigo}:{yyyyMMddTHHmmss}` -- migrada por el issue #419 (`RegistroDeMarcacionAggregateRoot.cs`, `ComputarStreamId`) | -- (ya en notacion objetivo) | Su forma legada (`{codigo}:{yyyy-MM-ddTHH:mm:ss}`, sin prefijo) era la unica del registro que **fallaba el paso 5**: la hora extendida aporta dos `:` propios, asi que `Split(':')` devolvia 4 partes en vez de 2 (verificado en .NET 10). Por eso #419 cambio **dos** cosas, no solo el prefijo: tambien la notacion del timestamp (extendido -> basico). |
+| `control_horas` | `ControlDiarioAggregateRoot` | `cd:{codigo}:{yyyyMMdd}` -- migrada por el issue #420 (`ControlDiarioAggregateRoot.cs`, `ComputarStreamId`) | -- (ya en notacion objetivo) | Su forma legada (`{codigo}:{yyyy-MM-dd}`, sin prefijo) si pasaba el paso 5 -- una fecha extendida no aporta `:` --, asi que aqui la renotacion la motivo unicamente el prefijo, frente al `dc:` que nace en #425. La fecha paso igual a ISO basico por la normalizacion BC-wide del paso 3. |
 | `control_horas` | `DiaCalculado` (nace en #425) | -- (no existe todavia como aggregate persistido) | `dc:{codigo}:{yyyyMMdd}` | Nace directamente en notacion objetivo -- ningun issue de migracion necesario. El prefijo `dc:` es lo que evita la colision con `ControlDiario` que motiva este ADR (misma identidad logica colaborador+fecha, mismo store). |
 | `colaboradores` | `ColaboradorAggregateRoot` | `{Tipo}-{Numero}` (contrato de `Identificacion.ToString()`, ej. `CC-79543210`) | Sin cambio | Vigente sin prefijo: decision del experto de dominio, 2026-08-19. Es identidad de UN componente que ya viaja en URL (ya URL-safe, `ObtenerFichaColaborador`), el store de Colaboradores tiene un solo aggregate (nada que prevenir todavia), y renotar exigiria migracion + rebuild de `FichaColaborador` (worker de proyecciones) sin comprar ninguna disjuncion real. |
 | `programacion` | `CatalogoTurnos`, `SolicitudProgramacionAggregateRoot` | Guid canonico "D" | Sin cambio | Paso 1 de la heuristica: ninguno de los dos necesita identidad natural. Sin registro adicional -- un Guid nunca colisiona con otro Guid de otro aggregate por construccion (espacio de valores, no de forma). |
@@ -222,12 +222,13 @@ adaptarse.
   test). Un aggregate nuevo que ignore el registro y elija una anatomia colisionante no lo detecta
   el compilador ni la suite; lo detecta `reviewer` o, en el peor caso, `ExistingStreamIdCollisionException`
   en produccion.
-- **Las claves legadas de `RegistroDeMarcacionAggregateRoot` y `ControlDiarioAggregateRoot` (sin
-  prefijo, timestamp/fecha extendidos) conviven con la notacion objetivo hasta que #419/#420
-  ejecuten.** Este ADR fija el destino y el registro; no ejecuta la migracion. La migracion sigue el
-  protocolo de dos despliegues (o purga en el mismo despliegue si el entorno no tiene streams reales
-  que preservar) que MEF-ADR-0036 seccion 5 ya fija para el caso analogo de mover la identidad de un
-  evento persistido.
+- **Migrar una clave ya desplegada cuesta un issue propio con ventana operativa.** Las claves
+  legadas de `RegistroDeMarcacionAggregateRoot` y `ControlDiarioAggregateRoot` (sin prefijo,
+  timestamp/fecha extendidos) se migraron en #419 y #420 purgando el store de dev en la misma
+  ventana de despliegue -- viable solo porque dev no tenia streams que preservar. En un entorno con
+  datos reales, la misma migracion exige el protocolo de dos despliegues que MEF-ADR-0036 seccion 5
+  fija para el caso analogo de mover la identidad de un evento persistido. Nada de eso lo detecta la
+  suite: un despliegue sin su purga parte la biografia del dia en dos streams, sin error visible.
 - **La tension textual entre MEF-ADR-0043 seccion 1.1/1.2 y MEF-ADR-0037 seccion 1 sigue sin resolver
   en el marco** (reportada como harness#681). Este ADR sostiene localmente la lectura "la unidad es
   el componente tipado" (seccion 1) mientras el marco no la incorpore; la propuesta de llevar esa
@@ -300,6 +301,11 @@ adaptarse.
   discriminar por tipo de aggregate, la causa raiz de la colision que este ADR previene. Deja fuera
   de alcance, por correccion de rumbo del 2026-08-18/19, el charset URL-safe de las claves (dominio
   de MEF-ADR-0043, no de este ADR).
+- 2026-08-19: enmienda del registro (paso 6 de la heuristica) tras ejecutar las dos migraciones del
+  store `control_horas`: `RegistroDeMarcacionAggregateRoot` (#419, `rdm:`) y `ControlDiarioAggregateRoot`
+  (#420, `cd:`) pasan de "anatomia objetivo" a **vigente**, y la deuda de "claves legadas conviviendo"
+  se reemplaza por el costo permanente de migrar una clave ya desplegada. El registro queda con una
+  sola fila pendiente de nacer: `DiaCalculado` (#425).
 - 2026-08-19: correcciones de revision (mismo issue #417). (a) La tabla de la seccion 4 declaraba las
   anatomias **vigentes** de `RegistroDeMarcacionAggregateRoot` y `ControlDiarioAggregateRoot` en ISO
   basico, cuando el codigo desplegado las produce en ISO **extendido**

--- a/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/MarcacionAdicionada.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/MarcacionAdicionada.cs
@@ -8,7 +8,7 @@ namespace Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 // ADR-0024: evento del aggregate (categoria event-sourcing), sin marker de bus.
 public sealed class MarcacionAdicionada
 {
-    // CA-7: Id es el stream ID del ControlDiario: "{CodigoColaborador}:{Fecha:yyyy-MM-dd}"
+    // CA-7: Id es el stream ID del ControlDiario: "cd:{CodigoColaborador}:{Fecha:yyyyMMdd}" (issue #420, CA-ADR-0031)
     public string Id { get; private set; } = null!;
     public string CodigoColaborador { get; private set; } = null!;
 

--- a/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/MarcacionAdicionada.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/MarcacionAdicionada.cs
@@ -8,7 +8,7 @@ namespace Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 // ADR-0024: evento del aggregate (categoria event-sourcing), sin marker de bus.
 public sealed class MarcacionAdicionada
 {
-    // CA-7: Id es el stream ID del ControlDiario: "cd:{CodigoColaborador}:{Fecha:yyyyMMdd}" (issue #420, CA-ADR-0031)
+    // Id es el stream key del ControlDiario, tal como lo computa ControlDiarioAggregateRoot.ComputarStreamId.
     public string Id { get; private set; } = null!;
     public string CodigoColaborador { get; private set; } = null!;
 

--- a/src/Bitakora.ControlAsistencia.ControlHoras/Entities/ControlDiarioAggregateRoot.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Entities/ControlDiarioAggregateRoot.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Bitakora.ControlAsistencia.ControlHoras.ValueObjects;
 using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 using Bitakora.ControlAsistencia.PublicEvents.ControlHoras;
@@ -69,14 +70,22 @@ public partial class ControlDiarioAggregateRoot : AggregateRoot
         _desgloseHoras = ConsolidadorDesgloseHoras.Consolidar(desgloses, anomalas);
     }
 
-    // CA-ADR-0031: prefijo por iniciales para evitar colision con el futuro DiaCalculado ("dc:"),
-    // que comparte la identidad logica colaborador+fecha en el mismo store.
-    private const string PrefijoStream = "cd";
+    // CA-ADR-0031: prefijo por iniciales -- disjunta este stream del futuro DiaCalculado ("dc:"), que
+    // comparte la identidad logica colaborador+fecha en el mismo store. La fecha va en ISO 8601 basico
+    // porque no aporta ':' propios: asi Split(SeparadorStreamId) devuelve siempre los 3 componentes.
+    // Los tres valores son el contrato de identidad de todo stream ya escrito -- cambiar cualquiera
+    // exige migracion. InvariantCulture: una culture con calendario no gregoriano (ar-SA) rendiria
+    // otro ano en la clave.
+    private const string PrefijoStreamId = "cd";
+    private const char SeparadorStreamId = ':';
+    private const string FormatoFechaStreamId = "yyyyMMdd";
 
-    // CA-7: stream ID determinista: "cd:{CodigoColaborador}:{Fecha:yyyyMMdd}" (issue #420)
     // CA-8: dos mensajes con mismo CodigoColaborador+Fecha comparten el mismo stream
-    public static string ComputarStreamId(string codigoColaborador, DateOnly fecha) =>
-        $"{PrefijoStream}:{codigoColaborador}:{fecha:yyyyMMdd}";
+    public static string ComputarStreamId(string codigoColaborador, DateOnly fecha)
+    {
+        var fechaBasica = fecha.ToString(FormatoFechaStreamId, CultureInfo.InvariantCulture);
+        return $"{PrefijoStreamId}{SeparadorStreamId}{codigoColaborador}{SeparadorStreamId}{fechaBasica}";
+    }
 
     // CA-6: actualiza estado interno al aplicar el evento
     // public: requerido para que TestStore.ApplyEvent lo encuentre via GetMethods()
@@ -123,13 +132,12 @@ public partial class ControlDiarioAggregateRoot : AggregateRoot
         RecalcularDesgloseHoras();
     }
 
-    // HU-108: stream ID tiene formato "cd:{CodigoColaborador}:{Fecha:yyyyMMdd}" (CA-7, issue #420).
-    // CA-ADR-0031: la anatomia garantiza exactamente 3 componentes separados por ':'; la fecha es
-    // siempre el ultimo para hidratar Fecha cuando no hay TurnoDiarioAsignado.
+    // HU-108: hidrata Fecha cuando el ControlDiario nace solo por marcacion, sin TurnoDiarioAsignado
+    // que la traiga. La anatomia de CA-ADR-0031 garantiza 3 componentes y la fecha es siempre el ultimo.
     private static DateOnly ExtraerFechaDeStreamId(string streamId)
     {
-        var partes = streamId.Split(':');
-        return DateOnly.ParseExact(partes[^1], "yyyyMMdd");
+        var partes = streamId.Split(SeparadorStreamId);
+        return DateOnly.ParseExact(partes[^1], FormatoFechaStreamId, CultureInfo.InvariantCulture);
     }
 
     // HU-106: segundo camino de creacion del ControlDiario, sin turno asignado

--- a/src/Bitakora.ControlAsistencia.ControlHoras/Entities/ControlDiarioAggregateRoot.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Entities/ControlDiarioAggregateRoot.cs
@@ -69,10 +69,14 @@ public partial class ControlDiarioAggregateRoot : AggregateRoot
         _desgloseHoras = ConsolidadorDesgloseHoras.Consolidar(desgloses, anomalas);
     }
 
-    // CA-7: stream ID determinista: "{CodigoColaborador}:{Fecha:yyyy-MM-dd}"
+    // CA-ADR-0031: prefijo por iniciales para evitar colision con el futuro DiaCalculado ("dc:"),
+    // que comparte la identidad logica colaborador+fecha en el mismo store.
+    private const string PrefijoStream = "cd";
+
+    // CA-7: stream ID determinista: "cd:{CodigoColaborador}:{Fecha:yyyyMMdd}" (issue #420)
     // CA-8: dos mensajes con mismo CodigoColaborador+Fecha comparten el mismo stream
     public static string ComputarStreamId(string codigoColaborador, DateOnly fecha) =>
-        $"{codigoColaborador}:{fecha:yyyy-MM-dd}";
+        $"{PrefijoStream}:{codigoColaborador}:{fecha:yyyyMMdd}";
 
     // CA-6: actualiza estado interno al aplicar el evento
     // public: requerido para que TestStore.ApplyEvent lo encuentre via GetMethods()
@@ -119,13 +123,13 @@ public partial class ControlDiarioAggregateRoot : AggregateRoot
         RecalcularDesgloseHoras();
     }
 
-    // HU-108: stream ID tiene formato "{CodigoColaborador}:{Fecha:yyyy-MM-dd}" (CA-7).
-    // Parsea la porcion final como DateOnly para hidratar Fecha cuando no hay TurnoDiarioAsignado.
+    // HU-108: stream ID tiene formato "cd:{CodigoColaborador}:{Fecha:yyyyMMdd}" (CA-7, issue #420).
+    // CA-ADR-0031: la anatomia garantiza exactamente 3 componentes separados por ':'; la fecha es
+    // siempre el ultimo para hidratar Fecha cuando no hay TurnoDiarioAsignado.
     private static DateOnly ExtraerFechaDeStreamId(string streamId)
     {
-        var separador = streamId.LastIndexOf(':');
-        var fechaTexto = streamId[(separador + 1)..];
-        return DateOnly.ParseExact(fechaTexto, "yyyy-MM-dd");
+        var partes = streamId.Split(':');
+        return DateOnly.ParseExact(partes[^1], "yyyyMMdd");
     }
 
     // HU-106: segundo camino de creacion del ControlDiario, sin turno asignado

--- a/src/Bitakora.ControlAsistencia.Projections/ControlHoras/TurnoVigenteProjection.cs
+++ b/src/Bitakora.ControlAsistencia.Projections/ControlHoras/TurnoVigenteProjection.cs
@@ -48,7 +48,8 @@ public sealed partial class TurnoVigenteProjection : SingleStreamProjection<Turn
 
     // CA-2: "el ultimo gana" -- una reasignacion sobre el mismo (colaborador, fecha) sobrescribe
     // turno, horario y bloques. Id, CodigoColaborador y Fecha no cambian: son la identidad del stream
-    // ("{CodigoColaborador}:{Fecha:yyyy-MM-dd}"), invariante para todos los eventos del mismo documento.
+    // ("cd:{CodigoColaborador}:{Fecha:yyyyMMdd}", issue #420, CA-ADR-0031), invariante para todos los
+    // eventos del mismo documento.
     //
     // NombreCompleto SI se refresca: cada TurnoDiarioAsignado trae el payload del colaborador
     // completo, y el criterio del "ultimo gana" aplica igual a un nombre corregido aguas arriba --

--- a/src/Bitakora.ControlAsistencia.Projections/ControlHoras/TurnoVigenteProjection.cs
+++ b/src/Bitakora.ControlAsistencia.Projections/ControlHoras/TurnoVigenteProjection.cs
@@ -48,8 +48,7 @@ public sealed partial class TurnoVigenteProjection : SingleStreamProjection<Turn
 
     // CA-2: "el ultimo gana" -- una reasignacion sobre el mismo (colaborador, fecha) sobrescribe
     // turno, horario y bloques. Id, CodigoColaborador y Fecha no cambian: son la identidad del stream
-    // ("cd:{CodigoColaborador}:{Fecha:yyyyMMdd}", issue #420, CA-ADR-0031), invariante para todos los
-    // eventos del mismo documento.
+    // ("cd:{CodigoColaborador}:{Fecha:yyyyMMdd}"), invariante para todos los eventos del mismo documento.
     //
     // NombreCompleto SI se refresca: cada TurnoDiarioAsignado trae el payload del colaborador
     // completo, y el criterio del "ultimo gana" aplica igual a un nombre corregido aguas arriba --

--- a/src/Bitakora.ControlAsistencia.Projections/Infraestructura/ConfiguracionMartenProjectionsControlHoras.cs
+++ b/src/Bitakora.ControlAsistencia.Projections/Infraestructura/ConfiguracionMartenProjectionsControlHoras.cs
@@ -46,8 +46,8 @@ public static class ConfiguracionMartenProjectionsControlHoras
                 // Replica de la identidad de stream que el write-side ya declara
                 // (Cosmos.EventSourcing.CritterStack 2.1.0, AgregarConfiguracionMartenComandos:
                 // Events.StreamIdentity = AsString): el stream key de este dominio lo computa
-                // ControlDiarioAggregateRoot.ComputarStreamId como "{CodigoColaborador}:{Fecha:yyyy-MM-dd}",
-                // un valor que ni por accidente es un Guid. Sin esta linea Marten aplica su default
+                // ControlDiarioAggregateRoot.ComputarStreamId como "cd:{CodigoColaborador}:{Fecha:yyyyMMdd}"
+                // (issue #420, CA-ADR-0031), un valor que ni por accidente es un Guid. Sin esta linea Marten aplica su default
                 // AsGuid ("Event Store Configuration" -> "Stream Identity" en
                 // https://martendb.io/events/configuration.html#stream-identity) y el daemon leeria
                 // el event store (stream_id varchar) como uuid, sin encontrar ningun stream (#253).

--- a/src/Bitakora.ControlAsistencia.Projections/Infraestructura/ConfiguracionMartenProjectionsControlHoras.cs
+++ b/src/Bitakora.ControlAsistencia.Projections/Infraestructura/ConfiguracionMartenProjectionsControlHoras.cs
@@ -46,8 +46,8 @@ public static class ConfiguracionMartenProjectionsControlHoras
                 // Replica de la identidad de stream que el write-side ya declara
                 // (Cosmos.EventSourcing.CritterStack 2.1.0, AgregarConfiguracionMartenComandos:
                 // Events.StreamIdentity = AsString): el stream key de este dominio lo computa
-                // ControlDiarioAggregateRoot.ComputarStreamId como "cd:{CodigoColaborador}:{Fecha:yyyyMMdd}"
-                // (issue #420, CA-ADR-0031), un valor que ni por accidente es un Guid. Sin esta linea Marten aplica su default
+                // ControlDiarioAggregateRoot.ComputarStreamId como "cd:{CodigoColaborador}:{Fecha:yyyyMMdd}",
+                // un valor que ni por accidente es un Guid. Sin esta linea Marten aplica su default
                 // AsGuid ("Event Store Configuration" -> "Stream Identity" en
                 // https://martendb.io/events/configuration.html#stream-identity) y el daemon leeria
                 // el event store (stream_id varchar) como uuid, sin encontrar ningun stream (#253).

--- a/src/Bitakora.ControlAsistencia.ReadModels/ControlHoras/TurnoVigente.cs
+++ b/src/Bitakora.ControlAsistencia.ReadModels/ControlHoras/TurnoVigente.cs
@@ -18,7 +18,8 @@ namespace Bitakora.ControlAsistencia.ReadModels.ControlHoras;
 /// de infraestructura del issue #317 CA-2 al read-side (ver issue #328, "ADRs aplicables").
 ///
 /// Id es el stream key que compone ControlDiarioAggregateRoot.ComputarStreamId:
-/// "{CodigoColaborador}:{Fecha:yyyy-MM-dd}" -- nunca un Guid (Events.StreamIdentity = AsString). Excluye
+/// "cd:{CodigoColaborador}:{Fecha:yyyyMMdd}" (issue #420, CA-ADR-0031) -- nunca un Guid
+/// (Events.StreamIdentity = AsString). Excluye
 /// deliberadamente la trazabilidad interna hacia la solicitud de programacion y la identificacion
 /// completa del colaborador (ambas las cargaba el read model del issue #289, que ningun cliente de
 /// calendario consumia): solo CodigoColaborador (lookup/resourceId) y NombreCompleto (un solo campo,

--- a/src/Bitakora.ControlAsistencia.ReadModels/ControlHoras/TurnoVigente.cs
+++ b/src/Bitakora.ControlAsistencia.ReadModels/ControlHoras/TurnoVigente.cs
@@ -18,9 +18,8 @@ namespace Bitakora.ControlAsistencia.ReadModels.ControlHoras;
 /// de infraestructura del issue #317 CA-2 al read-side (ver issue #328, "ADRs aplicables").
 ///
 /// Id es el stream key que compone ControlDiarioAggregateRoot.ComputarStreamId:
-/// "cd:{CodigoColaborador}:{Fecha:yyyyMMdd}" (issue #420, CA-ADR-0031) -- nunca un Guid
-/// (Events.StreamIdentity = AsString). Excluye
-/// deliberadamente la trazabilidad interna hacia la solicitud de programacion y la identificacion
+/// "cd:{CodigoColaborador}:{Fecha:yyyyMMdd}" -- nunca un Guid (Events.StreamIdentity = AsString).
+/// Excluye deliberadamente la trazabilidad interna hacia la solicitud de programacion y la identificacion
 /// completa del colaborador (ambas las cargaba el read model del issue #289, que ningun cliente de
 /// calendario consumia): solo CodigoColaborador (lookup/resourceId) y NombreCompleto (un solo campo,
 /// concatenado por la proyeccion desde ColaboradorProgramado.Nombres +

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/AsignarTurnoViaSbSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/AsignarTurnoViaSbSmokeTests.cs
@@ -67,7 +67,7 @@ public class AsignarTurnoViaSbSmokeTests(ServiceBusFixture serviceBus, PostgresF
         await serviceBus.PublishAsync(TopicEntrada, evento, correlationId);
 
         // Assert: verificar que el evento TurnoDiarioAsignado fue persistido en PostgreSQL
-        var streamId = $"{codigoColaborador}:{fecha:yyyy-MM-dd}";
+        var streamId = $"cd:{codigoColaborador}:{fecha:yyyyMMdd}";
         var tipoEvento = "turno_diario_asignado";
 
         var existe = await postgres.ExisteEventoAsync(
@@ -219,7 +219,7 @@ public class AsignarTurnoViaSbSmokeTests(ServiceBusFixture serviceBus, PostgresF
         await serviceBus.PublishAsync(TopicEntrada, evento, correlationId);
 
         // Assert: verificar que el evento TurnoDiarioAsignado fue persistido en PostgreSQL
-        var streamId = $"{codigoColaborador}:{fecha:yyyy-MM-dd}";
+        var streamId = $"cd:{codigoColaborador}:{fecha:yyyyMMdd}";
         var tipoEvento = "turno_diario_asignado";
 
         var existe = await postgres.ExisteEventoAsync(
@@ -337,7 +337,7 @@ public class AsignarTurnoViaSbSmokeTests(ServiceBusFixture serviceBus, PostgresF
         // Assert: verificar persistencia en Postgres.
         // Si la deserializacion falla (propiedades null), el handler lanza
         // NullReferenceException, el mensaje va a dead-letter y NUNCA se persiste.
-        var streamId = $"{codigoColaborador}:{fecha:yyyy-MM-dd}";
+        var streamId = $"cd:{codigoColaborador}:{fecha:yyyyMMdd}";
         var tipoEvento = "turno_diario_asignado";
 
         var existe = await postgres.ExisteEventoAsync(

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/Fixtures/WarmupFixture.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/Fixtures/WarmupFixture.cs
@@ -85,8 +85,8 @@ public class WarmupFixture : IAsyncLifetime
         var stopwatch = Stopwatch.StartNew();
 
         // CA-4: identificadores descartables y unicos. El stream cd:{codigoColaborador}:{fecha} queda
-        // aislado (issue #420, CA-ADR-0031); no toca los streams ni las suscripciones que verifican los
-        // tests reales. No leemos ni purgamos la suscripcion smoke-tests de dia-calculado: el
+        // aislado; no toca los streams ni las suscripciones que verifican los tests reales. No leemos
+        // ni purgamos la suscripcion smoke-tests de dia-calculado: el
         // DiaCalculado que emite este cebado lleva un CodigoColaborador distinto (los tests filtran por
         // el suyo) y, ademas, el test real purga esa suscripcion antes de su Act. Confirmamos el cebado
         // solo via Postgres, que ya prueba que ambos listeners procesaron.

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/Fixtures/WarmupFixture.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/Fixtures/WarmupFixture.cs
@@ -84,15 +84,15 @@ public class WarmupFixture : IAsyncLifetime
     {
         var stopwatch = Stopwatch.StartNew();
 
-        // CA-4: identificadores descartables y unicos. El stream {codigoColaborador}:{fecha} queda aislado;
-        // no toca los streams ni las suscripciones que verifican los tests reales. No leemos ni
-        // purgamos la suscripcion smoke-tests de dia-calculado: el DiaCalculado que emite este
-        // cebado lleva un CodigoColaborador distinto (los tests filtran por el suyo) y, ademas, el test
-        // real purga esa suscripcion antes de su Act. Confirmamos el cebado solo via Postgres,
-        // que ya prueba que ambos listeners procesaron.
+        // CA-4: identificadores descartables y unicos. El stream cd:{codigoColaborador}:{fecha} queda
+        // aislado (issue #420, CA-ADR-0031); no toca los streams ni las suscripciones que verifican los
+        // tests reales. No leemos ni purgamos la suscripcion smoke-tests de dia-calculado: el
+        // DiaCalculado que emite este cebado lleva un CodigoColaborador distinto (los tests filtran por
+        // el suyo) y, ademas, el test real purga esa suscripcion antes de su Act. Confirmamos el cebado
+        // solo via Postgres, que ya prueba que ambos listeners procesaron.
         var codigoColaborador = Guid.CreateVersion7().ToString();
         var fecha = new DateOnly(2026, 1, 1);
-        var streamId = $"{codigoColaborador}:{fecha:yyyy-MM-dd}";
+        var streamId = $"cd:{codigoColaborador}:{fecha:yyyyMMdd}";
 
         // Salto 1: publicar programacion-turno-diario-solicitada -> calienta el listener AsignarTurno,
         // que persiste turno_diario_asignado en el stream.

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/ListarTurnosVigentes/ListarTurnosVigentesSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/ListarTurnosVigentes/ListarTurnosVigentesSmokeTests.cs
@@ -350,7 +350,7 @@ public class ListarTurnosVigentesSmokeTests(ApiFixture api, ServiceBusFixture se
         // decision de entrevista del issue #329, "Notas tecnicas": una sola proyeccion sirve grilla
         // y calendario).
         var turno = respuesta.Turnos[0];
-        turno.Id.Should().Be($"{codigoColaborador}:{fechaTurno:yyyy-MM-dd}");
+        turno.Id.Should().Be($"cd:{codigoColaborador}:{fechaTurno:yyyyMMdd}");
         turno.CodigoColaborador.Should().Be(codigoColaborador);
         turno.NombreCompleto.Should().Be("[TEST] Smoke Listar [TEST] TurnosVigentes");
         turno.Fecha.Should().Be(fechaTurno);

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/ObtenerTurnoVigente/ObtenerTurnoVigenteSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/ObtenerTurnoVigente/ObtenerTurnoVigenteSmokeTests.cs
@@ -73,8 +73,7 @@ public class ObtenerTurnoVigenteSmokeTests(ApiFixture api, ServiceBusFixture ser
         $"/api/control-horas/turnos-vigentes/{codigoColaborador}/{fecha:yyyy-MM-dd}";
 
     // Mismo formato que ControlDiarioAggregateRoot.ComputarStreamId, reconstruido localmente:
-    // el smoke test no referencia el Function App (ControlHoras.Entities). Issue #420: prefijo "cd"
-    // y fecha en ISO 8601 basico (yyyyMMdd), CA-ADR-0031.
+    // el smoke test no referencia el Function App (ControlHoras.Entities).
     private static string ComputarStreamId(string codigoColaborador, DateOnly fecha) =>
         $"cd:{codigoColaborador}:{fecha:yyyyMMdd}";
 

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/ObtenerTurnoVigente/ObtenerTurnoVigenteSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/ObtenerTurnoVigente/ObtenerTurnoVigenteSmokeTests.cs
@@ -73,9 +73,10 @@ public class ObtenerTurnoVigenteSmokeTests(ApiFixture api, ServiceBusFixture ser
         $"/api/control-horas/turnos-vigentes/{codigoColaborador}/{fecha:yyyy-MM-dd}";
 
     // Mismo formato que ControlDiarioAggregateRoot.ComputarStreamId, reconstruido localmente:
-    // el smoke test no referencia el Function App (ControlHoras.Entities).
+    // el smoke test no referencia el Function App (ControlHoras.Entities). Issue #420: prefijo "cd"
+    // y fecha en ISO 8601 basico (yyyyMMdd), CA-ADR-0031.
     private static string ComputarStreamId(string codigoColaborador, DateOnly fecha) =>
-        $"{codigoColaborador}:{fecha:yyyy-MM-dd}";
+        $"cd:{codigoColaborador}:{fecha:yyyyMMdd}";
 
     [Fact]
     [Trait("Category", "Smoke")]

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/RegistrarMarcacionFunction/RegistrarMarcacionSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/RegistrarMarcacionFunction/RegistrarMarcacionSmokeTests.cs
@@ -307,7 +307,7 @@ public class RegistrarMarcacionSmokeTests(
         // Arrange: identificadores unicos por ejecucion
         var codigoColaborador = Guid.CreateVersion7().ToString();
         var fecha = new DateOnly(2026, 4, 27);
-        var streamId = $"{codigoColaborador}:{fecha:yyyy-MM-dd}";
+        var streamId = $"cd:{codigoColaborador}:{fecha:yyyyMMdd}";
 
         // Setup: publicar programacion-turno-diario-solicitada y esperar a que ControlHoras
         // persista turno_diario_asignado. Asi el ControlDiario tendra TurnoDiarioAsignado previo
@@ -429,7 +429,7 @@ public class RegistrarMarcacionSmokeTests(
         // Arrange: identificadores unicos por ejecucion.
         var codigoColaborador = Guid.CreateVersion7().ToString();
         var fecha = new DateOnly(2026, 4, 28);
-        var streamId = $"{codigoColaborador}:{fecha:yyyy-MM-dd}";
+        var streamId = $"cd:{codigoColaborador}:{fecha:yyyyMMdd}";
 
         // Setup: turno 08:00-16:00 via Service Bus; esperar a que ControlHoras persista
         // turno_diario_asignado antes de registrar las marcaciones.

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoRegistroDeMarcacionCreado/DepurarAlAdicionarMarcacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoRegistroDeMarcacionCreado/DepurarAlAdicionarMarcacionTests.cs
@@ -22,7 +22,6 @@ public class DepurarAlAdicionarMarcacionTests : PrivateEventHandlerAsyncTest<Reg
     // Datos de prueba fijos - misma ancla de fecha que los tests del handler
     private const string CodigoColaborador = "EMP-001";
     private static readonly DateOnly Fecha = new(2026, 3, 15);
-    // Issue #420: stream ID renotado con prefijo "cd" y fecha en ISO 8601 basico (CA-ADR-0031).
     private static readonly string StreamId = $"cd:{CodigoColaborador}:{Fecha:yyyyMMdd}";
     private static readonly string StreamIdDiaAnterior = $"cd:{CodigoColaborador}:20260314";
 

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoRegistroDeMarcacionCreado/DepurarAlAdicionarMarcacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoRegistroDeMarcacionCreado/DepurarAlAdicionarMarcacionTests.cs
@@ -22,8 +22,9 @@ public class DepurarAlAdicionarMarcacionTests : PrivateEventHandlerAsyncTest<Reg
     // Datos de prueba fijos - misma ancla de fecha que los tests del handler
     private const string CodigoColaborador = "EMP-001";
     private static readonly DateOnly Fecha = new(2026, 3, 15);
-    private static readonly string StreamId = $"{CodigoColaborador}:{Fecha:yyyy-MM-dd}";
-    private static readonly string StreamIdDiaAnterior = $"{CodigoColaborador}:2026-03-14";
+    // Issue #420: stream ID renotado con prefijo "cd" y fecha en ISO 8601 basico (CA-ADR-0031).
+    private static readonly string StreamId = $"cd:{CodigoColaborador}:{Fecha:yyyyMMdd}";
+    private static readonly string StreamIdDiaAnterior = $"cd:{CodigoColaborador}:20260314";
 
     // Issue #322: Colaborador (ControlHoras.DomainEvents) para construir TurnoDiarioAsignado en Given.
     private static readonly ColaboradorProgramado ColaboradorPersistido = new(

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoRegistroDeMarcacionCreado/DesgloseHorasTrasAdicionarMarcacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoRegistroDeMarcacionCreado/DesgloseHorasTrasAdicionarMarcacionTests.cs
@@ -27,7 +27,8 @@ public class DesgloseHorasTrasAdicionarMarcacionTests : PrivateEventHandlerAsync
     // Datos de prueba fijos - mismo ancla de fecha y stream ID compuesto que los tests del handler
     private const string CodigoColaborador = "EMP-001";
     private static readonly DateOnly Fecha = new(2026, 3, 15);
-    private static readonly string StreamId = $"{CodigoColaborador}:{Fecha:yyyy-MM-dd}";
+    // Issue #420: stream ID renotado con prefijo "cd" y fecha en ISO 8601 basico (CA-ADR-0031).
+    private static readonly string StreamId = $"cd:{CodigoColaborador}:{Fecha:yyyyMMdd}";
 
     // Issue #322: Colaborador (ControlHoras.DomainEvents) -- el tipo que persiste TurnoDiarioAsignado.
     private static readonly ColaboradorProgramado Colaborador = new(

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoRegistroDeMarcacionCreado/DesgloseHorasTrasAdicionarMarcacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoRegistroDeMarcacionCreado/DesgloseHorasTrasAdicionarMarcacionTests.cs
@@ -27,7 +27,6 @@ public class DesgloseHorasTrasAdicionarMarcacionTests : PrivateEventHandlerAsync
     // Datos de prueba fijos - mismo ancla de fecha y stream ID compuesto que los tests del handler
     private const string CodigoColaborador = "EMP-001";
     private static readonly DateOnly Fecha = new(2026, 3, 15);
-    // Issue #420: stream ID renotado con prefijo "cd" y fecha en ISO 8601 basico (CA-ADR-0031).
     private static readonly string StreamId = $"cd:{CodigoColaborador}:{Fecha:yyyyMMdd}";
 
     // Issue #322: Colaborador (ControlHoras.DomainEvents) -- el tipo que persiste TurnoDiarioAsignado.

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoRegistroDeMarcacionCreado/Eventos/MarcacionAdicionadaSerializacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoRegistroDeMarcacionCreado/Eventos/MarcacionAdicionadaSerializacionTests.cs
@@ -16,7 +16,8 @@ namespace Bitakora.ControlAsistencia.ControlHoras.Tests.AdicionarMarcacionCuando
 /// </summary>
 public class MarcacionAdicionadaSerializacionTests
 {
-    private static readonly string StreamId = "EMP-001:2026-03-15";
+    // Issue #420: stream ID renotado con prefijo "cd" y fecha en ISO 8601 basico (CA-ADR-0031).
+    private static readonly string StreamId = "cd:EMP-001:20260315";
     private static readonly string CodigoColaborador = "EMP-001";
     private static readonly DateTime Timestamp = new DateTime(2026, 3, 15, 8, 15, 0);
 

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoRegistroDeMarcacionCreado/Eventos/MarcacionAdicionadaSerializacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoRegistroDeMarcacionCreado/Eventos/MarcacionAdicionadaSerializacionTests.cs
@@ -16,7 +16,6 @@ namespace Bitakora.ControlAsistencia.ControlHoras.Tests.AdicionarMarcacionCuando
 /// </summary>
 public class MarcacionAdicionadaSerializacionTests
 {
-    // Issue #420: stream ID renotado con prefijo "cd" y fecha en ISO 8601 basico (CA-ADR-0031).
     private static readonly string StreamId = "cd:EMP-001:20260315";
     private static readonly string CodigoColaborador = "EMP-001";
     private static readonly DateTime Timestamp = new DateTime(2026, 3, 15, 8, 15, 0);

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoRegistroDeMarcacionCreado/RegistroDeMarcacionCreadoEventHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoRegistroDeMarcacionCreado/RegistroDeMarcacionCreadoEventHandlerTests.cs
@@ -23,9 +23,10 @@ public class RegistroDeMarcacionCreadoEventHandlerTests
     // CA-2: hora dentro de ventana nocturna (< 04:00) - dia calendario + dia anterior
     private static readonly DateTime TimestampDentroDeVentana = new DateTime(2026, 3, 15, 2, 30, 0);
 
+    // Issue #420: stream ID renotado con prefijo "cd" y fecha en ISO 8601 basico (CA-ADR-0031).
     // CA-7, CA-8: stream IDs computados desde TimestampNormalizado
-    private static readonly string StreamIdDia15 = $"{CodigoColaborador}:2026-03-15";
-    private static readonly string StreamIdDia14 = $"{CodigoColaborador}:2026-03-14";
+    private static readonly string StreamIdDia15 = $"cd:{CodigoColaborador}:20260315";
+    private static readonly string StreamIdDia14 = $"cd:{CodigoColaborador}:20260314";
 
     protected override IPrivateEventHandlerAsync<RegistroDeMarcacionCreado> Handler =>
         new RegistroDeMarcacionCreadoEventHandler(EventStore, PublicEventSender);
@@ -48,12 +49,13 @@ public class RegistroDeMarcacionCreadoEventHandlerTests
     // CA-1: hora fuera de ventana nocturna (08:15) -> un solo ControlDiario para dia calendario
     // CA-5: si no existe ControlDiario, se crea con Iniciar(MarcacionAdicionada)
     // CA-6: ControlDiario creado solo por marcacion tiene InformacionColaborador y DetalleTurno nulos
-    // CA-7: stream ID es "{CodigoColaborador}:{Fecha:yyyy-MM-dd}"
+    // CA-7: stream ID es "cd:{CodigoColaborador}:{Fecha:yyyyMMdd}" (issue #420)
     // CA-8: la fecha se extrae del TimestampNormalizado del evento
+    // Issue #420 CA-3: ExtraerFechaDeStreamId hidrata Fecha desde la notacion nueva del Id
     [Fact]
     public async Task RegistroDeMarcacionCreado_CreaControlDiarioConMarcacion_CuandoNoExisteYHoraFueraDeVentanaNocturna()
     {
-        // Sin Given - el stream no existe para EMP-001:2026-03-15
+        // Sin Given - el stream no existe para cd:EMP-001:20260315
         await WhenAsync(CrearRegistroDeMarcacionCreado(TimestampFueraDeVentana));
 
         Then(StreamIdDia15, CrearMarcacionAdicionada(StreamIdDia15, TimestampFueraDeVentana));
@@ -63,6 +65,8 @@ public class RegistroDeMarcacionCreadoEventHandlerTests
             StreamIdDia15, c => c.DetalleTurno, null);
         And<ControlDiarioAggregateRoot, int>(
             StreamIdDia15, c => c.Marcaciones.Count, 1);
+        And<ControlDiarioAggregateRoot, DateOnly>(
+            StreamIdDia15, c => c.Fecha, new DateOnly(2026, 3, 15));
     }
 
     // CA-2: hora dentro de ventana nocturna (02:30) -> dos ControlDiarios
@@ -78,11 +82,16 @@ public class RegistroDeMarcacionCreadoEventHandlerTests
         Then(StreamIdDia15, CrearMarcacionAdicionada(StreamIdDia15, TimestampDentroDeVentana));
         And<ControlDiarioAggregateRoot, int>(
             StreamIdDia15, c => c.Marcaciones.Count, 1);
+        And<ControlDiarioAggregateRoot, DateOnly>(
+            StreamIdDia15, c => c.Fecha, new DateOnly(2026, 3, 15));
 
         // Dia anterior: 2026-03-14 (traslape nocturno)
+        // Issue #420 CA-3: dos fechas distintas hidratadas desde dos Ids con la notacion nueva.
         Then(StreamIdDia14, CrearMarcacionAdicionada(StreamIdDia14, TimestampDentroDeVentana));
         And<ControlDiarioAggregateRoot, int>(
             StreamIdDia14, c => c.Marcaciones.Count, 1);
+        And<ControlDiarioAggregateRoot, DateOnly>(
+            StreamIdDia14, c => c.Fecha, new DateOnly(2026, 3, 14));
     }
 
     // CA-3: lista de marcaciones crece al adicionar una marcacion nueva

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoRegistroDeMarcacionCreado/RegistroDeMarcacionCreadoEventHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoRegistroDeMarcacionCreado/RegistroDeMarcacionCreadoEventHandlerTests.cs
@@ -23,7 +23,6 @@ public class RegistroDeMarcacionCreadoEventHandlerTests
     // CA-2: hora dentro de ventana nocturna (< 04:00) - dia calendario + dia anterior
     private static readonly DateTime TimestampDentroDeVentana = new DateTime(2026, 3, 15, 2, 30, 0);
 
-    // Issue #420: stream ID renotado con prefijo "cd" y fecha en ISO 8601 basico (CA-ADR-0031).
     // CA-7, CA-8: stream IDs computados desde TimestampNormalizado
     private static readonly string StreamIdDia15 = $"cd:{CodigoColaborador}:20260315";
     private static readonly string StreamIdDia14 = $"cd:{CodigoColaborador}:20260314";
@@ -49,9 +48,7 @@ public class RegistroDeMarcacionCreadoEventHandlerTests
     // CA-1: hora fuera de ventana nocturna (08:15) -> un solo ControlDiario para dia calendario
     // CA-5: si no existe ControlDiario, se crea con Iniciar(MarcacionAdicionada)
     // CA-6: ControlDiario creado solo por marcacion tiene InformacionColaborador y DetalleTurno nulos
-    // CA-7: stream ID es "cd:{CodigoColaborador}:{Fecha:yyyyMMdd}" (issue #420)
     // CA-8: la fecha se extrae del TimestampNormalizado del evento
-    // Issue #420 CA-3: ExtraerFechaDeStreamId hidrata Fecha desde la notacion nueva del Id
     [Fact]
     public async Task RegistroDeMarcacionCreado_CreaControlDiarioConMarcacion_CuandoNoExisteYHoraFueraDeVentanaNocturna()
     {
@@ -86,7 +83,6 @@ public class RegistroDeMarcacionCreadoEventHandlerTests
             StreamIdDia15, c => c.Fecha, new DateOnly(2026, 3, 15));
 
         // Dia anterior: 2026-03-14 (traslape nocturno)
-        // Issue #420 CA-3: dos fechas distintas hidratadas desde dos Ids con la notacion nueva.
         Then(StreamIdDia14, CrearMarcacionAdicionada(StreamIdDia14, TimestampDentroDeVentana));
         And<ControlDiarioAggregateRoot, int>(
             StreamIdDia14, c => c.Marcaciones.Count, 1);

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/DepurarAlAsignarTurnoTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/DepurarAlAsignarTurnoTests.cs
@@ -36,7 +36,6 @@ public class DepurarAlAsignarTurnoTests
         "EMP-001", "CC", "1234567890", "Luis Augusto", "Barreto");
 
     private static readonly DateOnly Fecha = new(2026, 3, 15);
-    // Issue #420: stream ID renotado con prefijo "cd" y fecha en ISO 8601 basico (CA-ADR-0031).
     private static readonly string StreamId = $"cd:{Colaborador.CodigoColaborador}:{Fecha:yyyyMMdd}";
 
     // CA-4: franja unica 06:00-14:00 para el turno asignado -- FranjaProgramada (ControlHoras.DomainEvents)

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/DepurarAlAsignarTurnoTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/DepurarAlAsignarTurnoTests.cs
@@ -36,7 +36,8 @@ public class DepurarAlAsignarTurnoTests
         "EMP-001", "CC", "1234567890", "Luis Augusto", "Barreto");
 
     private static readonly DateOnly Fecha = new(2026, 3, 15);
-    private static readonly string StreamId = $"{Colaborador.CodigoColaborador}:{Fecha:yyyy-MM-dd}";
+    // Issue #420: stream ID renotado con prefijo "cd" y fecha en ISO 8601 basico (CA-ADR-0031).
+    private static readonly string StreamId = $"cd:{Colaborador.CodigoColaborador}:{Fecha:yyyyMMdd}";
 
     // CA-4: franja unica 06:00-14:00 para el turno asignado -- FranjaProgramada (ControlHoras.DomainEvents)
     // es lo que el ControlDiario persiste; DetalleFranjaOrdinaria (PrivateEvents) es lo que trae el

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/DesgloseHorasTrasAsignarTurnoTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/DesgloseHorasTrasAsignarTurnoTests.cs
@@ -35,7 +35,6 @@ public class DesgloseHorasTrasAsignarTurnoTests
         "EMP-001", "CC", "1234567890", "Luis Augusto", "Barreto");
 
     private static readonly DateOnly Fecha = new(2026, 3, 15);
-    // Issue #420: stream ID renotado con prefijo "cd" y fecha en ISO 8601 basico (CA-ADR-0031).
     private static readonly string StreamId = $"cd:{Colaborador.CodigoColaborador}:{Fecha:yyyyMMdd}";
 
     // CA-3: franja unica 06:00-14:00 para el turno asignado -- FranjaProgramada (ControlHoras.DomainEvents)

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/DesgloseHorasTrasAsignarTurnoTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/DesgloseHorasTrasAsignarTurnoTests.cs
@@ -35,7 +35,8 @@ public class DesgloseHorasTrasAsignarTurnoTests
         "EMP-001", "CC", "1234567890", "Luis Augusto", "Barreto");
 
     private static readonly DateOnly Fecha = new(2026, 3, 15);
-    private static readonly string StreamId = $"{Colaborador.CodigoColaborador}:{Fecha:yyyy-MM-dd}";
+    // Issue #420: stream ID renotado con prefijo "cd" y fecha en ISO 8601 basico (CA-ADR-0031).
+    private static readonly string StreamId = $"cd:{Colaborador.CodigoColaborador}:{Fecha:yyyyMMdd}";
 
     // CA-3: franja unica 06:00-14:00 para el turno asignado -- FranjaProgramada (ControlHoras.DomainEvents)
     // es lo que el ControlDiario persiste; DetalleFranjaOrdinaria (PrivateEvents) es lo que trae el

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/TurnoDiarioAsignadoSerializacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/TurnoDiarioAsignadoSerializacionTests.cs
@@ -19,6 +19,10 @@ namespace Bitakora.ControlAsistencia.ControlHoras.Tests.AsignarTurnoCuandoProgra
 /// aqui SI cambian las claves JSON de mt_events. El JSON literal de estos tests se reescribio a las
 /// claves nuevas y por eso ya no acredita compatibilidad con los streams viejos: esos se purgan en
 /// el mismo despliegue (MEF-ADR-0036 seccion 5). Lo que fija desde ahora es la forma canonica.
+///
+/// Issue #420: el campo "Id" (stream key) se renoto de "{codigo}:{fecha:yyyy-MM-dd}" a
+/// "cd:{codigo}:{fecha:yyyyMMdd}" (CA-ADR-0031). Los literales JSON de este archivo reflejan la
+/// notacion nueva porque la ventana operativa purga los streams viejos en el mismo despliegue.
 /// </summary>
 public class TurnoDiarioAsignadoSerializacionTests
 {
@@ -37,7 +41,7 @@ public class TurnoDiarioAsignadoSerializacionTests
         [new FranjaProgramada(new TimeOnly(8, 0), new TimeOnly(16, 0), 0, [], [], "(08:00-16:00)")],
         "Turno Manana (08:00-16:00)");
 
-    private static readonly string StreamId = $"{ColaboradorDePrueba.CodigoColaborador}:{Fecha:yyyy-MM-dd}";
+    private static readonly string StreamId = $"cd:{ColaboradorDePrueba.CodigoColaborador}:{Fecha:yyyyMMdd}";
 
     // Regla 16: todo evento persistido en Marten debe tener test de serializacion roundtrip
     // Verifica con datos reales y completos (no listas vacias para VOs anidados)
@@ -85,7 +89,7 @@ public class TurnoDiarioAsignadoSerializacionTests
     {
         const string jsonPersistidoHoy = """
             {
-              "Id": "EMP-001:2026-03-15",
+              "Id": "cd:EMP-001:20260315",
               "InformacionColaborador": {
                 "CodigoColaborador": "EMP-001",
                 "TipoIdentificacion": "CC",
@@ -122,7 +126,7 @@ public class TurnoDiarioAsignadoSerializacionTests
             "Turno Manana (08:00-16:00)");
 
         deserializado.Should().NotBeNull();
-        deserializado!.Id.Should().Be("EMP-001:2026-03-15");
+        deserializado!.Id.Should().Be("cd:EMP-001:20260315");
         deserializado.SolicitudId.Should().Be(Guid.Parse("019600b0-0000-7000-8000-000000000001"));
         deserializado.Fecha.Should().Be(new DateOnly(2026, 3, 15));
         deserializado.InformacionColaborador.Should().Be(colaboradorEsperado);
@@ -139,7 +143,7 @@ public class TurnoDiarioAsignadoSerializacionTests
     {
         const string jsonPersistidoConSubFranjas = """
             {
-              "Id": "EMP-001:2026-03-15",
+              "Id": "cd:EMP-001:20260315",
               "InformacionColaborador": {
                 "CodigoColaborador": "EMP-001",
                 "TipoIdentificacion": "CC",
@@ -213,7 +217,7 @@ public class TurnoDiarioAsignadoSerializacionTests
     {
         const string jsonPersistidoAntesDeDescripcion = """
             {
-              "Id": "EMP-001:2026-03-15",
+              "Id": "cd:EMP-001:20260315",
               "InformacionColaborador": {
                 "CodigoColaborador": "EMP-001",
                 "TipoIdentificacion": "CC",
@@ -278,7 +282,7 @@ public class TurnoDiarioAsignadoSerializacionTests
     {
         const string jsonPersistidoSinSede = """
             {
-              "Id": "EMP-001:2026-03-15",
+              "Id": "cd:EMP-001:20260315",
               "InformacionColaborador": {
                 "CodigoColaborador": "EMP-001",
                 "TipoIdentificacion": "CC",

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/TurnoDiarioAsignadoSerializacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/TurnoDiarioAsignadoSerializacionTests.cs
@@ -19,10 +19,8 @@ namespace Bitakora.ControlAsistencia.ControlHoras.Tests.AsignarTurnoCuandoProgra
 /// aqui SI cambian las claves JSON de mt_events. El JSON literal de estos tests se reescribio a las
 /// claves nuevas y por eso ya no acredita compatibilidad con los streams viejos: esos se purgan en
 /// el mismo despliegue (MEF-ADR-0036 seccion 5). Lo que fija desde ahora es la forma canonica.
-///
-/// Issue #420: el campo "Id" (stream key) se renoto de "{codigo}:{fecha:yyyy-MM-dd}" a
-/// "cd:{codigo}:{fecha:yyyyMMdd}" (CA-ADR-0031). Los literales JSON de este archivo reflejan la
-/// notacion nueva porque la ventana operativa purga los streams viejos en el mismo despliegue.
+/// Mismo criterio para el campo "Id" (stream key): sus literales llevan la notacion vigente
+/// "cd:{codigo}:{fecha:yyyyMMdd}", no la de los streams que esa purga se lleva.
 /// </summary>
 public class TurnoDiarioAsignadoSerializacionTests
 {

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/ProgramacionTurnoDiarioSolicitadaEventHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/ProgramacionTurnoDiarioSolicitadaEventHandlerTests.cs
@@ -29,7 +29,8 @@ public class ProgramacionTurnoDiarioSolicitadaEventHandlerTests
     private static readonly DateOnly Fecha = new DateOnly(2026, 3, 15);
 
     // CA-7: stream ID determinista que el handler debe computar internamente
-    private static readonly string StreamId = $"{Colaborador.CodigoColaborador}:{Fecha:yyyy-MM-dd}";
+    // Issue #420: stream ID renotado con prefijo "cd" y fecha en ISO 8601 basico (CA-ADR-0031).
+    private static readonly string StreamId = $"cd:{Colaborador.CodigoColaborador}:{Fecha:yyyyMMdd}";
 
     // El evento privado sigue trayendo DetalleTurno (PrivateEvents) sin cambios.
     // Issue #288: Descripcion (dato derivado) es irrelevante para este test -> placeholder "".
@@ -57,7 +58,7 @@ public class ProgramacionTurnoDiarioSolicitadaEventHandlerTests
     // CA-3: NO existe ControlDiario para CodigoColaborador+Fecha - el handler inicia el stream
     // CA-5: el evento incluye InformacionColaborador, Fecha, DetalleTurno y SolicitudId
     // CA-6: el aggregate actualiza InformacionColaborador, Fecha y DetalleTurno
-    // CA-7: el stream ID resultante es "{CodigoColaborador}:{Fecha:yyyy-MM-dd}"
+    // CA-7: el stream ID resultante es "cd:{CodigoColaborador}:{Fecha:yyyyMMdd}" (issue #420)
     [Fact]
     public async Task ProgramacionTurnoDiarioSolicitada_EmiteTurnoDiarioAsignado_CuandoNoExisteControlDiario()
     {

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/ProgramacionTurnoDiarioSolicitadaEventHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/ProgramacionTurnoDiarioSolicitadaEventHandlerTests.cs
@@ -29,7 +29,6 @@ public class ProgramacionTurnoDiarioSolicitadaEventHandlerTests
     private static readonly DateOnly Fecha = new DateOnly(2026, 3, 15);
 
     // CA-7: stream ID determinista que el handler debe computar internamente
-    // Issue #420: stream ID renotado con prefijo "cd" y fecha en ISO 8601 basico (CA-ADR-0031).
     private static readonly string StreamId = $"cd:{Colaborador.CodigoColaborador}:{Fecha:yyyyMMdd}";
 
     // El evento privado sigue trayendo DetalleTurno (PrivateEvents) sin cambios.

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/ControlDiarioAggregateRootTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/ControlDiarioAggregateRootTests.cs
@@ -1,7 +1,6 @@
-// Issue #420: renotacion del stream ID de ControlDiarioAggregateRoot a "cd:{codigo}:{fecha}",
-// aplicando la heuristica de anatomia de CA-ADR-0031 seccion 2 -- mismo patron que #419 aplico a
-// RegistroDeMarcacionAggregateRoot. Test directo sobre el metodo estatico puro ComputarStreamId --
-// sin harness de event sourcing, porque no requiere stream ni evento.
+// Anatomia de la clave de stream de ControlDiario (CA-ADR-0031 seccion 2). Tests directos sobre el
+// metodo estatico puro ComputarStreamId -- sin harness de event sourcing, porque no requiere stream
+// ni evento.
 
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.ControlHoras.Entities;
@@ -10,7 +9,6 @@ namespace Bitakora.ControlAsistencia.ControlHoras.Tests.Entities;
 
 public class ControlDiarioAggregateRootTests
 {
-    // CA-1: ejemplo exacto del issue.
     [Fact]
     public void ComputarStreamId_ProduceNotacionConPrefijoCdYFechaBasica()
     {
@@ -19,10 +17,9 @@ public class ControlDiarioAggregateRootTests
         streamId.Should().Be("cd:ABC123:20260819");
     }
 
-    // CA-2 / CA-ADR-0031 seccion 2 paso 5: la clave vigente (yyyy-MM-dd) falla este test porque la
-    // fecha aporta sus propios '-', pero no ':'; sin prefijo el split solo devuelve 2 partes. Con el
-    // prefijo "cd" y la fecha en ISO basico (yyyyMMdd, sin separadores propios) el split devuelve
-    // exactamente los 3 componentes esperados.
+    // CA-ADR-0031 seccion 2 paso 5: ningun componente puede aportar el separador. Sin el prefijo el
+    // split devolveria 2 partes, y una fecha en ISO extendido tampoco alcanzaria para 3 -- este test
+    // es lo que impide "simplificar" cualquiera de las dos piezas.
     [Fact]
     public void ComputarStreamId_ProduceClaveDivisibleEnTresPartes_AlHacerSplitPorElSeparador()
     {

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/ControlDiarioAggregateRootTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/ControlDiarioAggregateRootTests.cs
@@ -1,0 +1,38 @@
+// Issue #420: renotacion del stream ID de ControlDiarioAggregateRoot a "cd:{codigo}:{fecha}",
+// aplicando la heuristica de anatomia de CA-ADR-0031 seccion 2 -- mismo patron que #419 aplico a
+// RegistroDeMarcacionAggregateRoot. Test directo sobre el metodo estatico puro ComputarStreamId --
+// sin harness de event sourcing, porque no requiere stream ni evento.
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.ControlHoras.Entities;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Tests.Entities;
+
+public class ControlDiarioAggregateRootTests
+{
+    // CA-1: ejemplo exacto del issue.
+    [Fact]
+    public void ComputarStreamId_ProduceNotacionConPrefijoCdYFechaBasica()
+    {
+        var streamId = ControlDiarioAggregateRoot.ComputarStreamId("ABC123", new DateOnly(2026, 8, 19));
+
+        streamId.Should().Be("cd:ABC123:20260819");
+    }
+
+    // CA-2 / CA-ADR-0031 seccion 2 paso 5: la clave vigente (yyyy-MM-dd) falla este test porque la
+    // fecha aporta sus propios '-', pero no ':'; sin prefijo el split solo devuelve 2 partes. Con el
+    // prefijo "cd" y la fecha en ISO basico (yyyyMMdd, sin separadores propios) el split devuelve
+    // exactamente los 3 componentes esperados.
+    [Fact]
+    public void ComputarStreamId_ProduceClaveDivisibleEnTresPartes_AlHacerSplitPorElSeparador()
+    {
+        var streamId = ControlDiarioAggregateRoot.ComputarStreamId("EMP-001", new DateOnly(2026, 3, 15));
+
+        var partes = streamId.Split(':');
+
+        partes.Should().HaveCount(3);
+        partes[0].Should().Be("cd");
+        partes[1].Should().Be("EMP-001");
+        partes[2].Should().Be("20260315");
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/CrearDiaCalculadoConHorasDiscriminadasTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/CrearDiaCalculadoConHorasDiscriminadasTests.cs
@@ -46,7 +46,8 @@ public class CrearDiaCalculadoConHorasDiscriminadasTests
         "EMP-001", "CC", "1234567890", "Luis Augusto", "Barreto");
 
     private static readonly DateOnly Fecha = new(2026, 3, 15);
-    private static readonly string StreamId = $"{Colaborador.CodigoColaborador}:{Fecha:yyyy-MM-dd}";
+    // Issue #420: stream ID renotado con prefijo "cd" y fecha en ISO 8601 basico (CA-ADR-0031).
+    private static readonly string StreamId = $"cd:{Colaborador.CodigoColaborador}:{Fecha:yyyyMMdd}";
     private static readonly Guid SolicitudId = Guid.Parse("019600d0-0000-7000-8000-000000000001");
 
     // Franja unica 06:00-14:00 usada por los escenarios de turno. FranjaProgramada

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/CrearDiaCalculadoConHorasDiscriminadasTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/CrearDiaCalculadoConHorasDiscriminadasTests.cs
@@ -46,7 +46,6 @@ public class CrearDiaCalculadoConHorasDiscriminadasTests
         "EMP-001", "CC", "1234567890", "Luis Augusto", "Barreto");
 
     private static readonly DateOnly Fecha = new(2026, 3, 15);
-    // Issue #420: stream ID renotado con prefijo "cd" y fecha en ISO 8601 basico (CA-ADR-0031).
     private static readonly string StreamId = $"cd:{Colaborador.CodigoColaborador}:{Fecha:yyyyMMdd}";
     private static readonly Guid SolicitudId = Guid.Parse("019600d0-0000-7000-8000-000000000001");
 

--- a/tests/Bitakora.ControlAsistencia.Projections.Tests/ControlHoras/TurnoVigenteProjectionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.Projections.Tests/ControlHoras/TurnoVigenteProjectionTests.cs
@@ -45,7 +45,7 @@ public class TurnoVigenteProjectionTests
     {
         var colaborador = ColaboradorDePrueba();
         var fecha = new DateOnly(2026, 8, 3);
-        var streamKey = "EMP-001:2026-08-03";
+        var streamKey = "cd:EMP-001:20260803";
 
         // Franja 06:00-14:00 con un descanso (10:00-10:15) y un extra ANTES del inicio nominal
         // (05:00-06:00): cubre los tres TipoBloque sin que ningun tramo cruce medianoche, para
@@ -94,7 +94,7 @@ public class TurnoVigenteProjectionTests
     {
         var colaborador = ColaboradorDePrueba();
         var fecha = new DateOnly(2026, 8, 3);
-        var streamKey = "EMP-001:2026-08-03";
+        var streamKey = "cd:EMP-001:20260803";
         var medianoche = fecha.ToDateTime(TimeOnly.MinValue);
 
         var vistaPrevia = new TurnoVigente(
@@ -136,7 +136,7 @@ public class TurnoVigenteProjectionTests
     public void Apply_RefrescaElNombreCompleto_CuandoLaReasignacionTraeElNombreCorregido()
     {
         var fecha = new DateOnly(2026, 8, 3);
-        var streamKey = "EMP-001:2026-08-03";
+        var streamKey = "cd:EMP-001:20260803";
         var medianoche = fecha.ToDateTime(TimeOnly.MinValue);
 
         var vistaPrevia = new TurnoVigente(
@@ -178,7 +178,7 @@ public class TurnoVigenteProjectionTests
     {
         var colaborador = ColaboradorDePrueba();
         var fecha = new DateOnly(2026, 8, 3);
-        var streamKey = "EMP-001:2026-08-03";
+        var streamKey = "cd:EMP-001:20260803";
         var sede = new SedeProgramada("SD-SUBA", "Suba");
 
         var franja = new FranjaProgramada(
@@ -205,7 +205,7 @@ public class TurnoVigenteProjectionTests
     {
         var colaborador = ColaboradorDePrueba();
         var fecha = new DateOnly(2026, 8, 3);
-        var streamKey = "EMP-001:2026-08-03";
+        var streamKey = "cd:EMP-001:20260803";
         var sede = new SedeProgramada("SD-SUBA", "Suba");
 
         var franja = new FranjaProgramada(
@@ -244,7 +244,7 @@ public class TurnoVigenteProjectionTests
     {
         var colaborador = ColaboradorDePrueba();
         var fecha = new DateOnly(2026, 8, 3);
-        var streamKey = "EMP-001:2026-08-03";
+        var streamKey = "cd:EMP-001:20260803";
 
         var franja = new FranjaProgramada(
             new TimeOnly(6, 0), new TimeOnly(14, 0), DiaOffsetFin: 0,
@@ -268,7 +268,7 @@ public class TurnoVigenteProjectionTests
     {
         var colaborador = ColaboradorDePrueba();
         var fecha = new DateOnly(2026, 8, 3);
-        var streamKey = "EMP-001:2026-08-03";
+        var streamKey = "cd:EMP-001:20260803";
         var suba = new SedeProgramada("SD-SUBA", "Suba");
         var chapinero = new SedeProgramada("SD-CHAPINERO", "Chapinero");
 
@@ -302,7 +302,7 @@ public class TurnoVigenteProjectionTests
     public void Apply_SobrescribeLaSedeDeLosBloques_CuandoLaReasignacionCambiaDeSede()
     {
         var fecha = new DateOnly(2026, 8, 3);
-        var streamKey = "EMP-001:2026-08-03";
+        var streamKey = "cd:EMP-001:20260803";
         var medianoche = fecha.ToDateTime(TimeOnly.MinValue);
 
         var vistaPrevia = new TurnoVigente(

--- a/tests/Bitakora.ControlAsistencia.Projections.Tests/Infraestructura/AssertsProyecciones.cs
+++ b/tests/Bitakora.ControlAsistencia.Projections.Tests/Infraestructura/AssertsProyecciones.cs
@@ -94,8 +94,8 @@ public static class AssertsProyecciones
     /// El named store lee el event store con la misma identidad de stream que el write-side ya
     /// declara (Cosmos.EventSourcing.CritterStack 2.1.0: Events.StreamIdentity = AsString): los
     /// stream keys de este BC son siempre strings -- e.Id.ToString() en la raiz de solicitud,
-    /// ComputarStreamId -> "{CodigoColaborador}:{Fecha:yyyy-MM-dd}" en control diario --, nunca el Guid
-    /// crudo. Con el default de Marten (AsGuid cuando nadie lo configura, docs "Event Store
+    /// ComputarStreamId -> "cd:{CodigoColaborador}:{Fecha:yyyyMMdd}" en control diario (issue #420,
+    /// CA-ADR-0031) --, nunca el Guid crudo. Con el default de Marten (AsGuid cuando nadie lo configura, docs "Event Store
     /// Configuration" -> "Stream Identity": https://martendb.io/events/configuration.html#stream-identity)
     /// el daemon leeria stream_id varchar como si fuera uuid y no encontraria ningun stream.
     ///

--- a/tests/Bitakora.ControlAsistencia.Projections.Tests/Infraestructura/AssertsProyecciones.cs
+++ b/tests/Bitakora.ControlAsistencia.Projections.Tests/Infraestructura/AssertsProyecciones.cs
@@ -94,8 +94,8 @@ public static class AssertsProyecciones
     /// El named store lee el event store con la misma identidad de stream que el write-side ya
     /// declara (Cosmos.EventSourcing.CritterStack 2.1.0: Events.StreamIdentity = AsString): los
     /// stream keys de este BC son siempre strings -- e.Id.ToString() en la raiz de solicitud,
-    /// ComputarStreamId -> "cd:{CodigoColaborador}:{Fecha:yyyyMMdd}" en control diario (issue #420,
-    /// CA-ADR-0031) --, nunca el Guid crudo. Con el default de Marten (AsGuid cuando nadie lo configura, docs "Event Store
+    /// ComputarStreamId -> "cd:{CodigoColaborador}:{Fecha:yyyyMMdd}" en control diario --, nunca el
+    /// Guid crudo. Con el default de Marten (AsGuid cuando nadie lo configura, docs "Event Store
     /// Configuration" -> "Stream Identity": https://martendb.io/events/configuration.html#stream-identity)
     /// el daemon leeria stream_id varchar como si fuera uuid y no encontraria ningun stream.
     ///


### PR DESCRIPTION
## Resumen

Pipeline TDD completado:
- Fase roja: tests escritos con stubs
- Fase verde: implementación completa
- Fase refactor: revisión de calidad

## Decisiones del pipeline

<details>
<summary>Test Writer (fase roja) — 10m 15s</summary>

## ES Test Writer - Decisiones (issue #420)

### Clasificacion de la tarea: TDD normal, no refactoring puro

El issue cambia el comportamiento observable de `ComputarStreamId` (CA-1 fija un ejemplo exacto
de entrada/salida) y de `ExtraerFechaDeStreamId` (CA-3). No es el "caso mandatorio" de refactor
puro (cambio de firma que impide un canal rojo): la firma de ambos metodos no cambia, solo su
implementacion interna, asi que existe un canal rojo perfectamente ejecutable -- tests que llaman
a `ComputarStreamId` con la firma actual y esperan el string nuevo, que fallan contra la
implementacion vieja. Se procedio con el flujo normal (no se crea `pipeline-state/refactor-signal.md`).

### Tests creados

- `Entities/ControlDiarioAggregateRootTests.cs` (archivo nuevo, espejo de
  `RegistroDeMarcacionAggregateRootTests.cs` del precedente #419): 2 tests
  - `ComputarStreamId_ProduceNotacionConPrefijoCdYFechaBasica` - CA-1 (ejemplo exacto del issue)
  - `ComputarStreamId_ProduceClaveDivisibleEnTresPartes_AlHacerSplitPorElSeparador` - CA-2 (split
    en 3 partes, CA-ADR-0031 seccion 2 paso 5)

### Tests modificados (renotacion mecanica de `StreamId`/literales)

- `AdicionarMarcacionCuandoRegistroDeMarcacionCreado/RegistroDeMarcacionCreadoEventHandlerTests.cs`:
  `StreamIdDia15`/`StreamIdDia14` renotados a `cd:{codigo}:{yyyyMMdd}`; se agregaron 3 asserts
  `And<ControlDiarioAggregateRoot, DateOnly>(..., c => c.Fecha, ...)` nuevos (no existian antes)
  para cubrir CA-3 explicitamente: que `ExtraerFechaDeStreamId` hidrata la fecha correcta desde la
  notacion nueva, incluyendo el caso de dos streams con fechas distintas (dia calendario + dia
  anterior por traslape nocturno).
- `AdicionarMarcacionCuandoRegistroDeMarcacionCreado/DepurarAlAdicionarMarcacionTests.cs`,
  `DesgloseHorasTrasAdicionarMarcacionTests.cs`,
  `AdicionarMarcacionCuandoRegistroDeMarcacionCreado/Eventos/MarcacionAdicionadaSerializacionTests.cs`,
  `AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/{ProgramacionTurnoDiarioSolicitadaEventHandlerTests,
  DepurarAlAsignarTurnoTests, DesgloseHorasTrasAsignarTurnoTests}.cs`,
  `Entities/CrearDiaCalculadoConHorasDiscriminadasTests.cs`: solo cambia la definicion de la
  constante `StreamId` (y comentarios CA-7 que citaban el formato viejo).
- `AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/Eventos/TurnoDiarioAsignadoSerializacionTests.cs`:
  `StreamId` renotado + 5 literales JSON `"Id": "EMP-001:2026-03-15"` -> `"cd:EMP-001:20260315"`
  (y el assert plano correspondiente). Estos tests de round-trip no ejercitan `ComputarStreamId`
  (el campo `Id` es un string plano del evento), asi que siguen en verde -- documentan la forma
  canonica hacia adelante, coherente con la nota ya existente en el archivo sobre la purga de
  streams viejos en el mismo despliegue (MEF-ADR-0036 seccion 5).
- `tests/Bitakora.ControlAsistencia.Projections.Tests/ControlHoras/TurnoVigenteProjectionTests.cs`:
  8 literales `"EMP-001:2026-08-03"` -> `"cd:EMP-001:20260803"` (CA-4: Id = StreamKey con notacion
  nueva). Este archivo pertenece a `Projections.Tests`, normalmente terreno de
  `projection-test-writer`, pero el issue lo lista explicitamente en "Impacto en archivos" y CA-4
  lo exige -- no hubo indicacion de un pipeline read-side separado para esta HU, asi que se
  actualizo aqui.
- `tests/Bitakora.ControlAsistencia.Projections.Tests/Infraestructura/AssertsProyecciones.cs`:
  comentario de `AssertStreamIdentityAsString` actualizado (citaba el formato viejo de
  `ComputarStreamId`).

### Stubs creados

Ninguno. Todos los tipos referenciados (`ControlDiarioAggregateRoot.ComputarStreamId`,
`ExtraerFechaDeStreamId`, `TurnoVigenteProjection`, etc.) ya existen en `src/` con la implementacion
vieja del formato de stream id -- no hace falta crear ningun stub de compilacion nuevo.

### Cobertura de criterios de aceptacion

| Criterio de aceptacion | Test(s) |
|---|---|
| CA-1: `ComputarStreamId` produce la notacion nueva (ejemplo exacto) | `ControlDiarioAggregateRootTests.ComputarStreamId_ProduceNotacionConPrefijoCdYFechaBasica` |
| CA-2: split en exactamente 3 partes | `ControlDiarioAggregateRootTests.ComputarStreamId_ProduceClaveDivisibleEnTresPartes_AlHacerSplitPorElSeparador` |
| CA-3: `ExtraerFechaDeStreamId` hidrata Fecha desde la notacion nueva | asserts `c => c.Fecha` agregados en `RegistroDeMarcacionCreadoEventHandlerTests` (2 tests, incluye caso de dia calendario + dia anterior) |
| CA-4: TurnoVigente materializa `Id` = StreamKey con notacion nueva, identidad invariante | `TurnoVigenteProjectionTests` (literales renotados; los tests `Apply_Sobrescribe*`/`Apply_Refresca*` ya verifican `vista.Id` invariante tras el segundo evento) |
| CA-5: formatos de fecha de la API no cambian | Verificado sin modificar: `ListarTurnosVigentes/FunctionEndpointTests.cs` solo usa `yyyy-MM-dd` en query params, ajeno a la clave de stream. No existen tests unitarios propios de `ObtenerTurnoVigente/FunctionEndpoint.cs` hoy (solo smoke tests) |
| CA-6: smoke tests bajo claves `cd:` | Fuera de este stage -- ver "Desviaciones" |

### Desviaciones del plan del planner

| Sugerencia del issue | Desviacion aplicada | Razon tecnica | Consecuencia |
|---|---|---|---|
| CA-6 y "Impacto en archivos" listan 4 archivos de `ControlHoras.SmokeTests` (`WarmupFixture`, `RegistrarMarcacionSmokeTests`, `ObtenerTurnoVigenteSmokeTests`, `ListarTurnosVigentesSmokeTests`) para modificar | No se tocaron | Los smoke tests son responsabilidad del agente `smoke-test-writer`, no de `test-writer` (rol de este agente: "unica responsabilidad es escribir tests de command handlers y los stubs minimos de compilacion" -- los smoke tests no son command handler tests contra el harness de event sourcing) | CA-6 queda pendiente de un stage/agente distinto en el pipeline; no bloquea esta fase roja |
| Archivo `MarcacionAdicionadaSerializacionTests.cs` no aparece en "Impacto en archivos" del issue | Se actualizo igual (`StreamId` literal renotado) | El literal `"EMP-001:2026-03-15"` es un dato de prueba arbitrario para un roundtrip de serializacion (no se computa via `ComputarStreamId`); dejarlo con el formato viejo no rompia nada pero generaba inconsistencia de datos de prueba dentro del mismo dominio | Cambio cosmetico, sin efecto en rojo/verde de ese archivo (el roundtrip no valida formato de Id) |
| Comentarios en `src/` (`ControlDiarioAggregateRoot.cs`, `TurnoVigente.cs`, `TurnoVigenteProjection.cs`, `ConfiguracionMartenProjectionsControlHoras.cs`) listados en "Impacto en archivos" | No se tocaron | Son archivos de produccion (aunque el cambio sea solo de comentarios); la regla absoluta 1 de este agente prohibe tocar `src/` salvo para stubs de compilacion, y aqui no hace falta ningun stub nuevo | El implementer actualiza esos comentarios junto con el cambio de `ComputarStreamId`/`ExtraerFechaDeStreamId` |

</details>

<details>
<summary>Implementer (fase verde) — 6m 25s</summary>

## ES Implementer - Decisiones

### Enfoque de implementacion
Cambio mecanico y acotado a la anatomia de la clave de stream de `ControlDiarioAggregateRoot`:

- `ComputarStreamId(codigoColaborador, fecha)` pasa de `"{codigo}:{yyyy-MM-dd}"` a
  `"cd:{codigo}:{yyyyMMdd}"`, con el prefijo extraido a la constante `PrefijoStream = "cd"`
  (espejo del patron que #419 aplico en `RegistroDeMarcacionAggregateRoot` con `"rdm"`).
- `ExtraerFechaDeStreamId` paso de `LastIndexOf(':') + ParseExact("yyyy-MM-dd")` a
  `streamId.Split(':')` + `ParseExact(partes[^1], "yyyyMMdd")`, aprovechando que la nueva
  anatomia garantiza exactamente 3 componentes (CA-ADR-0031) en vez de anclar solo por la
  derecha.

Sin cambios de logica en ningun otro archivo: el resto del trabajo fue actualizar comentarios
que citaban el formato viejo (documentacion) y literales/constantes de tests que ya asumian el
formato nuevo (test-writer) o que aun no lo tenian (smoke tests, ver "Desviaciones del plan del
planner").

### Decisiones de diseno
- La constante `PrefijoStream` vive junto al metodo que la usa (mismo archivo,
  `ControlDiarioAggregateRoot`), no en un tipo compartido: solo tiene un consumidor.
- Se preservo el criterio de "test de split en 3 partes" tal como lo fija CA-ADR-0031 seccion 2
  paso 5, usando `Split(':')` en `ExtraerFechaDeStreamId` en vez de mantener `LastIndexOf` (la
  nota tecnica del issue dejaba ambas opciones abiertas; se eligio `Split` porque es la misma
  operacion que el test de aceptacion CA-2 ejercita, dejando el codigo de produccion y el test
  hablando el mismo lenguaje).

### ADRs consultados
- CA-ADR-0031 (identidad de streams por store): heuristica de anatomia aplicada literalmente
  (prefijo `cd`, separador `:`, fecha ISO 8601 basico).
- MEF-ADR-0037 (identidad de stream como string): `ComputarStreamId` sigue siendo el unico punto
  de conversion; no se toco ningun consumidor (los tres identificados por el planner ya llaman al
  punto unico).
- MEF-ADR-0026: verificado (igual que hizo el planner) que no hay ningun `groupId`/sesion en
  juego; nada que cambiar.
- MEF-ADR-0036: no aplica (no se mueve ni renombra ningun tipo de evento).
- MEF-ADR-0034/MEF-ADR-0035: la logica de `TurnoVigenteProjection` no cambio, solo comentarios.
- MEF-ADR-0016: se preservaron los nombres de los tests tal como los dejo el test-writer.

### Desviaciones de ADRs
Ninguna desviacion — todos los ADRs aplicados al pie de la letra.

### Desviaciones del plan del planner
El planner listo en "Impacto en archivos" solo codigo de produccion y los tests que el
test-writer ya habia tocado; los smoke tests (`WarmupFixture`, `RegistrarMarcacionSmokeTests`,
`ObtenerTurnoVigenteSmokeTests`, `ListarTurnosVigentesSmokeTests`) SI estaban explicitamente
anticipados por el planner en esa misma seccion y por el CA-6, asi que su actualizacion no es una
desviacion sino la ejecucion directa del plan. La desviacion real es esta:

- **Sugerencia del issue**: "Impacto en archivos" no menciona
  `AsignarTurnoViaSbSmokeTests.cs` ni `src/.../MarcacionAdicionada.cs` (DomainEvents).
- **Desviacion aplicada**: se actualizaron tambien esos dos archivos. `AsignarTurnoViaSbSmokeTests.cs`
  componia localmente `$"{codigoColaborador}:{fecha:yyyy-MM-dd}"` para verificar la persistencia
  de `turno_diario_asignado` (3 ocurrencias) -- sin renotarlo, el smoke habria buscado el stream
  bajo la clave vieja, un stream inexistente en el store renotado, dejandolo permanentemente rojo
  contra dev. `MarcacionAdicionada.cs` (DomainEvents) tenia un comentario de documentacion citando
  el formato viejo del `Id`.
- **Razon**: ambos archivos ejercen exactamente el mismo eje que el resto del issue (la notacion
  de la clave) y el cambio es igual de mecanico; dejarlos con el formato viejo habria sido una
  inconsistencia documental (el comentario) y una regresion funcional real (el smoke test) no
  detectable por `dotnet test` local (los smoke tests que dependen de ServiceBus/Postgres se
  omiten sin esa infraestructura).
- **Consecuencia conocida**: ninguna adicional — el cambio es estrictamente el mismo patron
  aplicado ya al resto de archivos listados por el planner.

### Precedentes consultados
- `RegistroDeMarcacionAggregateRoot.ComputarStreamId` (issue #419, prefijo `rdm:`): patron
  espejo, alineado con CA-ADR-0031 — replicado sin modificacion de criterio.

### Infraestructura modificada
Ninguna — este issue no toca topics/subscriptions de Service Bus.

### Complejidad encontrada
Ninguna. Cambio de bajo riesgo, acotado y ya cubierto por los tests del test-writer; el unico
trabajo de descubrimiento fue localizar las composiciones de clave adicionales (grep de
`{codigoColaborador}:{fecha` en todo `src/`+`tests/`) que el planner no habia enumerado
explicitamente pero que comparten el mismo eje.

### Resultado
- Tests pasando: 1324/1324 (48 omitidos por falta de Postgres/ServiceBus en local, comportamiento
  esperado de los smoke tests).

</details>
<details>
<summary>Reviewer (fase refactor) — 44m 10s</summary>

## ES Reviewer - Revision (issue #420)

### Evaluacion general
- Calidad: **buena** (el eje del cambio -- la renotacion -- esta completo, consistente y bien cubierto)
- Cambios realizados: **si** (un refactor de robustez sobre el punto unico de conversion, limpieza de
  comentarios MEF-ADR-0044 y la enmienda del registro que CA-ADR-0031 paso 6 exige)
- Baseline y estado final: 1324/1324 verdes, 48 omitidos (smoke sin Postgres/ServiceBus local).
  Sin reporte de bloqueo heredado.

### Cumplimiento de ADRs aplicables

| ADR | Cumplimiento | Observacion |
|---|---|---|
| CA-ADR-0031: identidad de streams por store | **desviacion NO declarada** (corregida) | Pasos 1-5 de la heuristica cumplidos al pie de la letra (prefijo `cd` por iniciales, separador `:`, fecha ISO 8601 basico, split en 3 partes con test). **Paso 6 incumplido**: ni el implementer ni el test-writer enmendaron el registro de la seccion 4, que el propio ADR manda actualizar "cada vez que un issue crea un aggregate nuevo o migra uno existente". Corregido en esta fase. |
| MEF-ADR-0037: identidad de stream como string | ok | `ComputarStreamId` sigue siendo el unico punto de conversion en `src/` (grep exhaustivo: los 3 consumidores -- `ProgramacionTurnoDiarioSolicitadaEventHandler`, `RegistroDeMarcacionCreadoEventHandler`, `ObtenerTurnoVigente/FunctionEndpoint` -- lo invocan, ninguno concatena). Ningun `ToString` con especificador explicito sobre un `Guid`; el formato explicito esta donde el ADR lo exige (componente fecha). Seccion 3 respetada: la proyeccion materializa desde `StreamKey`, no reconstruye. |
| MEF-ADR-0037 seccion 2 (borde HTTP) | ok | `ObtenerTurnoVigente/FunctionEndpoint` recibe `codigoColaborador` y `fecha` como componentes tipados en segmentos separados, parsea la fecha una sola vez (`DateOnly.TryParseExact` + `InvariantCulture`) con `BadRequestObjectResult` **y mensaje**, y reconstruye la clave con `ComputarStreamId`. La clave concatenada nunca viaja en la URL. Sin cambios necesarios. |
| MEF-ADR-0026: convergencia sobre el mismo aggregate | n/a (verificado) | Re-verificado de forma independiente: `grep -rn 'groupId\|SessionId\|requires_session'` sobre `src/` e `infra/` devuelve cero. No hay `PublishOptions.GroupId` que renotar. |
| MEF-ADR-0036: identidad de eventos persistidos | n/a (protocolo) / **escalado** | Ningun tipo de evento se mueve ni se renombra, asi que su protocolo de dos despliegues no aplica. Su **disciplina de purga** si es el precedente que sostiene este PR y queda escalada abajo ("Riesgo escalado"). |
| MEF-ADR-0034 / MEF-ADR-0035: read-side | ok | `TurnoVigenteProjection` conserva `partial` sobre la clase companion, metodos estaticos que retornan `view with { ... }`, y el read model sigue siendo un `record` plano en `ReadModels` sin `ProjectReference`. Solo cambiaron comentarios y literales de test. |
| MEF-ADR-0016: naming de tests | ok | Los dos tests nuevos siguen `<Sujeto>_<LoQuePasa>[_Cuando<Condicion>]` con el sujeto = metodo bajo prueba (`ComputarStreamId_...`), espejo del precedente #419. Solo `[Fact]`. |
| MEF-ADR-0044: comentarios minimos | aplicado en esta fase | Ver "Limpieza de comentarios". |

### Desviaciones de ADRs

**Desviaciones declaradas por el implementer** (de `stage-2-implementer.md`):

#### Desviacion: plan del planner (no de un ADR) -- archivos fuera de "Impacto en archivos"
- **Regla**: el issue enumera los archivos anticipados; desviarse exige documentarlo.
- **Desviacion aplicada**: se renotaron ademas `AsignarTurnoViaSbSmokeTests.cs` (3 composiciones locales de clave) y el comentario de `MarcacionAdicionada.cs`.
- **Razon del implementer**: sin renotar, ese smoke test buscaria un stream inexistente contra el store renotado y quedaria permanentemente rojo en dev.
- **Consecuencia conocida**: ninguna adicional.
- **Evaluacion del reviewer**: **aceptable y necesaria**. Verificado que la afirmacion es correcta: las 3 ocurrencias eran composiciones de la clave de `ControlDiario` usadas contra `PostgresFixture.ExisteEventoAsync`. Omitirlas habria dejado el issue incompleto (el planner lo omitio, no el implementer). El comentario de `MarcacionAdicionada.cs` documenta el `Id` que ese evento transporta -- mismo eje.
- **Status**: cerrada favorablemente, no requiere evaluacion del usuario.

#### Desviacion (test-writer): CA-6 y los 4 smoke tests no tocados en fase roja
- **Evaluacion del reviewer**: **aceptable**. El deslinde de rol es correcto y el implementer cubrio los cuatro archivos en fase verde, mas el quinto que el planner no habia enumerado. CA-6 queda cubierto; ningun hueco.

**Desviaciones detectadas por el reviewer (NO declaradas por el implementer)**:

#### Desviacion: CA-ADR-0031, paso 6 de la heuristica
- **Regla del ADR**: *"Registrar la anatomia en el registro del store (seccion 3) -- este ADR se enmienda cada vez que un issue crea un aggregate nuevo o migra uno existente."*
- **Desviacion encontrada**: el PR ejecuta la migracion de `ControlDiarioAggregateRoot` pero dejo la seccion 4 declarando `{codigo}:{yyyy-MM-dd}` como "anatomia **vigente**" y `cd:{codigo}:{yyyyMMdd}` como "objetivo". El ADR quedaba afirmando como vigente algo que el codigo ya no hace -- justo la clase de desincronizacion que el registro existe para evitar (su propia seccion "Negativas" reconoce que el paso 6 depende de disciplina, sin enforcement mecanico).
- **Accion tomada**: **corregida** en `docs/adr/ca-adr-0031-identidad-de-streams-por-store.md` -- fila de `ControlDiario` a vigente, nota de deuda reescrita (de "claves legadas conviviendo" al costo permanente de migrar una clave ya desplegada), y entrada nueva en Control de cambios. El Contexto **no** se toco: describe el estado al momento de decidir y es historia del ADR, no registro.
- **Status**: resuelta; se informa al usuario por tratarse de una edicion de ADR.

#### Hallazgo del precedente: #419 dejo el mismo paso 6 sin ejecutar
- `RegistroDeMarcacionAggregateRoot` ya produce `rdm:{codigo}:{yyyyMMddTHHmmss}` en `main`, pero su fila del registro seguia declarando la forma legada como vigente. Es el mismo defecto, una iteracion antes -- **no** una justificacion para repetirlo (precedente != autoridad).
- **Accion tomada**: la fila de `rdm` se corrigio en la misma enmienda. Es documentacion de riesgo cero y dejar media tabla mintiendo habria sido peor que la desviacion de alcance. Se reporta explicitamente para que quede trazado.

### Precedentes consultados por el implementer

| Precedente | ADR aplicable | Veredicto |
|---|---|---|
| `RegistroDeMarcacionAggregateRoot.ComputarStreamId` (#419, prefijo `rdm:`) | CA-ADR-0031 | **alineado en el codigo**, con dos matices: (1) el precedente extrae `PrefijoStreamId` **y** `SeparadorStreamId` como constantes, y el diff solo replicaba la primera -- corregido en refactor; (2) el precedente incumplio el paso 6 del ADR (registro sin enmendar) -- reportado arriba como bug separado y corregido, no replicado. |

### Convenciones del pipeline (no ADRs)

| Convencion | Estado | Observacion |
|---|---|---|
| Cada test con `Then()` + `And<>()` | ok | Los tests de handler modificados conservan `Then(streamId, ...)` + `And<>()`; el test-writer sumo 3 `And<ControlDiarioAggregateRoot, DateOnly>(..., c => c.Fecha, ...)` para CA-3. Los 2 tests nuevos son unitarios puros sobre un metodo estatico (sin harness), donde el DSL no aplica -- mismo formato que el precedente #419. |
| Overloads correctos para stream IDs compuestos | ok | `ControlDiario` tiene clave compuesta y todos los tests usan `Then(streamId, ...)`, `And<T,P>(streamId, ...)`, `Given(streamId, ...)`. |
| Fakes manuales (no NSubstitute) | ok | Sin dependencias nuevas; no se introdujo ningun mock. |
| Feature folders (produccion y tests) | ok | Sin archivos nuevos de produccion; el test nuevo va a `Entities/`, espejo del aggregate y del precedente. |
| Smoke tests: SkipWhen, secrets, cobertura | ok | `Assert.SkipWhen` (xUnit v3, no `Skip.When`) presente en todos los tests que dependen de `ServiceBusFixture`/`PostgresFixture` de los 4 archivos tocados; los que solo usan `ApiFixture` no lo requieren (patron preexistente). Aserciones filtran por `SolicitudId`/`CodigoColaborador` unico, nunca por posicion. Sin secrets en `appsettings.json`. **Cobertura por efecto**: el PR no agrega efectos secundarios -- solo cambia la clave bajo la que ya se verificaban; ambos efectos siguen cubiertos (Postgres via `ExisteEventoAsync` sobre el stream `cd:`, Service Bus via la suscripcion `smoke-tests` de `dia-calculado`). Sin archivos duplicados por comando. |
| Proyecciones read-side (partial, inmutabilidad, read APIs, naming, cuarta isla) | ok | Solo comentarios y literales. `ReadModels.csproj` intacto (cero `ProjectReference`). |
| Antipatrones de habilitacion (MEF-ADR-0039) | n/a | `git diff main...HEAD -- '**/*.csproj'` vacio; ningun tipo de evento nuevo declarado. |
| Compatibilidad Marten write-side/read-side | ok | El gate dispara por tocar `ConfiguracionMartenProjectionsControlHoras.cs`, pero el cambio es **exclusivamente un comentario**: ningun atributo de la columna "debe coincidir" (`DatabaseSchemaName`, `StreamIdentity`, `EventNamingStyle`, `TenancyStyle`, `MetadataConfig`, serializador, `AddEventTypes`, `AllDocumentsAreMultiTenanted`) cambio en ninguno de los dos lados, ni la version de `Cosmos.EventSourcing.CritterStack`. No se decompilo: sin cambio de configuracion ni de version, la linea base previa se preserva por construccion. Nota adyacente: renotar la clave no interactua con `StreamIdentity = AsString` -- la clave nueva sigue siendo string. |
| Identidad de stream (MEF-ADR-0037) | ok | (1) Ningun especificador explicito sobre `Guid`; el formato explicito del componente fecha es lo que el ADR exige. (2) Ninguna construccion manual de clave fuera de `ComputarStreamId` en `src/` -- las reconstrucciones locales de los smoke tests son deliberadas y documentadas (ese proyecto no referencia el Function App), precedente ya vigente en Colaboradores. (3) El GET parsea tipado con `400` explicito y mensaje. |
| Contrato HTTP de comandos (MEF-ADR-0043) | n/a | El diff no agrega ningun `FunctionEndpoint.cs` de comando (`--diff-filter=A` vacio) ni el issue pacta la migracion de uno preexistente. El issue declara explicitamente "Contrato HTTP: no aplica". |
| Control de volumen de telemetria (MEF-ADR-0038) | n/a | El diff no toca `ComposicionServicios*`, `ConfiguracionObservabilidad*`, `SetSampler`, `UseAzureMonitorExporter` ni el callback de Wolverine. |
| Limpieza de comentarios (MEF-ADR-0044) | ok | Aplicada sobre los 22 `.cs` del diff, behavior-preserving, sin salir del diff propio. Ver seccion dedicada. |
| Tests via ToString/comportamiento | ok | Los tests nuevos ejercitan un metodo publico estatico; no se expuso ningun getter para test. |
| Sin numeros magicos | ok | Al contrario: el refactor **elimino** literales de anatomia (`':'`, `"yyyyMMdd"`) a constantes con nombre. |
| Condiciones en positivo | n/a | El diff no introduce ninguna bifurcacion `if`/`else`. |
| Caracter U+2500 | ok | Cero ocurrencias en los archivos del diff. |
| `dotnet format` sobre archivos del diff | ok | Un unico diagnostico (IDE0005 en `MarcacionAdicionadaSerializacionTests.cs:7`), **preexistente e identico en `main`** -- no lo introduce este PR y corregirlo seria fuera de alcance. |

### Elegancia del codigo

El diff llegaba mecanicamente correcto pero con dos debilidades reales en el punto unico de conversion,
ambas del tipo que no rompe ningun test hoy y rompe datos manana:

1. **Anatomia acoplada en literales sueltos.** `ComputarStreamId` escribia `":"` y `"yyyyMMdd"` como
   literales, y `ExtraerFechaDeStreamId` -- su inverso, en el mismo archivo -- repetia ambos por su
   cuenta (`Split(':')`, `ParseExact(..., "yyyyMMdd")`). Son dos sitios que **deben** coincidir por
   construccion: cambiar uno sin el otro compila limpio y falla en runtime al hidratar `Fecha`. El
   aggregate hermano del mismo store (`RegistroDeMarcacion`, #419) ya habia extraido `SeparadorStreamId`
   por esta misma razon; el diff solo replico `PrefijoStream`.
2. **`ToString`/`ParseExact` de la clave sin `CultureInfo`.** Ambos resolvian contra `CurrentCulture`.
   Bajo una culture con calendario no gregoriano (`ar-SA`, Umm al-Qura) `fecha.ToString("yyyyMMdd")`
   rinde otro ano: claves de stream corruptas, sin excepcion. Es preexistente, pero vive en las dos
   lineas exactas que este PR reescribe, y el propio dominio ya tiene el precedente correcto
   (`ObtenerTurnoVigente/FunctionEndpoint` usa `InvariantCulture` explicito).

Fuera de eso, el codigo es compacto, idiomatico y sin deuda: sin duplicacion, sin `switch` sustituible
por lookup, sin excepciones tragadas, sin debug cruft, sin warnings nuevos.

### Criticas y hallazgos

| # | Hallazgo | Severidad | Estado |
|---|---|---|---|
| 1 | CA-ADR-0031 paso 6: registro del store no enmendado tras la migracion | mayor (desviacion de ADR no declarada) | corregido |
| 2 | El precedente #419 arrastra el mismo defecto del paso 6 | mayor (bug de precedente, ajeno a este PR) | corregido en la misma enmienda, reportado aparte |
| 3 | Separador y formato de fecha duplicados entre `ComputarStreamId` y su inverso | menor (robustez) | corregido |
| 4 | Clave de stream formateada/parseada con `CurrentCulture` | menor (robustez en boundary persistido) | corregido |
| 5 | Provenance y narracion redundante en 12 comentarios del diff | cosmetico | corregido (MEF-ADR-0044) |
| 6 | 4 lineas de comentario pasadas de 120 columnas por el reflow del diff | cosmetico | corregido |
| 7 | IDE0005 en `MarcacionAdicionadaSerializacionTests.cs:7` | cosmetico | **no corregido**: preexistente e identico en `main`, fuera del alcance del issue |

Ningun comentario del diff contradice su implementacion.

### Refactorings aplicados

1. **`ControlDiarioAggregateRoot`: anatomia de la clave en tres constantes privadas.**
   `PrefijoStream` -> `PrefijoStreamId` (nombre del precedente hermano), mas `SeparadorStreamId` y
   `FormatoFechaStreamId` nuevas, usadas por `ComputarStreamId` **y** por `ExtraerFechaDeStreamId`. El
   inverso ya no puede desincronizarse del directo sin un error de compilacion. Alinea al aggregate con
   `RegistroDeMarcacionAggregateRoot`, su vecino de store.
2. **`CultureInfo.InvariantCulture` explicito** en `fecha.ToString(...)` y en `DateOnly.ParseExact(...)`
   (mas `using System.Globalization;`). Mismo criterio que ya aplica el GET del dominio.
3. **`ComputarStreamId` con cuerpo de bloque** en vez de expresion, para que la interpolacion con tres
   constantes quepa legible en una linea.

Cada refactor se verifico con `dotnet test` (verde), sin revertir nada.

### Limpieza de comentarios (MEF-ADR-0044)

| Archivo | Poda / compresion | Condicion del umbral no cumplida |
|---|---|---|
| `MarcacionAdicionada.cs` | `// CA-7: Id es el stream ID del ControlDiario: "cd:{...}:{...}" (issue #420, CA-ADR-0031)` comprimido a la restriccion, apuntando al punto unico en vez de copiar el literal | Context Delta (el literal duplica el oraculo real, que es `ComputarStreamId`; la copia envejece sola) + provenance |
| `TurnoVigenteProjection.cs`, `TurnoVigente.cs`, `ConfiguracionMartenProjectionsControlHoras.cs`, `AssertsProyecciones.cs` | `(issue #420, CA-ADR-0031)` eliminado; parrafos re-flowados a <=120 columnas | Cita de ADR **sola**, sin restriccion local activa que la acompane = provenance disfrazada (Skill paso 7). La restriccion de cada bloque se conservo intacta |
| 8 archivos de `ControlHoras.Tests` | `// Issue #420: stream ID renotado con prefijo "cd" y fecha en ISO 8601 basico (CA-ADR-0031).` sobre cada constante `StreamId` | Ambas: el literal de la linea siguiente dice exactamente lo mismo (sin Context Delta) y su ausencia no habilita ninguna edicion plausible-pero-incorrecta (sin Decision Delta) |
| `RegistroDeMarcacionCreadoEventHandlerTests.cs` | ademas, 3 lineas de provenance (`// CA-7: stream ID es "cd:..."`, dos `// Issue #420 CA-3: ...`) que narraban los asserts inmediatamente debajo | Ambas |
| `TurnoDiarioAsignadoSerializacionTests.cs` | parrafo XML doc nuevo (5 lineas) comprimido a 2, integrado en la advertencia que el archivo ya tenia sobre la purga | Context Delta: repetia para #420 lo que el parrafo previo ya enunciaba. La restriccion (los literales no acreditan compatibilidad con streams viejos) **se conserva** |
| `ObtenerTurnoVigenteSmokeTests.cs`, `WarmupFixture.cs` | provenance agregada por el diff; se conserva la restriccion preexistente (por que el smoke reconstruye la clave localmente / por que el stream del cebado queda aislado) | Provenance |
| `ControlDiarioAggregateRootTests.cs` (nuevo) | header y comentario de CA-2 comprimidos: se conserva **por que** no usa el harness y **que impide** el test (quitar el prefijo o volver a ISO extendido); se poda la narracion del issue y del precedente | Provenance; la restriccion sobrevive reformulada como consecuencia futura |

Sin cambios en `AsignarTurnoViaSbSmokeTests.cs`, `ListarTurnosVigentesSmokeTests.cs`,
`RegistrarMarcacionSmokeTests.cs`, `TurnoVigenteProjectionTests.cs`, `DepurarAlAsignarTurnoTests.cs` y
los demas: **ya estaban limpios** (el diff solo les cambio literales). Suite verde despues de la
limpieza, confirmando que fue puramente textual.

### Cobertura de criterios de aceptacion

| Criterio | Estado | Test(s) |
|---|---|---|
| CA-1: `ComputarStreamId` produce `cd:ABC123:20260819` | cubierto | `ControlDiarioAggregateRootTests.ComputarStreamId_ProduceNotacionConPrefijoCdYFechaBasica` |
| CA-2: `Split(':')` devuelve exactamente 3 partes | cubierto | `ControlDiarioAggregateRootTests.ComputarStreamId_ProduceClaveDivisibleEnTresPartes_AlHacerSplitPorElSeparador` (verifica ademas cada componente por separado) |
| CA-3: `ExtraerFechaDeStreamId` hidrata `Fecha` desde la notacion nueva | cubierto | `RegistroDeMarcacionCreadoEventHandlerTests.RegistroDeMarcacionCreado_CreaControlDiarioConMarcacion_CuandoNoExisteYHoraFueraDeVentanaNocturna` y `..._CreaDosControlDiarios_CuandoHoraEstaDentroDeVentanaNocturna` (este ultimo cubre el caso duro: dos streams del mismo colaborador con fechas distintas, cada uno hidratando la suya) |
| CA-4: `TurnoVigente.Id` = StreamKey renotado, identidad invariante entre eventos | cubierto | `TurnoVigenteProjectionTests` (8 literales renotados; `Apply_Sobrescribe*` / `Apply_Refresca*` verifican que `Id` no cambia tras el segundo evento del mismo stream) |
| CA-5: los formatos de fecha de la API no cambian | cubierto | `ListarTurnosVigentes/FunctionEndpointTests` y los smoke de ruta siguen verdes **sin modificar su logica**; verificado por lectura que `ObtenerTurnoVigente/FunctionEndpoint.FormatoFecha` sigue en `"yyyy-MM-dd"` y que los `yyyy-MM-dd` supervivientes en el repo son solo rutas, query params y payloads |
| CA-6: smoke tests bajo claves `cd:` | cubierto | `WarmupFixture`, `RegistrarMarcacionSmokeTests` (2 claves inline), `ObtenerTurnoVigenteSmokeTests` (helper + `respuesta.Id`), `ListarTurnosVigentesSmokeTests` (`turno.Id`) y -- fuera del plan, correctamente -- `AsignarTurnoViaSbSmokeTests` (3 claves) |

Verificacion independiente de completitud: grep sobre `src/` + `tests/` no deja ninguna composicion de
clave de `ControlDiario` en formato viejo.

### Tests agregados
Ninguno. Los 2 tests nuevos del test-writer cubren CA-1 y CA-2 con el mismo rigor que el precedente
#419, y los 3 asserts de `c => c.Fecha` cierran CA-3 incluyendo el caso de dos fechas simultaneas. No
aplica cobertura de contratos de VO (el diff no toca ningun `IEquatable<T>` ni `ConfigurarSerializacion`)
ni guardrail de portabilidad por bus (ningun evento con marker de bus en el diff).

### Riesgo escalado al humano (no lo cubre ningun test)

**La ventana operativa de purga es condicion de correctitud de este PR, no una tarea opcional.** El
codigo cambia la clave con la que se resuelven streams **ya escritos**; ningun test -- unitario, de
composicion o smoke -- puede detectar su ausencia:

- Sin purga del store de `control_horas` en dev, un `TurnoDiarioAsignado` o una `MarcacionAdicionada`
  sobre un dia que ya tiene stream viejo abre un stream nuevo bajo `cd:`: **la biografia del dia queda
  partida en dos** y el desglose de horas se calcula sobre la mitad. Silencioso, sin excepcion.
- Los documentos `TurnoVigente` viejos quedan huerfanos bajo su id anterior: el GET responde `404` para
  dias que "existian" hasta el despliegue. El rebuild es gratis **solo si** la purga se lleva tambien los
  documentos y la progresion del daemon.
- Drenar las colas de Service Bus en la misma ventana no es accesorio: un mensaje en vuelo computa la
  clave nueva sobre un store recien purgado y, si convive con reenvios, reintroduce el mismo particionado.

Es exactamente la disciplina que MEF-ADR-0036 seccion 5 fija para el caso analogo (identidad de evento
persistido) y que CA-ADR-0031 seccion 3 hereda para la clave de stream. Idealmente en la misma ventana
que #419. Queda registrado ademas en la enmienda del ADR: en un entorno con datos reales, esta misma
migracion exigiria el protocolo de dos despliegues, no la purga.

</details>

## Cobertura

| Archivo | Cobertura | Umbral | Estado |
|---|---|---|---|
| TurnoVigenteProjection.cs | 96.0% | 95% | ok |
| ControlDiarioAggregateRoot.cs | 100.0% | 95% | ok |
| TurnoVigente.cs | - | excluido | - |
| MarcacionAdicionada.cs | - | sin clasificar | ⚠ revisar |
| ConfiguracionMartenProjectionsControlHoras.cs | - | sin clasificar | ⚠ revisar |

> **Archivos sin clasificar** (`⚠ revisar`): ninguna regla de clasificacion los reconocio — el gate **no los midio**. No es una exclusion deliberada (a diferencia de `excluido`, donde si se decidio que no requieren cobertura): requieren revision humana para confirmar si necesitan tests.
## Commits

5363184 refactor(#420): constantes de anatomia, cultura invariante y registro del ADR
cd38413 feat(hu-420): renota stream ids de ControlDiario a cd:{codigo}:{yyyyMMdd} (fase verde)
b372ea7 test(issue-420): renotar stream ids de ControlDiario a cd: en tests (fase roja)

Closes #420