### PR TITLE
Crear el aggregate DiaCalculado que consume DiaDepurado

### DIFF
--- a/infra/environments/dev/main.tf
+++ b/infra/environments/dev/main.tf
@@ -80,6 +80,10 @@ module "service_bus" {
     "dia-depurado" = {
       subscriptions = [
         {
+          name               = "control-horas-escucha-dia-depurado"
+          correlation_filter = null
+        },
+        {
           name                = "smoke-tests"
           correlation_filter  = null
           default_message_ttl = "PT5M"

--- a/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/ConfiguracionSerializacionControlHoras.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/ConfiguracionSerializacionControlHoras.cs
@@ -26,5 +26,6 @@ public static class ConfiguracionSerializacionControlHoras
         TurnoDiarioAsignado.ConfigurarSerializacion(resolver);
         MarcacionRegistrada.ConfigurarSerializacion(resolver);
         MarcacionAdicionada.ConfigurarSerializacion(resolver);
+        DepuracionDiaRecibida.ConfigurarSerializacion(resolver);
     }
 }

--- a/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/DepuracionDiaRecibida.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/DepuracionDiaRecibida.cs
@@ -1,0 +1,72 @@
+using System.Reflection;
+using System.Text.Json.Serialization.Metadata;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
+
+// Issue #425: evento de event sourcing que registra la recepcion de una foto de DiaDepurado
+// (PrivateEvents.ControlHoras) sobre el stream de DiaCalculadoAggregateRoot. Siempre se emite --
+// sin comparacion contra el estado previo, sin deduplicacion de ningun tipo (decision de sesion
+// 2026-08-24): el productor ya controla los duplicados de negocio en origen, y re-aplicar la
+// misma foto ante un redelivery de transporte es idempotente.
+// ADR-0024: evento del aggregate (categoria event-sourcing), sin marker de bus.
+public sealed class DepuracionDiaRecibida
+{
+    // Id es el stream key de DiaCalculado, tal como lo computa DiaCalculadoAggregateRoot.ComputarStreamId.
+    public string Id { get; private set; } = null!;
+    public string CodigoColaborador { get; private set; } = null!;
+    public DateOnly Fecha { get; private set; }
+    public ResumenColaborador? Colaborador { get; private set; }
+    public string? NombreTurno { get; private set; }
+    public IReadOnlyList<FranjaDepurada> Franjas { get; private set; } = null!;
+    public IReadOnlyList<MarcacionDelDia> Marcaciones { get; private set; } = null!;
+    public HorasDiscriminadas HorasDiscriminadas { get; private set; } = null!;
+
+    public DepuracionDiaRecibida(
+        string id,
+        string codigoColaborador,
+        DateOnly fecha,
+        ResumenColaborador? colaborador,
+        string? nombreTurno,
+        IReadOnlyList<FranjaDepurada> franjas,
+        IReadOnlyList<MarcacionDelDia> marcaciones,
+        HorasDiscriminadas horasDiscriminadas)
+    {
+        Id = id;
+        CodigoColaborador = codigoColaborador;
+        Fecha = fecha;
+        Colaborador = colaborador;
+        NombreTurno = nombreTurno;
+        Franjas = franjas;
+        Marcaciones = marcaciones;
+        HorasDiscriminadas = horasDiscriminadas;
+    }
+
+    // Constructor privado para Marten/serializacion
+    private DepuracionDiaRecibida() { }
+
+    // Configuracion de serializacion STJ/Marten: permite deserializar con constructor privado
+    // y propiedades con private set. Ver MEF-ADR-0012 y DepuracionDiaRecibidaSerializacionTests.
+    public static void ConfigurarSerializacion(DefaultJsonTypeInfoResolver resolver)
+    {
+        var ctor = typeof(DepuracionDiaRecibida)
+            .GetConstructor(BindingFlags.NonPublic | BindingFlags.Instance, Type.EmptyTypes)!;
+
+        resolver.Modifiers.Add(typeInfo =>
+        {
+            if (typeInfo.Type != typeof(DepuracionDiaRecibida)) return;
+            if (typeInfo.Kind != JsonTypeInfoKind.Object) return;
+
+            typeInfo.CreateObject = () => (DepuracionDiaRecibida)ctor.Invoke(null);
+
+            foreach (var prop in typeInfo.Properties)
+            {
+                if (prop.Set is not null) continue;
+                var backingField = typeof(DepuracionDiaRecibida).GetField(
+                    $"<{prop.Name}>k__BackingField",
+                    BindingFlags.NonPublic | BindingFlags.Instance);
+                if (backingField is not null)
+                    prop.Set = (obj, val) => backingField.SetValue(obj, val);
+            }
+        });
+    }
+}

--- a/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/DepuracionDiaRecibida.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/DepuracionDiaRecibida.cs
@@ -3,12 +3,10 @@ using System.Text.Json.Serialization.Metadata;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 
-// Issue #425: evento de event sourcing que registra la recepcion de una foto de DiaDepurado
-// (PrivateEvents.ControlHoras) sobre el stream de DiaCalculadoAggregateRoot. Siempre se emite --
-// sin comparacion contra el estado previo, sin deduplicacion de ningun tipo (decision de sesion
-// 2026-08-24): el productor ya controla los duplicados de negocio en origen, y re-aplicar la
-// misma foto ante un redelivery de transporte es idempotente.
-// ADR-0024: evento del aggregate (categoria event-sourcing), sin marker de bus.
+// Foto completa de un dia depurado, persistida en el stream de DiaCalculadoAggregateRoot. Cada
+// recepcion emite una: no hay deduplicacion de ningun tipo (el productor controla los duplicados
+// de negocio y re-aplicar la misma foto es idempotente).
+// MEF-ADR-0024: evento del aggregate, sin marker de bus.
 public sealed class DepuracionDiaRecibida
 {
     // Id es el stream key de DiaCalculado, tal como lo computa DiaCalculadoAggregateRoot.ComputarStreamId.

--- a/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/FranjaDepurada.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/FranjaDepurada.cs
@@ -1,6 +1,6 @@
 namespace Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 
-// Issue #425: payload propio de esta isla, espejo de PrivateEvents.ControlHoras.FranjaDepurada
+// Payload propio de esta isla, espejo de PrivateEvents.ControlHoras.FranjaDepurada
 // (payload por rol, MEF-ADR-0039 decision #6) -- mismo termino del glosario, tipo distinto porque
 // ningun ensamblado de eventos referencia a otro (CA-ADR-0029 decision #2, tres islas).
 public record FranjaDepurada(

--- a/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/FranjaDepurada.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/FranjaDepurada.cs
@@ -1,0 +1,12 @@
+namespace Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
+
+// Issue #425: payload propio de esta isla, espejo de PrivateEvents.ControlHoras.FranjaDepurada
+// (payload por rol, MEF-ADR-0039 decision #6) -- mismo termino del glosario, tipo distinto porque
+// ningun ensamblado de eventos referencia a otro (CA-ADR-0029 decision #2, tres islas).
+public record FranjaDepurada(
+    TimeOnly HoraInicioProgramada,
+    TimeOnly HoraFinProgramada,
+    int DiaOffsetFin,
+    DateTime? Entrada,
+    DateTime? Salida,
+    bool EsAnomala);

--- a/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/HorasDiscriminadas.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/HorasDiscriminadas.cs
@@ -1,6 +1,6 @@
 namespace Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 
-// Issue #425: payload propio de esta isla, espejo de PrivateEvents.ControlHoras.HorasDiscriminadas
+// Payload propio de esta isla, espejo de PrivateEvents.ControlHoras.HorasDiscriminadas
 // (payload por rol, MEF-ADR-0039 decision #6).
 //
 // El record por defecto compara HorasPorConcepto/Trazabilidad por referencia; estos overrides las

--- a/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/HorasDiscriminadas.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/HorasDiscriminadas.cs
@@ -1,0 +1,35 @@
+namespace Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
+
+// Issue #425: payload propio de esta isla, espejo de PrivateEvents.ControlHoras.HorasDiscriminadas
+// (payload por rol, MEF-ADR-0039 decision #6).
+//
+// El record por defecto compara HorasPorConcepto/Trazabilidad por referencia; estos overrides las
+// comparan por valor (MEF-ADR-0012, nota sobre equality: un record con colecciones promete una
+// igualdad que el compilador no genera).
+public record HorasDiscriminadas(
+    IReadOnlyDictionary<string, decimal> HorasPorConcepto,
+    IReadOnlyList<string> Trazabilidad)
+{
+    public virtual bool Equals(HorasDiscriminadas? other)
+    {
+        if (other is null) return false;
+        if (ReferenceEquals(this, other)) return true;
+        return HorasPorConceptoIguales(other.HorasPorConcepto)
+            && Trazabilidad.SequenceEqual(other.Trazabilidad);
+    }
+
+    private bool HorasPorConceptoIguales(IReadOnlyDictionary<string, decimal> otros) =>
+        HorasPorConcepto.Count == otros.Count
+        && HorasPorConcepto.All(par => otros.TryGetValue(par.Key, out var valor) && valor == par.Value);
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        var hashHoras = 0;
+        foreach (var par in HorasPorConcepto)
+            hashHoras ^= HashCode.Combine(par.Key, par.Value);
+        hash.Add(hashHoras);
+        foreach (var nota in Trazabilidad) hash.Add(nota);
+        return hash.ToHashCode();
+    }
+}

--- a/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/IdentidadEventosControlHoras.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/IdentidadEventosControlHoras.cs
@@ -25,6 +25,7 @@ public static class IdentidadEventosControlHoras
     [
         typeof(MarcacionRegistrada),
         typeof(MarcacionAdicionada),
-        typeof(TurnoDiarioAsignado)
+        typeof(TurnoDiarioAsignado),
+        typeof(DepuracionDiaRecibida)
     ];
 }

--- a/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/MarcacionDelDia.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/MarcacionDelDia.cs
@@ -1,0 +1,5 @@
+namespace Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
+
+// Issue #425: payload propio de esta isla, espejo de PrivateEvents.ControlHoras.MarcacionDelDia
+// (payload por rol, MEF-ADR-0039 decision #6).
+public record MarcacionDelDia(DateTime Timestamp, string? Tipo);

--- a/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/MarcacionDelDia.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/MarcacionDelDia.cs
@@ -1,5 +1,5 @@
 namespace Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 
-// Issue #425: payload propio de esta isla, espejo de PrivateEvents.ControlHoras.MarcacionDelDia
+// Payload propio de esta isla, espejo de PrivateEvents.ControlHoras.MarcacionDelDia
 // (payload por rol, MEF-ADR-0039 decision #6).
 public record MarcacionDelDia(DateTime Timestamp, string? Tipo);

--- a/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/ResumenColaborador.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/ResumenColaborador.cs
@@ -1,6 +1,6 @@
 namespace Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 
-// Issue #425: payload propio de esta isla, espejo de PrivateEvents.Colaboradores.ResumenColaborador
+// Payload propio de esta isla, espejo de PrivateEvents.Colaboradores.ResumenColaborador
 // (payload por rol, MEF-ADR-0039 decision #6). Terna reducida de identidad del colaborador que
 // viaja en DepuracionDiaRecibida -- distinta de ColaboradorProgramado (foto completa del maestro
 // que ya usa TurnoDiarioAsignado en esta misma isla).

--- a/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/ResumenColaborador.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras.DomainEvents/ResumenColaborador.cs
@@ -1,0 +1,10 @@
+namespace Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
+
+// Issue #425: payload propio de esta isla, espejo de PrivateEvents.Colaboradores.ResumenColaborador
+// (payload por rol, MEF-ADR-0039 decision #6). Terna reducida de identidad del colaborador que
+// viaja en DepuracionDiaRecibida -- distinta de ColaboradorProgramado (foto completa del maestro
+// que ya usa TurnoDiarioAsignado en esta misma isla).
+public record ResumenColaborador(
+    string Identificacion,
+    string CodigoColaborador,
+    string NombreCompleto);

--- a/src/Bitakora.ControlAsistencia.ControlHoras/Entities/ControlDiarioAggregateRoot.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Entities/ControlDiarioAggregateRoot.cs
@@ -2,11 +2,8 @@ using System.Globalization;
 using Bitakora.ControlAsistencia.ControlHoras.ValueObjects;
 using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 using Cosmos.EventSourcing.Abstractions;
-// Issue #425: DiaDepurado (bus) y ControlHoras.DomainEvents ahora comparten nombres simples
-// homonimos (FranjaDepurada, MarcacionDelDia, ResumenColaborador -- payload por rol, MEF-ADR-0039
-// decision #6). Alias de tipo explicitos (tienen precedencia sobre un using de namespace) para que
-// este archivo -- que produce el evento de BUS DiaDepurado -- siga resolviendo sin calificar y sin
-// renombrar ningun metodo, evitando CS0104.
+// Alias de tipo: estos nombres existen homonimos en ControlHoras.DomainEvents (payload por rol,
+// MEF-ADR-0039 decision #6); este archivo produce DiaDepurado, asi que usa los del bus.
 using DiaDepurado = Bitakora.ControlAsistencia.PrivateEvents.ControlHoras.DiaDepurado;
 using FranjaDepurada = Bitakora.ControlAsistencia.PrivateEvents.ControlHoras.FranjaDepurada;
 using MarcacionDelDia = Bitakora.ControlAsistencia.PrivateEvents.ControlHoras.MarcacionDelDia;

--- a/src/Bitakora.ControlAsistencia.ControlHoras/Entities/ControlDiarioAggregateRoot.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Entities/ControlDiarioAggregateRoot.cs
@@ -1,9 +1,16 @@
 using System.Globalization;
 using Bitakora.ControlAsistencia.ControlHoras.ValueObjects;
 using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
-using Bitakora.ControlAsistencia.PrivateEvents.ControlHoras;
-using Bitakora.ControlAsistencia.PrivateEvents.Colaboradores;
 using Cosmos.EventSourcing.Abstractions;
+// Issue #425: DiaDepurado (bus) y ControlHoras.DomainEvents ahora comparten nombres simples
+// homonimos (FranjaDepurada, MarcacionDelDia, ResumenColaborador -- payload por rol, MEF-ADR-0039
+// decision #6). Alias de tipo explicitos (tienen precedencia sobre un using de namespace) para que
+// este archivo -- que produce el evento de BUS DiaDepurado -- siga resolviendo sin calificar y sin
+// renombrar ningun metodo, evitando CS0104.
+using DiaDepurado = Bitakora.ControlAsistencia.PrivateEvents.ControlHoras.DiaDepurado;
+using FranjaDepurada = Bitakora.ControlAsistencia.PrivateEvents.ControlHoras.FranjaDepurada;
+using MarcacionDelDia = Bitakora.ControlAsistencia.PrivateEvents.ControlHoras.MarcacionDelDia;
+using ResumenColaborador = Bitakora.ControlAsistencia.PrivateEvents.Colaboradores.ResumenColaborador;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.Entities;
 

--- a/src/Bitakora.ControlAsistencia.ControlHoras/Entities/DiaCalculadoAggregateRoot.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Entities/DiaCalculadoAggregateRoot.cs
@@ -1,0 +1,83 @@
+using System.Globalization;
+using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
+using Cosmos.EventSourcing.Abstractions;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Entities;
+
+// Issue #425: aggregate root del expediente de aprobacion de un dia de trabajo. Recibe cada foto
+// de DiaDepurado (traducida a tipos de dominio por el handler) y mantiene los valores
+// provisionales del dia -- el juicio humano del Aprobador vive separado del calculo automatico
+// de ControlDiario (sesion 2026-08-17). Vivira el ciclo Provisional -> Aprobado; este issue
+// construye unicamente el receptor.
+// CA-ADR-0031: prefijo "dc" (iniciales de DiaCalculado) disjunta este stream de ControlDiario
+// ("cd"), que comparte la identidad logica colaborador+fecha en el mismo store. La fecha va en
+// ISO 8601 basico por el mismo motivo que ControlDiarioAggregateRoot: no aporta ':' propios.
+// ADR-0015: partial class para soportar clase Mensajes en archivo separado si se requiere.
+public partial class DiaCalculadoAggregateRoot : AggregateRoot
+{
+    // Ciclo de vida del aggregate, no campo informativo (issue #425) -- se expone como propiedad
+    // publica de solo lectura, a diferencia de los valores provisionales de la foto (privados, mas
+    // abajo): sin ninguna propiedad publica el aggregate no seria verificable por el harness
+    // (CommandHandlerTestBase.And<>), y es consistente con el resto del dominio
+    // (ControlDiarioAggregateRoot expone Fecha/DetalleTurno/InformacionColaborador del mismo modo).
+    public EstadoDiaCalculado Estado { get; private set; }
+
+    // Valores provisionales de la ultima foto recibida -- NUNCA expuestos como propiedades sueltas
+    // (MEF-ADR-0012, Tell-don't-Ask): el aggregate no da estado crudo para calculo externo. Solo
+    // Apply los reemplaza; ningun consumidor externo los lee campo a campo.
+    private string _codigoColaborador = string.Empty;
+    private DateOnly _fecha;
+    private ResumenColaborador? _colaborador;
+    private string? _nombreTurno;
+    private IReadOnlyList<FranjaDepurada> _franjas = [];
+    private IReadOnlyList<MarcacionDelDia> _marcaciones = [];
+    private HorasDiscriminadas? _horasDiscriminadas;
+
+    private const string PrefijoStreamId = "dc";
+    private const char SeparadorStreamId = ':';
+    private const string FormatoFechaStreamId = "yyyyMMdd";
+
+    // Dos mensajes con el mismo CodigoColaborador+Fecha convergen sobre el mismo stream
+    // (MEF-ADR-0026: convergencia de eventos, riesgo de escritura concurrente declarado en el issue).
+    public static string ComputarStreamId(string codigoColaborador, DateOnly fecha)
+    {
+        var fechaBasica = fecha.ToString(FormatoFechaStreamId, CultureInfo.InvariantCulture);
+        return $"{PrefijoStreamId}{SeparadorStreamId}{codigoColaborador}{SeparadorStreamId}{fechaBasica}";
+    }
+
+    // MEF-ADR-0004: Apply no lanza -- recibir una depuracion no falla por regla de negocio.
+    // Siempre reemplaza los valores provisionales con la ultima foto, sin comparar contra el
+    // estado previo (sin deduplicacion de ningun tipo, decision de sesion 2026-08-24).
+    // public: requerido para que TestStore.ApplyEvent lo encuentre via GetMethods()
+    public void Apply(DepuracionDiaRecibida e)
+    {
+        Id = e.Id;
+        _codigoColaborador = e.CodigoColaborador;
+        _fecha = e.Fecha;
+        _colaborador = e.Colaborador;
+        _nombreTurno = e.NombreTurno;
+        _franjas = e.Franjas;
+        _marcaciones = e.Marcaciones;
+        _horasDiscriminadas = e.HorasDiscriminadas;
+        Estado = EstadoDiaCalculado.Provisional;
+    }
+
+    // Factory: crea el aggregate con el evento en _uncommittedEvents para StartStream.
+    // CA-1/CA-3: todo dia que llega nace, anomalo incluido -- sin comparacion previa de ningun tipo.
+    internal static DiaCalculadoAggregateRoot Iniciar(DepuracionDiaRecibida evento)
+    {
+        var dia = new DiaCalculadoAggregateRoot();
+        dia._uncommittedEvents.Add(evento);
+        dia.Apply(evento);
+        return dia;
+    }
+
+    // CA-2/CA-4: toda foto que llega a un dia ya existente se agrega al mismo stream, siempre --
+    // sin comparar contra el estado previo. Convergencia de eventos sobre el mismo aggregate
+    // (MEF-ADR-0026): la topologia de fan-in, si aplica, la resuelve la Function que invoca esto.
+    internal void RecibirDepuracion(DepuracionDiaRecibida evento)
+    {
+        _uncommittedEvents.Add(evento);
+        Apply(evento);
+    }
+}

--- a/src/Bitakora.ControlAsistencia.ControlHoras/Entities/DiaCalculadoAggregateRoot.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Entities/DiaCalculadoAggregateRoot.cs
@@ -4,27 +4,16 @@ using Cosmos.EventSourcing.Abstractions;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.Entities;
 
-// Issue #425: aggregate root del expediente de aprobacion de un dia de trabajo. Recibe cada foto
-// de DiaDepurado (traducida a tipos de dominio por el handler) y mantiene los valores
-// provisionales del dia -- el juicio humano del Aprobador vive separado del calculo automatico
-// de ControlDiario (sesion 2026-08-17). Vivira el ciclo Provisional -> Aprobado; este issue
-// construye unicamente el receptor.
-// CA-ADR-0031: prefijo "dc" (iniciales de DiaCalculado) disjunta este stream de ControlDiario
-// ("cd"), que comparte la identidad logica colaborador+fecha en el mismo store. La fecha va en
-// ISO 8601 basico por el mismo motivo que ControlDiarioAggregateRoot: no aporta ':' propios.
-// ADR-0015: partial class para soportar clase Mensajes en archivo separado si se requiere.
+// Expediente de aprobacion de un dia de trabajo: recibe cada foto de DiaDepurado (ya traducida a
+// tipos de dominio por el handler) y mantiene los valores provisionales del dia. Vive separado de
+// ControlDiario a proposito -- el juicio humano del Aprobador no comparte aggregate con el calculo
+// automatico. El ciclo Provisional -> Aprobado llega con el issue de acciones del Aprobador.
 public partial class DiaCalculadoAggregateRoot : AggregateRoot
 {
-    // Ciclo de vida del aggregate, no campo informativo (issue #425) -- se expone como propiedad
-    // publica de solo lectura, a diferencia de los valores provisionales de la foto (privados, mas
-    // abajo): sin ninguna propiedad publica el aggregate no seria verificable por el harness
-    // (CommandHandlerTestBase.And<>), y es consistente con el resto del dominio
-    // (ControlDiarioAggregateRoot expone Fecha/DetalleTurno/InformacionColaborador del mismo modo).
     public EstadoDiaCalculado Estado { get; private set; }
 
-    // Valores provisionales de la ultima foto recibida -- NUNCA expuestos como propiedades sueltas
-    // (MEF-ADR-0012, Tell-don't-Ask): el aggregate no da estado crudo para calculo externo. Solo
-    // Apply los reemplaza; ningun consumidor externo los lee campo a campo.
+    // Valores provisionales de la ultima foto recibida: nunca se exponen como propiedades sueltas
+    // (MEF-ADR-0012, Tell-don't-Ask). Solo Apply los reemplaza.
     private string _codigoColaborador = string.Empty;
     private DateOnly _fecha;
     private ResumenColaborador? _colaborador;
@@ -33,21 +22,25 @@ public partial class DiaCalculadoAggregateRoot : AggregateRoot
     private IReadOnlyList<MarcacionDelDia> _marcaciones = [];
     private HorasDiscriminadas? _horasDiscriminadas;
 
+    // CA-ADR-0031: el prefijo "dc" disjunta este stream del de ControlDiario ("cd"), que comparte la
+    // identidad logica colaborador+fecha en el mismo store; la fecha va en ISO 8601 basico para que
+    // no aporte ':' propios. Los tres valores son el contrato de identidad de todo stream ya
+    // escrito -- cambiar cualquiera exige migracion.
     private const string PrefijoStreamId = "dc";
     private const char SeparadorStreamId = ':';
     private const string FormatoFechaStreamId = "yyyyMMdd";
 
-    // Dos mensajes con el mismo CodigoColaborador+Fecha convergen sobre el mismo stream
-    // (MEF-ADR-0026: convergencia de eventos, riesgo de escritura concurrente declarado en el issue).
+    // Punto unico de conversion de la identidad (MEF-ADR-0037): dos mensajes del mismo
+    // colaborador+fecha convergen sobre el mismo stream. InvariantCulture: una culture con
+    // calendario no gregoriano (ar-SA) rendiria otro anio en la clave.
     public static string ComputarStreamId(string codigoColaborador, DateOnly fecha)
     {
         var fechaBasica = fecha.ToString(FormatoFechaStreamId, CultureInfo.InvariantCulture);
         return $"{PrefijoStreamId}{SeparadorStreamId}{codigoColaborador}{SeparadorStreamId}{fechaBasica}";
     }
 
-    // MEF-ADR-0004: Apply no lanza -- recibir una depuracion no falla por regla de negocio.
-    // Siempre reemplaza los valores provisionales con la ultima foto, sin comparar contra el
-    // estado previo (sin deduplicacion de ningun tipo, decision de sesion 2026-08-24).
+    // MEF-ADR-0004: Apply no lanza. Reemplaza la foto completa sin comparar contra el estado previo
+    // -- sin deduplicacion de ningun tipo (CA-4).
     // public: requerido para que TestStore.ApplyEvent lo encuentre via GetMethods()
     public void Apply(DepuracionDiaRecibida e)
     {
@@ -62,8 +55,8 @@ public partial class DiaCalculadoAggregateRoot : AggregateRoot
         Estado = EstadoDiaCalculado.Provisional;
     }
 
-    // Factory: crea el aggregate con el evento en _uncommittedEvents para StartStream.
-    // CA-1/CA-3: todo dia que llega nace, anomalo incluido -- sin comparacion previa de ningun tipo.
+    // CA-1/CA-3: todo dia que llega nace, anomalo incluido. Deja el evento en _uncommittedEvents
+    // para que el llamador lo persista con StartStream.
     internal static DiaCalculadoAggregateRoot Iniciar(DepuracionDiaRecibida evento)
     {
         var dia = new DiaCalculadoAggregateRoot();
@@ -72,9 +65,7 @@ public partial class DiaCalculadoAggregateRoot : AggregateRoot
         return dia;
     }
 
-    // CA-2/CA-4: toda foto que llega a un dia ya existente se agrega al mismo stream, siempre --
-    // sin comparar contra el estado previo. Convergencia de eventos sobre el mismo aggregate
-    // (MEF-ADR-0026): la topologia de fan-in, si aplica, la resuelve la Function que invoca esto.
+    // CA-2/CA-4: toda foto que llega a un dia ya existente se agrega al mismo stream, siempre.
     internal void RecibirDepuracion(DepuracionDiaRecibida evento)
     {
         _uncommittedEvents.Add(evento);

--- a/src/Bitakora.ControlAsistencia.ControlHoras/Entities/EstadoDiaCalculado.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/Entities/EstadoDiaCalculado.cs
@@ -1,0 +1,9 @@
+namespace Bitakora.ControlAsistencia.ControlHoras.Entities;
+
+// Issue #425: ciclo de vida de DiaCalculado. Unico valor de este issue -- Aprobado (y las
+// transiciones Provisional -> Aprobado, conciliar, reabrir, avalar dias vacios) llega con el
+// issue de acciones del Aprobador. El estado es ciclo de vida del aggregate, no campo informativo.
+public enum EstadoDiaCalculado
+{
+    Provisional
+}

--- a/src/Bitakora.ControlAsistencia.ControlHoras/RecibirDepuracionCuandoDiaDepurado/EventHandler/DiaDepuradoEventHandler.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/RecibirDepuracionCuandoDiaDepurado/EventHandler/DiaDepuradoEventHandler.cs
@@ -2,15 +2,17 @@ using Bitakora.ControlAsistencia.ControlHoras.Entities;
 using Bitakora.ControlAsistencia.PrivateEvents.ControlHoras;
 using Cosmos.EventDriven.Abstractions;
 using Cosmos.EventSourcing.Abstractions.Commands;
+// FranjaDepurada/MarcacionDelDia/HorasDiscriminadas existen homonimos en las dos islas: el nombre
+// corto resuelve al tipo de bus (using de arriba) y el persistido va calificado como DomainEvents.X.
+using ColaboradorBus = Bitakora.ControlAsistencia.PrivateEvents.Colaboradores.ResumenColaborador;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.RecibirDepuracionCuandoDiaDepurado.EventHandler;
 
-// Issue #425: recibe cada foto de DiaDepurado (PrivateEvents.ControlHoras) y la traduce a los
-// tipos ricos propios de ControlHoras.DomainEvents antes de entregarla al aggregate DiaCalculado
-// (CA-ADR-0029 decision #5: el Function App es el unico ensamblado que ve las tres islas, asi que
-// el mapeo vive aqui). Sin comando espejo: se consume directo con IPrivateEventHandlerAsync
-// (MEF-ADR-0024 decision #8). Ningun consumidor nuevo: no publica ningun evento (issue #425,
-// "Consumidores: ninguno nuevo").
+// Traduce cada foto de DiaDepurado (bus) a los tipos ricos de ControlHoras.DomainEvents antes de
+// entregarla al aggregate DiaCalculado: el mapeo vive aqui porque el Function App es el unico
+// ensamblado que ve las tres islas (CA-ADR-0029 decision #5). Se consume directo con
+// IPrivateEventHandlerAsync, sin comando espejo (MEF-ADR-0024 decision #8), y no publica ningun
+// evento.
 // MEF-ADR-0009: partial class para soportar clase Mensajes en archivo separado si se requiere.
 public partial class DiaDepuradoEventHandler : IPrivateEventHandlerAsync<DiaDepurado>
 {
@@ -49,8 +51,7 @@ public partial class DiaDepuradoEventHandler : IPrivateEventHandlerAsync<DiaDepu
         }
     }
 
-    private static DomainEvents.ResumenColaborador? MapearColaborador(
-        Bitakora.ControlAsistencia.PrivateEvents.Colaboradores.ResumenColaborador? colaborador) =>
+    private static DomainEvents.ResumenColaborador? MapearColaborador(ColaboradorBus? colaborador) =>
         colaborador is null
             ? null
             : new DomainEvents.ResumenColaborador(

--- a/src/Bitakora.ControlAsistencia.ControlHoras/RecibirDepuracionCuandoDiaDepurado/EventHandler/DiaDepuradoEventHandler.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/RecibirDepuracionCuandoDiaDepurado/EventHandler/DiaDepuradoEventHandler.cs
@@ -1,0 +1,25 @@
+using Bitakora.ControlAsistencia.PrivateEvents.ControlHoras;
+using Cosmos.EventDriven.Abstractions;
+using Cosmos.EventSourcing.Abstractions.Commands;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.RecibirDepuracionCuandoDiaDepurado.EventHandler;
+
+// Issue #425: recibe cada foto de DiaDepurado (PrivateEvents.ControlHoras) y la traduce a los
+// tipos ricos propios de ControlHoras.DomainEvents antes de entregarla al aggregate DiaCalculado
+// (CA-ADR-0029 decision #5: el Function App es el unico ensamblado que ve las tres islas, asi que
+// el mapeo vive aqui). Sin comando espejo: se consume directo con IPrivateEventHandlerAsync
+// (MEF-ADR-0024 decision #8). Ningun consumidor nuevo: no publica ningun evento (issue #425,
+// "Consumidores: ninguno nuevo").
+// MEF-ADR-0009: partial class para soportar clase Mensajes en archivo separado si se requiere.
+public partial class DiaDepuradoEventHandler : IPrivateEventHandlerAsync<DiaDepurado>
+{
+    private readonly IEventStore _eventStore;
+
+    public DiaDepuradoEventHandler(IEventStore eventStore)
+    {
+        _eventStore = eventStore;
+    }
+
+    public Task HandleAsync(DiaDepurado @event, CancellationToken ct = default)
+        => throw new NotImplementedException();
+}

--- a/src/Bitakora.ControlAsistencia.ControlHoras/RecibirDepuracionCuandoDiaDepurado/EventHandler/DiaDepuradoEventHandler.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/RecibirDepuracionCuandoDiaDepurado/EventHandler/DiaDepuradoEventHandler.cs
@@ -1,3 +1,4 @@
+using Bitakora.ControlAsistencia.ControlHoras.Entities;
 using Bitakora.ControlAsistencia.PrivateEvents.ControlHoras;
 using Cosmos.EventDriven.Abstractions;
 using Cosmos.EventSourcing.Abstractions.Commands;
@@ -20,6 +21,48 @@ public partial class DiaDepuradoEventHandler : IPrivateEventHandlerAsync<DiaDepu
         _eventStore = eventStore;
     }
 
-    public Task HandleAsync(DiaDepurado @event, CancellationToken ct = default)
-        => throw new NotImplementedException();
+    public async Task HandleAsync(DiaDepurado @event, CancellationToken ct = default)
+    {
+        var streamId = DiaCalculadoAggregateRoot.ComputarStreamId(@event.CodigoColaborador, @event.Fecha);
+
+        var evento = new DomainEvents.DepuracionDiaRecibida(
+            streamId,
+            @event.CodigoColaborador,
+            @event.Fecha,
+            MapearColaborador(@event.Colaborador),
+            @event.NombreTurno,
+            @event.Franjas.Select(MapearFranja).ToList(),
+            @event.Marcaciones.Select(MapearMarcacion).ToList(),
+            MapearHoras(@event.HorasDiscriminadas));
+
+        var existe = await _eventStore.ExistsAsync<DiaCalculadoAggregateRoot>(streamId, ct);
+
+        if (existe)
+        {
+            var dia = (await _eventStore.GetAggregateRootAsync<DiaCalculadoAggregateRoot>(streamId, ct))!;
+            dia.RecibirDepuracion(evento);
+        }
+        else
+        {
+            var dia = DiaCalculadoAggregateRoot.Iniciar(evento);
+            _eventStore.StartStream(dia);
+        }
+    }
+
+    private static DomainEvents.ResumenColaborador? MapearColaborador(
+        Bitakora.ControlAsistencia.PrivateEvents.Colaboradores.ResumenColaborador? colaborador) =>
+        colaborador is null
+            ? null
+            : new DomainEvents.ResumenColaborador(
+                colaborador.Identificacion, colaborador.CodigoColaborador, colaborador.NombreCompleto);
+
+    private static DomainEvents.FranjaDepurada MapearFranja(FranjaDepurada franja) =>
+        new(franja.HoraInicioProgramada, franja.HoraFinProgramada, franja.DiaOffsetFin,
+            franja.Entrada, franja.Salida, franja.EsAnomala);
+
+    private static DomainEvents.MarcacionDelDia MapearMarcacion(MarcacionDelDia marcacion) =>
+        new(marcacion.Timestamp, marcacion.Tipo);
+
+    private static DomainEvents.HorasDiscriminadas MapearHoras(HorasDiscriminadas horas) =>
+        new(horas.HorasPorConcepto, horas.Trazabilidad);
 }

--- a/src/Bitakora.ControlAsistencia.ControlHoras/RecibirDepuracionCuandoDiaDepurado/FunctionEndpoint.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/RecibirDepuracionCuandoDiaDepurado/FunctionEndpoint.cs
@@ -7,13 +7,10 @@ using Microsoft.Extensions.Logging;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.RecibirDepuracionCuandoDiaDepurado;
 
-// Issue #425: MEF-ADR-0024 decision #3: DiaDepurado cruza fisicamente el ASB interno del BC, aun
-// siendo consumido dentro del mismo BC; decision #8: se despacha directo al
-// IPrivateEventHandlerAsync via IPrivateEventRouter (PrivateEventEndpointBase) -- sin comando espejo.
-// MEF-ADR-0006: [Function("{Accion}Cuando{Evento}")], feature folder sin sufijo Function para
-// triggers de ServiceBus.
-// Topic "dia-depurado" ya existe en terraform con la suscripcion "smoke-tests" (issue #421); este
-// issue agrega la suscripcion del consumidor nuevo (CA-6).
+// MEF-ADR-0024 decision #3: DiaDepurado cruza fisicamente el ASB interno del BC aun siendo
+// consumido dentro del mismo BC; decision #8: se despacha directo al IPrivateEventHandlerAsync via
+// IPrivateEventRouter, sin comando espejo.
+// El nombre de la suscripcion debe coincidir con el declarado en infra/environments/dev/main.tf.
 public class FunctionEndpoint(IPrivateEventRouter privateEventRouter, ILogger<FunctionEndpoint> logger)
     : PrivateEventEndpointBase<DiaDepurado>(privateEventRouter, logger)
 {

--- a/src/Bitakora.ControlAsistencia.ControlHoras/RecibirDepuracionCuandoDiaDepurado/FunctionEndpoint.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/RecibirDepuracionCuandoDiaDepurado/FunctionEndpoint.cs
@@ -1,0 +1,30 @@
+using Azure.Messaging.ServiceBus;
+using Bitakora.ControlAsistencia.ControlHoras.Infraestructura;
+using Bitakora.ControlAsistencia.PrivateEvents.ControlHoras;
+using Cosmos.EventDriven.Abstractions;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.RecibirDepuracionCuandoDiaDepurado;
+
+// Issue #425: MEF-ADR-0024 decision #3: DiaDepurado cruza fisicamente el ASB interno del BC, aun
+// siendo consumido dentro del mismo BC; decision #8: se despacha directo al
+// IPrivateEventHandlerAsync via IPrivateEventRouter (PrivateEventEndpointBase) -- sin comando espejo.
+// MEF-ADR-0006: [Function("{Accion}Cuando{Evento}")], feature folder sin sufijo Function para
+// triggers de ServiceBus.
+// Topic "dia-depurado" ya existe en terraform con la suscripcion "smoke-tests" (issue #421); este
+// issue agrega la suscripcion del consumidor nuevo (CA-6).
+public class FunctionEndpoint(IPrivateEventRouter privateEventRouter, ILogger<FunctionEndpoint> logger)
+    : PrivateEventEndpointBase<DiaDepurado>(privateEventRouter, logger)
+{
+    [Function("RecibirDepuracionCuandoDiaDepurado")]
+    public async Task Run(
+        [ServiceBusTrigger(
+            topicName: "dia-depurado",
+            subscriptionName: "control-horas-escucha-dia-depurado",
+            Connection = "SERVICE_BUS_CONNECTION")]
+        ServiceBusReceivedMessage message,
+        ServiceBusMessageActions messageActions,
+        CancellationToken ct)
+        => await ProcesarMensaje(message, messageActions, ct);
+}

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/AsignarTurnoViaSbSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/AsignarTurnoViaSbSmokeTests.cs
@@ -3,9 +3,8 @@ using AwesomeAssertions;
 using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 using Bitakora.ControlAsistencia.ControlHoras.SmokeTests.Fixtures;
 using Bitakora.ControlAsistencia.PrivateEvents.ControlHoras;
-// Issue #425: ResumenColaborador ahora tambien existe, homonimo, en ControlHoras.DomainEvents
-// (payload por rol, MEF-ADR-0039 decision #6). Alias de tipo (precedencia sobre un using de
-// namespace) para que este archivo siga resolviendo sin calificar, sin CS0104.
+// Alias de tipo: ResumenColaborador existe homonimo en ControlHoras.DomainEvents (payload por
+// rol, MEF-ADR-0039 decision #6); este archivo usa el del bus.
 using ResumenColaborador = Bitakora.ControlAsistencia.PrivateEvents.Colaboradores.ResumenColaborador;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.SmokeTests.AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction;

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/AsignarTurnoViaSbSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/AsignarTurnoViaSbSmokeTests.cs
@@ -2,8 +2,11 @@ using System.Text.Json;
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 using Bitakora.ControlAsistencia.ControlHoras.SmokeTests.Fixtures;
-using Bitakora.ControlAsistencia.PrivateEvents.Colaboradores;
 using Bitakora.ControlAsistencia.PrivateEvents.ControlHoras;
+// Issue #425: ResumenColaborador ahora tambien existe, homonimo, en ControlHoras.DomainEvents
+// (payload por rol, MEF-ADR-0039 decision #6). Alias de tipo (precedencia sobre un using de
+// namespace) para que este archivo siga resolviendo sin calificar, sin CS0104.
+using ResumenColaborador = Bitakora.ControlAsistencia.PrivateEvents.Colaboradores.ResumenColaborador;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.SmokeTests.AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction;
 

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/RecibirDepuracionCuandoDiaDepurado/RecibirDepuracionViaSbSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/RecibirDepuracionCuandoDiaDepurado/RecibirDepuracionViaSbSmokeTests.cs
@@ -1,0 +1,141 @@
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.ControlHoras.SmokeTests.Fixtures;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.SmokeTests.RecibirDepuracionCuandoDiaDepurado;
+
+// Verifica contra dev el efecto del consumidor nuevo: cada DiaDepurado que cruza el ASB interno
+// persiste depuracion_dia_recibida en el stream de DiaCalculado. Se publica el evento directo al
+// topic (no via POST de marcacion) para aislar este consumidor de la cadena que lo alimenta.
+// Queda rojo hasta que el deploy publique la suscripcion control-horas-escucha-dia-depurado; el CI
+// de PR no lo ejecuta (solo corre *.Tests).
+public class RecibirDepuracionViaSbSmokeTests(ServiceBusFixture serviceBus, PostgresFixture postgres)
+{
+    private const string TopicDiaDepurado = "dia-depurado";
+    private const string SuscripcionConsumidor = "control-horas-escucha-dia-depurado";
+    private const string SchemaControlHoras = "control_horas";
+    private const string TipoEvento = "depuracion_dia_recibida";
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
+
+    // En sync con DiaCalculadoAggregateRoot.ComputarStreamId (CA-ADR-0031: prefijo "dc" para no
+    // colisionar con el "cd" de ControlDiario, que comparte colaborador+fecha en el mismo store).
+    private static string ComputarStreamId(string codigoColaborador, DateOnly fecha) =>
+        $"dc:{codigoColaborador}:{fecha:yyyyMMdd}";
+
+    private static object CrearDiaDepurado(
+        string codigoColaborador, DateOnly fecha, string? nombreTurno, bool conJornada) => new
+        {
+            CodigoColaborador = codigoColaborador,
+            Fecha = fecha.ToString("yyyy-MM-dd"),
+            Colaborador = conJornada
+                ? new
+                {
+                    Identificacion = "CC-555444333",
+                    CodigoColaborador = codigoColaborador,
+                    NombreCompleto = "[TEST] Smoke DiaCalculado"
+                }
+                : null,
+            NombreTurno = nombreTurno,
+            Franjas = conJornada
+                ? new object[]
+                {
+                    new
+                    {
+                        HoraInicioProgramada = "06:00:00",
+                        HoraFinProgramada = "14:00:00",
+                        DiaOffsetFin = 0,
+                        Entrada = $"{fecha:yyyy-MM-dd}T06:00:00",
+                        Salida = $"{fecha:yyyy-MM-dd}T14:00:00",
+                        EsAnomala = false
+                    }
+                }
+                : [],
+            Marcaciones = new object[]
+            {
+                new { Timestamp = $"{fecha:yyyy-MM-dd}T06:00:00", Tipo = "ENTRADA" }
+            },
+            HorasDiscriminadas = new
+            {
+                HorasPorConcepto = conJornada
+                    ? new Dictionary<string, decimal> { ["OrdinariaDiurna"] = 8.00m }
+                    : new Dictionary<string, decimal>(),
+                Trazabilidad = Array.Empty<string>()
+            }
+        };
+
+    // CA-1: un dia nuevo crea el stream dc:{codigo}:{yyyyMMdd} con la foto completa.
+    // CA-2/CA-4: una segunda entrega sobre el mismo dia agrega otra depuracion_dia_recibida al mismo
+    // stream -- sin deduplicacion. Las dos fotos se distinguen por NombreTurno para poder afirmar que
+    // ambas quedaron persistidas.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task DiaDepurado_PersisteCadaFotoEnElStreamDeDiaCalculado_CuandoLleganDosEntregasDelMismoDia()
+    {
+        Assert.SkipWhen(!serviceBus.IsConfigured,
+            "ServiceBus no configurado. Usa appsettings.local.json o variable ServiceBus__ConnectionString.");
+        Assert.SkipWhen(!postgres.IsConfigured,
+            postgres.SkipReason ?? "Postgres no disponible.");
+
+        var codigoColaborador = Guid.CreateVersion7().ToString();
+        var fecha = new DateOnly(2026, 5, 4);
+        var streamId = ComputarStreamId(codigoColaborador, fecha);
+
+        await serviceBus.PublishAsync(
+            TopicDiaDepurado,
+            CrearDiaDepurado(codigoColaborador, fecha, "[TEST] Turno Primera Foto", conJornada: true),
+            Guid.CreateVersion7().ToString());
+
+        var primeraFoto = await postgres.ExisteEventoAsync(
+            SchemaControlHoras, streamId, TipoEvento, Timeout,
+            campoJson: "NombreTurno", valorJson: "[TEST] Turno Primera Foto");
+
+        primeraFoto.Should().BeTrue(
+            $"el evento {TipoEvento} de la primera foto deberia existir en el stream {streamId}");
+
+        await serviceBus.PublishAsync(
+            TopicDiaDepurado,
+            CrearDiaDepurado(codigoColaborador, fecha, "[TEST] Turno Segunda Foto", conJornada: true),
+            Guid.CreateVersion7().ToString());
+
+        var segundaFoto = await postgres.ExisteEventoAsync(
+            SchemaControlHoras, streamId, TipoEvento, Timeout,
+            campoJson: "NombreTurno", valorJson: "[TEST] Turno Segunda Foto");
+
+        segundaFoto.Should().BeTrue(
+            $"la segunda entrega deberia agregar otra {TipoEvento} al mismo stream {streamId}, sin dedup");
+
+        var existeDeadLetter = await serviceBus.ExisteDeadLetterDeEstaCorridaAsync<DiaDepuradoMinimo>(
+            TopicDiaDepurado, SuscripcionConsumidor, e => e.CodigoColaborador == codigoColaborador);
+
+        existeDeadLetter.Should().BeFalse(
+            "no deberia haber dead letter de esta corrida (CodigoColaborador {0}) en '{1}' del topic '{2}'",
+            codigoColaborador, SuscripcionConsumidor, TopicDiaDepurado);
+    }
+
+    // CA-3: el dia sin jornada valida (Colaborador/NombreTurno null, franjas y horas vacias,
+    // marcaciones crudas como unica evidencia) tambien crea su stream.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task DiaDepurado_PersisteLaFoto_CuandoElDiaNoTieneJornadaValida()
+    {
+        Assert.SkipWhen(!serviceBus.IsConfigured,
+            "ServiceBus no configurado. Usa appsettings.local.json o variable ServiceBus__ConnectionString.");
+        Assert.SkipWhen(!postgres.IsConfigured,
+            postgres.SkipReason ?? "Postgres no disponible.");
+
+        var codigoColaborador = Guid.CreateVersion7().ToString();
+        var fecha = new DateOnly(2026, 5, 5);
+        var streamId = ComputarStreamId(codigoColaborador, fecha);
+
+        await serviceBus.PublishAsync(
+            TopicDiaDepurado,
+            CrearDiaDepurado(codigoColaborador, fecha, nombreTurno: null, conJornada: false),
+            Guid.CreateVersion7().ToString());
+
+        var existe = await postgres.ExisteEventoAsync(
+            SchemaControlHoras, streamId, TipoEvento, Timeout,
+            campoJson: "CodigoColaborador", valorJson: codigoColaborador);
+
+        existe.Should().BeTrue(
+            $"el dia anomalo tambien deberia persistir {TipoEvento} en el stream {streamId}");
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoRegistroDeMarcacionCreado/DepurarAlAdicionarMarcacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoRegistroDeMarcacionCreado/DepurarAlAdicionarMarcacionTests.cs
@@ -9,10 +9,18 @@ using Bitakora.ControlAsistencia.ControlHoras.ValueObjects;
 using Bitakora.ControlAsistencia.ControlHoras.AdicionarMarcacionCuandoRegistroDeMarcacionCreado.EventHandler;
 using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 using Bitakora.ControlAsistencia.ControlHoras.Entities;
-using Bitakora.ControlAsistencia.PrivateEvents.ControlHoras;
-using Bitakora.ControlAsistencia.PrivateEvents.Colaboradores;
 using Cosmos.EventDriven.Abstractions;
 using Cosmos.EventSourcing.Testing.Utilities;
+// Issue #425: FranjaDepurada/MarcacionDelDia/HorasDiscriminadas/ResumenColaborador ahora tambien
+// existen, homonimos, en ControlHoras.DomainEvents (payload por rol, MEF-ADR-0039 decision #6).
+// Alias de tipo explicitos (tienen precedencia sobre un using de namespace) para que este archivo
+// -- que produce el evento de BUS DiaDepurado -- siga resolviendo sin calificar, sin CS0104.
+using DiaDepurado = Bitakora.ControlAsistencia.PrivateEvents.ControlHoras.DiaDepurado;
+using FranjaDepurada = Bitakora.ControlAsistencia.PrivateEvents.ControlHoras.FranjaDepurada;
+using MarcacionDelDia = Bitakora.ControlAsistencia.PrivateEvents.ControlHoras.MarcacionDelDia;
+using HorasDiscriminadas = Bitakora.ControlAsistencia.PrivateEvents.ControlHoras.HorasDiscriminadas;
+using RegistroDeMarcacionCreado = Bitakora.ControlAsistencia.PrivateEvents.ControlHoras.RegistroDeMarcacionCreado;
+using ResumenColaborador = Bitakora.ControlAsistencia.PrivateEvents.Colaboradores.ResumenColaborador;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.Tests.AdicionarMarcacionCuandoRegistroDeMarcacionCreado;
 

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoRegistroDeMarcacionCreado/DepurarAlAdicionarMarcacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AdicionarMarcacionCuandoRegistroDeMarcacionCreado/DepurarAlAdicionarMarcacionTests.cs
@@ -11,10 +11,8 @@ using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 using Bitakora.ControlAsistencia.ControlHoras.Entities;
 using Cosmos.EventDriven.Abstractions;
 using Cosmos.EventSourcing.Testing.Utilities;
-// Issue #425: FranjaDepurada/MarcacionDelDia/HorasDiscriminadas/ResumenColaborador ahora tambien
-// existen, homonimos, en ControlHoras.DomainEvents (payload por rol, MEF-ADR-0039 decision #6).
-// Alias de tipo explicitos (tienen precedencia sobre un using de namespace) para que este archivo
-// -- que produce el evento de BUS DiaDepurado -- siga resolviendo sin calificar, sin CS0104.
+// Alias de tipo: estos nombres existen homonimos en ControlHoras.DomainEvents (payload por rol,
+// MEF-ADR-0039 decision #6); este archivo usa los del bus.
 using DiaDepurado = Bitakora.ControlAsistencia.PrivateEvents.ControlHoras.DiaDepurado;
 using FranjaDepurada = Bitakora.ControlAsistencia.PrivateEvents.ControlHoras.FranjaDepurada;
 using MarcacionDelDia = Bitakora.ControlAsistencia.PrivateEvents.ControlHoras.MarcacionDelDia;

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/DepurarAlAsignarTurnoTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/DepurarAlAsignarTurnoTests.cs
@@ -13,10 +13,8 @@ using Bitakora.ControlAsistencia.ControlHoras.Entities;
 using Bitakora.ControlAsistencia.PrivateEvents.Programacion;
 using Cosmos.EventDriven.Abstractions;
 using Cosmos.EventSourcing.Testing.Utilities;
-// Issue #425: FranjaDepurada/MarcacionDelDia/HorasDiscriminadas/ResumenColaborador ahora tambien
-// existen, homonimos, en ControlHoras.DomainEvents (payload por rol, MEF-ADR-0039 decision #6).
-// Alias de tipo explicitos (tienen precedencia sobre un using de namespace) para que este archivo
-// -- que produce el evento de BUS DiaDepurado -- siga resolviendo sin calificar, sin CS0104.
+// Alias de tipo: estos nombres existen homonimos en ControlHoras.DomainEvents (payload por rol,
+// MEF-ADR-0039 decision #6); este archivo usa los del bus.
 using DiaDepurado = Bitakora.ControlAsistencia.PrivateEvents.ControlHoras.DiaDepurado;
 using FranjaDepurada = Bitakora.ControlAsistencia.PrivateEvents.ControlHoras.FranjaDepurada;
 using MarcacionDelDia = Bitakora.ControlAsistencia.PrivateEvents.ControlHoras.MarcacionDelDia;

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/DepurarAlAsignarTurnoTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/DepurarAlAsignarTurnoTests.cs
@@ -11,10 +11,17 @@ using Bitakora.ControlAsistencia.ControlHoras.AsignarTurnoCuandoProgramacionTurn
 using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 using Bitakora.ControlAsistencia.ControlHoras.Entities;
 using Bitakora.ControlAsistencia.PrivateEvents.Programacion;
-using Bitakora.ControlAsistencia.PrivateEvents.ControlHoras;
-using Bitakora.ControlAsistencia.PrivateEvents.Colaboradores;
 using Cosmos.EventDriven.Abstractions;
 using Cosmos.EventSourcing.Testing.Utilities;
+// Issue #425: FranjaDepurada/MarcacionDelDia/HorasDiscriminadas/ResumenColaborador ahora tambien
+// existen, homonimos, en ControlHoras.DomainEvents (payload por rol, MEF-ADR-0039 decision #6).
+// Alias de tipo explicitos (tienen precedencia sobre un using de namespace) para que este archivo
+// -- que produce el evento de BUS DiaDepurado -- siga resolviendo sin calificar, sin CS0104.
+using DiaDepurado = Bitakora.ControlAsistencia.PrivateEvents.ControlHoras.DiaDepurado;
+using FranjaDepurada = Bitakora.ControlAsistencia.PrivateEvents.ControlHoras.FranjaDepurada;
+using MarcacionDelDia = Bitakora.ControlAsistencia.PrivateEvents.ControlHoras.MarcacionDelDia;
+using HorasDiscriminadas = Bitakora.ControlAsistencia.PrivateEvents.ControlHoras.HorasDiscriminadas;
+using ResumenColaborador = Bitakora.ControlAsistencia.PrivateEvents.Colaboradores.ResumenColaborador;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.Tests.AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction;
 

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/CrearDiaDepuradoConHorasDiscriminadasTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/CrearDiaDepuradoConHorasDiscriminadasTests.cs
@@ -26,11 +26,8 @@ using Bitakora.ControlAsistencia.ControlHoras.Entities;
 using Bitakora.ControlAsistencia.PrivateEvents.Programacion;
 using Cosmos.EventDriven.Abstractions;
 using Cosmos.EventSourcing.Testing.Utilities;
-// Issue #425: FranjaDepurada/MarcacionDelDia/HorasDiscriminadas ahora tambien existen, homonimos,
-// en ControlHoras.DomainEvents (payload por rol, MEF-ADR-0039 decision #6). Alias de tipo
-// explicitos (precedencia sobre un using de namespace) para que este archivo -- que verifica el
-// payload de DiaDepurado (bus) -- siga resolviendo sin calificar, sin CS0104.
-using DiaDepurado = Bitakora.ControlAsistencia.PrivateEvents.ControlHoras.DiaDepurado;
+// Alias de tipo: estos nombres existen homonimos en ControlHoras.DomainEvents (payload por rol,
+// MEF-ADR-0039 decision #6); este archivo usa los del bus.
 using FranjaDepurada = Bitakora.ControlAsistencia.PrivateEvents.ControlHoras.FranjaDepurada;
 using MarcacionDelDia = Bitakora.ControlAsistencia.PrivateEvents.ControlHoras.MarcacionDelDia;
 using HorasDiscriminadas = Bitakora.ControlAsistencia.PrivateEvents.ControlHoras.HorasDiscriminadas;

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/CrearDiaDepuradoConHorasDiscriminadasTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Entities/CrearDiaDepuradoConHorasDiscriminadasTests.cs
@@ -23,10 +23,18 @@ using Bitakora.ControlAsistencia.ControlHoras.AdicionarMarcacionCuandoRegistroDe
 using Bitakora.ControlAsistencia.ControlHoras.AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction.EventHandler;
 using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 using Bitakora.ControlAsistencia.ControlHoras.Entities;
-using Bitakora.ControlAsistencia.PrivateEvents.ControlHoras;
 using Bitakora.ControlAsistencia.PrivateEvents.Programacion;
 using Cosmos.EventDriven.Abstractions;
 using Cosmos.EventSourcing.Testing.Utilities;
+// Issue #425: FranjaDepurada/MarcacionDelDia/HorasDiscriminadas ahora tambien existen, homonimos,
+// en ControlHoras.DomainEvents (payload por rol, MEF-ADR-0039 decision #6). Alias de tipo
+// explicitos (precedencia sobre un using de namespace) para que este archivo -- que verifica el
+// payload de DiaDepurado (bus) -- siga resolviendo sin calificar, sin CS0104.
+using DiaDepurado = Bitakora.ControlAsistencia.PrivateEvents.ControlHoras.DiaDepurado;
+using FranjaDepurada = Bitakora.ControlAsistencia.PrivateEvents.ControlHoras.FranjaDepurada;
+using MarcacionDelDia = Bitakora.ControlAsistencia.PrivateEvents.ControlHoras.MarcacionDelDia;
+using HorasDiscriminadas = Bitakora.ControlAsistencia.PrivateEvents.ControlHoras.HorasDiscriminadas;
+using RegistroDeMarcacionCreado = Bitakora.ControlAsistencia.PrivateEvents.ControlHoras.RegistroDeMarcacionCreado;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.Tests.Entities;
 

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/AliasEventosControlHorasTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/AliasEventosControlHorasTests.cs
@@ -54,4 +54,13 @@ public class AliasEventosControlHorasTests
 
         AliasDe<TurnoDiarioAsignado>(options).Should().Be("turno_diario_asignado");
     }
+
+    // Issue #425 CA-5: congela el alias de DepuracionDiaRecibida antes de desplegarlo.
+    [Fact]
+    public void DepuracionDiaRecibida_TieneAliasDepuracionDiaRecibida()
+    {
+        var options = CrearOpcionesConEventosDeControlHorasRegistrados();
+
+        AliasDe<DepuracionDiaRecibida>(options).Should().Be("depuracion_dia_recibida");
+    }
 }

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/ComposicionServiciosTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/ComposicionServiciosTests.cs
@@ -200,7 +200,12 @@ public class ComposicionServiciosTests
         var store = scope.ServiceProvider.GetRequiredService<IDocumentStore>();
 
         store.AssertEventosPersistidosRegistrados(
-            [typeof(MarcacionRegistrada), typeof(MarcacionAdicionada), typeof(TurnoDiarioAsignado)]);
+        [
+            typeof(MarcacionRegistrada),
+            typeof(MarcacionAdicionada),
+            typeof(TurnoDiarioAsignado),
+            typeof(DepuracionDiaRecibida)
+        ]);
     }
 
     // Issue #279 CA-1: el validator del comando no se registra a mano -- lo descubre
@@ -237,7 +242,8 @@ public class ComposicionServiciosTests
         {
             [typeof(MarcacionRegistrada)] = "marcacion_registrada",
             [typeof(MarcacionAdicionada)] = "marcacion_adicionada",
-            [typeof(TurnoDiarioAsignado)] = "turno_diario_asignado"
+            [typeof(TurnoDiarioAsignado)] = "turno_diario_asignado",
+            [typeof(DepuracionDiaRecibida)] = "depuracion_dia_recibida"
         });
     }
 

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/IdentidadEventosControlHorasTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/IdentidadEventosControlHorasTests.cs
@@ -4,6 +4,8 @@
 // que este issue corrige). MarcacionRegistrada SI entra: ademas de IPrivateEvent, se persiste en
 // el stream de RegistroDeMarcacionAggregateRoot, que la aplica. No usa el harness Given/When/Then:
 // se verifica un dato estatico de configuracion, no el comportamiento de un command handler.
+// Issue #425: DepuracionDiaRecibida se persiste en el stream de DiaCalculadoAggregateRoot (CA-5)
+// y se suma a la lista literal.
 
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
@@ -15,13 +17,14 @@ namespace Bitakora.ControlAsistencia.ControlHoras.Tests.Infraestructura;
 public class IdentidadEventosControlHorasTests
 {
     [Fact]
-    public void TiposPersistidos_ContieneExactamenteLosTresEventosPersistidosDeControlHoras()
+    public void TiposPersistidos_ContieneExactamenteLosCuatroEventosPersistidosDeControlHoras()
     {
         IdentidadEventosControlHoras.TiposPersistidos.Should().BeEquivalentTo(
         [
             typeof(MarcacionRegistrada),
             typeof(MarcacionAdicionada),
-            typeof(TurnoDiarioAsignado)
+            typeof(TurnoDiarioAsignado),
+            typeof(DepuracionDiaRecibida)
         ]);
     }
 

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/RecibirDepuracionCuandoDiaDepurado/DiaDepuradoEventHandlerTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/RecibirDepuracionCuandoDiaDepurado/DiaDepuradoEventHandlerTests.cs
@@ -1,0 +1,135 @@
+// Issue #425: DiaCalculado recibe cada DiaDepurado, mantiene los valores provisionales del dia y
+// nace Provisional. Sin comparacion contra el estado previo, sin deduplicacion de ningun tipo
+// (decision de sesion 2026-08-24): toda entrega se persiste, incluida la del dia sin jornada valida.
+
+using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
+using Bitakora.ControlAsistencia.ControlHoras.Entities;
+using Bitakora.ControlAsistencia.ControlHoras.RecibirDepuracionCuandoDiaDepurado.EventHandler;
+using Cosmos.EventDriven.Abstractions;
+using Cosmos.EventSourcing.Testing.Utilities;
+using EventoBus = Bitakora.ControlAsistencia.PrivateEvents.ControlHoras;
+using ColaboradorBus = Bitakora.ControlAsistencia.PrivateEvents.Colaboradores.ResumenColaborador;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Tests.RecibirDepuracionCuandoDiaDepurado;
+
+public class DiaDepuradoEventHandlerTests : PrivateEventHandlerAsyncTest<EventoBus.DiaDepurado>
+{
+    private const string CodigoColaborador = "EMP-001";
+    private static readonly DateOnly Fecha = new(2026, 3, 15);
+    private static readonly string StreamId = $"dc:{CodigoColaborador}:20260315";
+
+    protected override IPrivateEventHandlerAsync<EventoBus.DiaDepurado> Handler =>
+        new DiaDepuradoEventHandler(EventStore);
+
+    // ---- Datos de entrada: DiaDepurado tal como lo publica el productor (PrivateEvents) ----
+
+    private static readonly ColaboradorBus ColaboradorRecibido =
+        new("CC-1234567890", CodigoColaborador, "Luis Augusto Barreto");
+
+    private static readonly EventoBus.FranjaDepurada FranjaRecibida = new(
+        new TimeOnly(6, 0), new TimeOnly(14, 0), 0,
+        new DateTime(2026, 3, 15, 6, 0, 0), new DateTime(2026, 3, 15, 14, 0, 0), false);
+
+    private static readonly EventoBus.MarcacionDelDia MarcacionRecibida =
+        new(new DateTime(2026, 3, 15, 6, 0, 0), "ENTRADA");
+
+    private static EventoBus.HorasDiscriminadas HorasRecibidas() => new(
+        new Dictionary<string, decimal> { ["OrdinariaDiurna"] = 8.00m }, []);
+
+    private static EventoBus.DiaDepurado CrearDiaDepurado(
+        ColaboradorBus? colaborador,
+        string? nombreTurno,
+        IReadOnlyList<EventoBus.FranjaDepurada> franjas,
+        IReadOnlyList<EventoBus.MarcacionDelDia> marcaciones,
+        EventoBus.HorasDiscriminadas horas) =>
+        new(CodigoColaborador, Fecha, colaborador, nombreTurno, franjas, marcaciones, horas);
+
+    // ---- Oraculo independiente (regla 20): el evento persistido esperado se arma a mano con los
+    //      tipos ricos propios de ControlHoras.DomainEvents, sin reusar el mapeo que ejercita el
+    //      handler bajo prueba. ----
+
+    private static ResumenColaborador ColaboradorEsperado() =>
+        new("CC-1234567890", CodigoColaborador, "Luis Augusto Barreto");
+
+    private static FranjaDepurada FranjaEsperada() => new(
+        new TimeOnly(6, 0), new TimeOnly(14, 0), 0,
+        new DateTime(2026, 3, 15, 6, 0, 0), new DateTime(2026, 3, 15, 14, 0, 0), false);
+
+    private static MarcacionDelDia MarcacionEsperada() =>
+        new(new DateTime(2026, 3, 15, 6, 0, 0), "ENTRADA");
+
+    private static HorasDiscriminadas HorasEsperadas() => new(
+        new Dictionary<string, decimal> { ["OrdinariaDiurna"] = 8.00m }, []);
+
+    // CA-1: dia nuevo -> crea el stream dc:{codigo}:{yyyyMMdd} con DepuracionDiaRecibida (foto
+    // completa) y el dia queda Provisional.
+    [Fact]
+    public async Task DiaDepurado_CreaDiaCalculadoProvisional_CuandoElDiaEsNuevo()
+    {
+        // Sin Given - el stream dc:EMP-001:20260315 no existe
+        await WhenAsync(CrearDiaDepurado(
+            ColaboradorRecibido, "Turno Manana", [FranjaRecibida], [MarcacionRecibida], HorasRecibidas()));
+
+        Then(StreamId, new DepuracionDiaRecibida(
+            StreamId, CodigoColaborador, Fecha, ColaboradorEsperado(), "Turno Manana",
+            [FranjaEsperada()], [MarcacionEsperada()], HorasEsperadas()));
+        And<DiaCalculadoAggregateRoot, EstadoDiaCalculado>(
+            StreamId, d => d.Estado, EstadoDiaCalculado.Provisional);
+    }
+
+    // CA-2: dia existente -> se agrega otra DepuracionDiaRecibida al mismo stream y los valores
+    // provisionales son los de la ultima foto (la foto previa no tenia turno ni franjas).
+    [Fact]
+    public async Task DiaDepurado_AgregaOtraDepuracionAlMismoStream_CuandoElDiaYaExiste()
+    {
+        var fotoPrevia = new DepuracionDiaRecibida(
+            StreamId, CodigoColaborador, Fecha, null, null, [], [MarcacionEsperada()],
+            new HorasDiscriminadas(new Dictionary<string, decimal>(), []));
+        Given(StreamId, fotoPrevia);
+
+        await WhenAsync(CrearDiaDepurado(
+            ColaboradorRecibido, "Turno Manana", [FranjaRecibida], [MarcacionRecibida], HorasRecibidas()));
+
+        Then(StreamId, new DepuracionDiaRecibida(
+            StreamId, CodigoColaborador, Fecha, ColaboradorEsperado(), "Turno Manana",
+            [FranjaEsperada()], [MarcacionEsperada()], HorasEsperadas()));
+        And<DiaCalculadoAggregateRoot, EstadoDiaCalculado>(
+            StreamId, d => d.Estado, EstadoDiaCalculado.Provisional);
+    }
+
+    // CA-3: dia sin jornada valida (Colaborador/NombreTurno null, franjas y horas vacias,
+    // marcaciones crudas) nace igual, con su foto persistida.
+    [Fact]
+    public async Task DiaDepurado_CreaDiaCalculadoProvisional_CuandoElDiaNoTieneJornadaValida()
+    {
+        await WhenAsync(CrearDiaDepurado(
+            null, null, [], [MarcacionRecibida],
+            new EventoBus.HorasDiscriminadas(new Dictionary<string, decimal>(), [])));
+
+        Then(StreamId, new DepuracionDiaRecibida(
+            StreamId, CodigoColaborador, Fecha, null, null, [], [MarcacionEsperada()],
+            new HorasDiscriminadas(new Dictionary<string, decimal>(), [])));
+        And<DiaCalculadoAggregateRoot, EstadoDiaCalculado>(
+            StreamId, d => d.Estado, EstadoDiaCalculado.Provisional);
+    }
+
+    // CA-4: dos entregas identicas producen dos eventos en el stream, sin dedup. Then verifica
+    // solo el evento NUEVO emitido en este WhenAsync (Given no cuenta como "nuevo").
+    [Fact]
+    public async Task DiaDepurado_EmiteUnNuevoEvento_CuandoLlegaLaMismaFotoQueYaExisteEnElStream()
+    {
+        var fotoIdentica = new DepuracionDiaRecibida(
+            StreamId, CodigoColaborador, Fecha, ColaboradorEsperado(), "Turno Manana",
+            [FranjaEsperada()], [MarcacionEsperada()], HorasEsperadas());
+        Given(StreamId, fotoIdentica);
+
+        await WhenAsync(CrearDiaDepurado(
+            ColaboradorRecibido, "Turno Manana", [FranjaRecibida], [MarcacionRecibida], HorasRecibidas()));
+
+        Then(StreamId, new DepuracionDiaRecibida(
+            StreamId, CodigoColaborador, Fecha, ColaboradorEsperado(), "Turno Manana",
+            [FranjaEsperada()], [MarcacionEsperada()], HorasEsperadas()));
+        And<DiaCalculadoAggregateRoot, EstadoDiaCalculado>(
+            StreamId, d => d.Estado, EstadoDiaCalculado.Provisional);
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/RecibirDepuracionCuandoDiaDepurado/Eventos/DepuracionDiaRecibidaSerializacionTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/RecibirDepuracionCuandoDiaDepurado/Eventos/DepuracionDiaRecibidaSerializacionTests.cs
@@ -1,0 +1,83 @@
+// Issue #425: Test de serializacion roundtrip para DepuracionDiaRecibida.
+// Requerido por regla 16: todo evento persistido en Marten debe sobrevivir Serialize -> Deserialize.
+
+using System.Text.Json;
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Tests.RecibirDepuracionCuandoDiaDepurado.Eventos;
+
+/// <summary>
+/// Verifica que DepuracionDiaRecibida sobrevive un roundtrip de serializacion STJ con las opciones
+/// reales de Marten (constructor privado + propiedades private set + tipos ricos anidados propios
+/// de esta isla). Ver MEF-ADR-0012 y patron canonico en MarcacionAdicionadaSerializacionTests.
+/// </summary>
+public class DepuracionDiaRecibidaSerializacionTests
+{
+    private const string StreamId = "dc:EMP-001:20260315";
+    private const string CodigoColaborador = "EMP-001";
+    private static readonly DateOnly Fecha = new(2026, 3, 15);
+
+    private static readonly ResumenColaborador Colaborador =
+        new("CC-1234567890", CodigoColaborador, "Luis Augusto Barreto");
+
+    private static readonly FranjaDepurada Franja = new(
+        new TimeOnly(6, 0), new TimeOnly(14, 0), 0,
+        new DateTime(2026, 3, 15, 6, 0, 0), new DateTime(2026, 3, 15, 14, 0, 0), false);
+
+    private static readonly MarcacionDelDia Marcacion =
+        new(new DateTime(2026, 3, 15, 6, 0, 0), "ENTRADA");
+
+    private static HorasDiscriminadas HorasConDatos() => new(
+        new Dictionary<string, decimal>
+        {
+            ["OrdinariaDiurna"] = 7.00m,
+            ["Retardo"] = 0.25m
+        },
+        ["06:00-14:00 OrdinariaDiurna"]);
+
+    // Regla 16: usa CrearOpcionesMarten() que registra ConfigurarSerializacion de todos los tipos.
+    // DepuracionDiaRecibida debe registrarse en ConfiguracionSerializacionControlHoras.ConfigurarResolver.
+    [Fact]
+    public void Deserializar_ReconstruyeEvento_ConTodosLosCampos()
+    {
+        var evento = new DepuracionDiaRecibida(
+            StreamId, CodigoColaborador, Fecha, Colaborador, "Turno Manana",
+            [Franja], [Marcacion], HorasConDatos());
+        var opciones = ConfiguracionSerializacionControlHoras.CrearOpcionesMarten();
+
+        var json = JsonSerializer.Serialize(evento, opciones);
+        var deserializado = JsonSerializer.Deserialize<DepuracionDiaRecibida>(json, opciones);
+
+        deserializado.Should().NotBeNull();
+        deserializado!.Id.Should().Be(StreamId);
+        deserializado.CodigoColaborador.Should().Be(CodigoColaborador);
+        deserializado.Fecha.Should().Be(Fecha);
+        deserializado.Colaborador.Should().Be(Colaborador);
+        deserializado.NombreTurno.Should().Be("Turno Manana");
+        deserializado.Franjas.Should().Equal(Franja);
+        deserializado.Marcaciones.Should().Equal(Marcacion);
+        deserializado.HorasDiscriminadas.Should().Be(HorasConDatos());
+    }
+
+    // CA-3: dia sin jornada valida -- Colaborador/NombreTurno null, Franjas y HorasPorConcepto
+    // vacios, Marcaciones cruda como unica evidencia.
+    [Fact]
+    public void Deserializar_ReconstruyeEvento_CuandoNoHayJornadaValida()
+    {
+        var evento = new DepuracionDiaRecibida(
+            StreamId, CodigoColaborador, Fecha, null, null, [], [Marcacion],
+            new HorasDiscriminadas(new Dictionary<string, decimal>(), []));
+        var opciones = ConfiguracionSerializacionControlHoras.CrearOpcionesMarten();
+
+        var json = JsonSerializer.Serialize(evento, opciones);
+        var deserializado = JsonSerializer.Deserialize<DepuracionDiaRecibida>(json, opciones);
+
+        deserializado.Should().NotBeNull();
+        deserializado!.Colaborador.Should().BeNull();
+        deserializado.NombreTurno.Should().BeNull();
+        deserializado.Franjas.Should().BeEmpty();
+        deserializado.Marcaciones.Should().Equal(Marcacion);
+        deserializado.HorasDiscriminadas.HorasPorConcepto.Should().BeEmpty();
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/RecibirDepuracionCuandoDiaDepurado/Eventos/HorasDiscriminadasIgualdadTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/RecibirDepuracionCuandoDiaDepurado/Eventos/HorasDiscriminadasIgualdadTests.cs
@@ -1,0 +1,64 @@
+// Tests de contrato IEquatable para la HorasDiscriminadas de ControlHoras.DomainEvents (la copia
+// persistida del payload, hermana de la de PrivateEvents). El record override manualmente
+// Equals/GetHashCode para comparar HorasPorConcepto y Trazabilidad por valor: sin estos tests, un
+// edit de esos overrides solo se veria al comparar dos DepuracionDiaRecibida.
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
+using Bitakora.ControlAsistencia.ControlHoras.Tests.ValueObjects;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Tests.RecibirDepuracionCuandoDiaDepurado.Eventos;
+
+public class HorasDiscriminadasIgualdadTests : IgualdadTestBase<HorasDiscriminadas>
+{
+    private static Dictionary<string, decimal> Horas() => new()
+    {
+        ["OrdinariaDiurna"] = 7.00m,
+        ["Retardo"] = 0.25m
+    };
+
+    protected override HorasDiscriminadas CrearInstancia() =>
+        new(Horas(), ["entro 06:15, retardo 15min"]);
+
+    protected override HorasDiscriminadas CrearInstanciaCopia() =>
+        new(Horas(), ["entro 06:15, retardo 15min"]);
+
+    protected override IEnumerable<(string, HorasDiscriminadas)> CrearInstanciasDiferentes()
+    {
+        yield return ("HorasPorConcepto (valor distinto)",
+            new HorasDiscriminadas(
+                new Dictionary<string, decimal> { ["OrdinariaDiurna"] = 9.99m, ["Retardo"] = 0.25m },
+                ["entro 06:15, retardo 15min"]));
+        yield return ("HorasPorConcepto (clave distinta)",
+            new HorasDiscriminadas(
+                new Dictionary<string, decimal> { ["OrdinariaNocturna"] = 7.00m, ["Retardo"] = 0.25m },
+                ["entro 06:15, retardo 15min"]));
+        yield return ("Trazabilidad",
+            new HorasDiscriminadas(Horas(), ["otra nota"]));
+    }
+
+    [Fact]
+    public void Equals_RetornaTrue_CuandoColeccionesSonInstanciasDiferentesConMismoContenido()
+    {
+        var a = new HorasDiscriminadas(
+            new Dictionary<string, decimal> { ["OrdinariaDiurna"] = 7.00m }, ["nota"]);
+        var b = new HorasDiscriminadas(
+            new Dictionary<string, decimal> { ["OrdinariaDiurna"] = 7.00m }, ["nota"]);
+
+        a.Equals(b).Should().BeTrue();
+    }
+
+    // El hash del diccionario se acumula con XOR justamente para no depender del orden de
+    // enumeracion: dos instancias iguales con distinto orden de insercion deben coincidir.
+    [Fact]
+    public void GetHashCode_RetornaMismoHash_CuandoElOrdenDeInsercionDifiere()
+    {
+        var a = new HorasDiscriminadas(
+            new Dictionary<string, decimal> { ["OrdinariaDiurna"] = 7.00m, ["Retardo"] = 0.25m }, []);
+        var b = new HorasDiscriminadas(
+            new Dictionary<string, decimal> { ["Retardo"] = 0.25m, ["OrdinariaDiurna"] = 7.00m }, []);
+
+        a.GetHashCode().Should().Be(b.GetHashCode());
+        a.Equals(b).Should().BeTrue();
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/RecibirDepuracionCuandoDiaDepurado/FunctionEndpointTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/RecibirDepuracionCuandoDiaDepurado/FunctionEndpointTests.cs
@@ -1,0 +1,191 @@
+// Issue #425: Tests del FunctionEndpoint del ServiceBus trigger RecibirDepuracionCuandoDiaDepurado.
+// MEF-ADR-0024 decision #3 + #8: DiaDepurado cruza fisicamente el ASB interno del BC, aun siendo
+// consumido dentro del mismo BC; el evento se despacha directo al IPrivateEventRouter (sin comando
+// espejo). Verifica orquestacion: deserializacion + despacho al private event router + manejo de
+// errores de Service Bus (patron identico a AdicionarMarcacionCuandoRegistroDeMarcacionCreado).
+
+using AwesomeAssertions;
+using Azure.Messaging.ServiceBus;
+using Bitakora.ControlAsistencia.ControlHoras.RecibirDepuracionCuandoDiaDepurado;
+using Cosmos.EventDriven.Abstractions;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Tests.RecibirDepuracionCuandoDiaDepurado;
+
+public class FunctionEndpointTests
+{
+    // JSON en formato camelCase - Wolverine serializa con camelCase por defecto al publicar al
+    // Service Bus. Dia sin jornada valida (Colaborador/NombreTurno null, Franjas y
+    // HorasPorConcepto vacios): el caso minimo valido del contrato de DiaDepurado.
+    private const string JsonFormatoWolverine = """
+        {
+          "codigoColaborador": "EMP-001",
+          "fecha": "2026-03-15",
+          "colaborador": null,
+          "nombreTurno": null,
+          "franjas": [],
+          "marcaciones": [],
+          "horasDiscriminadas": { "horasPorConcepto": {}, "trazabilidad": [] }
+        }
+        """;
+
+    private static ServiceBusReceivedMessage CrearMensaje()
+        => ServiceBusModelFactory.ServiceBusReceivedMessage(body: BinaryData.FromString(JsonFormatoWolverine));
+
+    // CA-1: camino feliz - deserializa el JSON, despacha al private event router, completa el mensaje
+    [Fact]
+    public async Task RecibirDepuracionCuandoDiaDepurado_CompletaMensaje_CuandoProcesamientoEsExitoso()
+    {
+        var router = new FakePrivateEventRouter();
+        var messageActions = new FakeServiceBusMessageActions();
+        var logger = new FakeLogger();
+        var endpoint = new FunctionEndpoint(router, logger);
+
+        await endpoint.Run(CrearMensaje(), messageActions, CancellationToken.None);
+
+        messageActions.MensajeCompletado.Should().BeTrue();
+        messageActions.MensajeEnDeadLetter.Should().BeFalse();
+    }
+
+    // Lock perdido al intentar completar -> log warning, NO dead-letter. El Service Bus re-entregara
+    // el mensaje automaticamente (regresion del issue #48, ya cubierta en los demas endpoints).
+    [Fact]
+    public async Task RecibirDepuracionCuandoDiaDepurado_LogueaWarning_CuandoSePierdeLockAlCompletar()
+    {
+        var lockLostException = new ServiceBusException(
+            "Lock del mensaje expirado",
+            ServiceBusFailureReason.MessageLockLost);
+        var router = new FakePrivateEventRouter();
+        var messageActions = new FakeServiceBusMessageActions(excepcionAlCompletar: lockLostException);
+        var logger = new FakeLogger();
+        var endpoint = new FunctionEndpoint(router, logger);
+
+        await endpoint.Run(CrearMensaje(), messageActions, CancellationToken.None);
+
+        messageActions.MensajeEnDeadLetter.Should().BeFalse("el lock ya no es valido, no se puede dead-letter");
+        logger.WarningLogueado.Should().BeTrue();
+    }
+
+    // Error generico durante el procesamiento -> dead-letter el mensaje para inspeccion
+    [Fact]
+    public async Task RecibirDepuracionCuandoDiaDepurado_EnviaADeadLetter_CuandoOcurreErrorGenerico()
+    {
+        var router = new FakePrivateEventRouter(
+            excepcion: new InvalidOperationException("Error inesperado en el handler"));
+        var messageActions = new FakeServiceBusMessageActions();
+        var logger = new FakeLogger();
+        var endpoint = new FunctionEndpoint(router, logger);
+
+        await endpoint.Run(CrearMensaje(), messageActions, CancellationToken.None);
+
+        messageActions.MensajeEnDeadLetter.Should().BeTrue();
+        messageActions.MensajeCompletado.Should().BeFalse();
+    }
+}
+
+// ---- Fakes manuales - NO NSubstitute ----
+// Duplicado deliberado del mismo patron que AdicionarMarcacionCuandoRegistroDeMarcacionCreado.
+// FunctionEndpointTests (MEF-ADR-0018 Rule of Three: sin ensamblado compartido de test doubles
+// entre feature folders todavia).
+
+/// <summary>
+/// Fake configurable de IPrivateEventRouter. Puede despachar exitosamente o lanzar
+/// una excepcion especifica para simular distintos escenarios de fallo.
+/// </summary>
+internal class FakePrivateEventRouter : IPrivateEventRouter
+{
+    private readonly Exception? _excepcion;
+
+    public FakePrivateEventRouter(Exception? excepcion = null)
+    {
+        _excepcion = excepcion;
+    }
+
+    public Task InvokeAsync<TEvent>(TEvent @event, CancellationToken cancellationToken)
+        where TEvent : class, IPrivateEvent
+    {
+        if (_excepcion is not null)
+            throw _excepcion;
+        return Task.CompletedTask;
+    }
+}
+
+/// <summary>
+/// Fake de ServiceBusMessageActions. Registra si el mensaje fue completado o enviado a dead-letter.
+/// Puede configurarse para lanzar una excepcion al completar (simulando lock perdido).
+/// </summary>
+internal class FakeServiceBusMessageActions : ServiceBusMessageActions
+{
+    private readonly Exception? _excepcionAlCompletar;
+
+    public bool MensajeCompletado { get; private set; }
+    public bool MensajeEnDeadLetter { get; private set; }
+
+    public FakeServiceBusMessageActions(Exception? excepcionAlCompletar = null)
+    {
+        _excepcionAlCompletar = excepcionAlCompletar;
+    }
+
+    public override Task CompleteMessageAsync(
+        ServiceBusReceivedMessage message,
+        CancellationToken cancellationToken = default)
+    {
+        if (_excepcionAlCompletar is not null)
+            throw _excepcionAlCompletar;
+        MensajeCompletado = true;
+        return Task.CompletedTask;
+    }
+
+    public override Task DeadLetterMessageAsync(
+        ServiceBusReceivedMessage message,
+        Dictionary<string, object>? propertiesToModify = null,
+        string? deadLetterReason = null,
+        string? deadLetterErrorDescription = null,
+        CancellationToken cancellationToken = default)
+    {
+        MensajeEnDeadLetter = true;
+        return Task.CompletedTask;
+    }
+
+    public override Task AbandonMessageAsync(
+        ServiceBusReceivedMessage message,
+        IDictionary<string, object>? propertiesToModify = null,
+        CancellationToken cancellationToken = default)
+        => throw new NotImplementedException();
+
+    public override Task DeferMessageAsync(
+        ServiceBusReceivedMessage message,
+        IDictionary<string, object>? propertiesToModify = null,
+        CancellationToken cancellationToken = default)
+        => throw new NotImplementedException();
+
+    public override Task RenewMessageLockAsync(
+        ServiceBusReceivedMessage message,
+        CancellationToken cancellationToken = default)
+        => throw new NotImplementedException();
+}
+
+/// <summary>
+/// Fake de ILogger[FunctionEndpoint]. Registra si se loguo algun Warning
+/// para verificar el camino de lock perdido.
+/// </summary>
+internal class FakeLogger : ILogger<FunctionEndpoint>
+{
+    public bool WarningLogueado { get; private set; }
+
+    public void Log<TState>(
+        LogLevel logLevel,
+        EventId eventId,
+        TState state,
+        Exception? exception,
+        Func<TState, Exception?, string> formatter)
+    {
+        if (logLevel == LogLevel.Warning)
+            WarningLogueado = true;
+    }
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+}


### PR DESCRIPTION
## Resumen

Pipeline TDD completado:
- Fase roja: tests escritos con stubs
- Fase verde: implementación completa
- Fase refactor: revisión de calidad

## Decisiones del pipeline

<details>
<summary>Test Writer (fase roja) — 22m 18s</summary>

## ES Test Writer - Decisiones

### Tests creados

- `DiaDepuradoEventHandlerTests.cs` (`RecibirDepuracionCuandoDiaDepurado/`): 4 tests
  - `DiaDepurado_CreaDiaCalculadoProvisional_CuandoElDiaEsNuevo` - CA-1
  - `DiaDepurado_AgregaOtraDepuracionAlMismoStream_CuandoElDiaYaExiste` - CA-2
  - `DiaDepurado_CreaDiaCalculadoProvisional_CuandoElDiaNoTieneJornadaValida` - CA-3
  - `DiaDepurado_EmiteUnNuevoEvento_CuandoLlegaLaMismaFotoQueYaExisteEnElStream` - CA-4
- `FunctionEndpointTests.cs` (`RecibirDepuracionCuandoDiaDepurado/`): 3 tests de orquestacion del
  endpoint ServiceBus (completar mensaje / lock perdido / dead-letter), patron identico al de
  `AdicionarMarcacionCuandoRegistroDeMarcacionCreado`.
- `DepuracionDiaRecibidaSerializacionTests.cs` (`RecibirDepuracionCuandoDiaDepurado/Eventos/`): 2
  tests de round-trip Marten (`CrearOpcionesMarten()`) - regla 16 / seccion 6d.
- Modificaciones a guardrails existentes de identidad de evento persistido (CA-5):
  - `IdentidadEventosControlHorasTests.cs`: lista literal ampliada de 3 a 4 tipos (incluye
    `DepuracionDiaRecibida`). Rojo hasta que el implementer registre el tipo.
  - `AliasEventosControlHorasTests.cs`: nuevo Fact `DepuracionDiaRecibida_TieneAliasDepuracionDiaRecibida`
    (alias esperado `depuracion_dia_recibida`, oraculo literal).
  - `ComposicionServiciosTests.cs`: se sumo `typeof(DepuracionDiaRecibida)` al
    `AssertEventosPersistidosRegistrados(...)` y la entrada de alias al
    `AssertAliasDeEventosPersistidos(...)` (guardrail sobre el contenedor real, seccion 6f).
  - `TiposPersistidos_IncluyeTodoEventoQueAplicaUnAggregateRootDelDominio` (ya existente, oraculo
    derivado por reflexion) NO se toco: detecta el caso nuevo automaticamente porque
    `DiaCalculadoAggregateRoot.Apply(DepuracionDiaRecibida)` ya existe como stub.

No se agrego test de portabilidad de bus (seccion 6e) para `DepuracionDiaRecibida`: no tiene
marker de bus (no implementa `IPrivateEvent`/`IPublicEvent`), solo se persiste. El evento que SI
tiene marker (`DiaDepurado`) ya tenia su test de portabilidad (`DiaDepuradoSerializacionTests.cs`,
issue #424) y no requeria cambios.

### Estructura elegida

- Una clase de test por responsabilidad (handler / endpoint / serializacion), feature folder
  `RecibirDepuracionCuandoDiaDepurado/` espejo de produccion (MEF-ADR-0006: `{Accion}Cuando{Evento}`).
- `PrivateEventHandlerAsyncTest<DiaDepurado>` para el EventHandler: `DiaDepurado` no tiene comando
  espejo (MEF-ADR-0024 decision #8), se consume directo.
- Overloads con `aggregateId` explicito (`Then(streamId, ...)`, `And<>(streamId, ...)`,
  `Given(streamId, ...)`) en todos los tests: `DiaCalculadoAggregateRoot` computa su stream ID
  compuesto (`dc:{codigo}:{yyyyMMdd}`), no usa `GuidAggregateId`.

### Stubs creados

- `DiaCalculadoAggregateRoot` (Entities): aggregate completo pero con logica trivial -- `Apply`,
  `Iniciar`, `RecibirDepuracion` y `ComputarStreamId` estan implementados de verdad porque son
  puro wiring mecanico (asignacion de campos, sin decision de negocio); no hay ninguna regla que
  stubear con `NotImplementedException` en este issue (MEF-ADR-0004: `Apply` nunca lanza y este
  aggregate no tiene reglas de fallo).
- `DiaDepuradoEventHandler.HandleAsync` - `throw new NotImplementedException()` (unico stub real
  de logica; el implementer debe traducir `DiaDepurado` a los tipos de dominio y invocar
  `Iniciar`/`RecibirDepuracion` segun `ExistsAsync`).
- `FunctionEndpoint` (RecibirDepuracionCuandoDiaDepurado) - delegacion mecanica a
  `PrivateEventEndpointBase<DiaDepurado>`, sin logica de negocio (mismo patron que los dos
  endpoints ya existentes del dominio).
- Tipos de payload nuevos en `ControlHoras.DomainEvents`: `FranjaDepurada`, `MarcacionDelDia`,
  `HorasDiscriminadas`, `ResumenColaborador` (records planos, sin ctor privado -- no lo necesitan,
  STJ los deserializa con su ctor publico) y `DepuracionDiaRecibida` (sealed class rica, ctor
  privado + `ConfigurarSerializacion`, patron `MarcacionAdicionada`).
- `EstadoDiaCalculado` (enum, unico valor `Provisional`).

### Decisiones de diseno

- **`Estado` expuesto como propiedad publica** (`get; private set`) pese a que el issue lo lista
  bajo "Estado interno privado". Ver "Desviaciones del plan del planner".
- **`RecibirDepuracion`/`Iniciar` reciben el evento ya armado** (`DepuracionDiaRecibida`), no los
  datos sueltos: mismo patron que `ControlDiarioAggregateRoot.AdicionarMarcacion(MarcacionAdicionada)`
  -- el handler arma el evento con el mapeo bus->dominio, el aggregate solo lo aplica. El issue
  sugeria "el metodo toma la foto ya traducida... y emite el evento", pero el patron dominante del
  codebase (los 2 productores existentes) es el opuesto; se prioriza consistencia con precedente
  real sobre la redaccion del issue (ambas formas son validas, el issue marca el nombre como
  "delegable").
- **Valores provisionales del dia (`_codigoColaborador`, `_fecha`, `_colaborador`, `_nombreTurno`,
  `_franjas`, `_marcaciones`, `_horasDiscriminadas`) se mantienen 100% privados**, sin ningun
  getter -- cumple al pie de la letra la restriccion explicita del issue ("NO es publico: los
  valores provisionales... como propiedades sueltas"). CA-2 ("los valores provisionales son los de
  la ultima foto") se verifica indirectamente: el `Then()` confirma que el evento nuevo emitido
  contiene exactamente la foto entrante, y `Apply()` es la unica funcion que muta el estado
  (reemplaza sin comparar) -- no se agrego un metodo adicional tipo `FotoActual()` porque el issue
  no lo pide y habria ampliado la interfaz publica mas alla de lo necesario para pasar los tests.

### Cobertura de criterios

| Criterio de aceptacion | Test(s) |
|---|---|
| CA-1: dia nuevo crea stream `dc:{codigo}:{yyyyMMdd}` con foto completa, Provisional | `DiaDepurado_CreaDiaCalculadoProvisional_CuandoElDiaEsNuevo` |
| CA-2: dia existente agrega otra `DepuracionDiaRecibida`, valores = ultima foto | `DiaDepurado_AgregaOtraDepuracionAlMismoStream_CuandoElDiaYaExiste` |
| CA-3: dia sin jornada valida nace igual, con su foto persistida | `DiaDepurado_CreaDiaCalculadoProvisional_CuandoElDiaNoTieneJornadaValida` |
| CA-4: dos entregas identicas producen dos eventos, sin dedup | `DiaDepurado_EmiteUnNuevoEvento_CuandoLlegaLaMismaFotoQueYaExisteEnElStream` |
| CA-5: `DepuracionDiaRecibida` registrada en `IdentidadEventosControlHoras.TiposPersistidos` | `IdentidadEventosControlHorasTests` (lista ampliada) + `AliasEventosControlHorasTests` (alias nuevo) + `ComposicionServiciosTests` (dos asserts ampliados) + `TiposPersistidos_IncluyeTodoEventoQueAplicaUnAggregateRootDelDominio` (ya existente, deteccion automatica) |
| CA-6: suscripcion terraform al topic `dia-depurado` | Fuera de alcance de este agente (infra-writer/pipeline de infra) |

### Desviaciones del plan del planner

| Sugerencia del issue | Desviacion aplicada | Razon tecnica | Consecuencia |
|---|---|---|---|
| "Estado interno privado (valores provisionales, estado Provisional)" | `Estado` (ciclo de vida) se expone como propiedad publica `get; private set`; los valores provisionales del dia siguen 100% privados | El harness exige `And<>()` en cada test (regla dura de este agente) y sin ninguna propiedad publica el aggregate no seria verificable en absoluto; ademas el propio issue reconoce "el estado es ciclo de vida del aggregate, no campo informativo" (valor de primera clase, no dato de calculo intermedio -- pasa la auditoria Tell-don't-Ask de la regla 12); es consistente con el patron ya usado por `ControlDiarioAggregateRoot`/`RegistroDeMarcacionAggregateRoot` (toda propiedad de estado del dominio es publica con `private set`) | CA-1/2/3/4 verificables con `And<DiaCalculadoAggregateRoot, EstadoDiaCalculado>`; los valores provisionales crudos siguen sin getter, tal como el issue proscribe explicitamente |
| "Reutilizar los terminos exactos del glosario (FranjaDepurada, MarcacionDelDia, HorasDiscriminadas), nunca sinonimos; la homonimia entre islas es correcta porque no se referencian" | Se mantuvo la homonimia exacta (mismos nombres simples en `ControlHoras.DomainEvents`), pero se resolvio el conflicto de compilacion resultante con **alias de tipo** (`using Tipo = Namespace.Tipo;`) en cada archivo del Function App / tests que ya usaba el nombre corto de la version de `PrivateEvents` | La homonimia es arquitectonicamente correcta (las tres islas no se referencian entre si), pero dentro del **mismo Function App** (que si ve las tres islas) varios archivos *preexistentes* (`ControlDiarioAggregateRoot.cs`, y ~5 archivos de test de handlers/smoke tests de HU-106/108/123/131, ninguno relacionado con este issue) usaban el nombre corto sin calificar de `PrivateEvents.ControlHoras`/`Colaboradores`, y mi tipo nuevo con el mismo nombre en `ControlHoras.DomainEvents` los volvia ambiguos (CS0104). Un alias de tipo tiene precedencia sobre un `using` de namespace en C#, asi que resuelve la ambiguedad sin renombrar ningun tipo ni tocar ninguna linea de comportamiento de esos archivos -- solo su bloque de `using` | Se preservo la homonimia pedida por el issue; el diff en los archivos preexistentes se limito estrictamente a la seccion de `using` (mas la eliminacion del calificador completo que se habia probado primero y luego se revirtio a favor del alias, mas limpio) |

### Archivos tocados por la desviacion de homonimia (solo `using`, sin cambio de comportamiento)

- `src/.../ControlHoras/Entities/ControlDiarioAggregateRoot.cs`
- `tests/.../ControlHoras.Tests/AdicionarMarcacionCuandoRegistroDeMarcacionCreado/DepurarAlAdicionarMarcacionTests.cs`
- `tests/.../ControlHoras.Tests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/DepurarAlAsignarTurnoTests.cs`
- `tests/.../ControlHoras.Tests/Entities/CrearDiaDepuradoConHorasDiscriminadasTests.cs`
- `tests/.../ControlHoras.SmokeTests/AsignarTurnoCuandoProgramacionTurnoDiarioSolicitadaFunction/AsignarTurnoViaSbSmokeTests.cs`

### Nota para el implementer

- `DiaDepuradoEventHandler.HandleAsync` debe: computar `DiaCalculadoAggregateRoot.ComputarStreamId(codigo, fecha)`,
  traducir los 7 campos de `DiaDepurado` a los tipos de `ControlHoras.DomainEvents` (mismo nombre
  simple, ensamblado distinto -- requiere alias o calificacion en el propio handler), armar
  `new DepuracionDiaRecibida(...)`, y `ExistsAsync` -> `RecibirDepuracion` o `Iniciar` + `StartStream`.
- `IdentidadEventosControlHoras.TiposPersistidos` debe sumar `typeof(DepuracionDiaRecibida)`.
- `ConfiguracionSerializacionControlHoras.ConfigurarResolver` debe sumar
  `DepuracionDiaRecibida.ConfigurarSerializacion(resolver);`.
- CA-6 (suscripcion terraform al topic `dia-depurado`) y la topologia de convergencia
  (MEF-ADR-0026, si aplica fan-in) quedan fuera de este stage -- responsabilidad del implementer /
  infra-writer.

</details>

<details>
<summary>Implementer (fase verde) — 8m 13s</summary>

## ES Implementer - Decisiones

### Enfoque de implementacion

El test-writer ya habia dejado completos casi todos los artefactos del issue: `DiaCalculadoAggregateRoot`,
`EstadoDiaCalculado`, `DepuracionDiaRecibida` + sus cuatro tipos ricos (`FranjaDepurada`, `MarcacionDelDia`,
`HorasDiscriminadas`, `ResumenColaborador`) y el `FunctionEndpoint` del trigger de Service Bus. El unico
stub real era `DiaDepuradoEventHandler.HandleAsync`, que lanzaba `NotImplementedException`. El trabajo de
esta fase se redujo a tres piezas:

1. Implementar `HandleAsync`: computa `DiaCalculadoAggregateRoot.ComputarStreamId(codigo, fecha)`, traduce
   el payload de `DiaDepurado` (PrivateEvents.ControlHoras) a los tipos ricos propios de
   `ControlHoras.DomainEvents` (mapeo 1:1 sin logica de negocio, CA-ADR-0029 decision #5) y aplica el
   patron crear-o-actualizar ya usado por los otros dos EventHandlers del dominio (`ExistsAsync` ->
   `GetAggregateRootAsync` + `RecibirDepuracion` en positivo, o `Iniciar` + `StartStream`).
2. Registrar `DepuracionDiaRecibida` en `IdentidadEventosControlHoras.TiposPersistidos` (CA-5) y en
   `ConfiguracionSerializacionControlHoras.ConfigurarResolver` (necesario para el roundtrip de
   serializacion que ya cubria `DepuracionDiaRecibidaSerializacionTests`).
3. Agregar la suscripcion `control-horas-escucha-dia-depurado` al topic `dia-depurado` ya existente en
   `infra/environments/dev/main.tf` (CA-6).

### Decisiones de diseno

- El mapeo bus -> dominio vive integramente en el `EventHandler` (unico ensamblado que ve las tres islas),
  con metodos privados `MapearColaborador`/`MapearFranja`/`MapearMarcacion`/`MapearHoras` — mismo patron
  que `ProgramacionTurnoDiarioSolicitadaEventHandler.MapearColaboradorProgramado`/`MapearTurnoDiario`.
- Para evitar ambiguedad de nombres entre `PrivateEvents.ControlHoras.{FranjaDepurada,MarcacionDelDia,
  HorasDiscriminadas}` (ya importados sin alias, porque el parametro del metodo es `DiaDepurado` de ese
  namespace) y sus homonimos de `ControlHoras.DomainEvents`, referencio el lado DomainEvents siempre
  calificado como `DomainEvents.X` dentro del cuerpo del handler. Inicialmente use un
  `using DomainEvents = Bitakora.ControlAsistencia.ControlHoras.DomainEvents;`, pero el analizador de
  `dotnet format` (IDE0005) senalo que ese alias es redundante: por las reglas de resolucion de nombres
  de C#, buscando desde el namespace del handler hacia afuera se llega a `Bitakora.ControlAsistencia.
  ControlHoras` como ancestro, y ese ancestro ya tiene un namespace hijo llamado `DomainEvents`
  (`Bitakora.ControlAsistencia.ControlHoras.DomainEvents`) que resuelve exactamente igual sin el `using`.
  Se elimino el alias.
- No se registro `groupId`/`PublishOptions` en ningun `PublishAsync`: este handler no publica ningun
  evento (issue: "Consumidores: ninguno nuevo").
- No se toco la topologia de fan-in (queue de sesion, MEF-ADR-0026) para la convergencia de los dos
  productores de `DiaDepurado` sobre el mismo stream `dc:`. El issue deja esa decision explicitamente
  abierta ("la topologia... la decide el implementer/infra-writer"); dado que ningun test del test-writer
  ejercita concurrencia real de productores (los tests de handler usan `PrivateEventHandlerAsyncTest`,
  que no simula dos publicaciones simultaneas), no hay senal roja que fuerce resolverlo en esta fase, y
  tocar los dos handlers productores existentes (que ya tienen su propia suite verde y no forman parte de
  los archivos listados por el test-writer para este issue) habria sido una desviacion no solicitada.
  Documentado aqui para seguimiento: la convergencia queda con el riesgo declarado de escritura
  concurrente sin mitigar via `groupId`, pendiente de un issue de infraestructura/fan-in si el ADR asi lo
  decide.

### ADRs consultados

- CA-ADR-0031 (identidad de streams por store): el aggregate ya traia `ComputarStreamId` con prefijo
  `dc:` en notacion objetivo; se verifico que cumple la heuristica (prefijo obligatorio, ISO 8601 basico,
  separador `:`, test de split simple) sin necesidad de cambios.
- CA-ADR-0029 (ensamblados de eventos por rol): el mapeo bus->dominio se implemento integramente en el
  Function App (el `EventHandler`), sin que `ControlHoras.DomainEvents` referencie `PrivateEvents`.
- MEF-ADR-0004 (manejo de errores, `Apply()` no lanza): `Apply(DepuracionDiaRecibida)` ya estaba escrito
  por el test-writer sin logica condicional ni throws; no se toco.
- MEF-ADR-0026 (convergencia de eventos): revisado; ver desviacion documentada mas abajo.
- MEF-ADR-0006 (naming de funciones Azure): el `[Function("RecibirDepuracionCuandoDiaDepurado")]` ya
  seguia el patron `{Accion}Cuando{Evento}`.
- MEF-ADR-0001 / MEF-ADR-0013 (topics y subscriptions): aplicado en el paso de infraestructura.

### Desviaciones de ADRs

Ninguna desviacion — todos los ADRs aplicados al pie de la letra. La unica decision de alcance (no cablear
`groupId`/fan-in para la convergencia de productores) no es una desviacion de MEF-ADR-0026: el propio ADR
y el issue delegan esa decision de topologia a una fase/issue posterior, y ningun test de esta fase la
exige.

### Precedentes consultados

- `ProgramacionTurnoDiarioSolicitadaEventHandler` y `RegistroDeMarcacionCreadoEventHandler` (ambos en
  `ControlHoras`): alineados con CA-ADR-0029 (mapeo en el Function App) y con el patron
  crear-o-actualizar de MEF-ADR-0037/CA-ADR-0031. Replicado sin modificaciones de fondo.

### Infraestructura modificada

- `infra/environments/dev/main.tf`: agregada la subscription `control-horas-escucha-dia-depurado` (sin
  filtro de correlacion) al topic `dia-depurado` ya existente en `module "service_bus"`, junto a la
  subscription `smoke-tests` preexistente. `terraform validate` limpio (verificado con
  `terraform init -backend=false` + `terraform validate`).

### Complejidad encontrada

Ninguna significativa: el test-writer dejo el aggregate, el evento persistido y sus tipos ricos completos
y correctos; solo faltaba el cableado del handler y los dos registros de infraestructura de codigo
(`IdentidadEventosControlHoras`, `ConfiguracionSerializacionControlHoras`) mas la subscription de
Terraform.

### Resultado

- Tests pasando: 1385/1385 (suite completa del repo, 49 omitidos por falta de infra desplegada — smoke
  tests, sin relacion con este issue).
- Tests del proyecto ControlHoras.Tests: 468/468.

</details>
<details>
<summary>Reviewer (fase refactor) — 20m 35s</summary>

## ES Reviewer - Revision

### Evaluacion general
- Calidad: **buena**
- Cambios realizados: **si** (commit `d5427a5`)
- Suite: 1395 correctos / 0 errores / 51 omitidos (smoke tests sin infra local). Baseline al inicio:
  1385/0/49 — el delta son los 10 tests de contrato de igualdad y los 2 smoke tests que agregue.

### Cumplimiento de ADRs aplicables

| ADR | Cumplimiento | Observacion |
|---|---|---|
| MEF-ADR-0037 (identidad de stream) | ok | `ComputarStreamId` es el unico punto de conversion; el handler lo invoca una vez y reusa el string para `ExistsAsync`/`GetAggregateRootAsync` y para el `Id` del evento. Ningun `ToString("N")`, ningun `.ToUpper()`, ninguna reconstruccion paralela. Sin borde HTTP en este issue. |
| CA-ADR-0031 (anatomia de clave por store) | ok | `dc:{codigo}:{yyyyMMdd}`: prefijo por iniciales (disjunta del `cd:` de `ControlDiario`, misma identidad logica en el mismo schema), ISO 8601 basico, separador `:`, `Split(':')` devuelve exactamente 3 componentes. Coincide con la fila que el propio ADR registra para `DiaCalculado`. |
| MEF-ADR-0026 (fan-in / serializacion por clave) | **desviacion declarada** | Ver seccion "Desviaciones". La convergencia existe y el issue declara que cumple las dos condiciones; la topologia quedo en topic+subscription simple, sin queue de sesion ni `groupId`. |
| MEF-ADR-0004 (manejo de errores) | ok | `Apply(DepuracionDiaRecibida)` no lanza, no bifurca y no tiene eventos de fallo. Recibir una depuracion no falla por regla de negocio; los fallos de transporte los cubre `PrivateEventEndpointBase` (lock perdido / dead-letter, con tests). |
| CA-ADR-0029 (ensamblados por rol) | ok | `DepuracionDiaRecibida` y sus cuatro tipos de payload viven en `ControlHoras.DomainEvents` sin ninguna `ProjectReference` nueva (el `.csproj` de la isla no se toco). El mapeo bus -> dominio vive integramente en el Function App (decision #5). CA-5 cumplido: el tipo entra en `IdentidadEventosControlHoras.TiposPersistidos` y en `ConfiguracionSerializacionControlHoras`. |
| MEF-ADR-0012 (modelado / serializacion) | ok | `DepuracionDiaRecibida`: `sealed class`, ctor publico + ctor privado vacio, `private set`, `ConfigurarSerializacion` con `CreateObject` por reflexion — patron identico a `MarcacionAdicionada`, sin `[JsonConstructor]`. `HorasDiscriminadas` es `record` con coleccion, pero **con `Equals`/`GetHashCode` manuales por valor** (mitiga el antipatron #6). Ninguna propiedad publica nueva de VO consumida por un externo; los siete valores provisionales del aggregate son privados sin getter. Ningun `InternalsVisibleTo` nuevo desde la isla de eventos. El evento persistido no tiene marker de bus, asi que el guardrail de portabilidad (6e) no aplica: `DiaDepurado`, que si lo tiene, ya lo tenia desde #424. |
| MEF-ADR-0006 (naming de Functions) | ok | `[Function("RecibirDepuracionCuandoDiaDepurado")]` = `{Accion}Cuando{Evento}`; feature folder sin sufijo `Function` (trigger de ServiceBus), `FunctionEndpoint.cs` + subcarpeta `EventHandler/`. |
| MEF-ADR-0001 (topics/subscriptions) | ok | Suscripcion `control-horas-escucha-dia-depurado` sobre el topic existente, con el mismo patron `{consumidor}-escucha-{productor}` de las otras dos del repo. `terraform fmt -check` y `terraform validate` limpios (verificados por mi, no solo declarados). |
| MEF-ADR-0009 (.resx) | n/a | El aggregate no declina nada y el handler no produce mensajes al usuario; no hay `.resx` que crear. |
| MEF-ADR-0013 (smoke tests) | **corregido por el reviewer** | El efecto nuevo no tenia cobertura contra dev. Ver "Criticas y hallazgos" #1. |

El issue tenia seccion `## ADRs aplicables` completa; no hay que escalar nada al planner por ese lado.

### Desviaciones de ADRs

**Desviaciones declaradas por el implementer** (de `stage-2-implementer.md`):

#### Desviacion: MEF-ADR-0026 (convergencia sobre el mismo aggregate)
- **Regla del ADR**: cuando varios eventos convergen en una decision sobre el mismo aggregate **y**
  consumirlos con subscriptions independientes permitiria escritura concurrente sobre el mismo
  stream de Marten, la topologia correcta es subscription sin sesion -> forward -> queue con
  `requires_session`, y el productor fija `groupId` = clave del aggregate destino.
- **Desviacion aplicada**: se consume con topic + subscription simple; ningun productor publica con
  `groupId`; no hay queue de fan-in.
- **Razon del implementer**: el issue delega explicitamente la topologia ("la decide el
  implementer/infra-writer"); ningun test de la fase roja ejercita concurrencia real, y cablear el
  fan-in obligaba a tocar los dos handlers productores existentes, fuera de los archivos del issue.
- **Consecuencia conocida**: el riesgo declarado en el issue queda sin mitigar. Los dos productores
  (`RegistroDeMarcacionCreadoEventHandler` y `ProgramacionTurnoDiarioSolicitadaEventHandler`)
  publican `DiaDepurado` al mismo topic, y Azure Functions puede procesar dos mensajes del mismo
  colaborador+fecha en paralelo desde la misma suscripcion: dos escrituras concurrentes sobre
  `dc:{codigo}:{yyyyMMdd}` producen un conflicto de version de Marten que termina en dead-letter
  ciego (la clase de error de la seccion "Contexto" de MEF-ADR-0026).
- **Evaluacion del reviewer**: **aceptable como alcance, pero debe quedar rastreada**. La razon es
  legitima y el issue la habilita; ademas verifique que **no es corregible trivialmente en este PR**:
  el modulo `infra/modules/service-bus` no soporta hoy `requires_session` ni `forward_to` (su
  `topics_config` solo modela `subscriptions` con `correlation_filter`/`default_message_ttl`), asi
  que el fan-in exige (a) extender el modulo Terraform, (b) cambiar el trigger a queue con
  `IsSessionsEnabled = true`, y (c) agregar `PublishOptions.GroupId` a los dos handlers productores
  — trabajo de un issue de infraestructura propio. Nota adicional: el `groupId`, cuando llegue, debe
  ser **el mismo string** que produce `DiaCalculadoAggregateRoot.ComputarStreamId` (MEF-ADR-0037
  seccion 3), no la clave del `ControlDiario` que origina la foto.
- **Status**: pendiente de evaluacion del usuario — se sugiere issue de seguimiento (infra + los dos
  productores).

**Desviaciones detectadas por el reviewer (NO declaradas por el implementer)**:

Ninguna desviacion de ADR no declarada. Los tres hallazgos que corregi (ver abajo) son de calidad y
de cobertura, no incumplimientos de un ADR aplicable.

Observacion adicional sobre MEF-ADR-0039 decision #6 (no es desviacion): el issue ordeno
explicitamente conservar la homonimia de los terminos del glosario (`FranjaDepurada`,
`MarcacionDelDia`, `ResumenColaborador`, `HorasDiscriminadas`) entre `PrivateEvents` y
`ControlHoras.DomainEvents`, y el ADR solo exige nombres simples **deliberadamente distintos** para
el **evento** con doble rol — cosa que aqui si se cumple (`DiaDepurado` de bus vs
`DepuracionDiaRecibida` persistido). Aun asi, el argumento del ADR ("un `using` equivocado sobre dos
tipos homonimos compila igual y resuelve al tipo incorrecto en silencio") se materializo en costo
real: cinco archivos preexistentes necesitaron alias de tipo para seguir compilando, y todo archivo
futuro del Function App que toque estos nombres queda expuesto al mismo riesgo. Lo dejo como
observacion para el planner; **no** lo corregi (renombrar terminos del glosario contradiria el issue
y seria una decision de lenguaje ubicuo, no de revision).

### Precedentes consultados por el implementer

| Precedente | ADR aplicable | Veredicto |
|---|---|---|
| `RegistroDeMarcacionCreadoEventHandler` (patron crear-o-actualizar, mapeo en el Function App) | CA-ADR-0029, MEF-ADR-0037 | alineado |
| `ProgramacionTurnoDiarioSolicitadaEventHandler` (mapeo bus -> dominio) | CA-ADR-0029 | alineado |
| `MarcacionAdicionada` (sealed class + `ConfigurarSerializacion`) | MEF-ADR-0012 | alineado |
| `ControlDiarioAggregateRoot` (`ComputarStreamId`, `Iniciar`/`Apply`) | CA-ADR-0031, MEF-ADR-0004 | alineado **salvo** su comentario `ADR-0015: partial class para soportar clase Mensajes`, que cita el ADR equivocado (el de mensajes `.resx` es MEF-ADR-0009). El copiado llego a `DiaCalculadoAggregateRoot`; lo corte alli. En `ControlDiarioAggregateRoot` no lo toque (fuera del alcance del issue). |

### Convenciones del pipeline (no ADRs)

| Convencion | Estado | Observacion |
|---|---|---|
| Cada test con `Then()` + `And<>()` | ok | Los 4 tests del handler tienen ambos. Verifique ademas por **mutacion** que el oraculo muerde: al cambiar `"Turno Manana"` por `"MUTANTE"` en el `Then` de CA-1, el test se pone rojo (no es un falso verde por overload equivocado). |
| Overloads correctos para stream IDs compuestos | ok | `Then(StreamId, ...)`, `And<T,P>(StreamId, ...)`, `Given(StreamId, ...)` en los 4 tests — el aggregate no usa GUID. |
| Fakes manuales (no NSubstitute) | ok | `FakePrivateEventRouter`, `FakeServiceBusMessageActions`, `FakeLogger` son clases concretas. |
| Feature folders (produccion y tests) | ok | `RecibirDepuracionCuandoDiaDepurado/{FunctionEndpoint.cs, EventHandler/}` en produccion; espejo en tests con un archivo por responsabilidad (handler / endpoint / serializacion / igualdad). |
| Smoke tests: SkipWhen, secrets, cobertura | **falla -> corregido** | No habia ninguno: el Stage 2b del pipeline se salto porque su filtro `grep -E 'Function/'` no detecta feature folders de ServiceBus (que por MEF-ADR-0006 no llevan sufijo `Function`). Agregue `RecibirDepuracionViaSbSmokeTests` con `Assert.SkipWhen` en ambos fixtures, filtrado por `CodigoColaborador` unico por corrida y sin secrets. |
| Proyecciones read-side | n/a | El diff no toca `ReadModels`/`Projections` ni ningun GET. |
| Antipatrones de habilitacion (MEF-ADR-0039) | ok | `git diff main...HEAD -- '**/*.csproj'` sale **vacio**: ningun `.csproj` tocado, asi que (a)/(b)/(c)/(e) no aplican. (d) verificado a mano: `DepuracionDiaRecibida` no tiene homonimo en `PublicEvents`/`PrivateEvents`. |
| Compatibilidad Marten write-side/read-side | **falla (no verificada del todo)** | El gate **si** aplica (el diff toca `IdentidadEventosControlHoras.cs` y `ConfiguracionSerializacionControlHoras.cs`). Las dos dimensiones que el diff realmente mueve estan **sincronizadas por construccion**, verificado por lectura directa: el worker registra `opts.Events.AddEventTypes(IdentidadEventosControlHoras.TiposPersistidos)` y `ConfiguracionSerializacionControlHoras.ConfigurarResolver(resolver)` — **la misma lista y la misma funcion** que amplia el write-side, no copias literales. Lo que **no** pude ejecutar es la comparacion decompilada de la linea base completa del paquete: `ilspycmd` no esta instalado en este entorno (`dotnet tool install -g ilspycmd`) y mi rol me prohibe instalarlo por cuenta propia. Riesgo residual bajo: el diff no cambia la version del paquete ni ningun atributo de Marten (schema, `StreamIdentity`, `EventNamingStyle`, `TenancyStyle`, metadata, `EnumStorage`/`Casing`). |
| Identidad de stream (MEF-ADR-0037) | ok | Ver fila del ADR arriba. Sin GET ni `GroupId` en este diff. |
| Contrato HTTP de comandos (MEF-ADR-0043) | n/a | `git diff main...HEAD --diff-filter=A -- '**/*Function/FunctionEndpoint.cs'` no lista nada: el endpoint nuevo es un trigger de ServiceBus, no un comando HTTP, y el issue no pacta migracion de ninguno preexistente. |
| Control de volumen de telemetria (MEF-ADR-0038) | n/a | El diff no toca `ComposicionServicios*`, `ConfiguracionObservabilidad*`, `SetSampler`, `UseAzureMonitorExporter` ni el callback de Wolverine. |
| Limpieza de comentarios (MEF-ADR-0044) | ok | Pasada aplicada sobre los 15 `.cs` del diff. Detalle abajo. |
| Tests via ToString/comportamiento | ok | Los valores provisionales no tienen getter; los tests verifican via el evento emitido (`Then`) y `Estado` (ciclo de vida, valor de primera clase). |
| Sin numeros magicos | ok | Prefijo, separador y formato de fecha son constantes con nombre. |
| Condiciones en positivo | ok | `if (existe) { ... } else { ... }` en el handler — afirmativa, ramas en el orden natural. |

### Elegancia del codigo
- El mapeo bus -> dominio quedo compacto y idiomatico (`Select(MapearFranja).ToList()`, expresiones
  de cuerpo unico, `is null ? null : new(...)`). No hay loops anidados ni trabajo O(n²).
- El aggregate es minimo y honesto: sin logica derivada, sin recalculos, sin estado que no venga del
  evento. `Apply` es asignacion pura, como exige MEF-ADR-0004.
- **Correccion aplicada**: `MapearColaborador` declaraba su parametro con el nombre totalmente
  calificado (`Bitakora.ControlAsistencia.PrivateEvents.Colaboradores.ResumenColaborador?`), la
  linea mas ruidosa del archivo. Sustituido por el alias `ColaboradorBus`, que ademas nombra la
  frontera que el metodo cruza.
- Build sin warnings nuevos del compilador (los `NU1902` de `OpenTelemetry.Api` son preexistentes y
  viven en Programacion, ajeno a este issue).
- **Deuda preexistente, no corregida** (regla de no refactorizar codigo ajeno al issue): (a) el
  bloque de `ConfigurarSerializacion` por backing fields esta ahora en **5** copias identicas
  (`TurnoDiarioAsignado`, `MarcacionRegistrada`, `MarcacionAdicionada`, `TurnoCreado`, y ahora
  `DepuracionDiaRecibida`) — la Rule of Three (MEF-ADR-0018) esta holgadamente cumplida y merece un
  helper generico en un issue propio; (b) `FakeServiceBusMessageActions`/`FakeLogger` estan en 4
  archivos de test y `FakePrivateEventRouter` en 3 — mismo caso. Ninguna de las dos la introduce
  este PR de forma decisiva.

### Criticas y hallazgos

1. **[mayor — corregido] Sin cobertura de smoke test del efecto nuevo.** El Stage 2b del pipeline se
   salto silenciosamente: su filtro `grep -E 'Function/'` sobre los archivos del diff no matchea
   `RecibirDepuracionCuandoDiaDepurado/FunctionEndpoint.cs`, porque los feature folders de triggers
   de ServiceBus no llevan sufijo `Function` (MEF-ADR-0006). Resultado: el unico efecto observable
   del issue (persistir `depuracion_dia_recibida` en `dc:{codigo}:{yyyyMMdd}`) no tenia verificacion
   contra dev, pese a que el propio issue lo contempla en MEF-ADR-0013. Agregue
   `RecibirDepuracionViaSbSmokeTests` (publica `DiaDepurado` directo al topic y verifica persistencia
   en Postgres + ausencia de dead letter en `control-horas-escucha-dia-depurado`), cubriendo CA-1,
   CA-2, CA-3 y CA-4 contra el entorno real. **Este gap es del harness, no del issue**: cualquier
   consumidor de ServiceBus nuevo lo sufre igual — vale reportarlo al repo del harness.
2. **[menor — corregido] `using` innecesario introducido por el diff.**
   `CrearDiaDepuradoConHorasDiscriminadasTests.cs` declaraba `using DiaDepurado = ...` sin usar nunca
   el tipo (IDE0005 reportado por `dotnet format`). Eliminado. Los IDE0005 restantes del repo (5) son
   preexistentes: `dotnet format --verify-no-changes` ya devuelve `2` en proyectos que este PR no
   toca (verificado contra `Colaboradores.Tests`), asi que no es deuda de este PR.
3. **[menor — corregido] Cita de ADR equivocada.** `DiaCalculadoAggregateRoot` decia
   `ADR-0015: partial class para soportar clase Mensajes` — MEF-ADR-0015 es el de snapshots de
   Marten; el de mensajes `.resx` es MEF-ADR-0009. Comentario podado (el aggregate no tiene ni
   tendra clase Mensajes en este issue).
4. **[menor — corregido] `HorasDiscriminadas` de la isla de dominio sin test de contrato.** El record
   trae `Equals`/`GetHashCode` manuales no triviales (XOR acumulado sobre el diccionario para que el
   hash no dependa del orden de enumeracion) y ningun test los ejercitaba directamente; su hermano de
   `PrivateEvents` si tiene `HorasDiscriminadasIgualdadTests` desde #183. Agregue el equivalente.
5. **[observacion, no corregido] Los siete valores provisionales del aggregate no tienen ningun
   lector.** `_codigoColaborador`, `_fecha`, `_colaborador`, `_nombreTurno`, `_franjas`,
   `_marcaciones`, `_horasDiscriminadas` se escriben en `Apply` y nadie los lee todavia: si `Apply`
   dejara de asignarlos, ningun test se pondria rojo. Es deliberado y correcto — el issue proscribe
   explicitamente exponerlos, y el issue de acciones del Aprobador sera su primer consumidor —, pero
   conviene saber que CA-2 ("los valores provisionales son los de la ultima foto") hoy se verifica
   **indirectamente**, via el evento emitido, no via el estado. No amplie la API publica del
   aggregate para cerrarlo: hacerlo contradiria el issue y MEF-ADR-0012.
6. **[observacion, no corregido] `HorasDiscriminadas` viaja al evento persistido compartiendo la
   instancia de sus colecciones con el evento de bus** (`MapearHoras` reusa `HorasPorConcepto` y
   `Trazabilidad`). Inofensivo hoy (el objeto de bus muere al terminar el handler y el evento se
   serializa de inmediato), pero es la unica pieza del mapeo que no construye estructura propia.

### Refactorings aplicados
- Alias `ColaboradorBus` en `DiaDepuradoEventHandler` (elimina el nombre totalmente calificado).
- Eliminacion del `using DiaDepurado` sobrante en `CrearDiaDepuradoConHorasDiscriminadasTests`.
- Ningun cambio de firma publica, de comportamiento ni de estructura de archivos. Cada cambio se
  siguio de `dotnet test`; no hubo que revertir nada.

### Limpieza de comentarios (MEF-ADR-0044)
Pasada sobre los 15 `.cs` del diff (produccion, tests y smoke tests). Podas y compresiones:

- `DiaCalculadoAggregateRoot.cs`: podado el bloque de 5 lineas que justificaba por que `Estado` es
  publico (**Context Delta** nulo: `EstadoDiaCalculado.cs` ya documenta el ciclo de vida, y el
  razonamiento sobre el harness `And<>` es deliberacion del test-writer, no restriccion). Podada la
  cita `ADR-0015` (cita sola, ademas equivocada). Comprimidos el encabezado de clase, el comentario
  de `ComputarStreamId` y los de `Iniciar`/`RecibirDepuracion` — se conservo la restriccion
  (prefijo/separador/formato son contrato de identidad, `Apply` no lanza, `public` es requisito de
  `TestStore.ApplyEvent`) y se poda la narracion. Se **agrego** la unica linea que faltaba con
  Decision Delta real: por que `InvariantCulture` (calendario no gregoriano).
- `DiaDepuradoEventHandler.cs`: encabezado comprimido de 6 a 5 lineas; se conservan las dos citas
  con restriccion activa (CA-ADR-0029 decision #5 y MEF-ADR-0024 decision #8) y se poda el
  provenance (`Issue #425`, la cita del texto del issue).
- `FunctionEndpoint.cs`: podado el parrafo de provenance sobre el topic y el issue #421
  (**Decision Delta** nulo). Conservada, comprimida, la restriccion que si condiciona una edicion
  futura: el nombre de la suscripcion debe coincidir con Terraform.
- `DepuracionDiaRecibida.cs`: comprimido el encabezado (poda de la fecha de sesion y del argumento
  de idempotencia, que ya vive junto al comportamiento en el aggregate); conservada la restriccion
  "sin marker de bus". Los comentarios del ctor privado y de `ConfigurarSerializacion` **no** se
  tocan: ambos tienen Decision Delta alto (borrar el ctor privado rompe la deserializacion).
- `FranjaDepurada.cs`, `MarcacionDelDia.cs`, `ResumenColaborador.cs`, `HorasDiscriminadas.cs`: podado
  el prefijo `Issue #425:` (provenance). El resto se conserva: "payload propio de esta isla" es la
  restriccion que evita que alguien "deduplique" importando el tipo de la otra isla.
- Bloque de alias repetido en 5 archivos (`ControlDiarioAggregateRoot`, 3 tests, 1 smoke test):
  comprimido de 4-5 lineas a 2. Se podo la explicacion de la mecanica de C# ("los alias tienen
  precedencia sobre un `using` de namespace", "evitando CS0104") — **Context Delta** nulo, es
  semantica del lenguaje — y se conservo cual isla usa cada archivo.
- Sin comentarios que contradigan la implementacion, salvo la cita erronea del punto 3 de hallazgos.
- Los tests nuevos (`DiaDepuradoEventHandlerTests`, `FunctionEndpointTests`,
  `DepuracionDiaRecibidaSerializacionTests`) ya estaban limpios: sus comentarios mapean CA -> test,
  que es Decision Delta legitimo (sin ellos, un agente futuro no sabe que criterio protege cada test).
- `dotnet test` en verde despues de la limpieza (behavior-preserving confirmado).

### Cobertura de criterios de aceptacion
| Criterio | Estado | Test(s) |
|---|---|---|
| CA-1: dia nuevo crea el stream `dc:{codigo}:{yyyyMMdd}` con la foto completa y queda `Provisional` | cubierto | `DiaDepurado_CreaDiaCalculadoProvisional_CuandoElDiaEsNuevo` + smoke `DiaDepurado_PersisteCadaFotoEnElStreamDeDiaCalculado_CuandoLleganDosEntregasDelMismoDia` |
| CA-2: dia existente agrega otra `DepuracionDiaRecibida` al mismo stream; valores = ultima foto | cubierto (estado, indirectamente — ver hallazgo 5) | `DiaDepurado_AgregaOtraDepuracionAlMismoStream_CuandoElDiaYaExiste` + el mismo smoke test |
| CA-3: el dia sin jornada valida nace igual, con su foto persistida | cubierto | `DiaDepurado_CreaDiaCalculadoProvisional_CuandoElDiaNoTieneJornadaValida`, `Deserializar_ReconstruyeEvento_CuandoNoHayJornadaValida`, smoke `DiaDepurado_PersisteLaFoto_CuandoElDiaNoTieneJornadaValida` |
| CA-4: dos entregas identicas producen dos eventos (sin dedup) | cubierto | `DiaDepurado_EmiteUnNuevoEvento_CuandoLlegaLaMismaFotoQueYaExisteEnElStream` + smoke de dos entregas |
| CA-5: `DepuracionDiaRecibida` registrada en `IdentidadEventosControlHoras.TiposPersistidos` | cubierto | `TiposPersistidos_ContieneExactamenteLosCuatroEventosPersistidosDeControlHoras`, `DepuracionDiaRecibida_TieneAliasDepuracionDiaRecibida` (alias `depuracion_dia_recibida` congelado antes del deploy), y los dos asserts de `ComposicionServiciosTests` sobre el store real |
| CA-6: suscripcion al topic `dia-depurado` en `main.tf`, `terraform validate` limpio | cubierto | `terraform fmt -check` y `terraform validate` ejecutados por mi: ambos limpios. La suscripcion nueva no destruye nada (se agrega al `topics_config` existente, junto a `smoke-tests`). |

### Tests agregados
- `HorasDiscriminadasIgualdadTests` (`ControlHoras.Tests/RecibirDepuracionCuandoDiaDepurado/Eventos/`):
  8 tests heredados de `IgualdadTestBase<T>` + 2 propios (igualdad y hash con colecciones
  equivalentes pero de instancia/orden distinto). Test de **contrato**, no de comportamiento.
- `RecibirDepuracionViaSbSmokeTests`
  (`ControlHoras.SmokeTests/RecibirDepuracionCuandoDiaDepurado/`): 2 smoke tests contra dev
  (dos entregas del mismo dia; dia sin jornada valida). Compilan; omitidos localmente por falta de
  connection strings, como el resto de la suite de smoke.

</details>

## Cobertura

| Archivo | Cobertura | Umbral | Estado |
|---|---|---|---|
| FunctionEndpoint.cs | 100.0% | 95% | ok |
| DiaDepuradoEventHandler.cs | 100.0% | 95% | ok |
| ControlDiarioAggregateRoot.cs | 100.0% | 95% | ok |
| DiaCalculadoAggregateRoot.cs | 100.0% | 95% | ok |
| ConfiguracionSerializacionControlHoras.cs | - | excluido | - |
| FranjaDepurada.cs | - | excluido | - |
| IdentidadEventosControlHoras.cs | - | excluido | - |
| MarcacionDelDia.cs | - | excluido | - |
| ResumenColaborador.cs | - | excluido | - |
| DepuracionDiaRecibida.cs | - | sin clasificar | ⚠ revisar |
| HorasDiscriminadas.cs | - | sin clasificar | ⚠ revisar |
| EstadoDiaCalculado.cs | - | sin clasificar | ⚠ revisar |

> **Archivos sin clasificar** (`⚠ revisar`): ninguna regla de clasificacion los reconocio — el gate **no los midio**. No es una exclusion deliberada (a diferencia de `excluido`, donde si se decidio que no requieren cobertura): requieren revision humana para confirmar si necesitan tests.
## Commits

d5427a5 refactor(hu-425): poda comentarios, alias sobrante y suma guardrails de igualdad y smoke
70ff5de feat(hu-425): implementa DiaDepuradoEventHandler y registra DepuracionDiaRecibida (fase verde)
d06ea18 test(hu-425): tests para DiaCalculadoAggregateRoot y su receptor de DiaDepurado (fase roja)

Closes #425