### PR TITLE
Enriquecer DiaDepurado con franjas, marcaciones y horas liquidables

### DIFF
--- a/src/Bitakora.ControlAsistencia.ControlHoras/Entities/ControlDiarioAggregateRoot.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Entities/ControlDiarioAggregateRoot.cs
@@ -172,10 +172,30 @@ public partial class ControlDiarioAggregateRoot : AggregateRoot
     // a campo. Debe invocarse DESPUES del Apply: lee DesgloseHoras, que RecalcularDesgloseHoras()
     // refresca al final de cada uno.
     //
-    // Issue #424: el payload se enriquece con NombreTurno (DetalleTurno?.Nombre), Franjas (espejo de
-    // ControlesDeFranja) y Marcaciones (todas, ordenadas cronologicamente) -- pendiente de
-    // implementacion (fase roja).
-    public DiaDepurado CrearDiaDepurado() => throw new NotImplementedException();
+    // Issue #424: NombreTurno es la senal estructural del plan (DetalleTurno?.Nombre); Franjas espeja
+    // ControlesDeFranja (plan + realidad); Marcaciones viaja completa y ordenada cronologicamente --
+    // CONTRATO del evento, no garantia incidental del orden de llegada al aggregate.
+    public DiaDepurado CrearDiaDepurado() =>
+        new(
+            ExtraerCodigoColaboradorDeStreamId(Id),
+            Fecha,
+            CrearResumenColaborador(),
+            DetalleTurno?.Nombre,
+            _controlesDeFranja.Select(CrearFranjaDepurada).ToList(),
+            _marcaciones
+                .OrderBy(m => m.TimestampNormalizado)
+                .Select(m => new MarcacionDelDia(m.TimestampNormalizado, m.TipoMarcacion))
+                .ToList(),
+            DesgloseHoras.Discriminar());
+
+    private static FranjaDepurada CrearFranjaDepurada(ControlFranja controlFranja) =>
+        new(
+            controlFranja.Programada.HoraInicio,
+            controlFranja.Programada.HoraFin,
+            controlFranja.Programada.DiaOffsetFin,
+            controlFranja.Entrada,
+            controlFranja.Salida,
+            controlFranja.EsAnomala);
 
     // El aggregate vive en el Function App, el unico proyecto que ve las tres islas de eventos, asi
     // que el mapeo entre ellas vive aqui (CA-ADR-0029 decision #5). Composicion transitoria:

--- a/src/Bitakora.ControlAsistencia.ControlHoras/Entities/ControlDiarioAggregateRoot.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Entities/ControlDiarioAggregateRoot.cs
@@ -171,12 +171,11 @@ public partial class ControlDiarioAggregateRoot : AggregateRoot
     // Tell-don't-Ask: el aggregate entrega el evento ya empaquetado al handler, que no lo arma campo
     // a campo. Debe invocarse DESPUES del Apply: lee DesgloseHoras, que RecalcularDesgloseHoras()
     // refresca al final de cada uno.
-    public DiaDepurado CrearDiaDepurado() =>
-        new(
-            ExtraerCodigoColaboradorDeStreamId(Id),
-            Fecha,
-            CrearResumenColaborador(),
-            DesgloseHoras.Discriminar());
+    //
+    // Issue #424: el payload se enriquece con NombreTurno (DetalleTurno?.Nombre), Franjas (espejo de
+    // ControlesDeFranja) y Marcaciones (todas, ordenadas cronologicamente) -- pendiente de
+    // implementacion (fase roja).
+    public DiaDepurado CrearDiaDepurado() => throw new NotImplementedException();
 
     // El aggregate vive en el Function App, el unico proyecto que ve las tres islas de eventos, asi
     // que el mapeo entre ellas vive aqui (CA-ADR-0029 decision #5). Composicion transitoria:

--- a/src/Bitakora.ControlAsistencia.ControlHoras/Entities/ControlDiarioAggregateRoot.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Entities/ControlDiarioAggregateRoot.cs
@@ -171,10 +171,6 @@ public partial class ControlDiarioAggregateRoot : AggregateRoot
     // Tell-don't-Ask: el aggregate entrega el evento ya empaquetado al handler, que no lo arma campo
     // a campo. Debe invocarse DESPUES del Apply: lee DesgloseHoras, que RecalcularDesgloseHoras()
     // refresca al final de cada uno.
-    //
-    // Issue #424: NombreTurno es la senal estructural del plan (DetalleTurno?.Nombre); Franjas espeja
-    // ControlesDeFranja (plan + realidad); Marcaciones viaja completa y ordenada cronologicamente --
-    // CONTRATO del evento, no garantia incidental del orden de llegada al aggregate.
     public DiaDepurado CrearDiaDepurado() =>
         new(
             ExtraerCodigoColaboradorDeStreamId(Id),
@@ -182,11 +178,16 @@ public partial class ControlDiarioAggregateRoot : AggregateRoot
             CrearResumenColaborador(),
             DetalleTurno?.Nombre,
             _controlesDeFranja.Select(CrearFranjaDepurada).ToList(),
-            _marcaciones
-                .OrderBy(m => m.TimestampNormalizado)
-                .Select(m => new MarcacionDelDia(m.TimestampNormalizado, m.TipoMarcacion))
-                .ToList(),
+            CrearMarcacionesCronologicas(),
             DesgloseHoras.Discriminar());
+
+    // El orden ascendente es contrato del evento, no un reflejo de _marcaciones: el aggregate las
+    // guarda por orden de llegada, que puede no ser cronologico.
+    private List<MarcacionDelDia> CrearMarcacionesCronologicas() =>
+        _marcaciones
+            .OrderBy(m => m.TimestampNormalizado)
+            .Select(m => new MarcacionDelDia(m.TimestampNormalizado, m.TipoMarcacion))
+            .ToList();
 
     private static FranjaDepurada CrearFranjaDepurada(ControlFranja controlFranja) =>
         new(

--- a/src/Bitakora.ControlAsistencia.ControlHoras/ValueObjects/DesgloseHoras.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ValueObjects/DesgloseHoras.cs
@@ -40,9 +40,21 @@ public record DesgloseHoras(
     // .resx); por retardo, RetardoTotal.ToString() cuando el neto es > 0. Solo viajan los strings ya
     // traducidos: el modelo de dominio rico no cruza el bus, pero su ToString() si.
     //
-    // Issue #424: el diccionario resultante habla horas liquidables (HorasLiquidables.DesdeMinutos),
-    // no minutos -- pendiente de implementacion (fase roja).
-    public HorasDiscriminadas Discriminar() => throw new NotImplementedException();
+    public HorasDiscriminadas Discriminar()
+    {
+        var horasPorConcepto = TotalMinutosPorConcepto
+            .ToDictionary(kv => kv.Key.ToString(), kv => HorasLiquidables.DesdeMinutos(kv.Value));
+
+        var trazabilidad = ConstruirTrazabilidadPorConcepto();
+
+        if (RetardoTotal.RetardoNeto > 0)
+        {
+            horasPorConcepto[ClaveRetardo] = HorasLiquidables.DesdeMinutos(RetardoTotal.RetardoNeto);
+            trazabilidad.Add(RetardoTotal.ToString());
+        }
+
+        return new HorasDiscriminadas(horasPorConcepto, trazabilidad);
+    }
 
     // Una linea por concepto presente en el dia: sus intervalos (de todas las franjas, en orden
     // cronologico) renderizados via ToString() y la etiqueta humana traducida una sola vez. Como cada

--- a/src/Bitakora.ControlAsistencia.ControlHoras/ValueObjects/DesgloseHoras.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ValueObjects/DesgloseHoras.cs
@@ -39,22 +39,10 @@ public record DesgloseHoras(
     // item con minutos > 0: por concepto, derivada de los ToString() ricos (IntervaloTemporal + etiqueta
     // .resx); por retardo, RetardoTotal.ToString() cuando el neto es > 0. Solo viajan los strings ya
     // traducidos: el modelo de dominio rico no cruza el bus, pero su ToString() si.
-    public HorasDiscriminadas Discriminar()
-    {
-        var minutosPorConcepto = TotalMinutosPorConcepto
-            .Where(par => par.Value > 0)
-            .ToDictionary(par => par.Key.ToString(), par => par.Value);
-
-        var trazabilidad = ConstruirTrazabilidadPorConcepto();
-
-        if (RetardoTotal.RetardoNeto > 0)
-        {
-            minutosPorConcepto[ClaveRetardo] = RetardoTotal.RetardoNeto;
-            trazabilidad.Add(RetardoTotal.ToString());
-        }
-
-        return new HorasDiscriminadas(minutosPorConcepto, trazabilidad);
-    }
+    //
+    // Issue #424: el diccionario resultante habla horas liquidables (HorasLiquidables.DesdeMinutos),
+    // no minutos -- pendiente de implementacion (fase roja).
+    public HorasDiscriminadas Discriminar() => throw new NotImplementedException();
 
     // Una linea por concepto presente en el dia: sus intervalos (de todas las franjas, en orden
     // cronologico) renderizados via ToString() y la etiqueta humana traducida una sola vez. Como cada

--- a/src/Bitakora.ControlAsistencia.ControlHoras/ValueObjects/DesgloseHoras.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ValueObjects/DesgloseHoras.cs
@@ -30,20 +30,16 @@ public record DesgloseHoras(
     // diccionario plano.
     private const string ClaveRetardo = "Retardo";
 
-    // Traduce el desglose rico al payload plano que viaja en DiaDepurado.
-    // Tell-don't-Ask: el desglose se discrimina a si mismo (no se exponen sus internos para que un
-    // colaborador externo arme el diccionario). Vuelca TotalMinutosPorConcepto con clave Concepto.ToString()
-    // y agrega la clave literal "Retardo" con RetardoTotal.RetardoNeto solo cuando es > 0.
-    //
-    // Ademas puebla Trazabilidad, la memoria de calculo legible del dia. Una linea por
-    // item con minutos > 0: por concepto, derivada de los ToString() ricos (IntervaloTemporal + etiqueta
-    // .resx); por retardo, RetardoTotal.ToString() cuando el neto es > 0. Solo viajan los strings ya
-    // traducidos: el modelo de dominio rico no cruza el bus, pero su ToString() si.
-    //
+    // Tell-don't-Ask: el desglose se discrimina a si mismo, sin exponer sus internos para que un
+    // colaborador externo arme el diccionario. El diccionario solo lleva claves con valor (minutos > 0):
+    // publicar un concepto en cero le daria al consumidor una clave sin significado.
+    // Del modelo rico solo viajan los strings ya traducidos de Trazabilidad (ToString() de
+    // IntervaloTemporal y Retardo): el modelo de dominio rico no cruza el bus (MEF-ADR-0012).
     public HorasDiscriminadas Discriminar()
     {
         var horasPorConcepto = TotalMinutosPorConcepto
-            .ToDictionary(kv => kv.Key.ToString(), kv => HorasLiquidables.DesdeMinutos(kv.Value));
+            .Where(par => par.Value > 0)
+            .ToDictionary(par => par.Key.ToString(), par => HorasLiquidables.DesdeMinutos(par.Value));
 
         var trazabilidad = ConstruirTrazabilidadPorConcepto();
 
@@ -56,10 +52,10 @@ public record DesgloseHoras(
         return new HorasDiscriminadas(horasPorConcepto, trazabilidad);
     }
 
-    // Una linea por concepto presente en el dia: sus intervalos (de todas las franjas, en orden
-    // cronologico) renderizados via ToString() y la etiqueta humana traducida una sola vez. Como cada
-    // intervalo dura > 0min, hay exactamente un concepto por clave de MinutosPorConcepto (sin contar
-    // "Retardo"). Para un concepto con un unico intervalo coincide con IntervaloClasificado.ToString().
+    // Una linea por concepto presente en el dia, con sus intervalos en orden cronologico y la etiqueta
+    // humana traducida una sola vez. Como IntervaloTemporal garantiza Inicio < Fin, cada concepto
+    // presente aporta minutos > 0: por eso hay tantas lineas como claves de HorasPorConcepto (sin
+    // contar "Retardo").
     private List<string> ConstruirTrazabilidadPorConcepto() =>
         DesglosePorFranja
             .SelectMany(franja => franja.Intervalos)

--- a/src/Bitakora.ControlAsistencia.ControlHoras/ValueObjects/HorasLiquidables.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ValueObjects/HorasLiquidables.cs
@@ -1,18 +1,15 @@
 namespace Bitakora.ControlAsistencia.ControlHoras.ValueObjects;
 
-// Issue #424: la frontera de idiomas del BC. El mundo maquina (ControlDiario) habla minutos enteros;
-// desde DiaDepurado hacia el mundo humano (aprobacion, vistas, nomina) se habla horas liquidables.
-// Unico punto de conversion del BC -- ninguna otra clase debe dividir minutos entre 60 a mano
-// (decision del humano, 2026-08-20): la precision queda centralizada aqui, nunca configurable por
-// vista (doctrina del glosario).
+// La frontera de idiomas del BC: el mundo maquina (ControlDiario) habla minutos enteros; desde
+// DiaDepurado hacia el mundo humano (aprobacion, vistas, nomina) se habla horas liquidables.
+// Unico punto de conversion del BC: ninguna otra clase divide minutos entre 60 a mano, y la precision
+// no es parametro del llamador ni configurable por vista.
 public static class HorasLiquidables
 {
-    // Constante NOMBRADA de precision -- NUNCA un literal suelto en la conversion. Cambiar la
-    // precision de negocio es cambiar este unico valor.
     private const int PosicionesDecimales = 2;
 
-    // AwayFromZero: sin midpoints exactos alcanzables con /60 a 2 decimales (nota del issue), el
-    // criterio de desempate es irrelevante en la practica; se deja explicito por si esa premisa cambia.
+    // AwayFromZero explicito: con /60 a 2 decimales no hay midpoints alcanzables, asi que el criterio
+    // de desempate hoy no cambia ningun resultado. Si la precision sube, empieza a importar.
     public static decimal DesdeMinutos(int minutos) =>
         Math.Round(minutos / 60m, PosicionesDecimales, MidpointRounding.AwayFromZero);
 }

--- a/src/Bitakora.ControlAsistencia.ControlHoras/ValueObjects/HorasLiquidables.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ValueObjects/HorasLiquidables.cs
@@ -11,5 +11,8 @@ public static class HorasLiquidables
     // precision de negocio es cambiar este unico valor.
     private const int PosicionesDecimales = 2;
 
-    public static decimal DesdeMinutos(int minutos) => throw new NotImplementedException();
+    // AwayFromZero: sin midpoints exactos alcanzables con /60 a 2 decimales (nota del issue), el
+    // criterio de desempate es irrelevante en la practica; se deja explicito por si esa premisa cambia.
+    public static decimal DesdeMinutos(int minutos) =>
+        Math.Round(minutos / 60m, PosicionesDecimales, MidpointRounding.AwayFromZero);
 }

--- a/src/Bitakora.ControlAsistencia.ControlHoras/ValueObjects/HorasLiquidables.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ValueObjects/HorasLiquidables.cs
@@ -1,0 +1,15 @@
+namespace Bitakora.ControlAsistencia.ControlHoras.ValueObjects;
+
+// Issue #424: la frontera de idiomas del BC. El mundo maquina (ControlDiario) habla minutos enteros;
+// desde DiaDepurado hacia el mundo humano (aprobacion, vistas, nomina) se habla horas liquidables.
+// Unico punto de conversion del BC -- ninguna otra clase debe dividir minutos entre 60 a mano
+// (decision del humano, 2026-08-20): la precision queda centralizada aqui, nunca configurable por
+// vista (doctrina del glosario).
+public static class HorasLiquidables
+{
+    // Constante NOMBRADA de precision -- NUNCA un literal suelto en la conversion. Cambiar la
+    // precision de negocio es cambiar este unico valor.
+    private const int PosicionesDecimales = 2;
+
+    public static decimal DesdeMinutos(int minutos) => throw new NotImplementedException();
+}

--- a/src/Bitakora.ControlAsistencia.PrivateEvents/ControlHoras/DiaDepurado.cs
+++ b/src/Bitakora.ControlAsistencia.PrivateEvents/ControlHoras/DiaDepurado.cs
@@ -3,22 +3,20 @@ using Cosmos.EventDriven.Abstractions;
 
 namespace Bitakora.ControlAsistencia.PrivateEvents.ControlHoras;
 
-// Nunca se persiste: IdentidadEventosControlHoras lo excluye a proposito. El nombre DiaCalculado
-// queda reservado al aggregate del flujo de aprobacion (#425), que consume este evento.
+// Nunca se persiste: IdentidadEventosControlHoras lo excluye a proposito.
 //
 // CodigoColaborador viaja top-level y siempre presente, tambien cuando Colaborador es null (dia
 // nacido solo por marcacion, sin turno): el consumidor arma "dc:{codigo}:{yyyyMMdd}" con el. Moverlo
 // dentro de Colaborador reintroduce el defecto que este campo corrige.
 //
-// Issue #424: NombreTurno es la senal ESTRUCTURAL del plan (sin enum): null = sin programacion;
-// nombre + Franjas vacia = descanso programado (#423); nombre + Franjas >= 1 = jornada valida. Un dia
-// sin jornada valida (sin turno, o turno con cero franjas) no tiene depuracion: Franjas vacia,
-// HorasDiscriminadas.HorasPorConcepto vacio y Marcaciones viaja cruda -- la anomalia la deriva el
-// receptor de esa combinacion, no un campo explicito (decision 2026-08-20, supersede el extinto #422).
-// Marcaciones viaja completa y en orden cronologico ascendente (CONTRATO del evento, no una garantia
-// incidental): es la unica evidencia de las anomalias del dia sin jornada valida y la superficie de
-// investigacion del Aprobador (#429); DiaCalculado no puede ir a buscarlas (aggregate separado, la
-// verdad viaja en el evento).
+// NombreTurno + Franjas son la senal estructural del plan, sin enum: null = sin programacion;
+// nombre + Franjas vacia = descanso programado; nombre + Franjas >= 1 = jornada valida. Un dia sin
+// jornada valida no tiene depuracion (Franjas y HorasPorConcepto vacios, Marcaciones cruda): la
+// anomalia la deriva el receptor de esa combinacion, no un campo explicito del payload.
+//
+// Marcaciones viaja completa y en orden cronologico ascendente: es contrato del evento, no reflejo
+// del orden de llegada al aggregate. Es la unica evidencia de las anomalias de un dia sin jornada
+// valida, y el consumidor no puede ir a buscarlas a otro aggregate.
 public record DiaDepurado(
     string CodigoColaborador,
     DateOnly Fecha,
@@ -28,9 +26,9 @@ public record DiaDepurado(
     IReadOnlyList<MarcacionDelDia> Marcaciones,
     HorasDiscriminadas HorasDiscriminadas) : IPrivateEvent
 {
-    // El record por defecto compararia Franjas/Marcaciones por referencia (ADR-0015): con dos
-    // colecciones nuevas, Equals/GetHashCode propios comparan por valor (SequenceEqual), precedente
-    // TurnoDiario/FranjaProgramada.
+    // El record por defecto compara Franjas/Marcaciones por referencia; estos overrides las comparan
+    // por valor. Todo campo nuevo del record debe sumarse a ambos a mano (MEF-ADR-0012, nota sobre
+    // equality: un record con colecciones promete una igualdad que el compilador no genera).
     public virtual bool Equals(DiaDepurado? other)
     {
         if (other is null) return false;

--- a/src/Bitakora.ControlAsistencia.PrivateEvents/ControlHoras/DiaDepurado.cs
+++ b/src/Bitakora.ControlAsistencia.PrivateEvents/ControlHoras/DiaDepurado.cs
@@ -9,8 +9,51 @@ namespace Bitakora.ControlAsistencia.PrivateEvents.ControlHoras;
 // CodigoColaborador viaja top-level y siempre presente, tambien cuando Colaborador es null (dia
 // nacido solo por marcacion, sin turno): el consumidor arma "dc:{codigo}:{yyyyMMdd}" con el. Moverlo
 // dentro de Colaborador reintroduce el defecto que este campo corrige.
+//
+// Issue #424: NombreTurno es la senal ESTRUCTURAL del plan (sin enum): null = sin programacion;
+// nombre + Franjas vacia = descanso programado (#423); nombre + Franjas >= 1 = jornada valida. Un dia
+// sin jornada valida (sin turno, o turno con cero franjas) no tiene depuracion: Franjas vacia,
+// HorasDiscriminadas.HorasPorConcepto vacio y Marcaciones viaja cruda -- la anomalia la deriva el
+// receptor de esa combinacion, no un campo explicito (decision 2026-08-20, supersede el extinto #422).
+// Marcaciones viaja completa y en orden cronologico ascendente (CONTRATO del evento, no una garantia
+// incidental): es la unica evidencia de las anomalias del dia sin jornada valida y la superficie de
+// investigacion del Aprobador (#429); DiaCalculado no puede ir a buscarlas (aggregate separado, la
+// verdad viaja en el evento).
 public record DiaDepurado(
     string CodigoColaborador,
     DateOnly Fecha,
     ResumenColaborador? Colaborador,
-    HorasDiscriminadas HorasDiscriminadas) : IPrivateEvent;
+    string? NombreTurno,
+    IReadOnlyList<FranjaDepurada> Franjas,
+    IReadOnlyList<MarcacionDelDia> Marcaciones,
+    HorasDiscriminadas HorasDiscriminadas) : IPrivateEvent
+{
+    // El record por defecto compararia Franjas/Marcaciones por referencia (ADR-0015): con dos
+    // colecciones nuevas, Equals/GetHashCode propios comparan por valor (SequenceEqual), precedente
+    // TurnoDiario/FranjaProgramada.
+    public virtual bool Equals(DiaDepurado? other)
+    {
+        if (other is null) return false;
+        if (ReferenceEquals(this, other)) return true;
+        return CodigoColaborador == other.CodigoColaborador
+            && Fecha == other.Fecha
+            && Colaborador == other.Colaborador
+            && NombreTurno == other.NombreTurno
+            && Franjas.SequenceEqual(other.Franjas)
+            && Marcaciones.SequenceEqual(other.Marcaciones)
+            && HorasDiscriminadas == other.HorasDiscriminadas;
+    }
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(CodigoColaborador);
+        hash.Add(Fecha);
+        hash.Add(Colaborador);
+        hash.Add(NombreTurno);
+        foreach (var franja in Franjas) hash.Add(franja);
+        foreach (var marcacion in Marcaciones) hash.Add(marcacion);
+        hash.Add(HorasDiscriminadas);
+        return hash.ToHashCode();
+    }
+}

--- a/src/Bitakora.ControlAsistencia.PrivateEvents/ControlHoras/FranjaDepurada.cs
+++ b/src/Bitakora.ControlAsistencia.PrivateEvents/ControlHoras/FranjaDepurada.cs
@@ -1,0 +1,17 @@
+namespace Bitakora.ControlAsistencia.PrivateEvents.ControlHoras;
+
+// Issue #424: payload plano de una franja ordinaria depurada, espejo de ControlFranja
+// (ControlHoras.Entities) para el mundo humano -- plan (HoraInicioProgramada, HoraFinProgramada,
+// DiaOffsetFin) + realidad (Entrada, Salida, EsAnomala). SIN sede, SIN descripcion, SIN
+// descansos/extras internos (ya digeridos en HorasDiscriminadas). La sede quedo explicitamente fuera
+// de la conversacion por ahora.
+//
+// Todos los campos son primitivos -> la igualdad por valor del record por defecto ya es correcta, sin
+// Equals/GetHashCode propios (MEF-ADR-0012).
+public record FranjaDepurada(
+    TimeOnly HoraInicioProgramada,
+    TimeOnly HoraFinProgramada,
+    int DiaOffsetFin,
+    DateTime? Entrada,
+    DateTime? Salida,
+    bool EsAnomala);

--- a/src/Bitakora.ControlAsistencia.PrivateEvents/ControlHoras/FranjaDepurada.cs
+++ b/src/Bitakora.ControlAsistencia.PrivateEvents/ControlHoras/FranjaDepurada.cs
@@ -1,13 +1,11 @@
 namespace Bitakora.ControlAsistencia.PrivateEvents.ControlHoras;
 
-// Issue #424: payload plano de una franja ordinaria depurada, espejo de ControlFranja
-// (ControlHoras.Entities) para el mundo humano -- plan (HoraInicioProgramada, HoraFinProgramada,
-// DiaOffsetFin) + realidad (Entrada, Salida, EsAnomala). SIN sede, SIN descripcion, SIN
-// descansos/extras internos (ya digeridos en HorasDiscriminadas). La sede quedo explicitamente fuera
-// de la conversacion por ahora.
+// Payload plano de una franja ordinaria depurada, espejo de ControlFranja (ControlHoras.Entities):
+// plan + realidad. Deliberadamente sin sede, sin descripcion y sin descansos/extras internos: esos
+// ultimos ya vienen digeridos en HorasDiscriminadas y duplicarlos aqui daria dos fuentes de verdad.
 //
-// Todos los campos son primitivos -> la igualdad por valor del record por defecto ya es correcta, sin
-// Equals/GetHashCode propios (MEF-ADR-0012).
+// Solo primitivos: sumar un campo con coleccion obligaria a escribir Equals/GetHashCode a mano
+// (MEF-ADR-0012, nota sobre equality).
 public record FranjaDepurada(
     TimeOnly HoraInicioProgramada,
     TimeOnly HoraFinProgramada,

--- a/src/Bitakora.ControlAsistencia.PrivateEvents/ControlHoras/HorasDiscriminadas.cs
+++ b/src/Bitakora.ControlAsistencia.PrivateEvents/ControlHoras/HorasDiscriminadas.cs
@@ -5,40 +5,44 @@ namespace Bitakora.ControlAsistencia.PrivateEvents.ControlHoras;
 // aplica al canal de publicacion a Service Bus, y llegaba lossy al consumidor (field notes
 // 2026-06-23). Con solo primitivos STJ lo (de)serializa nativo, sin ConfigurarSerializacion.
 //
-// MinutosPorConcepto: clave = Concepto.ToString() ("OrdinariaDiurna", ...) o la clave literal
-//   "Retardo"; valor = minutos agregados del dia para esa clave.
-// Trazabilidad: textos de auditoria del calculo.
+// Issue #424: HorasPorConcepto (ex MinutosPorConcepto) habla horas liquidables, no minutos -- la
+// frontera de idiomas del BC pasa por aqui. Clave = Concepto.ToString() ("OrdinariaDiurna", ...) o la
+// clave literal "Retardo"; valor = horas liquidables agregadas del dia para esa clave, producidas via
+// HorasLiquidables (unico punto de conversion del BC). Todo el diccionario habla el mismo idioma,
+// incluida la clave "Retardo".
+// Trazabilidad: textos de auditoria del calculo -- sigue narrando en minutos/intervalos (memoria del
+// calculo, no dato operable del mundo humano; decision explicita, no omision).
 //
 // Igualdad por valor de las colecciones via override manual de Equals/GetHashCode (precedente
-// DetalleFranjaOrdinaria, #129): el record por defecto compara MinutosPorConcepto/Trazabilidad por
+// DetalleFranjaOrdinaria, #129): el record por defecto compara HorasPorConcepto/Trazabilidad por
 // referencia. El override preserva la forma de record (constructor primario publico) y corrige el bug.
 public record HorasDiscriminadas(
-    IReadOnlyDictionary<string, int> MinutosPorConcepto,
+    IReadOnlyDictionary<string, decimal> HorasPorConcepto,
     IReadOnlyList<string> Trazabilidad)
 {
     public virtual bool Equals(HorasDiscriminadas? other)
     {
         if (other is null) return false;
         if (ReferenceEquals(this, other)) return true;
-        return MinutosPorConceptoIguales(other.MinutosPorConcepto)
+        return HorasPorConceptoIguales(other.HorasPorConcepto)
             && Trazabilidad.SequenceEqual(other.Trazabilidad);
     }
 
     // Igualdad de diccionario independiente del orden de insercion: mismo tamanio y cada par presente
     // con el mismo valor en el otro.
-    private bool MinutosPorConceptoIguales(IReadOnlyDictionary<string, int> otros) =>
-        MinutosPorConcepto.Count == otros.Count
-        && MinutosPorConcepto.All(par => otros.TryGetValue(par.Key, out var valor) && valor == par.Value);
+    private bool HorasPorConceptoIguales(IReadOnlyDictionary<string, decimal> otros) =>
+        HorasPorConcepto.Count == otros.Count
+        && HorasPorConcepto.All(par => otros.TryGetValue(par.Key, out var valor) && valor == par.Value);
 
     public override int GetHashCode()
     {
         var hash = new HashCode();
         // El diccionario se hashea con XOR de los pares para que el hash no dependa del orden de
         // enumeracion (objetos iguales deben producir el mismo hash). Trazabilidad es ordenada.
-        var hashMinutos = 0;
-        foreach (var par in MinutosPorConcepto)
-            hashMinutos ^= HashCode.Combine(par.Key, par.Value);
-        hash.Add(hashMinutos);
+        var hashHoras = 0;
+        foreach (var par in HorasPorConcepto)
+            hashHoras ^= HashCode.Combine(par.Key, par.Value);
+        hash.Add(hashHoras);
         foreach (var nota in Trazabilidad) hash.Add(nota);
         return hash.ToHashCode();
     }

--- a/src/Bitakora.ControlAsistencia.PrivateEvents/ControlHoras/HorasDiscriminadas.cs
+++ b/src/Bitakora.ControlAsistencia.PrivateEvents/ControlHoras/HorasDiscriminadas.cs
@@ -1,21 +1,18 @@
 namespace Bitakora.ControlAsistencia.PrivateEvents.ControlHoras;
 
-// Payload plano del dia que viaja en DiaDepurado. Debe permanecer 100% primitivo: el modelo rico
-// anterior (DesgloseHoras + DetalleControlFranja) dependia del resolver custom de Marten, que NO se
-// aplica al canal de publicacion a Service Bus, y llegaba lossy al consumidor (field notes
-// 2026-06-23). Con solo primitivos STJ lo (de)serializa nativo, sin ConfigurarSerializacion.
+// Payload plano del dia que viaja en DiaDepurado. Debe permanecer 100% primitivo: el resolver custom
+// de Marten NO se aplica al canal de publicacion a Service Bus, asi que un campo rico llegaria lossy
+// al consumidor (MEF-ADR-0012, frontera event store vs bus).
 //
-// Issue #424: HorasPorConcepto (ex MinutosPorConcepto) habla horas liquidables, no minutos -- la
-// frontera de idiomas del BC pasa por aqui. Clave = Concepto.ToString() ("OrdinariaDiurna", ...) o la
-// clave literal "Retardo"; valor = horas liquidables agregadas del dia para esa clave, producidas via
-// HorasLiquidables (unico punto de conversion del BC). Todo el diccionario habla el mismo idioma,
-// incluida la clave "Retardo".
-// Trazabilidad: textos de auditoria del calculo -- sigue narrando en minutos/intervalos (memoria del
-// calculo, no dato operable del mundo humano; decision explicita, no omision).
+// HorasPorConcepto: clave = Concepto.ToString() ("OrdinariaDiurna", ...) o la clave literal "Retardo";
+// valor = horas liquidables del dia, producidas via HorasLiquidables (unico punto de conversion del
+// BC). Todo el diccionario habla el mismo idioma, incluida la clave "Retardo".
+// Trazabilidad narra en minutos e intervalos a proposito: es memoria de auditoria del calculo, no
+// dato operable del mundo humano.
 //
-// Igualdad por valor de las colecciones via override manual de Equals/GetHashCode (precedente
-// DetalleFranjaOrdinaria, #129): el record por defecto compara HorasPorConcepto/Trazabilidad por
-// referencia. El override preserva la forma de record (constructor primario publico) y corrige el bug.
+// El record por defecto compara HorasPorConcepto/Trazabilidad por referencia; los overrides de
+// Equals/GetHashCode las comparan por valor sin perder la forma de record (MEF-ADR-0012, nota sobre
+// equality).
 public record HorasDiscriminadas(
     IReadOnlyDictionary<string, decimal> HorasPorConcepto,
     IReadOnlyList<string> Trazabilidad)

--- a/src/Bitakora.ControlAsistencia.PrivateEvents/ControlHoras/MarcacionDelDia.cs
+++ b/src/Bitakora.ControlAsistencia.PrivateEvents/ControlHoras/MarcacionDelDia.cs
@@ -1,0 +1,10 @@
+namespace Bitakora.ControlAsistencia.PrivateEvents.ControlHoras;
+
+// Issue #424: payload plano y crudo de UNA marcacion del dia, sin marca usada/descartada -- el
+// receptor la deriva (usada <=> el Timestamp coincide con Entrada o Salida de alguna FranjaDepurada;
+// la idempotencia por minuto garantiza timestamps unicos). Es la evidencia cruda sobre la que el
+// Aprobador juzga (#429) y la unica prueba de las anomalias del dia sin jornada valida.
+//
+// Todos los campos son primitivos -> la igualdad por valor del record por defecto ya es correcta, sin
+// Equals/GetHashCode propios (MEF-ADR-0012).
+public record MarcacionDelDia(DateTime Timestamp, string? Tipo);

--- a/src/Bitakora.ControlAsistencia.PrivateEvents/ControlHoras/MarcacionDelDia.cs
+++ b/src/Bitakora.ControlAsistencia.PrivateEvents/ControlHoras/MarcacionDelDia.cs
@@ -1,10 +1,6 @@
 namespace Bitakora.ControlAsistencia.PrivateEvents.ControlHoras;
 
-// Issue #424: payload plano y crudo de UNA marcacion del dia, sin marca usada/descartada -- el
-// receptor la deriva (usada <=> el Timestamp coincide con Entrada o Salida de alguna FranjaDepurada;
-// la idempotencia por minuto garantiza timestamps unicos). Es la evidencia cruda sobre la que el
-// Aprobador juzga (#429) y la unica prueba de las anomalias del dia sin jornada valida.
-//
-// Todos los campos son primitivos -> la igualdad por valor del record por defecto ya es correcta, sin
-// Equals/GetHashCode propios (MEF-ADR-0012).
+// Payload plano y crudo de UNA marcacion del dia. Sin marca usada/descartada a proposito: el receptor
+// la deriva comparando el Timestamp contra la Entrada o la Salida de cada FranjaDepurada, y la
+// idempotencia por minuto del aggregate garantiza que esos timestamps son unicos.
 public record MarcacionDelDia(DateTime Timestamp, string? Tipo);

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/AsignarTurnoViaSbSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/AsignarTurnoViaSbSmokeTests.cs
@@ -126,9 +126,14 @@ public class AsignarTurnoViaSbSmokeTests(ServiceBusFixture serviceBus, PostgresF
         diaDepurado.Colaborador.Should().Be(resumenColaboradorEsperado);
         // Issue #183 CA-6: el payload viaja plano (HorasDiscriminadas), deserializado con el serializador
         // POR DEFECTO del fixture (sin resolver custom). El turno se asigno sin marcaciones previas: la
-        // franja queda anomala -> sin minutos calculables -> MinutosPorConcepto vacio.
-        diaDepurado.HorasDiscriminadas.MinutosPorConcepto.Should().BeEmpty(
-            "el turno sin marcaciones deja la franja anomala, sin minutos por concepto");
+        // franja queda anomala -> sin horas calculables -> HorasPorConcepto vacio.
+        diaDepurado.HorasDiscriminadas.HorasPorConcepto.Should().BeEmpty(
+            "el turno sin marcaciones deja la franja anomala, sin horas por concepto");
+        // Issue #424 CA-3/CA-4/CA-5: NombreTurno presente, la franja anomala (sin marcaciones) y
+        // Marcaciones vacia (nada se registro antes del turno).
+        diaDepurado.NombreTurno.Should().Be("[TEST] Turno Smoke SB");
+        diaDepurado.Franjas.Should().ContainSingle(f => f.EsAnomala);
+        diaDepurado.Marcaciones.Should().BeEmpty();
 
         // Assert: verificar ausencia de dead letter de ESTA corrida en la suscripcion del consumidor
         // de entrada (issue #223: acotado por SolicitudId, no "DLQ globalmente vacio").
@@ -267,6 +272,10 @@ public class AsignarTurnoViaSbSmokeTests(ServiceBusFixture serviceBus, PostgresF
 
         diaDepurado.Fecha.Should().Be(fecha);
         diaDepurado.CodigoColaborador.Should().Be(codigoColaborador);
+        // Issue #424 CA-3/CA-5: el turno multi-sede sigue enriqueciendo el payload con NombreTurno y
+        // las dos FranjaDepurada (espejo de las franjas ordinarias asignadas).
+        diaDepurado.NombreTurno.Should().Be("[TEST] Turno Partido Sede");
+        diaDepurado.Franjas.Should().HaveCount(2);
 
         // Assert: ausencia de dead letter de ESTA corrida en la suscripcion del consumidor de
         // entrada -- confirma que el mapeo DetalleSede -> SedeProgramada no rompe el handler
@@ -391,8 +400,8 @@ public class AsignarTurnoViaSbSmokeTests(ServiceBusFixture serviceBus, PostgresF
         diaDepurado.CodigoColaborador.Should().Be(codigoColaborador);
         // Issue #183 CA-6: el payload plano (HorasDiscriminadas) se deserializa con el serializador POR
         // DEFECTO del fixture (sin resolver custom) incluso cuando el mensaje llega en camelCase. El turno
-        // se asigno sin marcaciones: franja anomala -> MinutosPorConcepto vacio.
-        diaDepurado.HorasDiscriminadas.MinutosPorConcepto.Should().BeEmpty(
-            "el turno sin marcaciones deja la franja anomala, sin minutos por concepto");
+        // se asigno sin marcaciones: franja anomala -> HorasPorConcepto vacio.
+        diaDepurado.HorasDiscriminadas.HorasPorConcepto.Should().BeEmpty(
+            "el turno sin marcaciones deja la franja anomala, sin horas por concepto");
     }
 }

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/RegistrarMarcacionFunction/RegistrarMarcacionSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/RegistrarMarcacionFunction/RegistrarMarcacionSmokeTests.cs
@@ -396,11 +396,16 @@ public class RegistrarMarcacionSmokeTests(
         diaDepurado.Colaborador.Should().Be(colaboradorEsperado);
         // Issue #183 CA-6: el payload viaja plano (HorasDiscriminadas) y se deserializo con el
         // serializador POR DEFECTO del fixture (sin resolver custom). Esta marcacion es solo ENTRADA:
-        // la franja queda anomala (sin salida) -> sin minutos calculables -> MinutosPorConcepto vacio.
+        // la franja queda anomala (sin salida) -> sin horas calculables -> HorasPorConcepto vacio.
         diaDepurado.HorasDiscriminadas.Should().NotBeNull(
             "DiaDepurado siempre se emite con HorasDiscriminadas");
-        diaDepurado.HorasDiscriminadas.MinutosPorConcepto.Should().BeEmpty(
-            "una entrada sola deja la franja anomala, sin minutos por concepto");
+        diaDepurado.HorasDiscriminadas.HorasPorConcepto.Should().BeEmpty(
+            "una entrada sola deja la franja anomala, sin horas por concepto");
+        // Issue #424 CA-3/CA-4/CA-5: el payload enriquecido lleva NombreTurno, la franja anomala
+        // (espejo del ControlFranja real) y la marcacion cruda de la entrada.
+        diaDepurado.NombreTurno.Should().Be("[TEST] Turno HU108");
+        diaDepurado.Franjas.Should().ContainSingle(f => f.EsAnomala);
+        diaDepurado.Marcaciones.Should().ContainSingle(m => m.Timestamp == timestamp);
 
         // Assert: ausencia de dead letter de ESTA corrida en la suscripcion smoke-tests del topic
         // dia-depurado (issue #223: acotado por CodigoColaborador, no "DLQ globalmente vacio").
@@ -522,15 +527,19 @@ public class RegistrarMarcacionSmokeTests(
 
         diaDepurado.Fecha.Should().Be(fecha);
 
-        // Issue #183 CA-6: el smoke verifica MinutosPorConcepto del payload plano, deserializado con el
+        // Issue #183 CA-6: el smoke verifica HorasPorConcepto del payload plano, deserializado con el
         // serializador POR DEFECTO del fixture (sin resolver custom). La franja quedo completa (entrada
         // 08:00 + salida 16:00), asi que una jornada 08:00-16:00 acumula horas ordinarias diurnas reales.
         // Clave = Concepto.ToString() ("OrdinariaDiurna").
-        diaDepurado.HorasDiscriminadas.MinutosPorConcepto
+        diaDepurado.HorasDiscriminadas.HorasPorConcepto
             .Should().ContainKey("OrdinariaDiurna");
-        diaDepurado.HorasDiscriminadas.MinutosPorConcepto["OrdinariaDiurna"]
-            .Should().BeGreaterThan(0,
+        diaDepurado.HorasDiscriminadas.HorasPorConcepto["OrdinariaDiurna"]
+            .Should().BeGreaterThan(0m,
                 "el desglose real discriminado lleva horas ordinarias diurnas (no un payload vacio)");
+        // Issue #424 CA-3/CA-4: la franja completa (entrada + salida) queda NO anomala y ambas
+        // marcaciones viajan crudas.
+        diaDepurado.Franjas.Should().ContainSingle(f => !f.EsAnomala);
+        diaDepurado.Marcaciones.Should().HaveCount(2);
 
         // Assert: ausencia de dead letter de ESTA corrida en la suscripcion smoke-tests del topic
         // dia-depurado (issue #223: acotado por CodigoColaborador, no "DLQ globalmente vacio").
@@ -598,6 +607,11 @@ public class RegistrarMarcacionSmokeTests(
         diaDepurado.Fecha.Should().Be(fecha);
         diaDepurado.Colaborador.Should().BeNull(
             "el dia nacio solo por marcacion, sin turno asignado que aporte la foto del colaborador");
+        // Issue #424 CA-5/CA-6: sin turno, NombreTurno viaja null y Franjas vacia (dia sin jornada
+        // valida); la marcacion cruda sigue viajando en Marcaciones.
+        diaDepurado.NombreTurno.Should().BeNull();
+        diaDepurado.Franjas.Should().BeEmpty();
+        diaDepurado.Marcaciones.Should().ContainSingle(m => m.Timestamp == timestamp);
 
         // Assert: ausencia de dead letter de ESTA corrida en la suscripcion smoke-tests del topic
         // dia-depurado (issue #223: acotado por CodigoColaborador, no "DLQ globalmente vacio").

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoRegistroDeMarcacionCreado/DepurarAlAdicionarMarcacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoRegistroDeMarcacionCreado/DepurarAlAdicionarMarcacionTests.cs
@@ -4,6 +4,8 @@
 // RegistroDeMarcacionCreado (CA-3, CA-5); el comportamiento verificado aqui no cambia.
 // Familia 1: verifica que Apply(MarcacionAdicionada) dispara el recalculo de ControlesDeFranja
 // y que el handler publica DiaDepurado via IPrivateEventSender tras cada recalculo.
+// Issue #424: el payload enriquecido lleva NombreTurno, Franjas (espejo de ControlesDeFranja),
+// Marcaciones (todas, cronologicas) y HorasDiscriminadas en horas liquidables (decimal).
 
 using Bitakora.ControlAsistencia.ControlHoras.ValueObjects;
 using Bitakora.ControlAsistencia.ControlHoras.AdicionarMarcacionCuandoRegistroDeMarcacionCreado.EventHandler;
@@ -76,6 +78,8 @@ public class DepurarAlAdicionarMarcacionTests : PrivateEventHandlerAsyncTest<Reg
     //        Verifica que el hook reactivo se dispara desde Apply(MarcacionAdicionada).
     // CA-1 (HU-108): el handler publica DiaDepurado con CodigoColaborador, Colaborador, Fecha y las
     //        horas discriminadas correctas.
+    // Issue #424 (CA-3/CA-4/CA-5): el payload ademas lleva NombreTurno, la FranjaDepurada anomala
+    //        (Salida null) y la marcacion cruda de las 07:00.
     [Fact]
     public async Task RegistroDeMarcacionCreado_CalculaControlFranja_CuandoHayTurnoYLlegaMarcacion()
     {
@@ -91,15 +95,17 @@ public class DepurarAlAdicionarMarcacionTests : PrivateEventHandlerAsyncTest<Reg
             new ControlFranja[] { new(Franja06_14, Timestamp07_00, null) });
 
         // HU-108 CA-1: el handler publica un DiaDepurado con el estado tras el recalculo.
-        // Issue #183 CA-4/CA-6: el payload viaja plano (HorasDiscriminadas), sin ControlesDeFranja.
-        // La franja quedo anomala (Salida null): no aporta minutos calculables y no hay retardo, asi
-        // que MinutosPorConcepto viaja vacio. Nota del issue (riesgo aceptado): el contrato plano ya no
+        // La franja quedo anomala (Salida null): no aporta horas calculables y no hay retardo, asi
+        // que HorasPorConcepto viaja vacio. Nota del issue (riesgo aceptado): el contrato plano no
         // distingue "franja anomala" de "dia sin horas"; ambos publican el mismo diccionario vacio.
         ThenIsPublishedPrivately(new DiaDepurado(
             CodigoColaborador,
             Fecha,
             ColaboradorResumen,
-            new HorasDiscriminadas(new Dictionary<string, int>(), [])));
+            "Turno Manana",
+            [new FranjaDepurada(new TimeOnly(6, 0), new TimeOnly(14, 0), 0, Timestamp07_00, null, true)],
+            [new MarcacionDelDia(Timestamp07_00, "ENTRADA")],
+            new HorasDiscriminadas(new Dictionary<string, decimal>(), [])));
     }
 
     // CA-2 (HU-123): sin turno previo, la marcacion crea el aggregate sin TurnoDiario.
@@ -108,6 +114,8 @@ public class DepurarAlAdicionarMarcacionTests : PrivateEventHandlerAsyncTest<Reg
     //        se inicia solo con marcacion y no hay nada que depurar.
     // CA-2/CA-4 (HU-108): el handler publica DiaDepurado incluso cuando ControlesDeFranja esta vacio,
     //        con Colaborador null pero CodigoColaborador top-level presente.
+    // Issue #424 (CA-5/CA-6): sin turno, NombreTurno viaja null y Franjas vacia (dia sin jornada
+    //        valida); la marcacion cruda sigue viajando en Marcaciones.
     [Fact]
     public async Task RegistroDeMarcacionCreado_DejaControlesDeFranjaVacios_CuandoNoHayTurnoPrevio()
     {
@@ -120,12 +128,15 @@ public class DepurarAlAdicionarMarcacionTests : PrivateEventHandlerAsyncTest<Reg
 
         // HU-108 CA-4: se publica DiaDepurado aunque no haya turno. Colaborador es null porque el
         // ControlDiario nacio solo por marcacion; CodigoColaborador top-level sigue presente.
-        // Issue #183 CA-6: sin turno no hay nada que consolidar -> MinutosPorConcepto viaja vacio.
+        // Issue #183 CA-6: sin turno no hay nada que consolidar -> HorasPorConcepto viaja vacio.
         ThenIsPublishedPrivately(new DiaDepurado(
             CodigoColaborador,
             Fecha,
             null,
-            new HorasDiscriminadas(new Dictionary<string, int>(), [])));
+            null,
+            [],
+            [new MarcacionDelDia(Timestamp07_00, "ENTRADA")],
+            new HorasDiscriminadas(new Dictionary<string, decimal>(), [])));
     }
 
     // CA-3 (HU-123): con turno partido (06:00-12:00 y 14:00-18:00) y 2 MarcacionAdicionada previas
@@ -133,6 +144,8 @@ public class DepurarAlAdicionarMarcacionTests : PrivateEventHandlerAsyncTest<Reg
     //        completo: F1(Entrada=05:50, Salida=12:05) + F2(Entrada=14:10, Salida=null).
     //        Verifica comportamiento idem-potente: no acumula sobre resultado anterior.
     // CA-3 (HU-108): el handler publica DiaDepurado; Issue #183: con el payload plano (HorasDiscriminadas).
+    // Issue #424 (CA-3/CA-4): Franjas lleva ambas FranjaDepurada (una no anomala, otra anomala) y
+    //        Marcaciones las tres marcaciones en orden cronologico.
     [Fact]
     public async Task RegistroDeMarcacionCreado_RecalculaControlesDeFranjaCompletos_CuandoHayTurnoPartidoYMarcacionesAcumuladas()
     {
@@ -155,14 +168,15 @@ public class DepurarAlAdicionarMarcacionTests : PrivateEventHandlerAsyncTest<Reg
             });
 
         // HU-108 CA-3: las dos franjas se recalculan. F1: no anomala (Entrada y Salida). F2: anomala
-        // (Salida null). Issue #183 CA-4/CA-6: el payload viaja plano (MinutosPorConcepto). Solo F1
-        // (no anomala) aporta minutos; F2 anomala no aporta. El contrato plano no lleva senal de la
+        // (Salida null). Issue #183 CA-4/CA-6: el payload viaja plano (HorasPorConcepto). Solo F1
+        // (no anomala) aporta horas; F2 anomala no aporta. El contrato plano no lleva senal de la
         // franja anomala (riesgo aceptado del issue).
-        // Esperado registrado A MANO con las primitivas del dominio (sin ejecutar Discriminar ni
-        // Consolidar, la logica bajo prueba). F1 06:00-12:00 trabajada 05:50-12:05 en domingo
-        // 2026-03-15: entro 05:50 -> recortado a 06:00 (sin retardo); ordinaria 06:00-12:00
-        // DominicalFestivaDiurna = 360min y excedente 12:00-12:05 ExtraDiurnaDominicalFestiva = 5min
-        // (sin retardo que lo compense). Sin retardo neto -> no hay clave "Retardo".
+        // Esperado registrado A MANO con las primitivas del dominio (sin ejecutar Discriminar,
+        // Consolidar ni HorasLiquidables.DesdeMinutos, la logica bajo prueba). F1 06:00-12:00
+        // trabajada 05:50-12:05 en domingo 2026-03-15: entro 05:50 -> recortado a 06:00 (sin retardo);
+        // ordinaria 06:00-12:00 DominicalFestivaDiurna = 360min = 6.00h y excedente 12:00-12:05
+        // ExtraDiurnaDominicalFestiva = 5min = 0.08h (5/60=0.0833..., sin retardo que lo compense). Sin
+        // retardo neto -> no hay clave "Retardo".
         // Issue #184: el DiaDepurado ahora viaja con la Trazabilidad (memoria de calculo) poblada. Dos
         // conceptos -> dos lineas, en orden cronologico (ordinaria antes que excedente), cada una armada
         // con LineaConcepto desde su intervalo y la etiqueta traducida. F2 es anomala (Salida null): no
@@ -171,11 +185,21 @@ public class DepurarAlAdicionarMarcacionTests : PrivateEventHandlerAsyncTest<Reg
             CodigoColaborador,
             Fecha,
             ColaboradorResumen,
+            "Turno Partido",
+            [
+                new FranjaDepurada(new TimeOnly(6, 0), new TimeOnly(12, 0), 0, Timestamp05_50, Timestamp12_05, false),
+                new FranjaDepurada(new TimeOnly(14, 0), new TimeOnly(18, 0), 0, Timestamp14_10, null, true)
+            ],
+            [
+                new MarcacionDelDia(Timestamp05_50, "ENTRADA"),
+                new MarcacionDelDia(Timestamp12_05, "ENTRADA"),
+                new MarcacionDelDia(Timestamp14_10, "ENTRADA")
+            ],
             new HorasDiscriminadas(
-                new Dictionary<string, int>
+                new Dictionary<string, decimal>
                 {
-                    ["DominicalFestivaDiurna"] = 360,
-                    ["ExtraDiurnaDominicalFestiva"] = 5
+                    ["DominicalFestivaDiurna"] = 6.00m,
+                    ["ExtraDiurnaDominicalFestiva"] = 0.08m
                 },
                 [
                     LineaConcepto(new TimeOnly(6, 0), new TimeOnly(12, 0), Concepto.DominicalFestivaDiurna),
@@ -204,11 +228,17 @@ public class DepurarAlAdicionarMarcacionTests : PrivateEventHandlerAsyncTest<Reg
             new MarcacionAdicionada(StreamIdDiaAnterior, CodigoColaborador, timestampNocturno, "ENTRADA", "DEV-001"));
 
         // CA-5: dos DiaDepurado publicados, en orden: dia calendario primero, dia anterior segundo.
-        // Ambos sin turno previo (Colaborador=null), pero con CodigoColaborador top-level.
-        // Issue #183 CA-6: sin turno en ninguno de los dos streams, MinutosPorConcepto viaja vacio en ambos.
+        // Ambos sin turno previo (Colaborador=null, NombreTurno=null, Franjas vacia), pero con
+        // CodigoColaborador top-level y la marcacion cruda en Marcaciones.
+        // Issue #183 CA-6: sin turno en ninguno de los dos streams, HorasPorConcepto viaja vacio en ambos.
+        var marcacionNocturna = new MarcacionDelDia(timestampNocturno, "ENTRADA");
         ThenIsPublishedPrivately(
-            new DiaDepurado(CodigoColaborador, fechaDiaCal, null, new HorasDiscriminadas(new Dictionary<string, int>(), [])),
-            new DiaDepurado(CodigoColaborador, fechaDiaAnt, null, new HorasDiscriminadas(new Dictionary<string, int>(), [])));
+            new DiaDepurado(
+                CodigoColaborador, fechaDiaCal, null, null, [], [marcacionNocturna],
+                new HorasDiscriminadas(new Dictionary<string, decimal>(), [])),
+            new DiaDepurado(
+                CodigoColaborador, fechaDiaAnt, null, null, [], [marcacionNocturna],
+                new HorasDiscriminadas(new Dictionary<string, decimal>(), [])));
 
         And<ControlDiarioAggregateRoot, int>(
             StreamId, c => c.ControlesDeFranja.Count, 0);

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoRegistroDeMarcacionCreado/DepurarAlAdicionarMarcacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoRegistroDeMarcacionCreado/DepurarAlAdicionarMarcacionTests.cs
@@ -4,8 +4,6 @@
 // RegistroDeMarcacionCreado (CA-3, CA-5); el comportamiento verificado aqui no cambia.
 // Familia 1: verifica que Apply(MarcacionAdicionada) dispara el recalculo de ControlesDeFranja
 // y que el handler publica DiaDepurado via IPrivateEventSender tras cada recalculo.
-// Issue #424: el payload enriquecido lleva NombreTurno, Franjas (espejo de ControlesDeFranja),
-// Marcaciones (todas, cronologicas) y HorasDiscriminadas en horas liquidables (decimal).
 
 using Bitakora.ControlAsistencia.ControlHoras.ValueObjects;
 using Bitakora.ControlAsistencia.ControlHoras.AdicionarMarcacionCuandoRegistroDeMarcacionCreado.EventHandler;

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoRegistroDeMarcacionCreado/Eventos/DiaDepuradoSerializacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoRegistroDeMarcacionCreado/Eventos/DiaDepuradoSerializacionTests.cs
@@ -1,7 +1,7 @@
-// CA-6: el payload completo de DiaDepurado, con datos realistas del dominio, round-trip
-// serializa/deserializa con el serializador POR DEFECTO del publisher (sin el resolver custom de
-// Marten) y sin perdida. Complementa el guardrail minimo de portabilidad de
-// PrivateEvents.Tests/ControlHoras/DiaDepuradoTests, que compila contra la isla sola.
+// CA-6/CA-7: el payload completo de DiaDepurado, con datos realistas del dominio (incluyendo Franjas
+// y Marcaciones, issue #424), round-trip serializa/deserializa con el serializador POR DEFECTO del
+// publisher (sin el resolver custom de Marten) y sin perdida. Complementa el guardrail minimo de
+// portabilidad de PrivateEvents.Tests/ControlHoras/DiaDepuradoTests, que compila contra la isla sola.
 //
 // La asercion es deliberadamente la OPUESTA a la del test legado, que afirmaba que la
 // deserializacion FALLABA sin resolver custom (Retardo tenia ctor privado): si alguien reintroduce
@@ -22,13 +22,21 @@ public class DiaDepuradoSerializacionTests
 
     private static readonly DateOnly Fecha = new(2026, 3, 15);
 
-    // Payload con datos reales: varias claves de concepto y la clave literal "Retardo".
+    private static readonly FranjaDepurada Franja = new(
+        new TimeOnly(6, 0), new TimeOnly(14, 0), 0,
+        new DateTime(2026, 3, 15, 7, 0, 0), new DateTime(2026, 3, 15, 15, 0, 0), false);
+
+    private static readonly MarcacionDelDia Marcacion =
+        new(new DateTime(2026, 3, 15, 7, 0, 0), "ENTRADA");
+
+    // Payload con datos reales: varias claves de concepto y la clave literal "Retardo", ya en horas
+    // liquidables (issue #424).
     private static HorasDiscriminadas HorasConDatos() => new(
-        new Dictionary<string, int>
+        new Dictionary<string, decimal>
         {
-            ["DominicalFestivaDiurna"] = 420,
-            ["ExtraDiurnaDominicalFestiva"] = 30,
-            ["Retardo"] = 15
+            ["DominicalFestivaDiurna"] = 7.00m,
+            ["ExtraDiurnaDominicalFestiva"] = 0.50m,
+            ["Retardo"] = 0.25m
         },
         []);
 
@@ -37,11 +45,13 @@ public class DiaDepuradoSerializacionTests
     // opciones para serializar y deserializar -> round-trip sin perdida si el payload es primitivo.
     private static JsonSerializerOptions OpcionesPorDefectoDelPublisher() => new();
 
-    // CA-6: round-trip preserva todos los campos con el serializador por defecto (sin resolver custom).
+    // CA-6/CA-7: round-trip preserva todos los campos con el serializador por defecto (sin resolver
+    // custom), incluidas Franjas y Marcaciones.
     [Fact]
     public void RoundTrip_PreservaTodosLosCampos_ConSerializadorPorDefectoDelPublisher()
     {
-        var original = new DiaDepurado("EMP-001", Fecha, Colaborador, HorasConDatos());
+        var original = new DiaDepurado(
+            "EMP-001", Fecha, Colaborador, "Turno Manana", [Franja], [Marcacion], HorasConDatos());
         var opciones = OpcionesPorDefectoDelPublisher();
 
         var json = JsonSerializer.Serialize(original, opciones);
@@ -51,18 +61,23 @@ public class DiaDepuradoSerializacionTests
         restaurado!.CodigoColaborador.Should().Be("EMP-001");
         restaurado.Colaborador.Should().Be(Colaborador);
         restaurado.Fecha.Should().Be(Fecha);
-        restaurado.HorasDiscriminadas.MinutosPorConcepto.Should().BeEquivalentTo(
-            original.HorasDiscriminadas.MinutosPorConcepto);
+        restaurado.NombreTurno.Should().Be("Turno Manana");
+        restaurado.Franjas.Should().Equal(Franja);
+        restaurado.Marcaciones.Should().Equal(Marcacion);
+        restaurado.HorasDiscriminadas.HorasPorConcepto.Should().BeEquivalentTo(
+            original.HorasDiscriminadas.HorasPorConcepto);
         restaurado.HorasDiscriminadas.Trazabilidad.Should().BeEmpty();
     }
 
-    // CA-4/CA-6: roundtrip con Colaborador null (caso "marcacion sin turno previo"), pero
-    // CodigoColaborador top-level SIEMPRE presente -- el defecto latente que este issue corrige.
+    // CA-4/CA-5/CA-6: roundtrip con Colaborador y NombreTurno null (dia sin jornada valida, caso
+    // "marcacion sin turno previo"), Franjas vacia pero CodigoColaborador top-level SIEMPRE presente
+    // -- el defecto latente que #421 corrigio -- y la marcacion cruda preservada.
     [Fact]
-    public void RoundTrip_PreservaCampos_CuandoColaboradorEsNulo()
+    public void RoundTrip_PreservaCampos_CuandoNoHayJornadaValida()
     {
         var original = new DiaDepurado(
-            "EMP-002", Fecha, null, new HorasDiscriminadas(new Dictionary<string, int>(), []));
+            "EMP-002", Fecha, null, null, [], [Marcacion],
+            new HorasDiscriminadas(new Dictionary<string, decimal>(), []));
         var opciones = OpcionesPorDefectoDelPublisher();
 
         var json = JsonSerializer.Serialize(original, opciones);
@@ -71,8 +86,11 @@ public class DiaDepuradoSerializacionTests
         restaurado.Should().NotBeNull();
         restaurado!.CodigoColaborador.Should().Be("EMP-002");
         restaurado.Colaborador.Should().BeNull();
+        restaurado.NombreTurno.Should().BeNull();
         restaurado.Fecha.Should().Be(Fecha);
-        restaurado.HorasDiscriminadas.MinutosPorConcepto.Should().BeEmpty();
+        restaurado.Franjas.Should().BeEmpty();
+        restaurado.Marcaciones.Should().Equal(Marcacion);
+        restaurado.HorasDiscriminadas.HorasPorConcepto.Should().BeEmpty();
     }
 
     // CA-6 (barrera anti-regresion invertida): con el resolver POR DEFECTO sin ningun
@@ -82,7 +100,8 @@ public class DiaDepuradoSerializacionTests
     [Fact]
     public void Deserializar_TieneExito_ConResolverPorDefectoSinRegistros()
     {
-        var original = new DiaDepurado("EMP-001", Fecha, Colaborador, HorasConDatos());
+        var original = new DiaDepurado(
+            "EMP-001", Fecha, Colaborador, "Turno Manana", [Franja], [Marcacion], HorasConDatos());
         var json = JsonSerializer.Serialize(original);
 
         var opcionesSinRegistros = new JsonSerializerOptions
@@ -93,6 +112,6 @@ public class DiaDepuradoSerializacionTests
         var act = () => JsonSerializer.Deserialize<DiaDepurado>(json, opcionesSinRegistros);
 
         act.Should().NotThrow();
-        act()!.HorasDiscriminadas.MinutosPorConcepto["DominicalFestivaDiurna"].Should().Be(420);
+        act()!.HorasDiscriminadas.HorasPorConcepto["DominicalFestivaDiurna"].Should().Be(7.00m);
     }
 }

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/DepurarAlAsignarTurnoTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/DepurarAlAsignarTurnoTests.cs
@@ -2,10 +2,9 @@
 // HU-131: Emitir DiaDepurado tras asignar turno (CA-1, CA-2)
 // Familia 2: verifica que Apply(TurnoDiarioAsignado) dispara el recalculo de ControlesDeFranja
 // y que el handler publica DiaDepurado via IPrivateEventSender tras el recalculo.
-// Issue #424: el payload enriquecido lleva NombreTurno, Franjas (espejo de ControlesDeFranja),
-// Marcaciones (todas, cronologicas) y HorasDiscriminadas en horas liquidables (decimal). El tercer
-// test (turno sin franjas) construye en unit el caso "dia sin jornada valida" de cero franjas que
-// #423 hara ocurrir en runtime (biunivocidad nombre+cero franjas = descanso programado).
+// El tercer test (turno con cero franjas) construye en unit un caso que hoy no ocurre en runtime:
+// el catalogo todavia no produce turnos sin franjas. No borrarlo por "imposible" -- congela el
+// contrato del descanso programado (nombre de turno presente + cero franjas).
 
 using Bitakora.ControlAsistencia.ControlHoras.ValueObjects;
 using Bitakora.ControlAsistencia.ControlHoras.AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction.EventHandler;

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/DepurarAlAsignarTurnoTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/DepurarAlAsignarTurnoTests.cs
@@ -2,6 +2,10 @@
 // HU-131: Emitir DiaDepurado tras asignar turno (CA-1, CA-2)
 // Familia 2: verifica que Apply(TurnoDiarioAsignado) dispara el recalculo de ControlesDeFranja
 // y que el handler publica DiaDepurado via IPrivateEventSender tras el recalculo.
+// Issue #424: el payload enriquecido lleva NombreTurno, Franjas (espejo de ControlesDeFranja),
+// Marcaciones (todas, cronologicas) y HorasDiscriminadas en horas liquidables (decimal). El tercer
+// test (turno sin franjas) construye en unit el caso "dia sin jornada valida" de cero franjas que
+// #423 hara ocurrir en runtime (biunivocidad nombre+cero franjas = descanso programado).
 
 using Bitakora.ControlAsistencia.ControlHoras.ValueObjects;
 using Bitakora.ControlAsistencia.ControlHoras.AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction.EventHandler;
@@ -78,6 +82,8 @@ public class DepurarAlAsignarTurnoTests
     //        Verifica el caso "marcaciones llegaron antes que el turno".
     // CA-1 (HU-131): el handler publica DiaDepurado con CodigoColaborador, Colaborador, Fecha
     //        y ControlesDeFranja actualizados (Entrada y Salida presentes, EsAnomala=false).
+    // Issue #424 (CA-3/CA-4/CA-5): el payload ademas lleva NombreTurno, la FranjaDepurada no anomala
+    //        y las dos marcaciones crudas en orden cronologico.
     [Fact]
     public async Task ProgramacionTurnoDiarioSolicitada_CalculaControlFranja_CuandoMarcacionesLlegaronAntesQueTurno()
     {
@@ -96,13 +102,12 @@ public class DepurarAlAsignarTurnoTests
             new ControlFranja[] { new(Franja06_14, Timestamp07_00, Timestamp15_00) });
 
         // HU-131 CA-1: publica DiaDepurado tras la depuracion. La franja 06:00-14:00 trabajada
-        // 07:00-15:00 no es anomala. Issue #183 CA-4/CA-6: el payload viaja plano (MinutosPorConcepto),
-        // sin ControlesDeFranja.
-        // Esperado registrado A MANO con las primitivas del dominio (sin ejecutar Discriminar ni
-        // Consolidar, la logica bajo prueba): en domingo 2026-03-15 el retardo 60min (06:00-07:00) se
-        // compensa con el excedente 60min (14:00-15:00) -> retardo neto 0 (no hay clave "Retardo") y
-        // queda visible la ordinaria 07:00-14:00 DominicalFestivaDiurna = 420min. Asi un bug en esa
-        // logica no se filtra al esperado y el test lo detecta.
+        // 07:00-15:00 no es anomala. Issue #183 CA-4/CA-6: el payload viaja plano (HorasPorConcepto).
+        // Esperado registrado A MANO con las primitivas del dominio (sin ejecutar Discriminar,
+        // Consolidar ni HorasLiquidables.DesdeMinutos, la logica bajo prueba): en domingo 2026-03-15 el
+        // retardo 60min (06:00-07:00) se compensa con el excedente 60min (14:00-15:00) -> retardo neto
+        // 0 (no hay clave "Retardo") y queda visible la ordinaria 07:00-14:00 DominicalFestivaDiurna =
+        // 420min = 7.00h. Asi un bug en esa logica no se filtra al esperado y el test lo detecta.
         // Issue #184: el DiaDepurado ahora viaja con la Trazabilidad (memoria de calculo) poblada. El
         // unico concepto del dia (ordinaria 07:00-14:00, DominicalFestivaDiurna) genera una sola linea,
         // construida con LineaConcepto desde el intervalo 07:00-14:00 y la etiqueta traducida del recurso.
@@ -110,14 +115,19 @@ public class DepurarAlAsignarTurnoTests
             Colaborador.CodigoColaborador,
             Fecha,
             ColaboradorResumen,
+            "Turno Manana",
+            [new FranjaDepurada(new TimeOnly(6, 0), new TimeOnly(14, 0), 0, Timestamp07_00, Timestamp15_00, false)],
+            [new MarcacionDelDia(Timestamp07_00, "ENTRADA"), new MarcacionDelDia(Timestamp15_00, "ENTRADA")],
             new HorasDiscriminadas(
-                new Dictionary<string, int> { ["DominicalFestivaDiurna"] = 420 },
+                new Dictionary<string, decimal> { ["DominicalFestivaDiurna"] = 7.00m },
                 [LineaConcepto(new TimeOnly(7, 0), new TimeOnly(14, 0), Concepto.DominicalFestivaDiurna)])));
     }
 
     // CA-2 (HU-131): sin marcaciones previas, el Apply(TurnoDiarioAsignado) dispara Depurar()
     //        pero sin marcaciones el depurador retorna una franja con Entrada=null, Salida=null.
     //        DiaDepurado se emite aunque todos los ControlesDeFranja sean anomalos.
+    // Issue #424 (CA-3/CA-5/CA-6): NombreTurno presente, Franjas con la franja anomala, Marcaciones
+    //        vacia (sin marcaciones previas).
     [Fact]
     public async Task ProgramacionTurnoDiarioSolicitada_PublicaDiaDepurado_CuandoNoHayMarcacionesPrevias()
     {
@@ -134,17 +144,23 @@ public class DepurarAlAsignarTurnoTests
             new ControlFranja[] { new(Franja06_14, null, null) }); // EsAnomala=true
 
         // HU-131 CA-2: DiaDepurado se publica aunque la franja sea anomala (Entrada y Salida null).
-        // Issue #183 CA-6: la franja anomala no aporta minutos calculables y no hay retardo, asi que
-        // MinutosPorConcepto viaja vacio. El contrato plano no lleva senal de anomalia (riesgo aceptado).
+        // Issue #183 CA-6: la franja anomala no aporta horas calculables y no hay retardo, asi que
+        // HorasPorConcepto viaja vacio. El contrato plano no lleva senal de anomalia (riesgo aceptado).
         ThenIsPublishedPrivately(new DiaDepurado(
             Colaborador.CodigoColaborador,
             Fecha,
             ColaboradorResumen,
-            new HorasDiscriminadas(new Dictionary<string, int>(), [])));
+            "Turno Manana",
+            [new FranjaDepurada(new TimeOnly(6, 0), new TimeOnly(14, 0), 0, null, null, true)],
+            [],
+            new HorasDiscriminadas(new Dictionary<string, decimal>(), [])));
     }
 
     // CA-2 (HU-131): turno sin franjas ordinarias genera ControlesDeFranja vacio.
     //        DiaDepurado se emite igual con lista vacia de controles.
+    // Issue #424 (CA-6): este es el caso "dia sin jornada valida" de cero franjas -- NombreTurno
+    //        presente pero Franjas vacia (biunivocidad con el descanso programado de #423): el
+    //        contrato plano ya se comporta como sin depuracion (Franjas y HorasPorConcepto vacios).
     [Fact]
     public async Task ProgramacionTurnoDiarioSolicitada_PublicaDiaDepurado_CuandoTurnoNoTieneFranjas()
     {
@@ -160,11 +176,16 @@ public class DepurarAlAsignarTurnoTests
             c => c.ControlesDeFranja.Count, 0);
 
         // HU-131 CA-2: DiaDepurado se publica aunque el turno no tenga franjas.
-        // Issue #183 CA-6: sin franjas que consolidar ni retardo, MinutosPorConcepto viaja vacio.
+        // Issue #183 CA-6: sin franjas que consolidar ni retardo, HorasPorConcepto viaja vacio.
+        // Issue #424 CA-6: NombreTurno = "Turno Sin Franjas" (presente) con Franjas vacia -- la senal
+        // estructural del plan (nombre + cero franjas) que #423 hara ocurrir en runtime.
         ThenIsPublishedPrivately(new DiaDepurado(
             Colaborador.CodigoColaborador,
             Fecha,
             ColaboradorResumen,
-            new HorasDiscriminadas(new Dictionary<string, int>(), [])));
+            "Turno Sin Franjas",
+            [],
+            [],
+            new HorasDiscriminadas(new Dictionary<string, decimal>(), [])));
     }
 }

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/CrearDiaDepuradoConHorasDiscriminadasTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/CrearDiaDepuradoConHorasDiscriminadasTests.cs
@@ -1,5 +1,7 @@
 // CrearDiaDepurado() empaqueta el payload plano via DesgloseHoras.Discriminar() sobre el desglose
-// real del aggregate (la propiedad DesgloseHoras que RecalcularDesgloseHoras() refresca en cada Apply).
+// real del aggregate (la propiedad DesgloseHoras que RecalcularDesgloseHoras() refresca en cada Apply),
+// enriquecido con NombreTurno (DetalleTurno?.Nombre), Franjas (espejo de ControlesDeFranja) y
+// Marcaciones (todas, en orden cronologico ascendente) -- issue #424.
 //
 // Test directo sobre CrearDiaDepurado() (metodo publico del aggregate). Como ControlHoras NO expone
 // InternalsVisibleTo, los factory internal (Iniciar/AsignarTurno/AdicionarMarcacion) no son accesibles
@@ -14,9 +16,10 @@
 // RegistroDeMarcacionCreado (issue #270: reemplaza a MarcacionRegistrada, que dejo de implementar
 // IPrivateEvent -- CA-3).
 //
-// El valor esperado se registra A MANO como oraculo independiente: el diccionario de minutos por
-// concepto se calcula de la geometria del dia, sin ejecutar Discriminar ni Consolidar (la logica bajo
-// prueba). Asi un bug en esa logica no se filtra al esperado y el test si detecta regresiones (regla 20).
+// El valor esperado se registra A MANO como oraculo independiente: el diccionario de horas por
+// concepto se calcula de la geometria del dia, sin ejecutar Discriminar ni Consolidar ni
+// HorasLiquidables.DesdeMinutos (la logica bajo prueba). Asi un bug en esa logica no se filtra al
+// esperado y el test si detecta regresiones (regla 20).
 
 using Bitakora.ControlAsistencia.ControlHoras.AdicionarMarcacionCuandoRegistroDeMarcacionCreado.EventHandler;
 using Bitakora.ControlAsistencia.ControlHoras.AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction.EventHandler;
@@ -68,9 +71,10 @@ public class CrearDiaDepuradoConHorasDiscriminadasTests
     // Oraculo independiente: dia con franja 06:00-14:00 trabajada 07:00-15:00 (domingo 2026-03-15,
     // no anomala). El retardo 60min (06:00-07:00) se compensa con el excedente 60min (14:00-15:00) ->
     // retardo neto 0 (no hay clave "Retardo"); queda visible la ordinaria 07:00-14:00 = 420min
-    // DominicalFestivaDiurna. Registrado a mano: ni Discriminar ni Consolidar se ejecutan para armarlo.
-    private static IReadOnlyDictionary<string, int> MinutosFranjaCompleta() =>
-        new Dictionary<string, int> { ["DominicalFestivaDiurna"] = 420 };
+    // DominicalFestivaDiurna = 7.00 horas liquidables (420/60). Registrado a mano: ni Discriminar, ni
+    // Consolidar, ni HorasLiquidables.DesdeMinutos se ejecutan para armarlo.
+    private static IReadOnlyDictionary<string, decimal> HorasFranjaCompleta() =>
+        new Dictionary<string, decimal> { ["DominicalFestivaDiurna"] = 7.00m };
 
     public class ViaAsignarTurnoTests
         : PrivateEventHandlerAsyncTest<ProgramacionTurnoDiarioSolicitada>
@@ -84,14 +88,16 @@ public class CrearDiaDepuradoConHorasDiscriminadasTests
 
         // CA-4: con turno (franja 06:00-14:00) y marcaciones previas que la completan (07:00, 15:00),
         //       la franja queda NO anomala. CrearDiaDepurado() debe empaquetar el payload plano
-        //       discriminado del desglose real: MinutosPorConcepto = {DominicalFestivaDiurna: 420}.
-        // Issue #184: CrearDiaDepurado() ahora ademas puebla la Trazabilidad via Discriminar(). Un solo
+        //       discriminado del desglose real: HorasPorConcepto = {DominicalFestivaDiurna: 7.00}.
+        // Issue #184: CrearDiaDepurado() ademas puebla la Trazabilidad via Discriminar(). Un solo
         //       concepto (DominicalFestivaDiurna) y retardo neto 0 -> exactamente una linea. Se verifica
         //       solo el conteo (robusto ante como el desglose descomponga los intervalos del concepto);
         //       el contenido exacto de las lineas se prueba en DesgloseHorasDiscriminarTests, con geometria
         //       controlada. Aqui basta probar que el aggregate enruta la trazabilidad hacia el payload.
+        // Issue #424 (CA-3/CA-5): Franjas lleva el espejo del ControlFranja real y NombreTurno la senal
+        //       estructural del plan (nombre presente + Franjas >= 1 -> jornada valida).
         [Fact]
-        public async Task CrearDiaDepurado_LlevaMinutosYTrazabilidadReales_CuandoFranjaNoEsAnomala()
+        public async Task CrearDiaDepurado_LlevaHorasYTrazabilidadReales_CuandoFranjaNoEsAnomala()
         {
             Given(StreamId,
                 CrearMarcacionAdicionada(Timestamp07_00),
@@ -103,23 +109,40 @@ public class CrearDiaDepuradoConHorasDiscriminadasTests
             var turnoFranjaUnica = new TurnoDiario("Turno Manana", [Franja06_14], "");
             Then(StreamId, CrearTurnoDiarioAsignado(turnoFranjaUnica));
 
-            And<ControlDiarioAggregateRoot, IReadOnlyDictionary<string, int>>(
+            And<ControlDiarioAggregateRoot, IReadOnlyDictionary<string, decimal>>(
                 StreamId,
-                c => c.CrearDiaDepurado().HorasDiscriminadas.MinutosPorConcepto,
-                MinutosFranjaCompleta());
+                c => c.CrearDiaDepurado().HorasDiscriminadas.HorasPorConcepto,
+                HorasFranjaCompleta());
 
             And<ControlDiarioAggregateRoot, int>(
                 StreamId,
                 c => c.CrearDiaDepurado().HorasDiscriminadas.Trazabilidad.Count,
                 1);
+
+            And<ControlDiarioAggregateRoot, string?>(
+                StreamId,
+                c => c.CrearDiaDepurado().NombreTurno,
+                "Turno Manana");
+
+            And<ControlDiarioAggregateRoot, IReadOnlyList<FranjaDepurada>>(
+                StreamId,
+                c => c.CrearDiaDepurado().Franjas,
+                [new FranjaDepurada(
+                    new TimeOnly(6, 0), new TimeOnly(14, 0), 0,
+                    Timestamp07_00, Timestamp15_00, false)]);
+
+            And<ControlDiarioAggregateRoot, IReadOnlyList<MarcacionDelDia>>(
+                StreamId,
+                c => c.CrearDiaDepurado().Marcaciones,
+                [new MarcacionDelDia(Timestamp07_00, "ENTRADA"), new MarcacionDelDia(Timestamp15_00, "ENTRADA")]);
         }
 
-        // CA-4 (todas las franjas anomalas): turno con franja 06:00-14:00 SIN marcaciones -> la franja
-        //       queda anomala (sin entrada ni salida). El desglose real no aporta minutos calculables
-        //       y no hay retardo, asi que el payload plano lleva MinutosPorConcepto vacio. El contrato
-        //       plano ya no distingue "anomala" de "dia vacio" (riesgo aceptado del issue).
+        // CA-4 (todas las franjas anomalas)/CA-6: turno con franja 06:00-14:00 SIN marcaciones -> la
+        //       franja queda anomala (sin entrada ni salida). El desglose real no aporta horas
+        //       calculables y no hay retardo, asi que HorasPorConcepto viaja vacio. Franjas SI lleva la
+        //       franja anomala (espejo de ControlesDeFranja); Marcaciones queda vacia.
         [Fact]
-        public async Task CrearDiaDepurado_LlevaMinutosPorConceptoVacio_CuandoTurnoSinMarcaciones()
+        public async Task CrearDiaDepurado_LlevaHorasPorConceptoVacio_CuandoTurnoSinMarcaciones()
         {
             // Sin Given - stream nuevo, turno sin marcaciones previas.
             var turnoFranjaUnicaDetalle = new DetalleTurno("Turno Manana", [Franja06_14Detalle], "");
@@ -131,7 +154,17 @@ public class CrearDiaDepuradoConHorasDiscriminadasTests
             And<ControlDiarioAggregateRoot, HorasDiscriminadas>(
                 StreamId,
                 c => c.CrearDiaDepurado().HorasDiscriminadas,
-                new HorasDiscriminadas(new Dictionary<string, int>(), []));
+                new HorasDiscriminadas(new Dictionary<string, decimal>(), []));
+
+            And<ControlDiarioAggregateRoot, IReadOnlyList<FranjaDepurada>>(
+                StreamId,
+                c => c.CrearDiaDepurado().Franjas,
+                [new FranjaDepurada(new TimeOnly(6, 0), new TimeOnly(14, 0), 0, null, null, true)]);
+
+            And<ControlDiarioAggregateRoot, IReadOnlyList<MarcacionDelDia>>(
+                StreamId,
+                c => c.CrearDiaDepurado().Marcaciones,
+                []);
         }
     }
 
@@ -145,11 +178,12 @@ public class CrearDiaDepuradoConHorasDiscriminadasTests
         private static RegistroDeMarcacionCreado CrearRegistroDeMarcacionCreado(DateTime timestamp) =>
             new(Colaborador.CodigoColaborador, timestamp, "ENTRADA", "DEV-001");
 
-        // CA-4 (sin turno): la marcacion crea el aggregate sin DetalleTurno -> Depurar() retorna lista
-        //       vacia -> no hay ControlesDeFranja que consolidar. CrearDiaDepurado() empaqueta el
-        //       payload plano con MinutosPorConcepto vacio.
+        // CA-4/CA-6 (sin turno): la marcacion crea el aggregate sin DetalleTurno -> Depurar() retorna
+        //       lista vacia -> no hay ControlesDeFranja que consolidar. CrearDiaDepurado() empaqueta el
+        //       payload plano con HorasPorConcepto vacio, NombreTurno null y Franjas vacia (dia sin
+        //       jornada valida); Marcaciones lleva la marcacion cruda.
         [Fact]
-        public async Task CrearDiaDepurado_LlevaMinutosPorConceptoVacio_CuandoNoHayTurno()
+        public async Task CrearDiaDepurado_LlevaHorasPorConceptoVacio_CuandoNoHayTurno()
         {
             // Sin Given - el aggregate nace solo con la marcacion (DetalleTurno queda null).
             await WhenAsync(CrearRegistroDeMarcacionCreado(Timestamp07_00));
@@ -159,7 +193,17 @@ public class CrearDiaDepuradoConHorasDiscriminadasTests
             And<ControlDiarioAggregateRoot, HorasDiscriminadas>(
                 StreamId,
                 c => c.CrearDiaDepurado().HorasDiscriminadas,
-                new HorasDiscriminadas(new Dictionary<string, int>(), []));
+                new HorasDiscriminadas(new Dictionary<string, decimal>(), []));
+
+            And<ControlDiarioAggregateRoot, string?>(
+                StreamId,
+                c => c.CrearDiaDepurado().NombreTurno,
+                null);
+
+            And<ControlDiarioAggregateRoot, IReadOnlyList<MarcacionDelDia>>(
+                StreamId,
+                c => c.CrearDiaDepurado().Marcaciones,
+                [new MarcacionDelDia(Timestamp07_00, "ENTRADA")]);
         }
 
         // CA-4: sin turno, Colaborador queda null y CodigoColaborador solo puede salir del stream ID.

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/CrearDiaDepuradoConHorasDiscriminadasTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/CrearDiaDepuradoConHorasDiscriminadasTests.cs
@@ -1,7 +1,5 @@
 // CrearDiaDepurado() empaqueta el payload plano via DesgloseHoras.Discriminar() sobre el desglose
-// real del aggregate (la propiedad DesgloseHoras que RecalcularDesgloseHoras() refresca en cada Apply),
-// enriquecido con NombreTurno (DetalleTurno?.Nombre), Franjas (espejo de ControlesDeFranja) y
-// Marcaciones (todas, en orden cronologico ascendente) -- issue #424.
+// real del aggregate (la propiedad DesgloseHoras que RecalcularDesgloseHoras() refresca en cada Apply).
 //
 // Test directo sobre CrearDiaDepurado() (metodo publico del aggregate). Como ControlHoras NO expone
 // InternalsVisibleTo, los factory internal (Iniciar/AsignarTurno/AdicionarMarcacion) no son accesibles
@@ -135,6 +133,31 @@ public class CrearDiaDepuradoConHorasDiscriminadasTests
                 StreamId,
                 c => c.CrearDiaDepurado().Marcaciones,
                 [new MarcacionDelDia(Timestamp07_00, "ENTRADA"), new MarcacionDelDia(Timestamp15_00, "ENTRADA")]);
+        }
+
+        // CA-4: el orden cronologico ascendente de Marcaciones es contrato del evento, no reflejo del
+        //       orden de llegada. Las marcaciones se aplican al aggregate en orden inverso (15:00 antes
+        //       que 07:00) y el payload igual las entrega ascendentes.
+        //       El esperado se proyecta a un string porque And<>() compara con BeEquivalentTo, que
+        //       ignora el orden de una coleccion: comparar IReadOnlyList<MarcacionDelDia> pasaria
+        //       igual con el orden invertido y el test no cubriria nada.
+        [Fact]
+        public async Task CrearDiaDepurado_OrdenaMarcacionesCronologicamente_CuandoLlegaronDesordenadas()
+        {
+            Given(StreamId,
+                CrearMarcacionAdicionada(Timestamp15_00),
+                CrearMarcacionAdicionada(Timestamp07_00));
+
+            await WhenAsync(CrearEvento(new DetalleTurno("Turno Manana", [Franja06_14Detalle], "")));
+
+            Then(StreamId, CrearTurnoDiarioAsignado(new TurnoDiario("Turno Manana", [Franja06_14], "")));
+
+            And<ControlDiarioAggregateRoot, string>(
+                StreamId,
+                c => string.Join(
+                    "|",
+                    c.CrearDiaDepurado().Marcaciones.Select(m => m.Timestamp.ToString("HH:mm"))),
+                "07:00|15:00");
         }
 
         // CA-4 (todas las franjas anomalas)/CA-6: turno con franja 06:00-14:00 SIN marcaciones -> la

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ValueObjects/DesgloseHorasDiscriminarTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ValueObjects/DesgloseHorasDiscriminarTests.cs
@@ -1,23 +1,26 @@
 // Issue #183: DesgloseHoras.Discriminar() - traduce el desglose rico al payload plano que viaja en
 // DiaDepurado (Tell-don't-Ask: el desglose se discrimina a si mismo).
-// CA-2 (#183): produce MinutosPorConcepto con una entrada por cada Concepto con minutos > 0 del dia,
-//       clave = Concepto.ToString(), valor = minutos agregados (reusa TotalMinutosPorConcepto).
-// CA-3 (#183): incluye la clave literal "Retardo" con RetardoTotal.RetardoNeto cuando es > 0; no la incluye
-//       cuando es 0. El enum Concepto permanece SIN un valor Retardo.
+// CA-2 (#183): produce HorasPorConcepto con una entrada por cada Concepto con minutos > 0 del dia,
+//       clave = Concepto.ToString(), valor = horas liquidables agregadas (reusa TotalMinutosPorConcepto
+//       y las convierte via HorasLiquidables.DesdeMinutos -- issue #424).
+// CA-3 (#183): incluye la clave literal "Retardo" con RetardoTotal.RetardoNeto (en horas) cuando es > 0;
+//       no la incluye cuando es 0. El enum Concepto permanece SIN un valor Retardo.
 //
-// Issue #184: Discriminar() ahora ademas puebla Trazabilidad (la memoria de calculo). Decision del planner
+// Issue #184: Discriminar() ademas puebla Trazabilidad (la memoria de calculo). Decision del planner
 // (2026-06-23): lista de lineas (IReadOnlyList<string>), una por item con valor, ya traducida en el back.
 // CA-1 (#184): una linea por concepto con minutos > 0, armada desde el/los IntervaloTemporal.ToString() del
 //       concepto y su etiqueta humana traducida (IntervaloClasificado.Mensajes.Etiqueta). Ej (issue):
 //       "18:15-21:00 (165min): Ordinaria diurna".
 // CA-2 (#184): incluye una linea para el retardo cuando RetardoNeto > 0, derivada de Retardo.ToString().
 // CA-3 (#184): las lineas estan traducidas (.resx); no hay lineas para items en cero.
-// CA-4 (#184): las claves de MinutosPorConcepto siguen como codigo ("OrdinariaDiurna", "Retardo"); solo
+// CA-4 (#184): las claves de HorasPorConcepto siguen como codigo ("OrdinariaDiurna", "Retardo"); solo
 //       Trazabilidad es texto humano.
 // "El modelo de dominio rico no cruza el bus": la trazabilidad se construye DESDE los ToString() de los
 // objetos ricos (IntervaloTemporal, Retardo); solo viajan los strings, no los objetos ricos.
 // Oraculo independiente (regla 20): las lineas esperadas se arman a mano con IntervaloTemporal.ToString()
-// (primitiva ya probada) y la etiqueta del recurso (no un literal), nunca ejecutando Discriminar.
+// (primitiva ya probada) y la etiqueta del recurso (no un literal), nunca ejecutando Discriminar. Los
+// valores de HorasPorConcepto se arman a mano dividiendo los minutos conocidos entre 60 (sin ejecutar
+// HorasLiquidables.DesdeMinutos, la logica bajo prueba).
 
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.ControlHoras.ValueObjects;
@@ -57,7 +60,8 @@ public class DesgloseHorasDiscriminarTests
     public void Discriminar_ProduceUnaEntradaPorConcepto_CuandoVariasFranjas()
     {
         // franja1: 120min OrdinariaNocturna + 240min OrdinariaDiurna; franja2: 240min OrdinariaDiurna.
-        // Esperado (oraculo a mano): OrdinariaDiurna = 480, OrdinariaNocturna = 120.
+        // Esperado (oraculo a mano, en horas liquidables): OrdinariaDiurna = 480/60 = 8.00,
+        // OrdinariaNocturna = 120/60 = 2.00.
         var franja1 = FranjaConIntervalos(
             (new TimeOnly(6, 0), new TimeOnly(8, 0), Concepto.OrdinariaNocturna),
             (new TimeOnly(8, 0), new TimeOnly(12, 0), Concepto.OrdinariaDiurna));
@@ -67,10 +71,10 @@ public class DesgloseHorasDiscriminarTests
 
         var resultado = desglose.Discriminar();
 
-        resultado.MinutosPorConcepto.Should().BeEquivalentTo(new Dictionary<string, int>
+        resultado.HorasPorConcepto.Should().BeEquivalentTo(new Dictionary<string, decimal>
         {
-            ["OrdinariaDiurna"] = 480,
-            ["OrdinariaNocturna"] = 120
+            ["OrdinariaDiurna"] = 8.00m,
+            ["OrdinariaNocturna"] = 2.00m
         });
     }
 
@@ -83,8 +87,8 @@ public class DesgloseHorasDiscriminarTests
 
         var resultado = desglose.Discriminar();
 
-        resultado.MinutosPorConcepto.Should().ContainKey("DominicalFestivaDiurna");
-        resultado.MinutosPorConcepto["DominicalFestivaDiurna"].Should().Be(240);
+        resultado.HorasPorConcepto.Should().ContainKey("DominicalFestivaDiurna");
+        resultado.HorasPorConcepto["DominicalFestivaDiurna"].Should().Be(4.00m); // 240min/60
     }
 
     [Fact]
@@ -96,16 +100,16 @@ public class DesgloseHorasDiscriminarTests
 
         var resultado = desglose.Discriminar();
 
-        resultado.MinutosPorConcepto.Should().NotContainKey("ExtraDiurna");
-        resultado.MinutosPorConcepto.Should().NotContainKey("OrdinariaNocturna");
+        resultado.HorasPorConcepto.Should().NotContainKey("ExtraDiurna");
+        resultado.HorasPorConcepto.Should().NotContainKey("OrdinariaNocturna");
     }
 
     [Fact]
-    public void Discriminar_ProduceMinutosPorConceptoVacio_CuandoDesgloseEsVacio()
+    public void Discriminar_ProduceHorasPorConceptoVacio_CuandoDesgloseEsVacio()
     {
         var resultado = DesgloseHoras.Vacio.Discriminar();
 
-        resultado.MinutosPorConcepto.Should().BeEmpty();
+        resultado.HorasPorConcepto.Should().BeEmpty();
     }
 
     // ---------- CA-3: clave literal "Retardo" segun RetardoNeto ----------
@@ -113,8 +117,8 @@ public class DesgloseHorasDiscriminarTests
     [Fact]
     public void Discriminar_IncluyeClaveRetardo_CuandoRetardoNetoEsMayorACero()
     {
-        // Retardo de 15min sin compensacion -> neto 15. Una franja ordinaria de 240min para verificar
-        // que la clave "Retardo" convive con las claves de concepto.
+        // Retardo de 15min sin compensacion -> neto 15min = 0.25h. Una franja ordinaria de 240min
+        // (4.00h) para verificar que la clave "Retardo" convive con las claves de concepto.
         var retardoNeto15 = Retardo.Crear(
             [CrearIntervalo(new TimeOnly(6, 0), new TimeOnly(6, 15))],
             []);
@@ -124,8 +128,8 @@ public class DesgloseHorasDiscriminarTests
 
         var resultado = desglose.Discriminar();
 
-        resultado.MinutosPorConcepto["Retardo"].Should().Be(15);
-        resultado.MinutosPorConcepto["OrdinariaDiurna"].Should().Be(240);
+        resultado.HorasPorConcepto["Retardo"].Should().Be(0.25m);
+        resultado.HorasPorConcepto["OrdinariaDiurna"].Should().Be(4.00m);
     }
 
     [Fact]
@@ -141,8 +145,8 @@ public class DesgloseHorasDiscriminarTests
 
         var resultado = desglose.Discriminar();
 
-        resultado.MinutosPorConcepto.Should().NotContainKey("Retardo");
-        resultado.MinutosPorConcepto.Should().ContainKey("OrdinariaDiurna");
+        resultado.HorasPorConcepto.Should().NotContainKey("Retardo");
+        resultado.HorasPorConcepto.Should().ContainKey("OrdinariaDiurna");
     }
 
     // ---------- Issue #184 - CA-1: una linea por concepto con minutos > 0 ----------
@@ -196,10 +200,10 @@ public class DesgloseHorasDiscriminarTests
     }
 
     [Fact]
-    public void Discriminar_ProduceUnaLineaPorEntradaDeMinutosPorConcepto_SinRetardo()
+    public void Discriminar_ProduceUnaLineaPorEntradaDeHorasPorConcepto_SinRetardo()
     {
         // Decision del planner: "una linea por item con valor". Sin retardo, los items son los conceptos,
-        // asi que Trazabilidad.Count == MinutosPorConcepto.Count.
+        // asi que Trazabilidad.Count == HorasPorConcepto.Count.
         var franja1 = FranjaConIntervalos(
             (new TimeOnly(6, 0), new TimeOnly(8, 0), Concepto.OrdinariaNocturna),
             (new TimeOnly(8, 0), new TimeOnly(12, 0), Concepto.OrdinariaDiurna));
@@ -209,7 +213,7 @@ public class DesgloseHorasDiscriminarTests
 
         var resultado = desglose.Discriminar();
 
-        resultado.Trazabilidad.Should().HaveCount(resultado.MinutosPorConcepto.Count);
+        resultado.Trazabilidad.Should().HaveCount(resultado.HorasPorConcepto.Count);
         resultado.Trazabilidad.Should().HaveCount(3);
     }
 
@@ -233,8 +237,8 @@ public class DesgloseHorasDiscriminarTests
 
         var resultado = desglose.Discriminar();
 
-        // CA-4: la clave de MinutosPorConcepto es el codigo estable Concepto.ToString().
-        resultado.MinutosPorConcepto.Should().ContainKey("DominicalFestivaDiurna");
+        // CA-4: la clave de HorasPorConcepto es el codigo estable Concepto.ToString().
+        resultado.HorasPorConcepto.Should().ContainKey("DominicalFestivaDiurna");
         // CA-3: la trazabilidad lleva el texto humano traducido del recurso, no el codigo camelCase.
         resultado.Trazabilidad.Should().ContainSingle()
             .Which.Should().Contain(IntervaloClasificado.Mensajes.Etiqueta(Concepto.DominicalFestivaDiurna));

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ValueObjects/HorasLiquidablesTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ValueObjects/HorasLiquidablesTests.cs
@@ -1,0 +1,60 @@
+// Issue #424: HorasLiquidables es la frontera de idiomas del BC -- el unico punto de conversion de
+// minutos enteros (mundo maquina) a horas decimales liquidables (mundo humano). CA-1: la precision
+// (2 posiciones) vive en una constante nombrada del tipo, nunca en un literal suelto en la conversion.
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.ControlHoras.ValueObjects;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Tests.ValueObjects;
+
+public class HorasLiquidablesTests
+{
+    // CA-1: 90 minutos son 1 hora 30 minutos exactos -> 1.50m.
+    [Fact]
+    public void DesdeMinutos_Convierte90MinutosA1Punto50Horas()
+    {
+        var resultado = HorasLiquidables.DesdeMinutos(90);
+
+        resultado.Should().Be(1.50m);
+    }
+
+    // CA-1: 50 minutos no caen en una fraccion exacta de hora (50/60 = 0.8333...) -> redondeo a 2
+    // posiciones decimales, sin midpoint exacto alcanzable con /60 (nota del issue).
+    [Fact]
+    public void DesdeMinutos_Convierte50MinutosA0Punto83Horas()
+    {
+        var resultado = HorasLiquidables.DesdeMinutos(50);
+
+        resultado.Should().Be(0.83m);
+    }
+
+    // CA-1: cero minutos son cero horas liquidables.
+    [Fact]
+    public void DesdeMinutos_Convierte0MinutosA0Horas()
+    {
+        var resultado = HorasLiquidables.DesdeMinutos(0);
+
+        resultado.Should().Be(0m);
+    }
+
+    // CA-1: el tipo de retorno es decimal, nunca double (evita el error de representacion binaria de
+    // fracciones que double introduciria en un valor de nomina).
+    [Fact]
+    public void DesdeMinutos_RetornaTipoDecimal()
+    {
+        var resultado = HorasLiquidables.DesdeMinutos(60);
+
+        resultado.Should().BeOfType(typeof(decimal));
+        resultado.Should().Be(1m);
+    }
+
+    // CA-1: 5 minutos de una franja completa (usado en escenarios de excedente del dominio) -> 0.08m,
+    // oraculo independiente registrado a mano (5/60 = 0.08333...).
+    [Fact]
+    public void DesdeMinutos_Convierte5MinutosA0Punto08Horas()
+    {
+        var resultado = HorasLiquidables.DesdeMinutos(5);
+
+        resultado.Should().Be(0.08m);
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.PrivateEvents.Tests/ControlHoras/DiaDepuradoIgualdadTests.cs
+++ b/tests/Bitakora.ControlAsistencia.PrivateEvents.Tests/ControlHoras/DiaDepuradoIgualdadTests.cs
@@ -1,0 +1,72 @@
+// Issue #424: DiaDepurado gana dos colecciones nuevas (Franjas, Marcaciones) -- el record por
+// defecto compararia por referencia (ADR-0015). Equals/GetHashCode propios comparan por valor
+// (SequenceEqual), precedente TurnoDiario/FranjaProgramada/HorasDiscriminadas.
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.PrivateEvents.Colaboradores;
+using Bitakora.ControlAsistencia.PrivateEvents.ControlHoras;
+
+namespace Bitakora.ControlAsistencia.PrivateEvents.Tests.ControlHoras;
+
+public class DiaDepuradoIgualdadTests : IgualdadTestBase<DiaDepurado>
+{
+    private static readonly DateOnly Fecha = new(2026, 3, 15);
+
+    private static readonly ResumenColaborador Colaborador =
+        new("CC-1234567890", "EMP-001", "Luis Augusto Barreto");
+
+    private static FranjaDepurada Franja() => new(
+        new TimeOnly(6, 0), new TimeOnly(14, 0), 0,
+        new DateTime(2026, 3, 15, 7, 0, 0), new DateTime(2026, 3, 15, 15, 0, 0), false);
+
+    private static MarcacionDelDia Marcacion() =>
+        new(new DateTime(2026, 3, 15, 7, 0, 0), "ENTRADA");
+
+    private static HorasDiscriminadas Horas() =>
+        new(new Dictionary<string, decimal> { ["DominicalFestivaDiurna"] = 7.00m }, ["nota"]);
+
+    protected override DiaDepurado CrearInstancia() =>
+        new("EMP-001", Fecha, Colaborador, "Turno Manana", [Franja()], [Marcacion()], Horas());
+
+    protected override DiaDepurado CrearInstanciaCopia() =>
+        new("EMP-001", Fecha, Colaborador, "Turno Manana", [Franja()], [Marcacion()], Horas());
+
+    protected override IEnumerable<(string, DiaDepurado)> CrearInstanciasDiferentes()
+    {
+        yield return ("CodigoColaborador",
+            new DiaDepurado("EMP-002", Fecha, Colaborador, "Turno Manana", [Franja()], [Marcacion()], Horas()));
+        yield return ("Fecha",
+            new DiaDepurado("EMP-001", Fecha.AddDays(1), Colaborador, "Turno Manana", [Franja()], [Marcacion()], Horas()));
+        yield return ("Colaborador",
+            new DiaDepurado("EMP-001", Fecha, null, "Turno Manana", [Franja()], [Marcacion()], Horas()));
+        yield return ("NombreTurno",
+            new DiaDepurado("EMP-001", Fecha, Colaborador, "Otro Turno", [Franja()], [Marcacion()], Horas()));
+        yield return ("Franjas (vacia)",
+            new DiaDepurado("EMP-001", Fecha, Colaborador, "Turno Manana", [], [Marcacion()], Horas()));
+        yield return ("Marcaciones (vacia)",
+            new DiaDepurado("EMP-001", Fecha, Colaborador, "Turno Manana", [Franja()], [], Horas()));
+        yield return ("HorasDiscriminadas",
+            new DiaDepurado("EMP-001", Fecha, Colaborador, "Turno Manana", [Franja()], [Marcacion()],
+                new HorasDiscriminadas(new Dictionary<string, decimal>(), [])));
+    }
+
+    // Cobertura especifica del override: las colecciones se comparan por valor, no por referencia.
+
+    [Fact]
+    public void Equals_RetornaTrue_CuandoColeccionesSonInstanciasDiferentesConMismoContenido()
+    {
+        var a = new DiaDepurado("EMP-001", Fecha, Colaborador, "Turno Manana", [Franja()], [Marcacion()], Horas());
+        var b = new DiaDepurado("EMP-001", Fecha, Colaborador, "Turno Manana", [Franja()], [Marcacion()], Horas());
+
+        a.Equals(b).Should().BeTrue();
+    }
+
+    [Fact]
+    public void GetHashCode_RetornaMismoHash_CuandoColeccionesSonInstanciasDiferentesConMismoContenido()
+    {
+        var a = new DiaDepurado("EMP-001", Fecha, Colaborador, "Turno Manana", [Franja()], [Marcacion()], Horas());
+        var b = new DiaDepurado("EMP-001", Fecha, Colaborador, "Turno Manana", [Franja()], [Marcacion()], Horas());
+
+        a.GetHashCode().Should().Be(b.GetHashCode());
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.PrivateEvents.Tests/ControlHoras/DiaDepuradoTests.cs
+++ b/tests/Bitakora.ControlAsistencia.PrivateEvents.Tests/ControlHoras/DiaDepuradoTests.cs
@@ -14,6 +14,9 @@ namespace Bitakora.ControlAsistencia.PrivateEvents.Tests.ControlHoras;
 ///
 /// Este test compila referenciando UNICAMENTE PrivateEvents (CA-ADR-0029 seccion 3: si necesitara
 /// mas, el tipo no seria portable).
+///
+/// Issue #424: el payload se enriquece con NombreTurno, Franjas y Marcaciones; HorasDiscriminadas
+/// habla horas liquidables (decimal), no minutos.
 /// </summary>
 public class DiaDepuradoTests
 {
@@ -23,20 +26,32 @@ public class DiaDepuradoTests
     private static readonly DateOnly Fecha = new(2026, 3, 15);
 
     private static HorasDiscriminadas HorasConDatos() => new(
-        new Dictionary<string, int>
+        new Dictionary<string, decimal>
         {
-            ["DominicalFestivaDiurna"] = 420,
-            ["ExtraDiurnaDominicalFestiva"] = 30,
-            ["Retardo"] = 15
+            ["DominicalFestivaDiurna"] = 7.00m,
+            ["ExtraDiurnaDominicalFestiva"] = 0.50m,
+            ["Retardo"] = 0.25m
         },
         ["06:00-14:00: Dominical festiva diurna"]);
 
-    // CA-1: round-trip con el serializador POR DEFECTO del bus preserva todo el payload.
+    private static FranjaDepurada FranjaConDatos() => new(
+        new TimeOnly(6, 0), new TimeOnly(14, 0), 0,
+        new DateTime(2026, 3, 15, 7, 0, 0), new DateTime(2026, 3, 15, 15, 0, 0), false);
+
+    private static readonly MarcacionDelDia MarcacionEntrada =
+        new(new DateTime(2026, 3, 15, 7, 0, 0), "ENTRADA");
+    private static readonly MarcacionDelDia MarcacionSalida =
+        new(new DateTime(2026, 3, 15, 15, 0, 0), "SALIDA");
+
+    // CA-3/CA-4/CA-7: round-trip con el serializador POR DEFECTO del bus preserva todo el payload
+    // enriquecido, incluidas Franjas y Marcaciones.
     [Fact]
     public void RoundTrip_PreservaTodosLosCampos_ConSerializadorPorDefectoDelBus()
     {
         var colaborador = new ResumenColaborador("CC-1234567890", "EMP-001", "Luis Augusto Barreto");
-        var evento = new DiaDepurado("EMP-001", Fecha, colaborador, HorasConDatos());
+        var evento = new DiaDepurado(
+            "EMP-001", Fecha, colaborador, "Turno Manana",
+            [FranjaConDatos()], [MarcacionEntrada, MarcacionSalida], HorasConDatos());
         var opciones = CrearOpcionesDelBus();
 
         var json = JsonSerializer.Serialize(evento, opciones);
@@ -46,12 +61,14 @@ public class DiaDepuradoTests
         restaurado.Should().Be(evento);
     }
 
-    // CA-4: sin turno previo Colaborador viaja null, pero CodigoColaborador top-level sigue presente.
+    // CA-4/CA-5/CA-6: sin turno previo, Colaborador y NombreTurno viajan null, Franjas queda vacia,
+    // pero las marcaciones crudas siguen viajando y CodigoColaborador top-level sigue presente.
     [Fact]
-    public void RoundTrip_PreservaCodigoColaboradorTopLevel_CuandoColaboradorEsNulo()
+    public void RoundTrip_PreservaCodigoColaboradorTopLevelYMarcacionesCrudas_CuandoNoHayJornadaValida()
     {
         var evento = new DiaDepurado(
-            "EMP-002", Fecha, null, new HorasDiscriminadas(new Dictionary<string, int>(), []));
+            "EMP-002", Fecha, null, null, [], [MarcacionEntrada],
+            new HorasDiscriminadas(new Dictionary<string, decimal>(), []));
         var opciones = CrearOpcionesDelBus();
 
         var json = JsonSerializer.Serialize(evento, opciones);
@@ -60,5 +77,8 @@ public class DiaDepuradoTests
         restaurado.Should().NotBeNull();
         restaurado!.CodigoColaborador.Should().Be("EMP-002");
         restaurado.Colaborador.Should().BeNull();
+        restaurado.NombreTurno.Should().BeNull();
+        restaurado.Franjas.Should().BeEmpty();
+        restaurado.Marcaciones.Should().Equal(MarcacionEntrada);
     }
 }

--- a/tests/Bitakora.ControlAsistencia.PrivateEvents.Tests/ControlHoras/FranjaDepuradaIgualdadTests.cs
+++ b/tests/Bitakora.ControlAsistencia.PrivateEvents.Tests/ControlHoras/FranjaDepuradaIgualdadTests.cs
@@ -1,0 +1,36 @@
+// Issue #424: todos los campos de FranjaDepurada son primitivos -- la igualdad por valor del record
+// por defecto ya es correcta y no necesita Equals/GetHashCode propios (MEF-ADR-0012). Este test
+// congela esa premisa: si el record gana una coleccion, la compararia por referencia y el test rojo
+// lo delata.
+
+using Bitakora.ControlAsistencia.PrivateEvents.ControlHoras;
+
+namespace Bitakora.ControlAsistencia.PrivateEvents.Tests.ControlHoras;
+
+public class FranjaDepuradaIgualdadTests : IgualdadTestBase<FranjaDepurada>
+{
+    private static readonly DateTime Entrada = new(2026, 3, 15, 6, 0, 0);
+    private static readonly DateTime Salida = new(2026, 3, 15, 14, 0, 0);
+
+    protected override FranjaDepurada CrearInstancia() =>
+        new(new TimeOnly(6, 0), new TimeOnly(14, 0), 0, Entrada, Salida, false);
+
+    protected override FranjaDepurada CrearInstanciaCopia() =>
+        new(new TimeOnly(6, 0), new TimeOnly(14, 0), 0, Entrada, Salida, false);
+
+    protected override IEnumerable<(string, FranjaDepurada)> CrearInstanciasDiferentes()
+    {
+        yield return ("HoraInicioProgramada",
+            new FranjaDepurada(new TimeOnly(7, 0), new TimeOnly(14, 0), 0, Entrada, Salida, false));
+        yield return ("HoraFinProgramada",
+            new FranjaDepurada(new TimeOnly(6, 0), new TimeOnly(15, 0), 0, Entrada, Salida, false));
+        yield return ("DiaOffsetFin",
+            new FranjaDepurada(new TimeOnly(6, 0), new TimeOnly(14, 0), 1, Entrada, Salida, false));
+        yield return ("Entrada",
+            new FranjaDepurada(new TimeOnly(6, 0), new TimeOnly(14, 0), 0, null, Salida, false));
+        yield return ("Salida",
+            new FranjaDepurada(new TimeOnly(6, 0), new TimeOnly(14, 0), 0, Entrada, null, false));
+        yield return ("EsAnomala",
+            new FranjaDepurada(new TimeOnly(6, 0), new TimeOnly(14, 0), 0, Entrada, Salida, true));
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.PrivateEvents.Tests/ControlHoras/HorasDiscriminadasIgualdadTests.cs
+++ b/tests/Bitakora.ControlAsistencia.PrivateEvents.Tests/ControlHoras/HorasDiscriminadasIgualdadTests.cs
@@ -1,8 +1,9 @@
 // Issue #183: Tests de contrato IEquatable para HorasDiscriminadas.
 // HorasDiscriminadas es record con override manual de Equals/GetHashCode que compara
-// MinutosPorConcepto y Trazabilidad por valor (en lugar de la igualdad por referencia que el record
+// HorasPorConcepto y Trazabilidad por valor (en lugar de la igualdad por referencia que el record
 // genera por defecto - precedente DetalleFranjaOrdinaria, #129; ADR-0015 advierte sobre records con
 // colecciones que prometen igualdad por valor que no cumplen).
+// Issue #424: HorasPorConcepto (ex MinutosPorConcepto) habla horas liquidables (decimal).
 
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.PrivateEvents.ControlHoras;
@@ -13,30 +14,30 @@ public class HorasDiscriminadasIgualdadTests : IgualdadTestBase<HorasDiscriminad
 {
     // Orden de insercion consistente entre instancia y copia para que la comparacion no dependa
     // del orden de enumeracion del diccionario.
-    private static Dictionary<string, int> Minutos() => new()
+    private static Dictionary<string, decimal> Horas() => new()
     {
-        ["OrdinariaDiurna"] = 420,
-        ["Retardo"] = 15
+        ["OrdinariaDiurna"] = 7.00m,
+        ["Retardo"] = 0.25m
     };
 
     protected override HorasDiscriminadas CrearInstancia() =>
-        new(Minutos(), ["entro 06:15, retardo 15min"]);
+        new(Horas(), ["entro 06:15, retardo 15min"]);
 
     protected override HorasDiscriminadas CrearInstanciaCopia() =>
-        new(Minutos(), ["entro 06:15, retardo 15min"]);
+        new(Horas(), ["entro 06:15, retardo 15min"]);
 
     protected override IEnumerable<(string, HorasDiscriminadas)> CrearInstanciasDiferentes()
     {
-        yield return ("MinutosPorConcepto (valor distinto)",
+        yield return ("HorasPorConcepto (valor distinto)",
             new HorasDiscriminadas(
-                new Dictionary<string, int> { ["OrdinariaDiurna"] = 999, ["Retardo"] = 15 },
+                new Dictionary<string, decimal> { ["OrdinariaDiurna"] = 9.99m, ["Retardo"] = 0.25m },
                 ["entro 06:15, retardo 15min"]));
-        yield return ("MinutosPorConcepto (clave distinta)",
+        yield return ("HorasPorConcepto (clave distinta)",
             new HorasDiscriminadas(
-                new Dictionary<string, int> { ["OrdinariaNocturna"] = 420, ["Retardo"] = 15 },
+                new Dictionary<string, decimal> { ["OrdinariaNocturna"] = 7.00m, ["Retardo"] = 0.25m },
                 ["entro 06:15, retardo 15min"]));
         yield return ("Trazabilidad",
-            new HorasDiscriminadas(Minutos(), ["otra nota"]));
+            new HorasDiscriminadas(Horas(), ["otra nota"]));
     }
 
     // Cobertura especifica del override: las colecciones se comparan por valor, no por referencia.
@@ -45,9 +46,9 @@ public class HorasDiscriminadasIgualdadTests : IgualdadTestBase<HorasDiscriminad
     public void Equals_RetornaTrue_CuandoColeccionesSonInstanciasDiferentesConMismoContenido()
     {
         var a = new HorasDiscriminadas(
-            new Dictionary<string, int> { ["OrdinariaDiurna"] = 420 }, ["nota"]);
+            new Dictionary<string, decimal> { ["OrdinariaDiurna"] = 7.00m }, ["nota"]);
         var b = new HorasDiscriminadas(
-            new Dictionary<string, int> { ["OrdinariaDiurna"] = 420 }, ["nota"]);
+            new Dictionary<string, decimal> { ["OrdinariaDiurna"] = 7.00m }, ["nota"]);
 
         a.Equals(b).Should().BeTrue();
     }
@@ -56,9 +57,9 @@ public class HorasDiscriminadasIgualdadTests : IgualdadTestBase<HorasDiscriminad
     public void GetHashCode_RetornaMismoHash_CuandoColeccionesSonInstanciasDiferentesConMismoContenido()
     {
         var a = new HorasDiscriminadas(
-            new Dictionary<string, int> { ["OrdinariaDiurna"] = 420 }, ["nota"]);
+            new Dictionary<string, decimal> { ["OrdinariaDiurna"] = 7.00m }, ["nota"]);
         var b = new HorasDiscriminadas(
-            new Dictionary<string, int> { ["OrdinariaDiurna"] = 420 }, ["nota"]);
+            new Dictionary<string, decimal> { ["OrdinariaDiurna"] = 7.00m }, ["nota"]);
 
         a.GetHashCode().Should().Be(b.GetHashCode());
     }

--- a/tests/Bitakora.ControlAsistencia.PrivateEvents.Tests/ControlHoras/HorasDiscriminadasTests.cs
+++ b/tests/Bitakora.ControlAsistencia.PrivateEvents.Tests/ControlHoras/HorasDiscriminadasTests.cs
@@ -1,6 +1,8 @@
 // HorasDiscriminadas - payload plano (100% primitivo) que viaja en DiaDepurado por el bus interno
 // del BC: serializa y deserializa con STJ POR DEFECTO, sin el resolver custom de Marten. Esa es la
 // cura del payload lossy -- ningun consumidor depende de nuestra serializacion interna.
+//
+// Issue #424: HorasPorConcepto (ex MinutosPorConcepto) habla horas liquidables (decimal), no minutos.
 
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
@@ -12,18 +14,18 @@ namespace Bitakora.ControlAsistencia.PrivateEvents.Tests.ControlHoras;
 public class HorasDiscriminadasTests
 {
     private static HorasDiscriminadas CrearConDatos() => new(
-        new Dictionary<string, int>
+        new Dictionary<string, decimal>
         {
-            ["OrdinariaDiurna"] = 420,
-            ["ExtraDiurna"] = 30,
-            ["Retardo"] = 15
+            ["OrdinariaDiurna"] = 7.00m,
+            ["ExtraDiurna"] = 0.50m,
+            ["Retardo"] = 0.25m
         },
         ["entro 06:15, retardo 15min"]);
 
-    // CA-1: round-trip con el serializador POR DEFECTO (sin TypeInfoResolver custom). No lanza
-    // NotSupportedException y preserva MinutosPorConcepto y Trazabilidad sin perdida.
+    // CA-1/CA-2: round-trip con el serializador POR DEFECTO (sin TypeInfoResolver custom). No lanza
+    // NotSupportedException y preserva HorasPorConcepto (decimal) y Trazabilidad sin perdida.
     [Fact]
-    public void RoundTrip_PreservaMinutosPorConceptoYTrazabilidad_ConSerializadorPorDefecto()
+    public void RoundTrip_PreservaHorasPorConceptoYTrazabilidad_ConSerializadorPorDefecto()
     {
         var original = CrearConDatos();
         var opciones = new JsonSerializerOptions();
@@ -32,7 +34,7 @@ public class HorasDiscriminadasTests
         var restaurado = JsonSerializer.Deserialize<HorasDiscriminadas>(json, opciones);
 
         restaurado.Should().NotBeNull();
-        restaurado!.MinutosPorConcepto.Should().BeEquivalentTo(original.MinutosPorConcepto);
+        restaurado!.HorasPorConcepto.Should().BeEquivalentTo(original.HorasPorConcepto);
         restaurado.Trazabilidad.Should().BeEquivalentTo(original.Trazabilidad);
     }
 
@@ -51,22 +53,22 @@ public class HorasDiscriminadasTests
         var act = () => JsonSerializer.Deserialize<HorasDiscriminadas>(json, opciones);
 
         act.Should().NotThrow();
-        act()!.MinutosPorConcepto["OrdinariaDiurna"].Should().Be(420);
+        act()!.HorasPorConcepto["OrdinariaDiurna"].Should().Be(7.00m);
     }
 
-    // CA-1: el diccionario vacio (dia sin horas calculables) round-trip a un diccionario vacio,
+    // CA-2: el diccionario vacio (dia sin horas calculables) round-trip a un diccionario vacio,
     // no a null. La trazabilidad vacia se preserva igual.
     [Fact]
     public void RoundTrip_PreservaColeccionesVacias_CuandoDiaSinHorasCalculables()
     {
-        var original = new HorasDiscriminadas(new Dictionary<string, int>(), []);
+        var original = new HorasDiscriminadas(new Dictionary<string, decimal>(), []);
         var opciones = new JsonSerializerOptions();
 
         var json = JsonSerializer.Serialize(original, opciones);
         var restaurado = JsonSerializer.Deserialize<HorasDiscriminadas>(json, opciones);
 
         restaurado.Should().NotBeNull();
-        restaurado!.MinutosPorConcepto.Should().BeEmpty();
+        restaurado!.HorasPorConcepto.Should().BeEmpty();
         restaurado.Trazabilidad.Should().BeEmpty();
     }
 }

--- a/tests/Bitakora.ControlAsistencia.PrivateEvents.Tests/ControlHoras/MarcacionDelDiaIgualdadTests.cs
+++ b/tests/Bitakora.ControlAsistencia.PrivateEvents.Tests/ControlHoras/MarcacionDelDiaIgualdadTests.cs
@@ -1,0 +1,23 @@
+// Issue #424: todos los campos de MarcacionDelDia son primitivos -- la igualdad por valor del record
+// por defecto ya es correcta y no necesita Equals/GetHashCode propios (MEF-ADR-0012). Este test
+// congela esa premisa.
+
+using Bitakora.ControlAsistencia.PrivateEvents.ControlHoras;
+
+namespace Bitakora.ControlAsistencia.PrivateEvents.Tests.ControlHoras;
+
+public class MarcacionDelDiaIgualdadTests : IgualdadTestBase<MarcacionDelDia>
+{
+    private static readonly DateTime Timestamp = new(2026, 3, 15, 7, 0, 0);
+
+    protected override MarcacionDelDia CrearInstancia() => new(Timestamp, "ENTRADA");
+
+    protected override MarcacionDelDia CrearInstanciaCopia() => new(Timestamp, "ENTRADA");
+
+    protected override IEnumerable<(string, MarcacionDelDia)> CrearInstanciasDiferentes()
+    {
+        yield return ("Timestamp", new MarcacionDelDia(Timestamp.AddMinutes(1), "ENTRADA"));
+        yield return ("Tipo", new MarcacionDelDia(Timestamp, "SALIDA"));
+        yield return ("Tipo (nulo)", new MarcacionDelDia(Timestamp, null));
+    }
+}


### PR DESCRIPTION
## Resumen

Pipeline TDD completado:
- Fase roja: tests escritos con stubs
- Fase verde: implementación completa
- Fase refactor: revisión de calidad

## Decisiones del pipeline

<details>
<summary>Test Writer (fase roja) — 15m 7s</summary>

## ES Test Writer - Decisiones (issue #424)

### Tests creados

- `ControlHoras.Tests/ValueObjects/HorasLiquidablesTests.cs`: 5 tests
  - `DesdeMinutos_Convierte90MinutosA1Punto50Horas` - CA-1
  - `DesdeMinutos_Convierte50MinutosA0Punto83Horas` - CA-1
  - `DesdeMinutos_Convierte0MinutosA0Horas` - CA-1
  - `DesdeMinutos_RetornaTipoDecimal` - CA-1 (tipo decimal, no double)
  - `DesdeMinutos_Convierte5MinutosA0Punto08Horas` - CA-1 (oraculo reutilizado en escenarios de excedente)
- `PrivateEvents.Tests/ControlHoras/FranjaDepuradaIgualdadTests.cs`: contrato IEquatable (8 heredados + casos por campo)
- `PrivateEvents.Tests/ControlHoras/MarcacionDelDiaIgualdadTests.cs`: contrato IEquatable
- `PrivateEvents.Tests/ControlHoras/DiaDepuradoIgualdadTests.cs`: contrato IEquatable + 2 tests de cobertura de colecciones por valor (Franjas/Marcaciones)

### Tests modificados (cambio de forma obligatorio para compilar + nuevas aserciones del payload enriquecido)

- `PrivateEvents.Tests/ControlHoras/HorasDiscriminadasTests.cs`: renombrado `MinutosPorConcepto` -> `HorasPorConcepto`, literales a `decimal`
- `PrivateEvents.Tests/ControlHoras/HorasDiscriminadasIgualdadTests.cs`: idem
- `PrivateEvents.Tests/ControlHoras/DiaDepuradoTests.cs`: nuevos campos (`NombreTurno`, `Franjas`, `Marcaciones`); 2 tests (camino feliz enriquecido + "sin jornada valida")
- `ControlHoras.Tests/Entities/CrearDiaDepuradoConHorasDiscriminadasTests.cs`: renombrado + decimal + nuevas `And<>()` para `NombreTurno`/`Franjas`/`Marcaciones` en los 4 tests existentes
- `ControlHoras.Tests/AdicionarMarcacionCuandoRegistroDeMarcacionCreado/DepurarAlAdicionarMarcacionTests.cs`: los 4 `ThenIsPublishedPrivately(new DiaDepurado(...))` actualizados al ctor de 7 argumentos
- `ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/DepurarAlAsignarTurnoTests.cs`: los 3 `ThenIsPublishedPrivately(new DiaDepurado(...))` actualizados; el tercer test (`CuandoTurnoNoTieneFranjas`) es el caso unitario de CA-6 "cero franjas" que #423 hara ocurrir en runtime
- `ControlHoras.Tests/AdicionarMarcacionCuandoRegistroDeMarcacionCreado/Eventos/DiaDepuradoSerializacionTests.cs`: reescrito con `Franjas`/`Marcaciones`/`NombreTurno` y horas decimal
- `ControlHoras.Tests/ValueObjects/DesgloseHorasDiscriminarTests.cs`: renombrado + decimal en todos los literales (480->8.00m, 120->2.00m, 240->4.00m, 15->0.25m); 2 metodos renombrados (`...HorasPorConceptoVacio...`, `...HorasPorConcepto_SinRetardo`)
- `ControlHoras.SmokeTests/RegistrarMarcacionFunction/RegistrarMarcacionSmokeTests.cs`: rename de propiedad + aserciones nuevas de `NombreTurno`/`Franjas`/`Marcaciones` en los 3 tests que ya verificaban `DiaDepurado` (CA-7)
- `ControlHoras.SmokeTests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/AsignarTurnoViaSbSmokeTests.cs`: idem, en los 3 tests que verifican `DiaDepurado`

### Estructura elegida

- `DiaDepurado` se mantiene como `record` (no sealed class) con `Equals`/`GetHashCode` manuales por `SequenceEqual` sobre `Franjas` y `Marcaciones` -- precedente `TurnoDiario`/`FranjaProgramada`/`HorasDiscriminadas` ya en el mismo ensamblado. Descartada la alternativa "sealed class" (precedente `Retardo`/extinto `DiaCalculado`) porque el record ya resuelve el problema con menos codigo y el ensamblado `PrivateEvents` no tiene precedente de encapsular estos DTOs planos.
- `HorasLiquidables` como clase estatica pura (no VO/record) -- precedente `DepuradorDeMarcaciones`, `ConsolidadorDesgloseHoras`. Constante `PosicionesDecimales` privada.
- `FranjaDepurada`/`MarcacionDelDia`: records simples, todos los campos primitivos, sin `Equals`/`GetHashCode` propios (igualdad por defecto ya correcta) -- congelado con `IgualdadTestBase<T>`, mismo patron que `ResumenColaboradorIgualdadTests` (precedente de "congelar la premisa" incluso sin override).

### Stubs creados / modificados

- `PrivateEvents/ControlHoras/FranjaDepurada.cs` (nuevo, record completo -- forma de dato, no logica)
- `PrivateEvents/ControlHoras/MarcacionDelDia.cs` (nuevo, record completo)
- `ControlHoras/ValueObjects/HorasLiquidables.cs` (nuevo) - `DesdeMinutos()` -> `throw new NotImplementedException()`
- `PrivateEvents/ControlHoras/HorasDiscriminadas.cs` (modificado) - campo renombrado + decimal; `Equals`/`GetHashCode` reescritos completos (forma de dato, mismo criterio que la version anterior ya committeada sin ser un stub)
- `PrivateEvents/ControlHoras/DiaDepurado.cs` (modificado) - nuevos campos + `Equals`/`GetHashCode` completos (forma de dato)
- `ControlHoras/ValueObjects/DesgloseHoras.cs` - `Discriminar()` reducido a `throw new NotImplementedException()` (logica bajo prueba, todo el metodo pasa a stub)
- `ControlHoras/Entities/ControlDiarioAggregateRoot.cs` - `CrearDiaDepurado()` reducido a `throw new NotImplementedException()` (logica bajo prueba)

### Decisiones de diseno

- **`Discriminar()` y `CrearDiaDepurado()` se convirtieron INTEGRAMENTE en stubs** (`throw new NotImplementedException()`), no una implementacion parcial. Ambos metodos cambian de comportamiento (int->decimal via `HorasLiquidables`; payload enriquecido con `NombreTurno`/`Franjas`/`Marcaciones`) y son exactamente la logica que este issue pone bajo prueba -- dejar la implementacion vieja mezclada con el nuevo tipo de retorno habria requerido escribir logica real (prohibido para este agente). Consecuencia: TODOS los tests que invocan estos dos metodos (directa o transitivamente via el handler) fallan en fase roja con `NotImplementedException`, incluidos los que antes pasaban.
- Los valores decimales esperados en cada test se calcularon A MANO (oraculo independiente, regla 20): nunca se invoco `HorasLiquidables.DesdeMinutos` para construir el esperado. Conversion usada: minutos/60 redondeado a 2 decimales (90->1.50, 50->0.83, 5->0.08, 15->0.25, 20->0.33, 360->6.00, 420->7.00, 480->8.00, 120->2.00, 240->4.00). Ninguno de estos valores cae en un midpoint exacto de redondeo a 2 decimales, consistente con la nota tecnica del issue.

### Cobertura de criterios

| Criterio de aceptacion | Test(s) |
|---|---|
| CA-1 | `HorasLiquidablesTests` (5 tests) |
| CA-2 | `HorasDiscriminadasTests`, `HorasDiscriminadasIgualdadTests`, `DesgloseHorasDiscriminarTests` (todos), `CrearDiaDepuradoConHorasDiscriminadasTests` |
| CA-3 | `CrearDiaDepuradoConHorasDiscriminadasTests` (`Franjas` en ambos escenarios), `DepurarAlAdicionarMarcacionTests`, `DepurarAlAsignarTurnoTests`, `DiaDepuradoTests.RoundTrip_PreservaTodosLosCampos...`, smoke tests |
| CA-4 | `DepurarAlAdicionarMarcacionTests` (marcaciones en orden cronologico, incluido el caso de dos streams por ventana nocturna), `DiaDepuradoTests`, `DiaDepuradoSerializacionTests` |
| CA-5 | `CrearDiaDepuradoConHorasDiscriminadasTests` (`NombreTurno` null vs presente), `DepurarAlAdicionarMarcacionTests`, `DepurarAlAsignarTurnoTests`, smoke tests |
| CA-6 | `DepurarAlAsignarTurnoTests.ProgramacionTurnoDiarioSolicitada_PublicaDiaDepurado_CuandoTurnoNoTieneFranjas` (turno con cero franjas, construido en test) + los multiples casos "sin turno" ya cubiertos en CA-5 |
| CA-7 | `DiaDepuradoTests`, `DiaDepuradoSerializacionTests`, `RegistrarMarcacionSmokeTests` (3 tests), `AsignarTurnoViaSbSmokeTests` (3 tests) |

### Desviaciones del plan del planner

| Sugerencia del issue | Desviacion aplicada | Razon tecnica | Consecuencia |
|---|---|---|---|
| "Modifica tests: ... `DesgloseHorasTrasAdicionarMarcacionTests`, `DesgloseHorasTrasAsignarTurnoTests`" | NO se modificaron estos dos archivos | Ambos verifican `ControlDiarioAggregateRoot.DesgloseHoras` (el VO rico en minutos, `DesgloseFranja`/`Retardo`/`FranjasAnomalas`), que este issue no toca -- solo cambia lo que produce `DesgloseHoras.Discriminar()`. Verificado por grep: ninguno de los dos archivos referencia `HorasDiscriminadas` ni `MinutosPorConcepto`/`HorasPorConcepto`. El `using Bitakora.ControlAsistencia.PrivateEvents.ControlHoras;` en `DesgloseHorasTrasAdicionarMarcacionTests.cs` es vestigial (no se usa en el archivo) | Ambos siguen verdes tras el cambio; no aportan cobertura nueva de este issue pero tampoco requieren tocarse. `dotnet build` confirma que no rompieron |
| "Igualdad revisable" para `DiaDepurado` (record + Equals manual vs sealed class) | Se elige record + Equals/GetHashCode manual | Precedente directo en el mismo ensamblado (`TurnoDiario`, `FranjaProgramada`, `HorasDiscriminadas`); menos codigo que una sealed class y consistente con el resto de `PrivateEvents/ControlHoras/` | Sin impacto en cobertura; documentado para que el implementer no reabra la decision |
| Issue: "si el test-writer lo juzga necesario" tests de forma de records nuevos | Se agregaron `FranjaDepuradaIgualdadTests`, `MarcacionDelDiaIgualdadTests` y ademas `DiaDepuradoIgualdadTests` (no listado explicitamente, pero necesario porque `DiaDepurado` ahora tiene `Equals`/`GetHashCode` manuales que requieren congelarse) | `DiaDepurado` gana el mismo riesgo estructural que `HorasDiscriminadas` ya tiene cubierto con `HorasDiscriminadasIgualdadTests` -- omitirlo dejaria el override sin test dedicado | Cobertura adicional, ningun archivo de produccion nuevo |

</details>

<details>
<summary>Implementer (fase verde) — 4m 27s</summary>

## ES Implementer - Decisiones

### Enfoque de implementacion
Solo habia tres stubs `throw new NotImplementedException()` dejados por el test-writer, todos
en la ruta ya prevista por el issue:

1. `HorasLiquidables.DesdeMinutos(int minutos)` -- `Math.Round(minutos / 60m, PosicionesDecimales, MidpointRounding.AwayFromZero)`.
2. `DesgloseHoras.Discriminar()` -- vuelca `TotalMinutosPorConcepto` a `HorasPorConcepto` (clave
   `Concepto.ToString()`, valor `HorasLiquidables.DesdeMinutos(...)`), reusa
   `ConstruirTrazabilidadPorConcepto()` (ya provisto) y agrega la clave/linea "Retardo" solo
   cuando `RetardoTotal.RetardoNeto > 0`.
3. `ControlDiarioAggregateRoot.CrearDiaDepurado()` -- compone `CodigoColaborador` (via
   `ExtraerCodigoColaboradorDeStreamId`, ya existente), `NombreTurno` (`DetalleTurno?.Nombre`),
   `Franjas` (mapeo 1:1 de `_controlesDeFranja` a `FranjaDepurada`), `Marcaciones` (`_marcaciones`
   ordenadas por `TimestampNormalizado` ascendente, mapeadas a `MarcacionDelDia`) y
   `HorasDiscriminadas` (`DesgloseHoras.Discriminar()`).

No fue necesario tocar ningun record de `PrivateEvents/ControlHoras/` (`DiaDepurado`,
`FranjaDepurada`, `MarcacionDelDia`, `HorasDiscriminadas`): el test-writer ya los dejo completos
(campos, Equals/GetHashCode) en la fase roja.

### Decisiones de diseno
- `MidpointRounding.AwayFromZero` en `HorasLiquidables.DesdeMinutos`: el propio issue advierte que
  con `/60` y 2 decimales no hay midpoints exactos alcanzables, asi que el criterio de desempate es
  irrelevante en la practica; se deja explicito (no `MidpointRounding.ToEven` implicito por default)
  para que quede documentado en codigo, tal como pedia la nota tecnica del issue.
- `CrearFranjaDepurada` como metodo privado estatico del aggregate (Tell-don't-Ask: el mapeo
  `ControlFranja -> FranjaDepurada` es responsabilidad de quien arma el evento, no se expuso
  ninguna propiedad nueva de `ControlFranja` para lograrlo -- ya eran publicas `Programada`,
  `Entrada`, `Salida`, `EsAnomala`).
- El orden cronologico de `Marcaciones` se resuelve con `OrderBy(m => m.TimestampNormalizado)` en el
  propio `CrearDiaDepurado()`, coherente con el comentario ya presente en el codigo ("CrearDiaDepurado()
  ordena al construir") y con CA-4.

### ADRs consultados
- MEF-ADR-0023 / CA-ADR-0025: payload plano y portable -- verificado, no se toco ningun tipo del
  bus con campos no primitivos.
- CA-ADR-0029 / MEF-ADR-0039: payload por rol, tres islas -- el mapeo `ControlFranja -> FranjaDepurada`
  y `MarcacionNormalizada -> MarcacionDelDia` vive en el Function App (`ControlDiarioAggregateRoot`),
  unico proyecto que ve las tres islas.
- MEF-ADR-0012: Tell-don't-Ask -- `Discriminar()` sigue siendo el propio `DesgloseHoras` quien se
  empaqueta a si mismo; no se expuso ningun campo interno nuevo.
- MEF-ADR-0005 / MEF-ADR-0002 / MEF-ADR-0016: sin cambios de naming del evento; tests ya usan la
  convencion `<Sujeto>_<LoQuePasa>_Cuando<Condicion>`.
- MEF-ADR-0013: sin cambios de infraestructura -- la suscripcion `smoke-tests` del topic `dia-depurado`
  ya existe desde #421; los smoke tests del test-writer solo actualizan aserciones del payload.
- MEF-ADR-0018: `HorasLiquidables` se implemento como clase estatica pura (no VO/record), siguiendo
  el precedente citado por el planner (`DepuradorDeMarcaciones`, `ConsolidadorDesgloseHoras`) -- forma
  ya fijada por el stub que dejo el test-writer.

### Desviaciones de ADRs
Ninguna desviacion -- todos los ADRs aplicados al pie de la letra.

### Desviaciones del plan del planner
Ninguna desviacion relevante: la interfaz publica sugerida (`HorasLiquidables.DesdeMinutos`,
`FranjaDepurada`, `MarcacionDelDia`, forma de `DiaDepurado`/`HorasDiscriminadas`, firma de
`CrearDiaDepurado()`/`Discriminar()`) ya venia fijada en los stubs y records dejados por el
test-writer; el implementer solo completo los cuerpos.

### Precedentes consultados
- `DepuradorDeMarcaciones` / `ConsolidadorDesgloseHoras` (clases estaticas puras) -- alineado con
  MEF-ADR-0018, usado como forma para `HorasLiquidables`.
- `TurnoDiario` / `FranjaProgramada` (Equals/GetHashCode por SequenceEqual) -- ya aplicado por el
  test-writer en `DiaDepurado`/`FranjaDepurada`/`HorasDiscriminadas`; no se toco.

### Infraestructura modificada
Ninguna -- el topic `dia-depurado` y su suscripcion `smoke-tests` ya existen desde #421; este issue
no cambia el nombre del evento ni el canal.

### Complejidad encontrada
Ninguna. Los tres stubs eran directos dado el estado ya expuesto del aggregate (`ControlesDeFranja`,
`Marcaciones`, `DetalleTurno`, `DesgloseHoras` ya publicos) y los tipos de payload ya completos en
`PrivateEvents/ControlHoras/`.

### Resultado
- Tests del dominio (`ControlHoras.Tests`): 457/457
- Tests de eventos (`PrivateEvents.Tests`): 99/99
- Suite completa de la solucion: 1374 correctos / 0 errores / 49 omitidos (smoke tests que
  requieren Postgres/ServiceBus reales, sin relacion con este issue)

</details>
<details>
<summary>Reviewer (fase refactor) — 14m 46s</summary>

## ES Reviewer - Revision

### Evaluacion general
- Calidad: buena (con dos hallazgos mayores corregidos)
- Cambios realizados: si

Baseline de entrada: verde (1423 tests, 0 errores, 49 omitidos por smoke sin Postgres/ServiceBus).
Sin `blockage-report.md`. Tras la revision: 459 en `ControlHoras.Tests` (+1 test nuevo), 99 en
`PrivateEvents.Tests`, `dotnet build` 0 errores, `dotnet format --verify-no-changes` limpio sobre
todos los `.cs` del diff.

### Cumplimiento de ADRs aplicables

| ADR | Cumplimiento | Observacion |
|---|---|---|
| MEF-ADR-0023 / CA-ADR-0025: payload plano y portable, el modelo rico no cruza el bus | ok | `DiaDepurado` y sus tres tipos anidados (`FranjaDepurada`, `MarcacionDelDia`, `HorasDiscriminadas`) son 100% primitivos + `record` DTO planos. Ningun campo con ctor privado ni `ConfigurarSerializacion` |
| CA-ADR-0029 / MEF-ADR-0039: payload por rol, tres islas sin referencias entre si | ok | `git diff main...HEAD -- '**/*.csproj'` vacio: ninguna isla gano referencias. El mapeo `ControlFranja -> FranjaDepurada` y `MarcacionNormalizada -> MarcacionDelDia` vive en el Function App (`ControlDiarioAggregateRoot`), el unico proyecto que ve las tres islas |
| MEF-ADR-0012: Tell-don't-Ask, encapsulamiento, frontera de serializacion | desviacion NO declarada (evaluada aceptable) | Ver "Desviaciones". Ninguna propiedad nueva expuesta; `Discriminar()` sigue siendo el desglose empaquetandose a si mismo; el mapeo a `FranjaDepurada` es privado del aggregate |
| MEF-ADR-0005: naming del evento sin versionar | ok | El evento conserva nombre y canal; enriquecer el payload de un evento no persistido y sin consumidores no versiona el nombre |
| MEF-ADR-0002 / MEF-ADR-0016: estrategia y naming de tests | ok | `<Sujeto>_<LoQuePasa>_Cuando<Condicion>`, solo `[Fact]`, DSL Given/WhenAsync/Then/And. El test que agregue sigue la misma convencion |
| MEF-ADR-0013: smoke tests contra dev | ok | Aserciones del payload enriquecido en los 6 tests que ya consumian `DiaDepurado`; sin cambios de infra (la suscripcion `smoke-tests` del topic existe desde #421) |
| MEF-ADR-0018: Rule of Three / evolucion | ok | `HorasLiquidables` como clase estatica pura sigue el precedente `DepuradorDeMarcaciones` / `ConsolidadorDesgloseHoras`; sus dos llamadores (conceptos y clave "Retardo") justifican el punto unico |
| MEF-ADR-0036: identidad del evento persistido | n/a (verificado) | El issue lo declara no aplicable; confirme que `IdentidadEventosControlHoras.TiposPersistidos` excluye `DiaDepurado` y que el diff no renombra ningun tipo persistido |
| MEF-ADR-0044: comentarios minimos | ok | Limpieza aplicada (ver seccion propia) |

### Desviaciones de ADRs

**Desviaciones declaradas por el implementer**: ninguna ("todos los ADRs aplicados al pie de la letra").

**Desviaciones detectadas por el reviewer (NO declaradas por el implementer)**:

#### Desviacion: MEF-ADR-0012 (nota sobre equality / antipatron "record con IReadOnlyList como propiedad de igualdad")
- **Regla del ADR**: *"Usar `record` para eventos con colecciones (ej: `IReadOnlyList<T>`) promete igualdad por valor que no cumple -- `sealed class` no hace esa promesa"*.
- **Desviacion encontrada en el diff**: `PrivateEvents/ControlHoras/DiaDepurado.cs` sigue siendo `record` y gana dos `IReadOnlyList<T>` (`Franjas`, `Marcaciones`), en vez de migrar a `sealed class`.
- **Accion tomada**: se conserva la forma `record`. La razon por la que el ADR proscribe el patron -- prometer una igualdad que el compilador no genera -- **esta neutralizada**: el diff trae `Equals`/`GetHashCode` manuales por `SequenceEqual` y `DiaDepuradoIgualdadTests` los congela. Ademas el issue dejo la decision explicitamente abierta ("Igualdad revisable... el pipeline decide") y hay precedente vigente en el mismo ensamblado (`HorasDiscriminadas`, `TurnoDiario`, `FranjaProgramada`). Endurecí el comentario del override para que un campo nuevo no se olvide de sumarse a ambos metodos.
- **Evaluacion del reviewer**: aceptable. Migrar a `sealed class` no aportaria correccion (el defecto ya no existe) y romperia la consistencia del ensamblado.
- **Status**: pendiente de evaluacion del usuario

### Precedentes consultados por el implementer

| Precedente | ADR aplicable | Veredicto |
|---|---|---|
| `DepuradorDeMarcaciones` / `ConsolidadorDesgloseHoras` (clases estaticas puras) | MEF-ADR-0012 (antipatron #2), MEF-ADR-0018 | alineado. `HorasLiquidables.DesdeMinutos(int)` opera sobre un `int` primitivo, no sobre los datos crudos de un VO: no hay objeto al que mover la operacion, asi que no cae en el antipatron de "clase estatica que opera sobre datos de un VO" |
| `TurnoDiario` / `FranjaProgramada` (Equals/GetHashCode por SequenceEqual) | MEF-ADR-0012 | alineado con el mismo matiz de la desviacion de arriba: el override manual cumple la promesa que el `record` por defecto no cumple |

### Convenciones del pipeline (no ADRs)

| Convencion | Estado | Observacion |
|---|---|---|
| Cada test con `Then()` + `And<>()` | ok | Verificado en los tests de handler/aggregate; el test que agregue lleva `Then` + `And<>` |
| Overloads correctos para stream IDs compuestos | ok | `ComputarStreamId` es `cd:{codigo}:{yyyyMMdd}`: todos los tests usan `Given(StreamId, ...)`, `Then(StreamId, ...)` y `And<T,P>(StreamId, ...)` |
| Fakes manuales (no NSubstitute) | ok | `EventStore` / `PrivateEventSender` del harness; sin NSubstitute |
| Feature folders (produccion y tests) | ok | Tests espejo del feature folder; `Entities/` y `ValueObjects/` a nivel raiz |
| Smoke tests: SkipWhen, secrets, cobertura | ok | `Assert.SkipWhen` en los 14 tests de los dos archivos; filtran por `CodigoColaborador`/`SolicitudId` (nunca por posicion); sin archivos duplicados por comando; los efectos secundarios (Postgres + publicacion a `dia-depurado`) siguen cubiertos y ahora tambien el payload enriquecido. Los literales de nombre de turno afirmados (`[TEST] Turno HU108`, `[TEST] Turno Smoke SB`, `[TEST] Turno Partido Sede`) coinciden con los que cada test envia |
| Proyecciones read-side | n/a | El diff no toca `ReadModels`/`Projections` ni ninguna Function GET |
| Antipatrones de habilitacion (MEF-ADR-0039) | ok | `git diff main...HEAD -- '**/*.csproj'` vacio -> (a),(b),(c),(e) sin superficie. (d): `FranjaDepurada` y `MarcacionDelDia` no tienen homonimo en `ControlHoras.DomainEvents` (verificado por grep sobre `src/`) |
| Compatibilidad Marten write-side/read-side | n/a | El diff no toca version de `Cosmos.EventSourcing.*` ni configuracion de Marten |
| Identidad de stream (MEF-ADR-0037) | n/a | Ninguna conversion de identidad nueva: sin `ToString(formato)` sobre `Guid`, sin construccion manual de clave fuera de `ComputarStreamId`, sin GET de read-side |
| Contrato HTTP de comandos (MEF-ADR-0043) | n/a | El diff no crea ni modifica ningun `FunctionEndpoint.cs` de comando |
| Control de volumen de telemetria (MEF-ADR-0038) | n/a | El diff no toca `ComposicionServicios*`, `ConfiguracionObservabilidad*` ni el callback de Wolverine |
| Limpieza de comentarios (MEF-ADR-0044) | ok | Ver seccion propia |
| Tests via ToString/comportamiento | ok | Ninguna propiedad se expuso para satisfacer un test; el test nuevo verifica el orden proyectando a string, no exponiendo estado |
| Sin numeros magicos | ok | `PosicionesDecimales = 2` es constante nombrada; `60m` es la definicion de la unidad hora, no un magic number oculto |
| Condiciones en positivo | ok | Sin guardas negadas nuevas en bifurcaciones `if`/`else` |

### Elegancia del codigo
- El diff de la fase verde ya era compacto e idiomatico (LINQ, `record`, expresiones de cuerpo unico). Dos ajustes:
  - `CrearDiaDepurado()` tenia el mapeo de franjas extraido a metodo pero el de marcaciones en linea (tres operadores LINQ anidados dentro de la lista de argumentos del constructor). Extraje `CrearMarcacionesCronologicas()`: el nombre codifica el contrato de orden -- jerarquia de MEF-ADR-0044 seccion 1, codigo autodocumentado antes que comentario -- y `CrearDiaDepurado()` queda como composicion legible de 7 argumentos.
  - Consistencia de nombres de lambda en `Discriminar()`: `kv` -> `par`, el que ya usa el resto del metodo y `HorasDiscriminadas`.
- Sin warnings nuevos del compilador, sin debug cruft, sin imports innecesarios en los archivos del diff.

### Criticas y hallazgos

1. **[MAYOR - corregido] `Discriminar()` perdio el filtro `.Where(par => par.Value > 0)`.** Al reescribirse el metodo (stub en fase roja -> implementacion en fase verde) el filtro desaparecio y no quedo declarado como desviacion. Hoy no es observable: `IntervaloTemporal.Crear` impone `Inicio < Fin`, asi que todo concepto presente aporta minutos > 0 y la suma nunca es cero. Pero (a) era un cambio fuera del alcance del issue, y (b) dejaba sin custodia el contrato del payload -- publicar una clave en cero le da al consumidor (#425) una clave sin significado, y con una precision menor a 2 posiciones el redondeo la produciria. **Restaurado.**

2. **[MAYOR - corregido] CA-4 tenia un falso verde estructural: el `OrderBy` no estaba cubierto.** CA-4 exige orden cronologico ascendente *"aun cuando llegaron desordenadas al aggregate"*, y **ningun** test alimentaba marcaciones desordenadas -- todos los `Given` son cronologicos. Verificado por mutacion: al eliminar `.OrderBy(m => m.TimestampNormalizado)` la suite quedaba **458/458 verde**. Peor todavia: el primer test que escribi, afirmando sobre `IReadOnlyList<MarcacionDelDia>` con `And<>()`, **tambien pasaba con el `OrderBy` eliminado**, porque `And<>()` compara con `BeEquivalentTo`, que ignora el orden de una coleccion -- ningun `And<>()` del diff puede verificar orden, ni los que el test-writer escribio para `Marcaciones`. Test reescrito proyectando a un escalar sensible al orden (`"07:00|15:00"`); verificado rojo sin el `OrderBy` y verde con el.

3. **[MENOR - reportado, NO tocado] Dos comentarios contradicen la implementacion tras el enriquecimiento.** En `DepurarAlAdicionarMarcacionTests.cs` (*"El contrato plano no lleva senal de la franja anomala (riesgo aceptado del issue)"*) y en `DepurarAlAsignarTurnoTests.cs` (*"El contrato plano no lleva senal de anomalia (riesgo aceptado)"*). Con `FranjaDepurada.EsAnomala` en el payload esa afirmacion ya es falsa -- el riesgo que #183 acepto es justamente lo que #424 paga. El test-writer actualizo esta nota en `CrearDiaDepuradoConHorasDiscriminadasTests.cs` y la dejo en los otros dos. MEF-ADR-0044 seccion 6 manda reportar sin resolver: decidir si la nota se borra o se reformula es criterio humano.

4. **[COSMETICO - corregido]** Linea `//` vacia introducida en `DesgloseHoras.cs` sobre `Discriminar()`; cita `(ADR-0015)` en `DiaDepurado.cs` apuntando a la numeracion local retirada -> actualizada a MEF-ADR-0012, que es donde vive hoy la nota sobre equality.

5. **[COSMETICO - no tocado]** `HorasLiquidablesTests.DesdeMinutos_RetornaTipoDecimal` usa `BeOfType(typeof(decimal))` sobre el retorno de un metodo cuyo tipo estatico ya es `decimal`: esa asercion es tautologica (el compilador la garantiza). Su segunda asercion (`Be(1m)`) si aporta. Lo dejo: es un test legitimo del CA-1, solo con una asercion redundante.

### Refactorings aplicados
- `ControlDiarioAggregateRoot`: extraccion de `CrearMarcacionesCronologicas()` desde el cuerpo de `CrearDiaDepurado()` (legibilidad + el nombre codifica el contrato de orden).
- `DesgloseHoras.Discriminar()`: restauracion del filtro de claves con valor y consistencia de nombres de lambda (`par`).
- Sin cambios de API publica: ninguna firma ni tipo publico se modifico.

### Limpieza de comentarios (MEF-ADR-0044)

Aplicada sobre los `.cs` del diff (produccion completa; en tests, acotada -- ver criterio al final). Behavior-preserving: `dotnet test` verde despues de cada pasada.

| Archivo | Poda / compresion | Condicion del umbral que fallaba |
|---|---|---|
| `HorasLiquidables.cs` | provenance (`Issue #424:`, `decision del humano, 2026-08-20`, `doctrina del glosario`) y el comentario de la constante (*"Constante NOMBRADA de precision -- NUNCA un literal suelto"*) | Context Delta: `private const int PosicionesDecimales = 2` **es** la constante nombrada; el comentario narraba el codigo. Se conserva comprimida la restriccion real (punto unico de conversion, precision no configurable por vista) y el rationale de `AwayFromZero` (Context + Decision Delta: la premisa "sin midpoints alcanzables" caduca si la precision sube) |
| `DiaDepurado.cs` | provenance e historia (`Issue #424:`, `#423`, `#425`, `#429`, `decision 2026-08-20, supersede el extinto #422`, *"El nombre DiaCalculado queda reservado..."*, *"DiaCalculado no puede ir a buscarlas (aggregate separado...)"*) | Context Delta / narracion temporal (MEF-ADR-0044 seccion 3). Se conservan comprimidas las tres restricciones activas: no se persiste, `CodigoColaborador` top-level nunca se mueve dentro de `Colaborador`, y la trinidad estructural `NombreTurno` + `Franjas` (no inferible de `string?` + lista) |
| `HorasDiscriminadas.cs` | provenance y narracion temporal (`Issue #424: ... (ex MinutosPorConcepto)`, `field notes 2026-06-23`, `precedente DetalleFranjaOrdinaria, #129`, *"el modelo rico anterior (DesgloseHoras + DetalleControlFranja)"*, *"corrige el bug"*) | Ambas: era historia del cambio, no restriccion vigente. Se conserva la restriccion (100% primitivo porque el resolver de Marten no alcanza el canal de Service Bus) con la cita MEF-ADR-0012 como puntero resoluble |
| `FranjaDepurada.cs` | provenance (`Issue #424:`), *"La sede quedo explicitamente fuera de la conversacion por ahora"* y *"Todos los campos son primitivos -> la igualdad por valor del record por defecto ya es correcta"* | Context Delta: lo segundo es semantica convencional del lenguaje (proscrito, "explicacion de sintaxis"). Se conserva por que faltan sede/descansos (dos fuentes de verdad) y la consecuencia de sumar una coleccion |
| `MarcacionDelDia.cs` | provenance (`Issue #424:`, `#429`) y el bloque de igualdad por defecto del record | Igual que arriba. Se conserva la restriccion util: sin marca usada/descartada a proposito, el receptor la deriva por coincidencia de `Timestamp`, garantizada unica por la idempotencia por minuto |
| `DesgloseHoras.cs` | narracion del codigo (*"Vuelca TotalMinutosPorConcepto con clave Concepto.ToString() y agrega la clave literal Retardo... solo cuando es > 0"* -- el codigo lo dice literalmente) y la linea `//` vacia | Context Delta. Se conserva Tell-don't-Ask, el porque del filtro y la frontera del modelo rico |
| 3 encabezados de test (`DepurarAlAdicionarMarcacionTests`, `DepurarAlAsignarTurnoTests`, `CrearDiaDepuradoConHorasDiscriminadasTests`) | el bloque "Issue #424: el payload enriquecido lleva NombreTurno, Franjas..., Marcaciones..., HorasDiscriminadas en horas liquidables" | Ambas: es "resumen de la implementacion o del cambio" (MEF-ADR-0044 seccion 3), y los literales del propio test ya lo dicen. En `DepurarAlAsignarTurnoTests` se conservo comprimida la parte con Decision Delta real: por que existe un test de un caso que hoy no ocurre en runtime (no borrarlo por "imposible") |

**Criterio y frontera declarados**: en archivos de test conserve deliberadamente los mapeos `CA-x` inline y los comentarios de oraculo independiente (*"registrado A MANO... sin ejecutar Discriminar"*). Los segundos pasan el umbral con holgura (un agente futuro podria "simplificar" el esperado invocando la logica bajo prueba -- exactamente el error que documentan). Los primeros son provenance por la letra de MEF-ADR-0044 seccion 3, pero su retiro sistematico corresponde al issue dependiente que propaga esta doctrina a los agentes escritores, no a una poda unilateral mia sobre un PR de dominio. No abri ningun `.cs` ajeno al diff.

### Cobertura de criterios de aceptacion

| Criterio | Estado | Test(s) |
|---|---|---|
| CA-1: `HorasLiquidables` convierte con precision en constante nombrada, tipo `decimal` | cubierto | `HorasLiquidablesTests` (5 tests: 90->1.50, 50->0.83, 0->0, 5->0.08, tipo decimal) |
| CA-2: `HorasPorConcepto` decimal via `HorasLiquidables`, incluida la clave "Retardo"; `Trazabilidad` sin cambios | cubierto | `DesgloseHorasDiscriminarTests` (10 tests), `HorasDiscriminadasTests`, `HorasDiscriminadasIgualdadTests`, `CrearDiaDepurado_LlevaHorasYTrazabilidadReales_CuandoFranjaNoEsAnomala` |
| CA-3: una `FranjaDepurada` por franja ordinaria, espejo de `ControlesDeFranja` | cubierto | `CrearDiaDepurado_LlevaHorasYTrazabilidadReales_CuandoFranjaNoEsAnomala`, `CrearDiaDepurado_LlevaHorasPorConceptoVacio_CuandoTurnoSinMarcaciones`, `DepurarAlAdicionarMarcacionTests` (turno partido: 2 franjas), `DepurarAlAsignarTurnoTests`, smoke (`Franjas.HaveCount(2)`, `ContainSingle(f => f.EsAnomala)`) |
| CA-4: TODAS las marcaciones, crudas, en orden cronologico ascendente aun llegando desordenadas | cubierto (reforzado en esta fase) | Contenido: `CrearDiaDepurado_LlevaHorasYTrazabilidadReales_...`, `DepurarAlAdicionarMarcacionTests`, `DiaDepuradoTests`. **Orden ante llegada desordenada: `CrearDiaDepurado_OrdenaMarcacionesCronologicamente_CuandoLlegaronDesordenadas` (agregado en esta fase -- antes no existia y el `OrderBy` era codigo sin cobertura)** |
| CA-5: senal del plan estructural, sin enum adicional | cubierto | `CrearDiaDepurado_LlevaHorasPorConceptoVacio_CuandoNoHayTurno` (`NombreTurno` null), `CrearDiaDepurado_LlevaHorasYTrazabilidadReales_...` (nombre presente), `DepurarAlAsignarTurnoTests`, smoke (`NombreTurno.Should().Be(...)` / `BeNull()`) |
| CA-6: dia sin jornada valida (sin turno y turno con cero franjas) | cubierto | `ProgramacionTurnoDiarioSolicitada_PublicaDiaDepurado_CuandoTurnoNoTieneFranjas` (cero franjas), `RegistroDeMarcacionCreado_DejaControlesDeFranjaVacios_CuandoNoHayTurnoPrevio`, `RoundTrip_PreservaCampos_CuandoNoHayJornadaValida`, smoke sin turno |
| CA-7: round-trip con serializador por defecto + smoke en ambos flujos | cubierto | `DiaDepuradoTests` (isla sola), `DiaDepuradoSerializacionTests` (3 tests, incluido el resolver vacio), `RegistrarMarcacionSmokeTests` (3), `AsignarTurnoViaSbSmokeTests` (3) |

### Tests agregados
- `CrearDiaDepuradoConHorasDiscriminadasTests.ViaAsignarTurnoTests.CrearDiaDepurado_OrdenaMarcacionesCronologicamente_CuandoLlegaronDesordenadas` -- cierra el gap de CA-4. Aplica las marcaciones en orden inverso (15:00 antes que 07:00) y afirma el orden del payload proyectando a `"07:00|15:00"`, porque `And<>()` compara con `BeEquivalentTo` e ignora el orden de una coleccion. Verificado por mutacion: rojo al quitar el `OrderBy`, verde con el.
- Los tests de contrato de igualdad y serializacion que este paso habria exigido ya venian completos de la fase roja (`FranjaDepuradaIgualdadTests`, `MarcacionDelDiaIgualdadTests`, `DiaDepuradoIgualdadTests`, round-trip con serializador por defecto para los tres tipos con marker de bus): no hizo falta agregar ninguno.

</details>

## Cobertura

| Archivo | Cobertura | Umbral | Estado |
|---|---|---|---|
| ControlDiarioAggregateRoot.cs | 100.0% | 95% | ok |
| FranjaDepurada.cs | - | excluido | - |
| MarcacionDelDia.cs | - | excluido | - |
| DesgloseHoras.cs | - | sin clasificar | ⚠ revisar |
| HorasLiquidables.cs | - | sin clasificar | ⚠ revisar |
| DiaDepurado.cs | - | sin clasificar | ⚠ revisar |
| HorasDiscriminadas.cs | - | sin clasificar | ⚠ revisar |

> **Archivos sin clasificar** (`⚠ revisar`): ninguna regla de clasificacion los reconocio — el gate **no los midio**. No es una exclusion deliberada (a diferencia de `excluido`, donde si se decidio que no requieren cobertura): requieren revision humana para confirmar si necesitan tests.
## Commits

7fa1967 refactor(#424): restaurar filtro de conceptos con valor y cubrir el orden de Marcaciones
aeaad13 feat(issue-424): enriquece DiaDepurado con franjas, marcaciones y horas liquidables (fase verde)
d040378 test(424): tests para enriquecer DiaDepurado con franjas, marcaciones y horas liquidables (fase roja)

Closes #424