### PR TITLE
Listar las asistencias diarias de un colaborador por rango de fechas

### DIFF
--- a/src/Bitakora.ControlAsistencia.ControlHoras/ListarAsistenciasDiarias/EstadoAsistenciaPresentado.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ListarAsistenciasDiarias/EstadoAsistenciaPresentado.cs
@@ -1,15 +1,9 @@
 namespace Bitakora.ControlAsistencia.ControlHoras.ListarAsistenciasDiarias;
 
 /// <summary>
-/// Estado presentado de una fila de ListarAsistenciasDiarias (issue #427). Vive en el DTO de
-/// respuesta del endpoint, NUNCA en el read model AsistenciaDiaria (#426): SinDatos describe un
-/// dia que no genero documento -- fila sintetica -- y el read model nunca materializa filas
-/// sinteticas (issue #427, "Necesidad de lectura").
-///
-/// Provisional/Aprobado mapean 1:1 con EstadoAsistencia (ReadModels.ControlHoras). SinDatos no
-/// tiene contraparte en el read model: es el estado real que decision A del Aprobador exige para
-/// avalar un dia vacio ("no vino y no debia venir") -- cuando llegue el aval, probablemente un
-/// cuarto valor (issue #427, "Contexto").
+/// Estado presentado de una fila de la respuesta, nunca del read model AsistenciaDiaria: SinDatos
+/// describe un dia sin documento -- fila sintetica que la proyeccion no materializa. Provisional y
+/// Aprobado mapean 1:1 con EstadoAsistencia.
 /// </summary>
 public enum EstadoAsistenciaPresentado
 {

--- a/src/Bitakora.ControlAsistencia.ControlHoras/ListarAsistenciasDiarias/EstadoAsistenciaPresentado.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ListarAsistenciasDiarias/EstadoAsistenciaPresentado.cs
@@ -1,0 +1,19 @@
+namespace Bitakora.ControlAsistencia.ControlHoras.ListarAsistenciasDiarias;
+
+/// <summary>
+/// Estado presentado de una fila de ListarAsistenciasDiarias (issue #427). Vive en el DTO de
+/// respuesta del endpoint, NUNCA en el read model AsistenciaDiaria (#426): SinDatos describe un
+/// dia que no genero documento -- fila sintetica -- y el read model nunca materializa filas
+/// sinteticas (issue #427, "Necesidad de lectura").
+///
+/// Provisional/Aprobado mapean 1:1 con EstadoAsistencia (ReadModels.ControlHoras). SinDatos no
+/// tiene contraparte en el read model: es el estado real que decision A del Aprobador exige para
+/// avalar un dia vacio ("no vino y no debia venir") -- cuando llegue el aval, probablemente un
+/// cuarto valor (issue #427, "Contexto").
+/// </summary>
+public enum EstadoAsistenciaPresentado
+{
+    Provisional,
+    Aprobado,
+    SinDatos
+}

--- a/src/Bitakora.ControlAsistencia.ControlHoras/ListarAsistenciasDiarias/FilaAsistenciaDiaria.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ListarAsistenciasDiarias/FilaAsistenciaDiaria.cs
@@ -1,0 +1,26 @@
+using Bitakora.ControlAsistencia.ReadModels.ControlHoras;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.ListarAsistenciasDiarias;
+
+/// <summary>
+/// Fila de un dia en la respuesta de ListarAsistenciasDiarias (issue #427). DTO de respuesta
+/// propio -- excepcion bajo Rule of Three (MEF-ADR-0041 decision 4): la fila sintetica no existe
+/// como read model y el estado presentado de tres valores (<see cref="EstadoAsistenciaPresentado"/>)
+/// no tiene forma en AsistenciaDiaria (#426) -- devolver el documento crudo no puede expresar la
+/// respuesta.
+///
+/// Plan/NombreTurno/las cuatro anomalias/HorasPorConcepto reusan los tipos ya definidos en
+/// ReadModels.ControlHoras (mismo shape que AsistenciaDiaria) cuando el dia tiene documento; una
+/// fila sintetica (issue #427, CA-2) los sintetiza: Plan = SinProgramar, NombreTurno = null, las
+/// cuatro anomalias en false, HorasPorConcepto vacio.
+/// </summary>
+public sealed record FilaAsistenciaDiaria(
+    DateOnly Fecha,
+    EstadoAsistenciaPresentado Estado,
+    PlanDelDia Plan,
+    string? NombreTurno,
+    bool NoSePresento,
+    bool FranjasIncompletas,
+    bool VinoEnDescanso,
+    bool TrabajoSinProgramacion,
+    IReadOnlyDictionary<string, decimal> HorasPorConcepto);

--- a/src/Bitakora.ControlAsistencia.ControlHoras/ListarAsistenciasDiarias/FilaAsistenciaDiaria.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ListarAsistenciasDiarias/FilaAsistenciaDiaria.cs
@@ -3,16 +3,9 @@ using Bitakora.ControlAsistencia.ReadModels.ControlHoras;
 namespace Bitakora.ControlAsistencia.ControlHoras.ListarAsistenciasDiarias;
 
 /// <summary>
-/// Fila de un dia en la respuesta de ListarAsistenciasDiarias (issue #427). DTO de respuesta
-/// propio -- excepcion bajo Rule of Three (MEF-ADR-0041 decision 4): la fila sintetica no existe
-/// como read model y el estado presentado de tres valores (<see cref="EstadoAsistenciaPresentado"/>)
-/// no tiene forma en AsistenciaDiaria (#426) -- devolver el documento crudo no puede expresar la
-/// respuesta.
-///
-/// Plan/NombreTurno/las cuatro anomalias/HorasPorConcepto reusan los tipos ya definidos en
-/// ReadModels.ControlHoras (mismo shape que AsistenciaDiaria) cuando el dia tiene documento; una
-/// fila sintetica (issue #427, CA-2) los sintetiza: Plan = SinProgramar, NombreTurno = null, las
-/// cuatro anomalias en false, HorasPorConcepto vacio.
+/// DTO de respuesta propio en vez de servir AsistenciaDiaria crudo -- excepcion justificada de
+/// MEF-ADR-0041 decision 4: la fila sintetica no existe como read model y el estado presentado
+/// tiene un valor (SinDatos) que el read model no tiene.
 /// </summary>
 public sealed record FilaAsistenciaDiaria(
     DateOnly Fecha,

--- a/src/Bitakora.ControlAsistencia.ControlHoras/ListarAsistenciasDiarias/FiltroListarAsistenciasDiarias.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ListarAsistenciasDiarias/FiltroListarAsistenciasDiarias.cs
@@ -1,0 +1,17 @@
+namespace Bitakora.ControlAsistencia.ControlHoras.ListarAsistenciasDiarias;
+
+/// <summary>
+/// Filtro tipado del body de ListarAsistenciasDiarias (issue #427, verbo QUERY -- MEF-ADR-0042).
+/// Los tres campos son AND por defecto y los tres son obligatorios (issue #427, "Filtro"):
+/// <c>CodigoColaborador</c> ausente/vacio, o cualquiera de las dos fechas ausente, o un rango
+/// invertido (<c>DesdeFecha</c> posterior a <c>HastaFecha</c>) son 422 -- nunca 400: el JSON esta
+/// bien formado, pero su contenido no es procesable (RFC 10008 seccion 2.1).
+///
+/// Todos nullable a proposito: permite distinguir "el campo no vino" (422 con mensaje propio) de
+/// "el campo vino con un valor invalido para el tipo" (400 por el catch de JsonException del
+/// endpoint, antes de llegar a este record).
+/// </summary>
+public sealed record FiltroListarAsistenciasDiarias(
+    string? CodigoColaborador,
+    DateOnly? DesdeFecha,
+    DateOnly? HastaFecha);

--- a/src/Bitakora.ControlAsistencia.ControlHoras/ListarAsistenciasDiarias/FiltroListarAsistenciasDiarias.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ListarAsistenciasDiarias/FiltroListarAsistenciasDiarias.cs
@@ -1,15 +1,10 @@
 namespace Bitakora.ControlAsistencia.ControlHoras.ListarAsistenciasDiarias;
 
 /// <summary>
-/// Filtro tipado del body de ListarAsistenciasDiarias (issue #427, verbo QUERY -- MEF-ADR-0042).
-/// Los tres campos son AND por defecto y los tres son obligatorios (issue #427, "Filtro"):
-/// <c>CodigoColaborador</c> ausente/vacio, o cualquiera de las dos fechas ausente, o un rango
-/// invertido (<c>DesdeFecha</c> posterior a <c>HastaFecha</c>) son 422 -- nunca 400: el JSON esta
-/// bien formado, pero su contenido no es procesable (RFC 10008 seccion 2.1).
-///
-/// Todos nullable a proposito: permite distinguir "el campo no vino" (422 con mensaje propio) de
-/// "el campo vino con un valor invalido para el tipo" (400 por el catch de JsonException del
-/// endpoint, antes de llegar a este record).
+/// Filtro tipado del body (QUERY, MEF-ADR-0042), campos combinados con AND. Los tres son
+/// obligatorios pese a declararse nullable: nullable distingue "el campo no vino" (422 con mensaje
+/// propio) de "el campo vino con un valor invalido para su tipo" (400 del catch de JsonException,
+/// antes de llegar a este record).
 /// </summary>
 public sealed record FiltroListarAsistenciasDiarias(
     string? CodigoColaborador,

--- a/src/Bitakora.ControlAsistencia.ControlHoras/ListarAsistenciasDiarias/FunctionEndpoint.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ListarAsistenciasDiarias/FunctionEndpoint.cs
@@ -8,22 +8,13 @@ using Microsoft.Azure.Functions.Worker;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.ListarAsistenciasDiarias;
 
-// Issue #427: Function QUERY (RFC 10008, MEF-ADR-0042) sobre la vista materializada
-// AsistenciaDiaria (#426), via (a') de MEF-ADR-0035 -- session.Query<AsistenciaDiaria>(). Este
-// issue NO crea proyeccion ni toca el worker (issue #427, "Necesidad de lectura"): compone el
-// filtro tipado del body, el recorte de rango (RangoConsulta) y la sintesis del calendario
-// completo (SintesisCalendarioAsistencia) en el envelope de respuesta.
+// Function QUERY (RFC 10008, MEF-ADR-0042) sobre la vista materializada AsistenciaDiaria, via (a')
+// de MEF-ADR-0035.
 //
-// Primer QUERY desplegado de este consumidor (issue #427, "Notas tecnicas"): el trigger "query"
-// esta verificado por POC del marco contra .NET 10 + Azure Functions Core Tools 4.6.0
-// (skills/projections/read-apis.md), pero projection-implementer debe reconfirmarlo contra Core
-// Tools de este repo antes del primer despliegue.
-//
-// Guard 415/400/422 identico al ejemplo canonico QUERY de skills/projections/read-apis.md: 415
-// ANTES de leer el body (HasJsonContentType), 400 si el body no es JSON valido (catch JsonException
-// -- ReadFromJsonAsync lanza una excepcion que NO es JsonException cuando el Content-Type no es
-// JSON conocido, de ahi el guard 415 previo), 422 cuando el JSON es valido pero su contenido no es
-// procesable (CodigoColaborador ausente/vacio, fechas ausentes, rango invertido -- CA-4).
+// Primer endpoint QUERY de este consumidor: los gates NO VERIFICADO de MEF-ADR-0042 seccion 6
+// (front-end de App Service y APIM reenviando un verbo no estandar) solo los cierra el smoke test
+// contra dev despues del deploy -- un 404 en dev puede significar tanto "no desplegado" como "el
+// borde filtro el verbo".
 public class FunctionEndpoint(IDocumentStore store, ITenantResolver tenantResolver)
 {
     [Function("ListarAsistenciasDiarias")]
@@ -32,6 +23,8 @@ public class FunctionEndpoint(IDocumentStore store, ITenantResolver tenantResolv
         HttpRequest req,
         CancellationToken ct)
     {
+        // El 415 va ANTES de leer el body: ante un Content-Type no-JSON, ReadFromJsonAsync lanza
+        // una excepcion que NO es JsonException y escaparia como 500 pese al catch de abajo.
         if (!req.HasJsonContentType())
             return new ObjectResult("La query exige Content-Type: application/json")
             { StatusCode = StatusCodes.Status415UnsupportedMediaType };
@@ -49,7 +42,8 @@ public class FunctionEndpoint(IDocumentStore store, ITenantResolver tenantResolv
         if (filtro is null)
             return new BadRequestObjectResult("El body de la query es obligatorio");
 
-        // CA-4: CodigoColaborador obligatorio -- pantalla de UN colaborador (issue #427, "Contexto").
+        // Obligatorio, a diferencia del filtro homonimo de ListarTurnosVigentes: esta es la
+        // pantalla de UN colaborador.
         if (string.IsNullOrWhiteSpace(filtro.CodigoColaborador))
             return new ObjectResult("CodigoColaborador es obligatorio")
             { StatusCode = StatusCodes.Status422UnprocessableEntity };
@@ -62,34 +56,24 @@ public class FunctionEndpoint(IDocumentStore store, ITenantResolver tenantResolv
             return new ObjectResult("DesdeFecha no puede ser posterior a HastaFecha")
             { StatusCode = StatusCodes.Status422UnprocessableEntity };
 
+        var codigoColaborador = filtro.CodigoColaborador;
         var desde = filtro.DesdeFecha.Value;
-        var hasta = filtro.HastaFecha.Value;
+        var rangoAplicado = RangoConsulta.Recortar(desde, filtro.HastaFecha.Value);
 
-        // CA-3: recorte de la cota de 31 dias, siempre hacia adelante desde `desde`.
-        var rangoAplicado = RangoConsulta.Recortar(desde, hasta);
-
-        // CA-6: la QuerySession se abre SIEMPRE acotada al tenant que resuelve ITenantResolver --
-        // nunca a un tenant id que llegara por el body (mitigacion estructural contra BOLA/IDOR,
-        // MEF-ADR-0028/skills/projections/read-apis.md). CodigoColaborador/DesdeFecha/HastaFecha SI
-        // vienen del body: son el filtro del recurso, no el tenant.
+        // Sesion acotada al tenant que resuelve ITenantResolver, nunca a un dato de la request
+        // (mitigacion estructural contra BOLA/IDOR, MEF-ADR-0028).
         await using var session = store.QuerySession(tenantResolver.TenantId);
 
-        // Via (a') de MEF-ADR-0035: session.Query<TView>() sobre la proyeccion materializada
-        // AsistenciaDiaria (#426). Este issue no crea proyeccion ni toca el worker.
         var documentos = await session.Query<AsistenciaDiaria>()
-            .Where(a => a.CodigoColaborador == filtro.CodigoColaborador
+            .Where(a => a.CodigoColaborador == codigoColaborador
                         && a.Fecha >= desde
                         && a.Fecha <= rangoAplicado.HastaAplicado)
             .ToListAsync(ct);
 
-        // CA-1/CA-2/CA-5: el calendario completo -- una fila por cada dia del rango aplicado, dias
-        // sin documento sintetizados -- lo produce la funcion pura, no la consulta LINQ.
         var filas = SintesisCalendarioAsistencia.Completar(desde, rangoAplicado.HastaAplicado, documentos);
 
-        var respuesta = new ListaAsistenciasDiarias(
-            desde, rangoAplicado.HastaAplicado, rangoAplicado.RangoRecortado, filas);
-
-        // Nunca 404 (CA-5): un rango sin documentos son 31 filas sinteticas, no un error.
-        return new OkObjectResult(respuesta);
+        // Nunca 404: un rango sin documentos son filas sinteticas, no un error.
+        return new OkObjectResult(new ListaAsistenciasDiarias(
+            desde, rangoAplicado.HastaAplicado, rangoAplicado.RangoRecortado, filas));
     }
 }

--- a/src/Bitakora.ControlAsistencia.ControlHoras/ListarAsistenciasDiarias/FunctionEndpoint.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ListarAsistenciasDiarias/FunctionEndpoint.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+using Bitakora.ControlAsistencia.ReadModels.ControlHoras;
 using Cosmos.MultiTenancy;
 using Marten;
 using Microsoft.AspNetCore.Http;
@@ -17,17 +19,77 @@ namespace Bitakora.ControlAsistencia.ControlHoras.ListarAsistenciasDiarias;
 // (skills/projections/read-apis.md), pero projection-implementer debe reconfirmarlo contra Core
 // Tools de este repo antes del primer despliegue.
 //
-// Stub de fase roja (projection-test-writer): el cuerpo real -- guard 415/400/422
-// (HasJsonContentType + catch JsonException), CodigoColaborador/fechas obligatorios, rango
-// invertido, apertura de QuerySession acotada al tenant del resolver (nunca a un tenant de la
-// request), consulta LINQ y composicion del envelope de respuesta -- es responsabilidad de
-// projection-implementer (skills/projections/read-apis.md, ejemplo canonico QUERY).
+// Guard 415/400/422 identico al ejemplo canonico QUERY de skills/projections/read-apis.md: 415
+// ANTES de leer el body (HasJsonContentType), 400 si el body no es JSON valido (catch JsonException
+// -- ReadFromJsonAsync lanza una excepcion que NO es JsonException cuando el Content-Type no es
+// JSON conocido, de ahi el guard 415 previo), 422 cuando el JSON es valido pero su contenido no es
+// procesable (CodigoColaborador ausente/vacio, fechas ausentes, rango invertido -- CA-4).
 public class FunctionEndpoint(IDocumentStore store, ITenantResolver tenantResolver)
 {
     [Function("ListarAsistenciasDiarias")]
-    public Task<IActionResult> Run(
+    public async Task<IActionResult> Run(
         [HttpTrigger(AuthorizationLevel.Anonymous, "query", Route = "control-horas/asistencias-diarias")]
         HttpRequest req,
-        CancellationToken ct) =>
-        throw new NotImplementedException();
+        CancellationToken ct)
+    {
+        if (!req.HasJsonContentType())
+            return new ObjectResult("La query exige Content-Type: application/json")
+            { StatusCode = StatusCodes.Status415UnsupportedMediaType };
+
+        FiltroListarAsistenciasDiarias? filtro;
+        try
+        {
+            filtro = await req.ReadFromJsonAsync<FiltroListarAsistenciasDiarias>(ct);
+        }
+        catch (JsonException)
+        {
+            return new BadRequestObjectResult("El body de la query no es un JSON valido");
+        }
+
+        if (filtro is null)
+            return new BadRequestObjectResult("El body de la query es obligatorio");
+
+        // CA-4: CodigoColaborador obligatorio -- pantalla de UN colaborador (issue #427, "Contexto").
+        if (string.IsNullOrWhiteSpace(filtro.CodigoColaborador))
+            return new ObjectResult("CodigoColaborador es obligatorio")
+            { StatusCode = StatusCodes.Status422UnprocessableEntity };
+
+        if (filtro.DesdeFecha is null || filtro.HastaFecha is null)
+            return new ObjectResult("DesdeFecha y HastaFecha son obligatorios")
+            { StatusCode = StatusCodes.Status422UnprocessableEntity };
+
+        if (filtro.DesdeFecha > filtro.HastaFecha)
+            return new ObjectResult("DesdeFecha no puede ser posterior a HastaFecha")
+            { StatusCode = StatusCodes.Status422UnprocessableEntity };
+
+        var desde = filtro.DesdeFecha.Value;
+        var hasta = filtro.HastaFecha.Value;
+
+        // CA-3: recorte de la cota de 31 dias, siempre hacia adelante desde `desde`.
+        var rangoAplicado = RangoConsulta.Recortar(desde, hasta);
+
+        // CA-6: la QuerySession se abre SIEMPRE acotada al tenant que resuelve ITenantResolver --
+        // nunca a un tenant id que llegara por el body (mitigacion estructural contra BOLA/IDOR,
+        // MEF-ADR-0028/skills/projections/read-apis.md). CodigoColaborador/DesdeFecha/HastaFecha SI
+        // vienen del body: son el filtro del recurso, no el tenant.
+        await using var session = store.QuerySession(tenantResolver.TenantId);
+
+        // Via (a') de MEF-ADR-0035: session.Query<TView>() sobre la proyeccion materializada
+        // AsistenciaDiaria (#426). Este issue no crea proyeccion ni toca el worker.
+        var documentos = await session.Query<AsistenciaDiaria>()
+            .Where(a => a.CodigoColaborador == filtro.CodigoColaborador
+                        && a.Fecha >= desde
+                        && a.Fecha <= rangoAplicado.HastaAplicado)
+            .ToListAsync(ct);
+
+        // CA-1/CA-2/CA-5: el calendario completo -- una fila por cada dia del rango aplicado, dias
+        // sin documento sintetizados -- lo produce la funcion pura, no la consulta LINQ.
+        var filas = SintesisCalendarioAsistencia.Completar(desde, rangoAplicado.HastaAplicado, documentos);
+
+        var respuesta = new ListaAsistenciasDiarias(
+            desde, rangoAplicado.HastaAplicado, rangoAplicado.RangoRecortado, filas);
+
+        // Nunca 404 (CA-5): un rango sin documentos son 31 filas sinteticas, no un error.
+        return new OkObjectResult(respuesta);
+    }
 }

--- a/src/Bitakora.ControlAsistencia.ControlHoras/ListarAsistenciasDiarias/FunctionEndpoint.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ListarAsistenciasDiarias/FunctionEndpoint.cs
@@ -1,0 +1,33 @@
+using Cosmos.MultiTenancy;
+using Marten;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.ListarAsistenciasDiarias;
+
+// Issue #427: Function QUERY (RFC 10008, MEF-ADR-0042) sobre la vista materializada
+// AsistenciaDiaria (#426), via (a') de MEF-ADR-0035 -- session.Query<AsistenciaDiaria>(). Este
+// issue NO crea proyeccion ni toca el worker (issue #427, "Necesidad de lectura"): compone el
+// filtro tipado del body, el recorte de rango (RangoConsulta) y la sintesis del calendario
+// completo (SintesisCalendarioAsistencia) en el envelope de respuesta.
+//
+// Primer QUERY desplegado de este consumidor (issue #427, "Notas tecnicas"): el trigger "query"
+// esta verificado por POC del marco contra .NET 10 + Azure Functions Core Tools 4.6.0
+// (skills/projections/read-apis.md), pero projection-implementer debe reconfirmarlo contra Core
+// Tools de este repo antes del primer despliegue.
+//
+// Stub de fase roja (projection-test-writer): el cuerpo real -- guard 415/400/422
+// (HasJsonContentType + catch JsonException), CodigoColaborador/fechas obligatorios, rango
+// invertido, apertura de QuerySession acotada al tenant del resolver (nunca a un tenant de la
+// request), consulta LINQ y composicion del envelope de respuesta -- es responsabilidad de
+// projection-implementer (skills/projections/read-apis.md, ejemplo canonico QUERY).
+public class FunctionEndpoint(IDocumentStore store, ITenantResolver tenantResolver)
+{
+    [Function("ListarAsistenciasDiarias")]
+    public Task<IActionResult> Run(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "query", Route = "control-horas/asistencias-diarias")]
+        HttpRequest req,
+        CancellationToken ct) =>
+        throw new NotImplementedException();
+}

--- a/src/Bitakora.ControlAsistencia.ControlHoras/ListarAsistenciasDiarias/ListaAsistenciasDiarias.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ListarAsistenciasDiarias/ListaAsistenciasDiarias.cs
@@ -1,0 +1,16 @@
+namespace Bitakora.ControlAsistencia.ControlHoras.ListarAsistenciasDiarias;
+
+/// <summary>
+/// Envelope de respuesta de ListarAsistenciasDiarias (issue #427) -- mismo patron que
+/// ListaTurnosVigentes (issue #329): declara el rango efectivamente aplicado (ya recortado por
+/// <see cref="RangoConsulta.Recortar"/>, CA-3) junto con la lista de filas, una por dia del rango
+/// (issue #427, "Que devuelve").
+///
+/// <c>Filas</c> nunca esta vacia -- CA-5: un rango sin ningun documento produce todas filas
+/// sinteticas, nunca una lista vacia ni 404.
+/// </summary>
+public sealed record ListaAsistenciasDiarias(
+    DateOnly DesdeAplicado,
+    DateOnly HastaAplicado,
+    bool RangoRecortado,
+    IReadOnlyList<FilaAsistenciaDiaria> Filas);

--- a/src/Bitakora.ControlAsistencia.ControlHoras/ListarAsistenciasDiarias/ListaAsistenciasDiarias.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ListarAsistenciasDiarias/ListaAsistenciasDiarias.cs
@@ -1,13 +1,9 @@
 namespace Bitakora.ControlAsistencia.ControlHoras.ListarAsistenciasDiarias;
 
 /// <summary>
-/// Envelope de respuesta de ListarAsistenciasDiarias (issue #427) -- mismo patron que
-/// ListaTurnosVigentes (issue #329): declara el rango efectivamente aplicado (ya recortado por
-/// <see cref="RangoConsulta.Recortar"/>, CA-3) junto con la lista de filas, una por dia del rango
-/// (issue #427, "Que devuelve").
-///
-/// <c>Filas</c> nunca esta vacia -- CA-5: un rango sin ningun documento produce todas filas
-/// sinteticas, nunca una lista vacia ni 404.
+/// Envelope de respuesta (mismo patron que ListaTurnosVigentes): el rango que declara es el
+/// efectivamente APLICADO -- ya recortado por <see cref="RangoConsulta.Recortar"/> --, nunca el
+/// que pidio el cliente.
 /// </summary>
 public sealed record ListaAsistenciasDiarias(
     DateOnly DesdeAplicado,

--- a/src/Bitakora.ControlAsistencia.ControlHoras/ListarAsistenciasDiarias/RangoConsulta.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ListarAsistenciasDiarias/RangoConsulta.cs
@@ -1,37 +1,26 @@
 namespace Bitakora.ControlAsistencia.ControlHoras.ListarAsistenciasDiarias;
 
 /// <summary>
-/// Resultado de aplicar la cota de <see cref="RangoConsulta.CotaDias"/> sobre el rango de fechas
-/// pedido a ListarAsistenciasDiarias (issue #427, CA-3).
+/// Rango efectivamente aplicado tras acotar el pedido a <see cref="RangoConsulta.CotaDias"/>.
 /// </summary>
 public readonly record struct RangoAplicado(DateOnly HastaAplicado, bool RangoRecortado);
 
 /// <summary>
-/// Logica pura de recorte del rango de consulta de ListarAsistenciasDiarias (issue #427, CA-3) --
-/// misma politica exacta que RangoConsulta de ListarTurnosVigentes (issue #329): 31 dias inclusive,
-/// recorte SIEMPRE hacia adelante desde <c>desde</c>, nunca relativo a la fecha de hoy.
+/// Recorte del rango de consulta: SIEMPRE hacia adelante desde <c>desde</c> -- nunca hacia atras
+/// desde <c>hasta</c> ni relativo a la fecha de hoy, que haria que la misma consulta devolviera
+/// datos distintos segun el dia en que se ejecuta.
 ///
-/// Duplicada a proposito (SEGUNDA aparicion de esta politica en el dominio -- MEF-ADR-0018 Rule of
-/// Three): el issue #427 la deja explicitamente revisable ("Recorte de rango -- propuesta
-/// revisable") y con solo dos instancias duplicar en el feature folder propio sigue siendo
-/// legitimo -- reusar la clase de ListarTurnosVigentes cruzaria fronteras de feature folder
-/// (skills/projections/naming.md: cada Function GET/QUERY es un feature folder propio). Un tercer
-/// consumidor de esta misma politica es quien decide si se extrae a un lugar comun del dominio.
-///
-/// Sin dependencias de Marten/Postgres: se prueba como funcion pura sobre DateOnly, sin
-/// QuerySession (skills/projections/read-apis.md).
+/// Duplicada a proposito de ListarTurnosVigentes.RangoConsulta: segunda aparicion de la politica,
+/// tolerada por MEF-ADR-0018 (Rule of Three). Un tercer consumidor decide si se extrae a un lugar
+/// comun del dominio; reusar la clase del otro feature folder no es la salida.
 /// </summary>
 public static class RangoConsulta
 {
-    /// <summary>Cota maxima del rango, en dias, INCLUSIVE (CA-3): desde y desde + 30 dias caben.</summary>
+    /// <summary>Cota maxima del rango, en dias, INCLUSIVE: desde y desde + 30 dias caben.</summary>
     public const int CotaDias = 31;
 
     public static RangoAplicado Recortar(DateOnly desde, DateOnly hasta)
     {
-        // CotaDias es INCLUSIVE: desde + (CotaDias - 1) dias es el limite exacto que todavia no
-        // excede la cota (31 dias inclusive = desde + 30 dias). Misma formula exacta que
-        // ListarTurnosVigentes.RangoConsulta.Recortar (issue #329) -- duplicacion deliberada, ver
-        // el comentario de clase.
         var hastaMaxima = desde.AddDays(CotaDias - 1);
 
         return hasta > hastaMaxima

--- a/src/Bitakora.ControlAsistencia.ControlHoras/ListarAsistenciasDiarias/RangoConsulta.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ListarAsistenciasDiarias/RangoConsulta.cs
@@ -1,0 +1,33 @@
+namespace Bitakora.ControlAsistencia.ControlHoras.ListarAsistenciasDiarias;
+
+/// <summary>
+/// Resultado de aplicar la cota de <see cref="RangoConsulta.CotaDias"/> sobre el rango de fechas
+/// pedido a ListarAsistenciasDiarias (issue #427, CA-3).
+/// </summary>
+public readonly record struct RangoAplicado(DateOnly HastaAplicado, bool RangoRecortado);
+
+/// <summary>
+/// Logica pura de recorte del rango de consulta de ListarAsistenciasDiarias (issue #427, CA-3) --
+/// misma politica exacta que RangoConsulta de ListarTurnosVigentes (issue #329): 31 dias inclusive,
+/// recorte SIEMPRE hacia adelante desde <c>desde</c>, nunca relativo a la fecha de hoy.
+///
+/// Duplicada a proposito (SEGUNDA aparicion de esta politica en el dominio -- MEF-ADR-0018 Rule of
+/// Three): el issue #427 la deja explicitamente revisable ("Recorte de rango -- propuesta
+/// revisable") y con solo dos instancias duplicar en el feature folder propio sigue siendo
+/// legitimo -- reusar la clase de ListarTurnosVigentes cruzaria fronteras de feature folder
+/// (skills/projections/naming.md: cada Function GET/QUERY es un feature folder propio). Un tercer
+/// consumidor de esta misma politica es quien decide si se extrae a un lugar comun del dominio.
+///
+/// Sin dependencias de Marten/Postgres: se prueba como funcion pura sobre DateOnly, sin
+/// QuerySession (skills/projections/read-apis.md).
+/// </summary>
+public static class RangoConsulta
+{
+    /// <summary>Cota maxima del rango, en dias, INCLUSIVE (CA-3): desde y desde + 30 dias caben.</summary>
+    public const int CotaDias = 31;
+
+    public static RangoAplicado Recortar(DateOnly desde, DateOnly hasta)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/Bitakora.ControlAsistencia.ControlHoras/ListarAsistenciasDiarias/RangoConsulta.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ListarAsistenciasDiarias/RangoConsulta.cs
@@ -28,6 +28,14 @@ public static class RangoConsulta
 
     public static RangoAplicado Recortar(DateOnly desde, DateOnly hasta)
     {
-        throw new NotImplementedException();
+        // CotaDias es INCLUSIVE: desde + (CotaDias - 1) dias es el limite exacto que todavia no
+        // excede la cota (31 dias inclusive = desde + 30 dias). Misma formula exacta que
+        // ListarTurnosVigentes.RangoConsulta.Recortar (issue #329) -- duplicacion deliberada, ver
+        // el comentario de clase.
+        var hastaMaxima = desde.AddDays(CotaDias - 1);
+
+        return hasta > hastaMaxima
+            ? new RangoAplicado(hastaMaxima, true)
+            : new RangoAplicado(hasta, false);
     }
 }

--- a/src/Bitakora.ControlAsistencia.ControlHoras/ListarAsistenciasDiarias/SintesisCalendarioAsistencia.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ListarAsistenciasDiarias/SintesisCalendarioAsistencia.cs
@@ -1,0 +1,33 @@
+using Bitakora.ControlAsistencia.ReadModels.ControlHoras;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.ListarAsistenciasDiarias;
+
+/// <summary>
+/// Sintesis pura del calendario completo de ListarAsistenciasDiarias (issue #427, CA-1/CA-2/CA-3/
+/// CA-5). Dado el rango aplicado [desde, hastaAplicado] (ya recortado por
+/// <see cref="RangoConsulta.Recortar"/>) y los documentos AsistenciaDiaria que la consulta LINQ del
+/// endpoint trajo para ese colaborador y ese rango, produce EXACTAMENTE una fila por dia, orden
+/// Fecha ascendente:
+///
+/// - Dia con documento: mapea sus campos (Plan, NombreTurno, las cuatro anomalias,
+///   HorasPorConcepto) 1:1, con Estado presentado segun EstadoAsistencia -> EstadoAsistenciaPresentado
+///   (Provisional/Aprobado).
+/// - Dia sin documento: fila sintetica -- Estado = SinDatos, Plan = SinProgramar, NombreTurno =
+///   null, las cuatro anomalias en false, HorasPorConcepto vacio (decision A: el vacio se avala, no
+///   se aprueba).
+///
+/// Funcion pura sin QuerySession/Marten (skills/projections/read-apis.md): el filtrado por
+/// CodigoColaborador y por rango ya ocurrio en la consulta LINQ del endpoint -- esta funcion solo
+/// decide, para cada fecha del rango [desde, hastaAplicado], si existe un documento con esa Fecha;
+/// un documento cuya Fecha caiga fuera del rango se ignora.
+/// </summary>
+public static class SintesisCalendarioAsistencia
+{
+    public static IReadOnlyList<FilaAsistenciaDiaria> Completar(
+        DateOnly desde,
+        DateOnly hastaAplicado,
+        IReadOnlyList<AsistenciaDiaria> documentos)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/Bitakora.ControlAsistencia.ControlHoras/ListarAsistenciasDiarias/SintesisCalendarioAsistencia.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ListarAsistenciasDiarias/SintesisCalendarioAsistencia.cs
@@ -28,6 +28,55 @@ public static class SintesisCalendarioAsistencia
         DateOnly hastaAplicado,
         IReadOnlyList<AsistenciaDiaria> documentos)
     {
-        throw new NotImplementedException();
+        // Un documento fuera de [desde, hastaAplicado] se ignora (contrato de la clase): el
+        // filtrado por rango ya deberia haber ocurrido en la consulta LINQ del endpoint, esto es
+        // solo una salvaguarda de la funcion pura.
+        var documentoPorFecha = documentos
+            .Where(d => d.Fecha >= desde && d.Fecha <= hastaAplicado)
+            .ToDictionary(d => d.Fecha);
+
+        var filas = new List<FilaAsistenciaDiaria>();
+        for (var fecha = desde; fecha <= hastaAplicado; fecha = fecha.AddDays(1))
+        {
+            filas.Add(documentoPorFecha.TryGetValue(fecha, out var documento)
+                ? MapearConDocumento(documento)
+                : FilaSintetica(fecha));
+        }
+
+        return filas;
     }
+
+    private static FilaAsistenciaDiaria MapearConDocumento(AsistenciaDiaria documento) =>
+        new(
+            documento.Fecha,
+            MapearEstado(documento.Estado),
+            documento.Plan,
+            documento.NombreTurno,
+            documento.NoSePresento,
+            documento.FranjasIncompletas,
+            documento.VinoEnDescanso,
+            documento.TrabajoSinProgramacion,
+            documento.HorasPorConcepto);
+
+    // CA-2: dia sin documento -- decision A del Aprobador, "no vino y no debia venir" se avala, no
+    // se aprueba.
+    private static FilaAsistenciaDiaria FilaSintetica(DateOnly fecha) =>
+        new(
+            fecha,
+            EstadoAsistenciaPresentado.SinDatos,
+            PlanDelDia.SinProgramar,
+            null,
+            false,
+            false,
+            false,
+            false,
+            new Dictionary<string, decimal>());
+
+    private static EstadoAsistenciaPresentado MapearEstado(EstadoAsistencia estado) => estado switch
+    {
+        EstadoAsistencia.Provisional => EstadoAsistenciaPresentado.Provisional,
+        EstadoAsistencia.Aprobado => EstadoAsistenciaPresentado.Aprobado,
+        _ => throw new ArgumentOutOfRangeException(
+            nameof(estado), estado, "EstadoAsistencia no reconocido por el mapeo de estado presentado")
+    };
 }

--- a/src/Bitakora.ControlAsistencia.ControlHoras/ListarAsistenciasDiarias/SintesisCalendarioAsistencia.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ListarAsistenciasDiarias/SintesisCalendarioAsistencia.cs
@@ -3,23 +3,9 @@ using Bitakora.ControlAsistencia.ReadModels.ControlHoras;
 namespace Bitakora.ControlAsistencia.ControlHoras.ListarAsistenciasDiarias;
 
 /// <summary>
-/// Sintesis pura del calendario completo de ListarAsistenciasDiarias (issue #427, CA-1/CA-2/CA-3/
-/// CA-5). Dado el rango aplicado [desde, hastaAplicado] (ya recortado por
-/// <see cref="RangoConsulta.Recortar"/>) y los documentos AsistenciaDiaria que la consulta LINQ del
-/// endpoint trajo para ese colaborador y ese rango, produce EXACTAMENTE una fila por dia, orden
-/// Fecha ascendente:
-///
-/// - Dia con documento: mapea sus campos (Plan, NombreTurno, las cuatro anomalias,
-///   HorasPorConcepto) 1:1, con Estado presentado segun EstadoAsistencia -> EstadoAsistenciaPresentado
-///   (Provisional/Aprobado).
-/// - Dia sin documento: fila sintetica -- Estado = SinDatos, Plan = SinProgramar, NombreTurno =
-///   null, las cuatro anomalias en false, HorasPorConcepto vacio (decision A: el vacio se avala, no
-///   se aprueba).
-///
-/// Funcion pura sin QuerySession/Marten (skills/projections/read-apis.md): el filtrado por
-/// CodigoColaborador y por rango ya ocurrio en la consulta LINQ del endpoint -- esta funcion solo
-/// decide, para cada fecha del rango [desde, hastaAplicado], si existe un documento con esa Fecha;
-/// un documento cuya Fecha caiga fuera del rango se ignora.
+/// Produce exactamente una fila por cada dia del rango [desde, hastaAplicado], en orden ascendente
+/// de fecha: el documento mapeado cuando ese dia lo tiene, o una fila sintetica cuando no. Funcion
+/// pura -- el filtrado por colaborador ya ocurrio en la consulta del endpoint.
 /// </summary>
 public static class SintesisCalendarioAsistencia
 {
@@ -28,9 +14,8 @@ public static class SintesisCalendarioAsistencia
         DateOnly hastaAplicado,
         IReadOnlyList<AsistenciaDiaria> documentos)
     {
-        // Un documento fuera de [desde, hastaAplicado] se ignora (contrato de la clase): el
-        // filtrado por rango ya deberia haber ocurrido en la consulta LINQ del endpoint, esto es
-        // solo una salvaguarda de la funcion pura.
+        // Re-filtrar por rango no es redundante con el endpoint: es el contrato de esta funcion
+        // frente a un llamador que traiga documentos de mas.
         var documentoPorFecha = documentos
             .Where(d => d.Fecha >= desde && d.Fecha <= hastaAplicado)
             .ToDictionary(d => d.Fecha);
@@ -58,8 +43,8 @@ public static class SintesisCalendarioAsistencia
             documento.TrabajoSinProgramacion,
             documento.HorasPorConcepto);
 
-    // CA-2: dia sin documento -- decision A del Aprobador, "no vino y no debia venir" se avala, no
-    // se aprueba.
+    // Un dia sin documento no es una anomalia: no hubo programacion NI marcaciones, asi que las
+    // cuatro banderas van en false -- el vacio se avala, no se aprueba.
     private static FilaAsistenciaDiaria FilaSintetica(DateOnly fecha) =>
         new(
             fecha,

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/ListarAsistenciasDiarias/ListarAsistenciasDiariasSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/ListarAsistenciasDiarias/ListarAsistenciasDiariasSmokeTests.cs
@@ -1,35 +1,26 @@
-// Issue #427: smoke tests de ListarAsistenciasDiarias, verbo QUERY (RFC 10008, MEF-ADR-0042) sobre
-// control-horas/asistencias-diarias -- pantalla 2 del Aprobador: los dias de UN colaborador en un
-// rango, con el calendario COMPLETO (dias sin documento sintetizados, decision A: "no vino y no
-// debia venir" se avala, no se aprueba). No hay proyeccion ni read model nuevos: esta clase consulta
-// la MISMA vista materializada AsistenciaDiaria (#426) via (a') session.Query<AsistenciaDiaria>().
+// Smoke tests de ListarAsistenciasDiarias -- QUERY control-horas/asistencias-diarias: el calendario
+// completo de UN colaborador en un rango, con los dias sin documento sintetizados.
 //
-// Arrange via el bus interno, nunca sembrando el event store por fuera de el: cada dia real se crea
-// publicando DiaDepurado al topic "dia-depurado" (mismo mecanismo que RecibirDepuracionViaSbSmokeTests,
-// issue #425) -- ControlHoras persiste depuracion_dia_recibida en el stream "dc:{codigo}:{yyyyMMdd}" y
-// el worker de proyecciones materializa AsistenciaDiaria de forma asincrona.
+// Quedan ROJOS hasta que el deploy publique la Function en dev: mientras tanto la ruta no existe y
+// el host responde 404 a todo. El CI de PR no los ejecuta (solo corre *.Tests); su veredicto real
+// se lee despues del deploy. Ese mismo 404 es ademas el gate NO VERIFICADO de MEF-ADR-0042 seccion
+// 6 -- si persiste tras un deploy exitoso, el sospechoso es el borde filtrando un verbo no
+// estandar, no el endpoint.
 //
-// Lifecycle Async (MEF-ADR-0034 seccion 3): los casos que dependen de datos sembrados envuelven la
-// consulta en Polling.WaitUntilAsync (timeout estandar 30s) -- unica excepcion documentada al "no usar
-// Polling directo en tests". Si el timeout se agota es un fallo real (worker no desplegado, o la
-// proyeccion nunca materializo el efecto del arrange), nunca un caso para Assert.Skip.
+// Arrange via el bus interno, nunca sembrando el event store por fuera de el: cada dia real se
+// publica como DiaDepurado al topic "dia-depurado" (mismo mecanismo que
+// RecibirDepuracionViaSbSmokeTests). La proyeccion tiene lifecycle Async (MEF-ADR-0034 seccion 3),
+// asi que los casos que dependen del arrange envuelven la consulta en Polling.WaitUntilAsync --
+// agotar el timeout es un fallo real (worker no desplegado, proyeccion sin materializar), nunca un
+// skip.
 //
-// Formas locales DESACOPLADAS del read model de produccion (ReadModels.ControlHoras.AsistenciaDiaria)
-// y del DTO de respuesta de produccion (ControlHoras.ListarAsistenciasDiarias.*): el smoke test no
+// Formas locales DESACOPLADAS del read model y del DTO de respuesta de produccion: el smoke test no
 // referencia ReadModels ni el Function App (isla, MEF-ADR-0034 seccion 5). Los enums locales
-// (EstadoAsistenciaPresentadoSmoke/PlanDelDiaSmoke) replican el orden de valores de produccion porque
-// STJ los serializa como el entero subyacente (ComposicionServicios no registra JsonStringEnumConverter
-// para las respuestas HTTP) -- si produccion reordenara alguno de los dos enums, este test detectaria
-// el cambio de contrato al fallar la comparacion.
-//
-// No se repite aqui el detalle de "el ultimo gana" ni el mapeo fino de las cuatro anomalias: esas
-// reglas de negocio de la proyeccion companion ya las cubre el unit test de AsistenciaDiariaProjection
-// (projection-test-writer). Este smoke test es black-box: solo verifica que el endpoint desplegado
-// combina filas reales y sinteticas, recorta el rango, y responde los codigos correctos.
+// replican el ORDEN de valores de produccion porque STJ los serializa como el entero subyacente --
+// si produccion reordenara alguno, la comparacion falla y delata el cambio de contrato.
 //
 // CA-6 (tenant scoping de la QuerySession) no tiene superficie observable via HTTP negro-caja en un
-// entorno de un solo tenant (CA-ADR-0027): lo cubre el test de composicion de la Function
-// (test-writer/projection-implementer), no este archivo.
+// entorno de un solo tenant (CA-ADR-0027): lo cubre el test de composicion de la Function.
 using System.Net;
 using System.Net.Http.Json;
 using System.Text;
@@ -48,8 +39,8 @@ public class ListarAsistenciasDiariasSmokeTests(ApiFixture api, ServiceBusFixtur
     private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
     private static readonly HttpMethod MetodoQuery = new("QUERY");
 
-    // Case-insensitive: la respuesta viaja en camelCase (ComposicionServicios configura
-    // JsonNamingPolicy.CamelCase), mientras que las formas locales de este archivo son PascalCase.
+    // La respuesta viaja en camelCase (ComposicionServicios fija JsonNamingPolicy.CamelCase) y las
+    // formas locales de este archivo son PascalCase.
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         PropertyNameCaseInsensitive = true
@@ -86,23 +77,20 @@ public class ListarAsistenciasDiariasSmokeTests(ApiFixture api, ServiceBusFixtur
         bool RangoRecortado,
         IReadOnlyList<FilaAsistenciaDiariaSmoke> Filas);
 
-    private Task<HttpResponseMessage> ConsultarAsync(object filtro, CancellationToken ct)
+    private async Task<HttpResponseMessage> ConsultarAsync(object filtro, CancellationToken ct)
     {
         using var request = new HttpRequestMessage(MetodoQuery, RutaListado)
         {
             Content = JsonContent.Create(filtro)
         };
-        return _client.SendAsync(request, ct);
+        return await _client.SendAsync(request, ct);
     }
 
-    // Reintenta la consulta hasta que la proyeccion asincrona satisfaga la condicion -- unica
-    // excepcion documentada al "no usar Polling directo en tests" (lifecycle Async, MEF-ADR-0034
-    // seccion 3). Si el timeout se agota, Polling.WaitUntilAsync lanza TimeoutException (fallo real).
     private Task<ListaAsistenciasDiariasSmoke> ConsultarHastaQueAsync(
         object filtro, Func<ListaAsistenciasDiariasSmoke, bool> condicion, CancellationToken ct) =>
         Polling.WaitUntilAsync(async () =>
         {
-            var response = await ConsultarAsync(filtro, ct);
+            using var response = await ConsultarAsync(filtro, ct);
             response.StatusCode.Should().Be(HttpStatusCode.OK);
 
             var body = await response.Content.ReadFromJsonAsync<ListaAsistenciasDiariasSmoke>(
@@ -110,9 +98,6 @@ public class ListarAsistenciasDiariasSmokeTests(ApiFixture api, ServiceBusFixtur
             return body is not null && condicion(body) ? body : null;
         }, Timeout);
 
-    // Arrange comun: publica DiaDepurado al bus interno -- mismo mecanismo de
-    // RecibirDepuracionViaSbSmokeTests (issue #425). ControlHoras persiste depuracion_dia_recibida y
-    // el worker de proyecciones materializa AsistenciaDiaria de forma asincrona.
     private async Task PublicarDiaDepuradoAsync(
         string codigoColaborador, DateOnly fecha, string? nombreTurno,
         object[] franjas, object[] marcaciones, IReadOnlyDictionary<string, decimal> horasPorConcepto)
@@ -140,7 +125,7 @@ public class ListarAsistenciasDiariasSmokeTests(ApiFixture api, ServiceBusFixtur
         await serviceBus.PublishAsync(TopicDiaDepurado, evento, Guid.CreateVersion7().ToString());
     }
 
-    // Dia con jornada valida: nombreTurno + al menos una franja -- ClasificarPlan produce ConJornada.
+    // ClasificarPlan produce ConJornada solo con nombreTurno Y al menos una franja.
     private Task PublicarDiaConJornadaAsync(
         string codigoColaborador, DateOnly fecha, string nombreTurno) =>
         PublicarDiaDepuradoAsync(
@@ -164,8 +149,8 @@ public class ListarAsistenciasDiariasSmokeTests(ApiFixture api, ServiceBusFixtur
             ],
             horasPorConcepto: new Dictionary<string, decimal> { ["OrdinariaDiurna"] = 8.00m });
 
-    // Descanso programado: nombreTurno presente, sin franjas ni marcaciones -- ClasificarPlan produce
-    // Descanso (issue #427, "Necesidad de lectura": el descanso programado tambien crea el stream).
+    // ClasificarPlan produce Descanso con nombreTurno presente y sin franjas ni marcaciones -- ese
+    // dia tambien crea el stream, por eso no es un dia sintetico.
     private Task PublicarDiaDeDescansoAsync(
         string codigoColaborador, DateOnly fecha, string nombreTurno) =>
         PublicarDiaDepuradoAsync(
@@ -184,7 +169,6 @@ public class ListarAsistenciasDiariasSmokeTests(ApiFixture api, ServiceBusFixtur
         response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
-    // CA-4: sin Content-Type: application/json -> 415, verificado ANTES de leer el body.
     [Fact]
     [Trait("Category", "Smoke")]
     public async Task ListarAsistenciasDiarias_Retorna415_CuandoContentTypeNoEsJson()
@@ -201,7 +185,6 @@ public class ListarAsistenciasDiariasSmokeTests(ApiFixture api, ServiceBusFixtur
         response.StatusCode.Should().Be(HttpStatusCode.UnsupportedMediaType);
     }
 
-    // CA-4: body con Content-Type json pero sintacticamente invalido -> 400.
     [Fact]
     [Trait("Category", "Smoke")]
     public async Task ListarAsistenciasDiarias_Retorna400_CuandoElBodyNoEsJsonValido()
@@ -218,7 +201,6 @@ public class ListarAsistenciasDiariasSmokeTests(ApiFixture api, ServiceBusFixtur
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
-    // CA-4: body ausente (Content-Type json, cero bytes) -> 400.
     [Fact]
     [Trait("Category", "Smoke")]
     public async Task ListarAsistenciasDiarias_Retorna400_CuandoElBodyEstaVacio()
@@ -235,7 +217,6 @@ public class ListarAsistenciasDiariasSmokeTests(ApiFixture api, ServiceBusFixtur
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
-    // CA-4: JSON valido sin CodigoColaborador -> 422 (obligatorio; pantalla de UN colaborador).
     [Fact]
     [Trait("Category", "Smoke")]
     public async Task ListarAsistenciasDiarias_Retorna422_CuandoCodigoColaboradorEstaAusente()
@@ -253,7 +234,6 @@ public class ListarAsistenciasDiariasSmokeTests(ApiFixture api, ServiceBusFixtur
         response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
     }
 
-    // CA-4: JSON valido sin DesdeFecha/HastaFecha -> 422 (ambas obligatorias).
     [Fact]
     [Trait("Category", "Smoke")]
     public async Task ListarAsistenciasDiarias_Retorna422_CuandoLasFechasEstanAusentes()
@@ -267,7 +247,6 @@ public class ListarAsistenciasDiariasSmokeTests(ApiFixture api, ServiceBusFixtur
         response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
     }
 
-    // CA-4: DesdeFecha posterior a HastaFecha -> 422 (rango invertido).
     [Fact]
     [Trait("Category", "Smoke")]
     public async Task ListarAsistenciasDiarias_Retorna422_CuandoElRangoEstaInvertido()
@@ -286,15 +265,13 @@ public class ListarAsistenciasDiariasSmokeTests(ApiFixture api, ServiceBusFixtur
         response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
     }
 
-    // CA-2/CA-5: un colaborador sin ningun documento en el rango recibe 200 con el calendario
-    // COMPLETO sintetizado -- nunca 404 (un rango sin documentos son N filas sinteticas, no un error).
     [Fact]
     [Trait("Category", "Smoke")]
     public async Task ListarAsistenciasDiarias_Retorna200ConTodasLasFilasSinteticas_CuandoElColaboradorNoTieneNingunDocumentoEnElRango()
     {
         var ct = TestContext.Current.CancellationToken;
 
-        // Arrange: codigoColaborador nuevo, nunca sembrado por ningun test -- no puede tener documento.
+        // Codigo nunca sembrado por ningun test: no puede tener documento en dev.
         var codigoColaborador = Guid.CreateVersion7().ToString();
         var desde = new DateOnly(2026, 7, 1);
         var hasta = new DateOnly(2026, 7, 5);
@@ -311,7 +288,6 @@ public class ListarAsistenciasDiariasSmokeTests(ApiFixture api, ServiceBusFixtur
         respuesta.HastaAplicado.Should().Be(hasta);
         respuesta.RangoRecortado.Should().BeFalse();
 
-        // CA-2/CA-5: 5 filas, una por dia del rango, orden Fecha ascendente.
         respuesta.Filas.Should().HaveCount(5);
         respuesta.Filas.Select(f => f.Fecha).Should().Equal(
             desde, desde.AddDays(1), desde.AddDays(2), desde.AddDays(3), desde.AddDays(4));
@@ -327,10 +303,8 @@ public class ListarAsistenciasDiariasSmokeTests(ApiFixture api, ServiceBusFixtur
             && f.HorasPorConcepto.Count == 0);
     }
 
-    // CA-1/CA-2: un rango con SOLO algunos dias con documento combina, en la misma respuesta, filas
-    // reales (mapeadas de AsistenciaDiaria) y filas sinteticas para el resto del rango -- el nucleo de
-    // "Que devuelve" del issue #427. Se siembran DOS dias reales de forma distinta (jornada y
-    // descanso), no uno solo, para distinguir "mapea el documento real" de "siempre sintetiza".
+    // Se siembran DOS dias reales de forma distinta (jornada y descanso), no uno solo, para
+    // distinguir "mapea el documento real" de "siempre sintetiza".
     [Fact]
     [Trait("Category", "Smoke")]
     public async Task ListarAsistenciasDiarias_CombinaFilasRealesYSinteticasEnElMismoRango_CuandoSoloAlgunosDiasTienenDocumento()
@@ -342,7 +316,7 @@ public class ListarAsistenciasDiariasSmokeTests(ApiFixture api, ServiceBusFixtur
 
         var codigoColaborador = Guid.CreateVersion7().ToString();
         var desde = new DateOnly(2026, 7, 10);
-        var hasta = new DateOnly(2026, 7, 14); // 5 dias: 10, 11, 12, 13, 14
+        var hasta = new DateOnly(2026, 7, 14);
         var fechaConJornada = new DateOnly(2026, 7, 11);
         var fechaDescanso = new DateOnly(2026, 7, 13);
 
@@ -351,18 +325,15 @@ public class ListarAsistenciasDiariasSmokeTests(ApiFixture api, ServiceBusFixtur
 
         var filtro = new { codigoColaborador, desdeFecha = desde, hastaFecha = hasta };
 
-        // Act + Assert: reintentar hasta que AMBOS dias reales esten materializados por el worker.
         var respuesta = await ConsultarHastaQueAsync(filtro, lista =>
             lista.Filas.Any(f => f.Fecha == fechaConJornada && f.Estado != EstadoAsistenciaPresentadoSmoke.SinDatos)
             && lista.Filas.Any(f => f.Fecha == fechaDescanso && f.Estado != EstadoAsistenciaPresentadoSmoke.SinDatos),
             ct);
 
-        // Assert: CA-1 -- exactamente una fila por dia del rango, orden Fecha ascendente.
         respuesta.Filas.Should().HaveCount(5);
         respuesta.Filas.Select(f => f.Fecha).Should().Equal(
             desde, desde.AddDays(1), desde.AddDays(2), desde.AddDays(3), desde.AddDays(4));
 
-        // Assert: el dia con jornada mapea los campos reales de AsistenciaDiaria.
         var filaConJornada = respuesta.Filas.Single(f => f.Fecha == fechaConJornada);
         filaConJornada.Estado.Should().Be(EstadoAsistenciaPresentadoSmoke.Provisional);
         filaConJornada.Plan.Should().Be(PlanDelDiaSmoke.ConJornada);
@@ -371,14 +342,12 @@ public class ListarAsistenciasDiariasSmokeTests(ApiFixture api, ServiceBusFixtur
         filaConJornada.FranjasIncompletas.Should().BeFalse();
         filaConJornada.HorasPorConcepto.Should().ContainKey("OrdinariaDiurna").WhoseValue.Should().Be(8.00m);
 
-        // Assert: el dia de descanso programado tambien mapea como fila real, sin horas.
         var filaDescanso = respuesta.Filas.Single(f => f.Fecha == fechaDescanso);
         filaDescanso.Estado.Should().Be(EstadoAsistenciaPresentadoSmoke.Provisional);
         filaDescanso.Plan.Should().Be(PlanDelDiaSmoke.Descanso);
         filaDescanso.NombreTurno.Should().Be("[TEST] Turno Descanso Dos");
         filaDescanso.HorasPorConcepto.Should().BeEmpty();
 
-        // Assert: CA-2 -- el resto del rango (sin documento) son filas sinteticas.
         DateOnly[] fechasSinteticas = [desde, desde.AddDays(2), desde.AddDays(4)];
         foreach (var fecha in fechasSinteticas)
         {
@@ -389,8 +358,6 @@ public class ListarAsistenciasDiariasSmokeTests(ApiFixture api, ServiceBusFixtur
         }
     }
 
-    // CA-3: rango que excede 31 dias se recorta hacia adelante desde DesdeFecha, la respuesta lo
-    // declara, y la sintesis del calendario cubre SOLO el rango aplicado (no lo pedido).
     [Fact]
     [Trait("Category", "Smoke")]
     public async Task ListarAsistenciasDiarias_RecortaHaciaAdelanteYSintetizaSoloElRangoAplicado_CuandoElRangoExcedeLaCotaDe31Dias()
@@ -399,8 +366,9 @@ public class ListarAsistenciasDiariasSmokeTests(ApiFixture api, ServiceBusFixtur
 
         var codigoColaborador = Guid.CreateVersion7().ToString();
         var desde = new DateOnly(2026, 8, 1);
-        var hastaSolicitado = new DateOnly(2026, 12, 31); // ~152 dias, muy por encima de la cota
-        var hastaAplicadaEsperada = desde.AddDays(30); // cota de 31 dias, inclusive
+        var hastaSolicitado = new DateOnly(2026, 12, 31);
+        // La cota son 31 dias INCLUSIVE; el literal se afirma a mano, nunca leyendo CotaDias.
+        var hastaAplicadaEsperada = desde.AddDays(30);
 
         var filtro = new { codigoColaborador, desdeFecha = desde, hastaFecha = hastaSolicitado };
         var response = await ConsultarAsync(filtro, ct);
@@ -414,7 +382,6 @@ public class ListarAsistenciasDiariasSmokeTests(ApiFixture api, ServiceBusFixtur
         respuesta.HastaAplicado.Should().Be(hastaAplicadaEsperada);
         respuesta.RangoRecortado.Should().BeTrue();
 
-        // Assert: la sintesis del calendario cubre EXACTAMENTE el rango aplicado (31 dias).
         respuesta.Filas.Should().HaveCount(31);
         respuesta.Filas.First().Fecha.Should().Be(desde);
         respuesta.Filas.Last().Fecha.Should().Be(hastaAplicadaEsperada);

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/ListarAsistenciasDiarias/ListarAsistenciasDiariasSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/ListarAsistenciasDiarias/ListarAsistenciasDiariasSmokeTests.cs
@@ -1,0 +1,422 @@
+// Issue #427: smoke tests de ListarAsistenciasDiarias, verbo QUERY (RFC 10008, MEF-ADR-0042) sobre
+// control-horas/asistencias-diarias -- pantalla 2 del Aprobador: los dias de UN colaborador en un
+// rango, con el calendario COMPLETO (dias sin documento sintetizados, decision A: "no vino y no
+// debia venir" se avala, no se aprueba). No hay proyeccion ni read model nuevos: esta clase consulta
+// la MISMA vista materializada AsistenciaDiaria (#426) via (a') session.Query<AsistenciaDiaria>().
+//
+// Arrange via el bus interno, nunca sembrando el event store por fuera de el: cada dia real se crea
+// publicando DiaDepurado al topic "dia-depurado" (mismo mecanismo que RecibirDepuracionViaSbSmokeTests,
+// issue #425) -- ControlHoras persiste depuracion_dia_recibida en el stream "dc:{codigo}:{yyyyMMdd}" y
+// el worker de proyecciones materializa AsistenciaDiaria de forma asincrona.
+//
+// Lifecycle Async (MEF-ADR-0034 seccion 3): los casos que dependen de datos sembrados envuelven la
+// consulta en Polling.WaitUntilAsync (timeout estandar 30s) -- unica excepcion documentada al "no usar
+// Polling directo en tests". Si el timeout se agota es un fallo real (worker no desplegado, o la
+// proyeccion nunca materializo el efecto del arrange), nunca un caso para Assert.Skip.
+//
+// Formas locales DESACOPLADAS del read model de produccion (ReadModels.ControlHoras.AsistenciaDiaria)
+// y del DTO de respuesta de produccion (ControlHoras.ListarAsistenciasDiarias.*): el smoke test no
+// referencia ReadModels ni el Function App (isla, MEF-ADR-0034 seccion 5). Los enums locales
+// (EstadoAsistenciaPresentadoSmoke/PlanDelDiaSmoke) replican el orden de valores de produccion porque
+// STJ los serializa como el entero subyacente (ComposicionServicios no registra JsonStringEnumConverter
+// para las respuestas HTTP) -- si produccion reordenara alguno de los dos enums, este test detectaria
+// el cambio de contrato al fallar la comparacion.
+//
+// No se repite aqui el detalle de "el ultimo gana" ni el mapeo fino de las cuatro anomalias: esas
+// reglas de negocio de la proyeccion companion ya las cubre el unit test de AsistenciaDiariaProjection
+// (projection-test-writer). Este smoke test es black-box: solo verifica que el endpoint desplegado
+// combina filas reales y sinteticas, recorta el rango, y responde los codigos correctos.
+//
+// CA-6 (tenant scoping de la QuerySession) no tiene superficie observable via HTTP negro-caja en un
+// entorno de un solo tenant (CA-ADR-0027): lo cubre el test de composicion de la Function
+// (test-writer/projection-implementer), no este archivo.
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.ControlHoras.SmokeTests.Fixtures;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.SmokeTests.ListarAsistenciasDiarias;
+
+public class ListarAsistenciasDiariasSmokeTests(ApiFixture api, ServiceBusFixture serviceBus)
+{
+    private readonly HttpClient _client = api.Client;
+
+    private const string RutaListado = "/api/control-horas/asistencias-diarias";
+    private const string TopicDiaDepurado = "dia-depurado";
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
+    private static readonly HttpMethod MetodoQuery = new("QUERY");
+
+    // Case-insensitive: la respuesta viaja en camelCase (ComposicionServicios configura
+    // JsonNamingPolicy.CamelCase), mientras que las formas locales de este archivo son PascalCase.
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    private enum EstadoAsistenciaPresentadoSmoke
+    {
+        Provisional,
+        Aprobado,
+        SinDatos
+    }
+
+    private enum PlanDelDiaSmoke
+    {
+        ConJornada,
+        Descanso,
+        SinProgramar
+    }
+
+    private sealed record FilaAsistenciaDiariaSmoke(
+        DateOnly Fecha,
+        EstadoAsistenciaPresentadoSmoke Estado,
+        PlanDelDiaSmoke Plan,
+        string? NombreTurno,
+        bool NoSePresento,
+        bool FranjasIncompletas,
+        bool VinoEnDescanso,
+        bool TrabajoSinProgramacion,
+        IReadOnlyDictionary<string, decimal> HorasPorConcepto);
+
+    private sealed record ListaAsistenciasDiariasSmoke(
+        DateOnly DesdeAplicado,
+        DateOnly HastaAplicado,
+        bool RangoRecortado,
+        IReadOnlyList<FilaAsistenciaDiariaSmoke> Filas);
+
+    private Task<HttpResponseMessage> ConsultarAsync(object filtro, CancellationToken ct)
+    {
+        using var request = new HttpRequestMessage(MetodoQuery, RutaListado)
+        {
+            Content = JsonContent.Create(filtro)
+        };
+        return _client.SendAsync(request, ct);
+    }
+
+    // Reintenta la consulta hasta que la proyeccion asincrona satisfaga la condicion -- unica
+    // excepcion documentada al "no usar Polling directo en tests" (lifecycle Async, MEF-ADR-0034
+    // seccion 3). Si el timeout se agota, Polling.WaitUntilAsync lanza TimeoutException (fallo real).
+    private Task<ListaAsistenciasDiariasSmoke> ConsultarHastaQueAsync(
+        object filtro, Func<ListaAsistenciasDiariasSmoke, bool> condicion, CancellationToken ct) =>
+        Polling.WaitUntilAsync(async () =>
+        {
+            var response = await ConsultarAsync(filtro, ct);
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+            var body = await response.Content.ReadFromJsonAsync<ListaAsistenciasDiariasSmoke>(
+                JsonOptions, cancellationToken: ct);
+            return body is not null && condicion(body) ? body : null;
+        }, Timeout);
+
+    // Arrange comun: publica DiaDepurado al bus interno -- mismo mecanismo de
+    // RecibirDepuracionViaSbSmokeTests (issue #425). ControlHoras persiste depuracion_dia_recibida y
+    // el worker de proyecciones materializa AsistenciaDiaria de forma asincrona.
+    private async Task PublicarDiaDepuradoAsync(
+        string codigoColaborador, DateOnly fecha, string? nombreTurno,
+        object[] franjas, object[] marcaciones, IReadOnlyDictionary<string, decimal> horasPorConcepto)
+    {
+        var evento = new
+        {
+            CodigoColaborador = codigoColaborador,
+            Fecha = fecha.ToString("yyyy-MM-dd"),
+            Colaborador = new
+            {
+                Identificacion = "CC-777888999",
+                CodigoColaborador = codigoColaborador,
+                NombreCompleto = "[TEST] Smoke Asistencias Diarias"
+            },
+            NombreTurno = nombreTurno,
+            Franjas = franjas,
+            Marcaciones = marcaciones,
+            HorasDiscriminadas = new
+            {
+                HorasPorConcepto = horasPorConcepto,
+                Trazabilidad = Array.Empty<string>()
+            }
+        };
+
+        await serviceBus.PublishAsync(TopicDiaDepurado, evento, Guid.CreateVersion7().ToString());
+    }
+
+    // Dia con jornada valida: nombreTurno + al menos una franja -- ClasificarPlan produce ConJornada.
+    private Task PublicarDiaConJornadaAsync(
+        string codigoColaborador, DateOnly fecha, string nombreTurno) =>
+        PublicarDiaDepuradoAsync(
+            codigoColaborador, fecha, nombreTurno,
+            franjas:
+            [
+                new
+                {
+                    HoraInicioProgramada = "06:00:00",
+                    HoraFinProgramada = "14:00:00",
+                    DiaOffsetFin = 0,
+                    Entrada = $"{fecha:yyyy-MM-dd}T06:00:00",
+                    Salida = $"{fecha:yyyy-MM-dd}T14:00:00",
+                    EsAnomala = false
+                }
+            ],
+            marcaciones:
+            [
+                new { Timestamp = $"{fecha:yyyy-MM-dd}T06:00:00", Tipo = "ENTRADA" },
+                new { Timestamp = $"{fecha:yyyy-MM-dd}T14:00:00", Tipo = "SALIDA" }
+            ],
+            horasPorConcepto: new Dictionary<string, decimal> { ["OrdinariaDiurna"] = 8.00m });
+
+    // Descanso programado: nombreTurno presente, sin franjas ni marcaciones -- ClasificarPlan produce
+    // Descanso (issue #427, "Necesidad de lectura": el descanso programado tambien crea el stream).
+    private Task PublicarDiaDeDescansoAsync(
+        string codigoColaborador, DateOnly fecha, string nombreTurno) =>
+        PublicarDiaDepuradoAsync(
+            codigoColaborador, fecha, nombreTurno,
+            franjas: [],
+            marcaciones: [],
+            horasPorConcepto: new Dictionary<string, decimal>());
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task DebeEstarDisponible_CuandoSeConsultaHealthCheck()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var response = await _client.GetAsync("/api/health", ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    // CA-4: sin Content-Type: application/json -> 415, verificado ANTES de leer el body.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarAsistenciasDiarias_Retorna415_CuandoContentTypeNoEsJson()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        using var request = new HttpRequestMessage(MetodoQuery, RutaListado)
+        {
+            Content = new StringContent("{}", Encoding.UTF8, "text/plain")
+        };
+
+        var response = await _client.SendAsync(request, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnsupportedMediaType);
+    }
+
+    // CA-4: body con Content-Type json pero sintacticamente invalido -> 400.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarAsistenciasDiarias_Retorna400_CuandoElBodyNoEsJsonValido()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        using var request = new HttpRequestMessage(MetodoQuery, RutaListado)
+        {
+            Content = new StringContent("{ esto no es json valido", Encoding.UTF8, "application/json")
+        };
+
+        var response = await _client.SendAsync(request, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    // CA-4: body ausente (Content-Type json, cero bytes) -> 400.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarAsistenciasDiarias_Retorna400_CuandoElBodyEstaVacio()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        using var request = new HttpRequestMessage(MetodoQuery, RutaListado)
+        {
+            Content = new StringContent(string.Empty, Encoding.UTF8, "application/json")
+        };
+
+        var response = await _client.SendAsync(request, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    // CA-4: JSON valido sin CodigoColaborador -> 422 (obligatorio; pantalla de UN colaborador).
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarAsistenciasDiarias_Retorna422_CuandoCodigoColaboradorEstaAusente()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        var filtro = new
+        {
+            desdeFecha = new DateOnly(2026, 7, 1),
+            hastaFecha = new DateOnly(2026, 7, 5)
+        };
+
+        var response = await ConsultarAsync(filtro, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    // CA-4: JSON valido sin DesdeFecha/HastaFecha -> 422 (ambas obligatorias).
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarAsistenciasDiarias_Retorna422_CuandoLasFechasEstanAusentes()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        var filtro = new { codigoColaborador = Guid.CreateVersion7().ToString() };
+
+        var response = await ConsultarAsync(filtro, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    // CA-4: DesdeFecha posterior a HastaFecha -> 422 (rango invertido).
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarAsistenciasDiarias_Retorna422_CuandoElRangoEstaInvertido()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        var filtro = new
+        {
+            codigoColaborador = Guid.CreateVersion7().ToString(),
+            desdeFecha = new DateOnly(2026, 7, 10),
+            hastaFecha = new DateOnly(2026, 7, 1)
+        };
+
+        var response = await ConsultarAsync(filtro, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    // CA-2/CA-5: un colaborador sin ningun documento en el rango recibe 200 con el calendario
+    // COMPLETO sintetizado -- nunca 404 (un rango sin documentos son N filas sinteticas, no un error).
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarAsistenciasDiarias_Retorna200ConTodasLasFilasSinteticas_CuandoElColaboradorNoTieneNingunDocumentoEnElRango()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        // Arrange: codigoColaborador nuevo, nunca sembrado por ningun test -- no puede tener documento.
+        var codigoColaborador = Guid.CreateVersion7().ToString();
+        var desde = new DateOnly(2026, 7, 1);
+        var hasta = new DateOnly(2026, 7, 5);
+
+        var filtro = new { codigoColaborador, desdeFecha = desde, hastaFecha = hasta };
+        var response = await ConsultarAsync(filtro, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var respuesta = await response.Content.ReadFromJsonAsync<ListaAsistenciasDiariasSmoke>(
+            JsonOptions, cancellationToken: ct);
+
+        respuesta.Should().NotBeNull();
+        respuesta!.DesdeAplicado.Should().Be(desde);
+        respuesta.HastaAplicado.Should().Be(hasta);
+        respuesta.RangoRecortado.Should().BeFalse();
+
+        // CA-2/CA-5: 5 filas, una por dia del rango, orden Fecha ascendente.
+        respuesta.Filas.Should().HaveCount(5);
+        respuesta.Filas.Select(f => f.Fecha).Should().Equal(
+            desde, desde.AddDays(1), desde.AddDays(2), desde.AddDays(3), desde.AddDays(4));
+
+        respuesta.Filas.Should().OnlyContain(f =>
+            f.Estado == EstadoAsistenciaPresentadoSmoke.SinDatos
+            && f.Plan == PlanDelDiaSmoke.SinProgramar
+            && f.NombreTurno == null
+            && !f.NoSePresento
+            && !f.FranjasIncompletas
+            && !f.VinoEnDescanso
+            && !f.TrabajoSinProgramacion
+            && f.HorasPorConcepto.Count == 0);
+    }
+
+    // CA-1/CA-2: un rango con SOLO algunos dias con documento combina, en la misma respuesta, filas
+    // reales (mapeadas de AsistenciaDiaria) y filas sinteticas para el resto del rango -- el nucleo de
+    // "Que devuelve" del issue #427. Se siembran DOS dias reales de forma distinta (jornada y
+    // descanso), no uno solo, para distinguir "mapea el documento real" de "siempre sintetiza".
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarAsistenciasDiarias_CombinaFilasRealesYSinteticasEnElMismoRango_CuandoSoloAlgunosDiasTienenDocumento()
+    {
+        Assert.SkipWhen(!serviceBus.IsConfigured,
+            "ServiceBus no configurado. Usa appsettings.local.json o variable ServiceBus__ConnectionString.");
+
+        var ct = TestContext.Current.CancellationToken;
+
+        var codigoColaborador = Guid.CreateVersion7().ToString();
+        var desde = new DateOnly(2026, 7, 10);
+        var hasta = new DateOnly(2026, 7, 14); // 5 dias: 10, 11, 12, 13, 14
+        var fechaConJornada = new DateOnly(2026, 7, 11);
+        var fechaDescanso = new DateOnly(2026, 7, 13);
+
+        await PublicarDiaConJornadaAsync(codigoColaborador, fechaConJornada, "[TEST] Turno Real Uno");
+        await PublicarDiaDeDescansoAsync(codigoColaborador, fechaDescanso, "[TEST] Turno Descanso Dos");
+
+        var filtro = new { codigoColaborador, desdeFecha = desde, hastaFecha = hasta };
+
+        // Act + Assert: reintentar hasta que AMBOS dias reales esten materializados por el worker.
+        var respuesta = await ConsultarHastaQueAsync(filtro, lista =>
+            lista.Filas.Any(f => f.Fecha == fechaConJornada && f.Estado != EstadoAsistenciaPresentadoSmoke.SinDatos)
+            && lista.Filas.Any(f => f.Fecha == fechaDescanso && f.Estado != EstadoAsistenciaPresentadoSmoke.SinDatos),
+            ct);
+
+        // Assert: CA-1 -- exactamente una fila por dia del rango, orden Fecha ascendente.
+        respuesta.Filas.Should().HaveCount(5);
+        respuesta.Filas.Select(f => f.Fecha).Should().Equal(
+            desde, desde.AddDays(1), desde.AddDays(2), desde.AddDays(3), desde.AddDays(4));
+
+        // Assert: el dia con jornada mapea los campos reales de AsistenciaDiaria.
+        var filaConJornada = respuesta.Filas.Single(f => f.Fecha == fechaConJornada);
+        filaConJornada.Estado.Should().Be(EstadoAsistenciaPresentadoSmoke.Provisional);
+        filaConJornada.Plan.Should().Be(PlanDelDiaSmoke.ConJornada);
+        filaConJornada.NombreTurno.Should().Be("[TEST] Turno Real Uno");
+        filaConJornada.NoSePresento.Should().BeFalse();
+        filaConJornada.FranjasIncompletas.Should().BeFalse();
+        filaConJornada.HorasPorConcepto.Should().ContainKey("OrdinariaDiurna").WhoseValue.Should().Be(8.00m);
+
+        // Assert: el dia de descanso programado tambien mapea como fila real, sin horas.
+        var filaDescanso = respuesta.Filas.Single(f => f.Fecha == fechaDescanso);
+        filaDescanso.Estado.Should().Be(EstadoAsistenciaPresentadoSmoke.Provisional);
+        filaDescanso.Plan.Should().Be(PlanDelDiaSmoke.Descanso);
+        filaDescanso.NombreTurno.Should().Be("[TEST] Turno Descanso Dos");
+        filaDescanso.HorasPorConcepto.Should().BeEmpty();
+
+        // Assert: CA-2 -- el resto del rango (sin documento) son filas sinteticas.
+        DateOnly[] fechasSinteticas = [desde, desde.AddDays(2), desde.AddDays(4)];
+        foreach (var fecha in fechasSinteticas)
+        {
+            var filaSintetica = respuesta.Filas.Single(f => f.Fecha == fecha);
+            filaSintetica.Estado.Should().Be(EstadoAsistenciaPresentadoSmoke.SinDatos);
+            filaSintetica.Plan.Should().Be(PlanDelDiaSmoke.SinProgramar);
+            filaSintetica.NombreTurno.Should().BeNull();
+        }
+    }
+
+    // CA-3: rango que excede 31 dias se recorta hacia adelante desde DesdeFecha, la respuesta lo
+    // declara, y la sintesis del calendario cubre SOLO el rango aplicado (no lo pedido).
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarAsistenciasDiarias_RecortaHaciaAdelanteYSintetizaSoloElRangoAplicado_CuandoElRangoExcedeLaCotaDe31Dias()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        var codigoColaborador = Guid.CreateVersion7().ToString();
+        var desde = new DateOnly(2026, 8, 1);
+        var hastaSolicitado = new DateOnly(2026, 12, 31); // ~152 dias, muy por encima de la cota
+        var hastaAplicadaEsperada = desde.AddDays(30); // cota de 31 dias, inclusive
+
+        var filtro = new { codigoColaborador, desdeFecha = desde, hastaFecha = hastaSolicitado };
+        var response = await ConsultarAsync(filtro, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var respuesta = await response.Content.ReadFromJsonAsync<ListaAsistenciasDiariasSmoke>(
+            JsonOptions, cancellationToken: ct);
+
+        respuesta.Should().NotBeNull();
+        respuesta!.DesdeAplicado.Should().Be(desde);
+        respuesta.HastaAplicado.Should().Be(hastaAplicadaEsperada);
+        respuesta.RangoRecortado.Should().BeTrue();
+
+        // Assert: la sintesis del calendario cubre EXACTAMENTE el rango aplicado (31 dias).
+        respuesta.Filas.Should().HaveCount(31);
+        respuesta.Filas.First().Fecha.Should().Be(desde);
+        respuesta.Filas.Last().Fecha.Should().Be(hastaAplicadaEsperada);
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/ComposicionServiciosTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/ComposicionServiciosTests.cs
@@ -40,6 +40,7 @@ using OpenTelemetry.Trace;
 using Wolverine;
 using ObtenerTurnoVigenteEndpoint = Bitakora.ControlAsistencia.ControlHoras.ObtenerTurnoVigente.FunctionEndpoint;
 using ListarTurnosVigentesEndpoint = Bitakora.ControlAsistencia.ControlHoras.ListarTurnosVigentes.FunctionEndpoint;
+using ListarAsistenciasDiariasEndpoint = Bitakora.ControlAsistencia.ControlHoras.ListarAsistenciasDiarias.FunctionEndpoint;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.Tests.Infraestructura;
 
@@ -350,6 +351,30 @@ public class ComposicionServiciosTests
         await using var scope = provider.CreateAsyncScope();
 
         var act = () => ActivatorUtilities.CreateInstance<ListarTurnosVigentesEndpoint>(scope.ServiceProvider);
+
+        act.Should().NotThrow();
+    }
+
+    // Issue #427: test de composicion de la Function QUERY sobre AsistenciaDiaria (#426), hermano
+    // del de ListarTurnosVigentes (arriba) y de MEF-ADR-0029. ActivatorUtilities.CreateInstance
+    // reproduce la activacion por tipo que hace el host de Azure Functions isolated worker, sin
+    // levantar el host real (Alt 1 de MEF-ADR-0029).
+    //
+    // Se prueba solo la RESOLUCION de IDocumentStore/ITenantResolver por constructor -- no el
+    // comportamiento de Run (guard 415/422, parseo del filtro, recorte de rango, session.Query y
+    // la sintesis del calendario completo), que es responsabilidad de projection-implementer y del
+    // smoke test, no de este guardrail de wiring. Este issue no crea proyeccion nueva ni toca el
+    // seam del worker (issue #427, "Necesidad de lectura") -- por eso este test queda en verde tan
+    // pronto exista el FunctionEndpoint stub con el constructor correcto; el rojo de este issue lo
+    // dan los unit tests puros de RangoConsulta y SintesisCalendarioAsistencia
+    // (ListarAsistenciasDiarias/), no este guardrail.
+    [Fact]
+    public async Task AgregarServiciosControlHoras_ResuelveElEndpointDeListarAsistenciasDiarias_CuandoElContenedorEstaCompuesto()
+    {
+        await using var provider = ComponerServiceProvider();
+        await using var scope = provider.CreateAsyncScope();
+
+        var act = () => ActivatorUtilities.CreateInstance<ListarAsistenciasDiariasEndpoint>(scope.ServiceProvider);
 
         act.Should().NotThrow();
     }

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/ComposicionServiciosTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/ComposicionServiciosTests.cs
@@ -23,7 +23,6 @@ using System.Globalization;
 using System.Reflection;
 using System.Text;
 using AwesomeAssertions;
-using Bitakora.ControlAsistencia.ControlHoras;
 using Bitakora.ControlAsistencia.ControlHoras.DomainEvents;
 using Bitakora.ControlAsistencia.ControlHoras.Infraestructura;
 using Bitakora.ControlAsistencia.ControlHoras.RegistrarMarcacionFunction;
@@ -355,19 +354,9 @@ public class ComposicionServiciosTests
         act.Should().NotThrow();
     }
 
-    // Issue #427: test de composicion de la Function QUERY sobre AsistenciaDiaria (#426), hermano
-    // del de ListarTurnosVigentes (arriba) y de MEF-ADR-0029. ActivatorUtilities.CreateInstance
-    // reproduce la activacion por tipo que hace el host de Azure Functions isolated worker, sin
-    // levantar el host real (Alt 1 de MEF-ADR-0029).
-    //
-    // Se prueba solo la RESOLUCION de IDocumentStore/ITenantResolver por constructor -- no el
-    // comportamiento de Run (guard 415/422, parseo del filtro, recorte de rango, session.Query y
-    // la sintesis del calendario completo), que es responsabilidad de projection-implementer y del
-    // smoke test, no de este guardrail de wiring. Este issue no crea proyeccion nueva ni toca el
-    // seam del worker (issue #427, "Necesidad de lectura") -- por eso este test queda en verde tan
-    // pronto exista el FunctionEndpoint stub con el constructor correcto; el rojo de este issue lo
-    // dan los unit tests puros de RangoConsulta y SintesisCalendarioAsistencia
-    // (ListarAsistenciasDiarias/), no este guardrail.
+    // Hermano del de ListarTurnosVigentes (arriba) y de MEF-ADR-0029: verifica la RESOLUCION por
+    // constructor de IDocumentStore/ITenantResolver, no el comportamiento de Run (guards 415/422,
+    // recorte, sintesis), que cubren los unit tests puros del feature folder y el smoke test.
     [Fact]
     public async Task AgregarServiciosControlHoras_ResuelveElEndpointDeListarAsistenciasDiarias_CuandoElContenedorEstaCompuesto()
     {

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ListarAsistenciasDiarias/FunctionEndpointTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ListarAsistenciasDiarias/FunctionEndpointTests.cs
@@ -1,0 +1,108 @@
+// Guards del borde HTTP (415/400/422) de la Function QUERY, la unica capa de CA-4 que corre en CI:
+// el smoke test que lo cubre end-to-end depende del deploy y el test de composicion solo verifica
+// wiring.
+//
+// El IDocumentStore se pasa null! a proposito: los tres guards deben retornar ANTES de abrir la
+// QuerySession, asi que mover la apertura de sesion por encima de ellos rompe estos tests con
+// NullReferenceException en vez de pasar inadvertido.
+
+using System.Text;
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.ControlHoras.Infraestructura;
+using Bitakora.ControlAsistencia.ControlHoras.ListarAsistenciasDiarias;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Tests.ListarAsistenciasDiarias;
+
+public class FunctionEndpointTests
+{
+    private static FunctionEndpoint Endpoint() => new(null!, new TenantResolverFijo());
+
+    private static HttpRequest Request(string? contentType, string body)
+    {
+        var context = new DefaultHttpContext();
+        var bytes = Encoding.UTF8.GetBytes(body);
+        context.Request.ContentType = contentType;
+        context.Request.ContentLength = bytes.Length;
+        context.Request.Body = new MemoryStream(bytes);
+        return context.Request;
+    }
+
+    private static HttpRequest RequestJson(string body) => Request("application/json", body);
+
+    private static async Task<int?> EjecutarAsync(HttpRequest request)
+    {
+        var resultado = await Endpoint().Run(request, CancellationToken.None);
+        return resultado.Should().BeAssignableTo<ObjectResult>().Subject.StatusCode;
+    }
+
+    [Fact]
+    public async Task ListarAsistenciasDiarias_Retorna415_CuandoElContentTypeNoEsJson()
+    {
+        var codigo = await EjecutarAsync(Request("text/plain", "{}"));
+
+        codigo.Should().Be(StatusCodes.Status415UnsupportedMediaType);
+    }
+
+    [Fact]
+    public async Task ListarAsistenciasDiarias_Retorna415_CuandoNoViajaContentType()
+    {
+        var codigo = await EjecutarAsync(Request(contentType: null, body: "{}"));
+
+        codigo.Should().Be(StatusCodes.Status415UnsupportedMediaType);
+    }
+
+    [Fact]
+    public async Task ListarAsistenciasDiarias_Retorna400_CuandoElBodyNoEsJsonValido()
+    {
+        var codigo = await EjecutarAsync(RequestJson("{ esto no es json valido"));
+
+        codigo.Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    // El literal null es JSON valido y deserializa a null: rama distinta del catch de JsonException.
+    [Fact]
+    public async Task ListarAsistenciasDiarias_Retorna400_CuandoElBodyDeserializaANull()
+    {
+        var codigo = await EjecutarAsync(RequestJson("null"));
+
+        codigo.Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    [Fact]
+    public async Task ListarAsistenciasDiarias_Retorna422_CuandoElCodigoDeColaboradorEstaAusente()
+    {
+        var codigo = await EjecutarAsync(RequestJson(
+            """{"desdeFecha":"2026-07-01","hastaFecha":"2026-07-05"}"""));
+
+        codigo.Should().Be(StatusCodes.Status422UnprocessableEntity);
+    }
+
+    [Fact]
+    public async Task ListarAsistenciasDiarias_Retorna422_CuandoElCodigoDeColaboradorEsSoloEspacios()
+    {
+        var codigo = await EjecutarAsync(RequestJson(
+            """{"codigoColaborador":"   ","desdeFecha":"2026-07-01","hastaFecha":"2026-07-05"}"""));
+
+        codigo.Should().Be(StatusCodes.Status422UnprocessableEntity);
+    }
+
+    [Fact]
+    public async Task ListarAsistenciasDiarias_Retorna422_CuandoFaltaAlgunaDeLasDosFechas()
+    {
+        var codigo = await EjecutarAsync(RequestJson(
+            """{"codigoColaborador":"E001","desdeFecha":"2026-07-01"}"""));
+
+        codigo.Should().Be(StatusCodes.Status422UnprocessableEntity);
+    }
+
+    [Fact]
+    public async Task ListarAsistenciasDiarias_Retorna422_CuandoElRangoEstaInvertido()
+    {
+        var codigo = await EjecutarAsync(RequestJson(
+            """{"codigoColaborador":"E001","desdeFecha":"2026-07-10","hastaFecha":"2026-07-01"}"""));
+
+        codigo.Should().Be(StatusCodes.Status422UnprocessableEntity);
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ListarAsistenciasDiarias/RangoConsultaTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ListarAsistenciasDiarias/RangoConsultaTests.cs
@@ -1,0 +1,77 @@
+// Issue #427 CA-3: logica pura de recorte del rango de ListarAsistenciasDiarias. Sin Marten, sin
+// Postgres, sin QuerySession -- funciona sobre DateOnly (skills/projections/read-apis.md: la cota
+// y el recorte son logica de la Function, no de la proyeccion, que este issue no toca). Cada
+// oraculo se arma a mano (MEF-ADR-0002): nunca se deriva ejecutando RangoConsulta.Recortar sobre
+// si mismo.
+//
+// Duplicado a proposito del RangoConsultaTests de ListarTurnosVigentes (issue #329) -- SEGUNDA
+// aparicion de esta politica en el dominio, tolerada bajo Rule of Three (MEF-ADR-0018; ver
+// RangoConsulta.cs de este feature folder para el razonamiento completo).
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.ControlHoras.ListarAsistenciasDiarias;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Tests.ListarAsistenciasDiarias;
+
+public class RangoConsultaTests
+{
+    [Fact]
+    public void Recortar_DevuelveHastaSinCambios_CuandoElRangoEstaDentroDeLaCotaDe31Dias()
+    {
+        var desde = new DateOnly(2026, 8, 1);
+        var hasta = new DateOnly(2026, 8, 10);
+
+        var resultado = RangoConsulta.Recortar(desde, hasta);
+
+        resultado.Should().Be(new RangoAplicado(new DateOnly(2026, 8, 10), false));
+    }
+
+    [Fact]
+    public void Recortar_DevuelveHastaSinCambios_CuandoElRangoEsExactamente31DiasInclusive()
+    {
+        // CA-3: 31 dias inclusive (desde + 30 dias) es el limite exacto de la cota, no la excede.
+        var desde = new DateOnly(2026, 8, 1);
+        var hasta = new DateOnly(2026, 8, 31);
+
+        var resultado = RangoConsulta.Recortar(desde, hasta);
+
+        resultado.Should().Be(new RangoAplicado(new DateOnly(2026, 8, 31), false));
+    }
+
+    [Fact]
+    public void Recortar_RecortaHaciaAdelanteDesdeDesde_CuandoElRangoExcedeLargamenteLaCotaDe31Dias()
+    {
+        var desde = new DateOnly(2026, 8, 1);
+        var hasta = new DateOnly(2026, 12, 31);
+
+        var resultado = RangoConsulta.Recortar(desde, hasta);
+
+        // CA-3: hastaAplicado = desde + 30 dias (31 dias inclusive), rangoRecortado: true. El
+        // recorte es hacia ADELANTE desde `desde` -- nunca hacia atras desde `hasta`, y nunca
+        // relativo a la fecha de hoy.
+        resultado.Should().Be(new RangoAplicado(new DateOnly(2026, 8, 31), true));
+    }
+
+    [Fact]
+    public void Recortar_RecortaUnSoloDiaDeExceso_CuandoElRangoSuperaLaCotaPorUnSoloDia()
+    {
+        var desde = new DateOnly(2026, 8, 1);
+        var hasta = new DateOnly(2026, 9, 1); // 32 dias inclusive: un dia por encima de la cota
+
+        var resultado = RangoConsulta.Recortar(desde, hasta);
+
+        resultado.Should().Be(new RangoAplicado(new DateOnly(2026, 8, 31), true));
+    }
+
+    [Fact]
+    public void Recortar_DevuelveElMismoDia_CuandoDesdeYHastaCoinciden()
+    {
+        // Consulta de un solo dia (desde == hasta): la pantalla del Aprobador para una fecha
+        // puntual.
+        var desde = new DateOnly(2026, 8, 5);
+
+        var resultado = RangoConsulta.Recortar(desde, desde);
+
+        resultado.Should().Be(new RangoAplicado(desde, false));
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ListarAsistenciasDiarias/RangoConsultaTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ListarAsistenciasDiarias/RangoConsultaTests.cs
@@ -1,12 +1,6 @@
-// Issue #427 CA-3: logica pura de recorte del rango de ListarAsistenciasDiarias. Sin Marten, sin
-// Postgres, sin QuerySession -- funciona sobre DateOnly (skills/projections/read-apis.md: la cota
-// y el recorte son logica de la Function, no de la proyeccion, que este issue no toca). Cada
-// oraculo se arma a mano (MEF-ADR-0002): nunca se deriva ejecutando RangoConsulta.Recortar sobre
-// si mismo.
-//
-// Duplicado a proposito del RangoConsultaTests de ListarTurnosVigentes (issue #329) -- SEGUNDA
-// aparicion de esta politica en el dominio, tolerada bajo Rule of Three (MEF-ADR-0018; ver
-// RangoConsulta.cs de este feature folder para el razonamiento completo).
+// Duplicado a proposito del RangoConsultaTests de ListarTurnosVigentes -- ver el comentario de
+// clase de RangoConsulta.cs en este feature folder. Cada oraculo se arma a mano (MEF-ADR-0002):
+// nunca se deriva ejecutando Recortar sobre si mismo.
 
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.ControlHoras.ListarAsistenciasDiarias;
@@ -29,7 +23,6 @@ public class RangoConsultaTests
     [Fact]
     public void Recortar_DevuelveHastaSinCambios_CuandoElRangoEsExactamente31DiasInclusive()
     {
-        // CA-3: 31 dias inclusive (desde + 30 dias) es el limite exacto de la cota, no la excede.
         var desde = new DateOnly(2026, 8, 1);
         var hasta = new DateOnly(2026, 8, 31);
 
@@ -46,9 +39,6 @@ public class RangoConsultaTests
 
         var resultado = RangoConsulta.Recortar(desde, hasta);
 
-        // CA-3: hastaAplicado = desde + 30 dias (31 dias inclusive), rangoRecortado: true. El
-        // recorte es hacia ADELANTE desde `desde` -- nunca hacia atras desde `hasta`, y nunca
-        // relativo a la fecha de hoy.
         resultado.Should().Be(new RangoAplicado(new DateOnly(2026, 8, 31), true));
     }
 
@@ -66,8 +56,6 @@ public class RangoConsultaTests
     [Fact]
     public void Recortar_DevuelveElMismoDia_CuandoDesdeYHastaCoinciden()
     {
-        // Consulta de un solo dia (desde == hasta): la pantalla del Aprobador para una fecha
-        // puntual.
         var desde = new DateOnly(2026, 8, 5);
 
         var resultado = RangoConsulta.Recortar(desde, desde);

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ListarAsistenciasDiarias/SintesisCalendarioAsistenciaTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ListarAsistenciasDiarias/SintesisCalendarioAsistenciaTests.cs
@@ -1,15 +1,14 @@
-// Issue #427 CA-1/CA-2/CA-3/CA-5: sintesis pura del calendario completo de
-// ListarAsistenciasDiarias. Funcion pura documentos+rango -> filas: se invoca directamente, sin
-// QuerySession/Marten (skills/projections/read-apis.md) y sin el DSL Given/When/Then de
-// CommandHandlerTestBase (reservado a command handlers contra el event store, MEF-ADR-0002).
+// Funcion pura documentos+rango -> filas: se invoca directamente, sin QuerySession/Marten y sin el
+// DSL Given/When/Then de CommandHandlerTestBase, reservado a command handlers contra el event store
+// (MEF-ADR-0002). Cada oraculo se arma a mano, campo por campo: nunca se reusa el mapeo bajo prueba
+// para construir el esperado.
 //
-// Cada oraculo se arma a mano, campo por campo (MEF-ADR-0002, no-tautologia): nunca se reusa el
-// mapeo de Estado ni la sintesis de la fila sintetica bajo prueba para construir el esperado.
-// HorasPorConcepto se verifica con BeEquivalentTo, nunca comparando la fila entera con
+// HorasPorConcepto se verifica con BeEquivalentTo y nunca comparando la fila entera con
 // Should().Be(...): IReadOnlyDictionary<string, decimal> no recibe equality estructural del
-// compilador de records (mismo motivo documentado en AsistenciaDiariaProjectionTests, #426).
+// compilador de records.
 
 using AwesomeAssertions;
+using Bitakora.ControlAsistencia.ControlHoras.Entities;
 using Bitakora.ControlAsistencia.ControlHoras.ListarAsistenciasDiarias;
 using Bitakora.ControlAsistencia.ReadModels.ControlHoras;
 
@@ -30,7 +29,7 @@ public class SintesisCalendarioAsistenciaTests
         bool trabajoSinProgramacion = false,
         IReadOnlyDictionary<string, decimal>? horasPorConcepto = null) =>
         new(
-            $"dc:{CodigoColaborador}:{fecha:yyyyMMdd}",
+            DiaCalculadoAggregateRoot.ComputarStreamId(CodigoColaborador, fecha),
             CodigoColaborador,
             fecha,
             estado,

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ListarAsistenciasDiarias/SintesisCalendarioAsistenciaTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ListarAsistenciasDiarias/SintesisCalendarioAsistenciaTests.cs
@@ -1,0 +1,141 @@
+// Issue #427 CA-1/CA-2/CA-3/CA-5: sintesis pura del calendario completo de
+// ListarAsistenciasDiarias. Funcion pura documentos+rango -> filas: se invoca directamente, sin
+// QuerySession/Marten (skills/projections/read-apis.md) y sin el DSL Given/When/Then de
+// CommandHandlerTestBase (reservado a command handlers contra el event store, MEF-ADR-0002).
+//
+// Cada oraculo se arma a mano, campo por campo (MEF-ADR-0002, no-tautologia): nunca se reusa el
+// mapeo de Estado ni la sintesis de la fila sintetica bajo prueba para construir el esperado.
+// HorasPorConcepto se verifica con BeEquivalentTo, nunca comparando la fila entera con
+// Should().Be(...): IReadOnlyDictionary<string, decimal> no recibe equality estructural del
+// compilador de records (mismo motivo documentado en AsistenciaDiariaProjectionTests, #426).
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.ControlHoras.ListarAsistenciasDiarias;
+using Bitakora.ControlAsistencia.ReadModels.ControlHoras;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Tests.ListarAsistenciasDiarias;
+
+public class SintesisCalendarioAsistenciaTests
+{
+    private const string CodigoColaborador = "EMP-001";
+
+    private static AsistenciaDiaria DocumentoDePrueba(
+        DateOnly fecha,
+        EstadoAsistencia estado = EstadoAsistencia.Provisional,
+        PlanDelDia plan = PlanDelDia.ConJornada,
+        string? nombreTurno = "Turno Manana",
+        bool noSePresento = false,
+        bool franjasIncompletas = false,
+        bool vinoEnDescanso = false,
+        bool trabajoSinProgramacion = false,
+        IReadOnlyDictionary<string, decimal>? horasPorConcepto = null) =>
+        new(
+            $"dc:{CodigoColaborador}:{fecha:yyyyMMdd}",
+            CodigoColaborador,
+            fecha,
+            estado,
+            plan,
+            nombreTurno,
+            noSePresento,
+            franjasIncompletas,
+            vinoEnDescanso,
+            trabajoSinProgramacion,
+            horasPorConcepto ?? new Dictionary<string, decimal> { ["OrdinariaDiurna"] = 8.00m });
+
+    [Fact]
+    public void Completar_ProduceFilaConLosDatosDelDocumento_CuandoElDiaTieneDocumentoProvisional()
+    {
+        var fecha = new DateOnly(2026, 8, 3);
+        var horas = new Dictionary<string, decimal> { ["OrdinariaDiurna"] = 8.00m };
+        var documento = DocumentoDePrueba(fecha, horasPorConcepto: horas);
+
+        var filas = SintesisCalendarioAsistencia.Completar(fecha, fecha, [documento]);
+
+        filas.Should().HaveCount(1);
+        var fila = filas[0];
+        fila.Fecha.Should().Be(fecha);
+        fila.Estado.Should().Be(EstadoAsistenciaPresentado.Provisional);
+        fila.Plan.Should().Be(PlanDelDia.ConJornada);
+        fila.NombreTurno.Should().Be("Turno Manana");
+        fila.NoSePresento.Should().BeFalse();
+        fila.FranjasIncompletas.Should().BeFalse();
+        fila.VinoEnDescanso.Should().BeFalse();
+        fila.TrabajoSinProgramacion.Should().BeFalse();
+        fila.HorasPorConcepto.Should().BeEquivalentTo(horas);
+    }
+
+    [Fact]
+    public void Completar_MapeaEstadoAprobado_CuandoElDocumentoEstaEnEstadoAprobado()
+    {
+        var fecha = new DateOnly(2026, 8, 3);
+        var documento = DocumentoDePrueba(fecha, estado: EstadoAsistencia.Aprobado);
+
+        var filas = SintesisCalendarioAsistencia.Completar(fecha, fecha, [documento]);
+
+        filas.Should().ContainSingle().Which.Estado.Should().Be(EstadoAsistenciaPresentado.Aprobado);
+    }
+
+    [Fact]
+    public void Completar_ProduceFilaSinteticaSinDatos_CuandoElDiaNoTieneDocumento()
+    {
+        var fecha = new DateOnly(2026, 8, 3);
+
+        var filas = SintesisCalendarioAsistencia.Completar(fecha, fecha, []);
+
+        filas.Should().HaveCount(1);
+        var fila = filas[0];
+        fila.Fecha.Should().Be(fecha);
+        fila.Estado.Should().Be(EstadoAsistenciaPresentado.SinDatos);
+        fila.Plan.Should().Be(PlanDelDia.SinProgramar);
+        fila.NombreTurno.Should().BeNull();
+        fila.NoSePresento.Should().BeFalse();
+        fila.FranjasIncompletas.Should().BeFalse();
+        fila.VinoEnDescanso.Should().BeFalse();
+        fila.TrabajoSinProgramacion.Should().BeFalse();
+        fila.HorasPorConcepto.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Completar_ProduceUnaFilaPorCadaDiaDelRango_EnOrdenAscendentePorFecha_CuandoSoloElDiaDelMedioTieneDocumento()
+    {
+        var dia1 = new DateOnly(2026, 8, 1);
+        var dia2 = new DateOnly(2026, 8, 2);
+        var dia3 = new DateOnly(2026, 8, 3);
+        var documentoDia2 = DocumentoDePrueba(dia2);
+
+        var filas = SintesisCalendarioAsistencia.Completar(dia1, dia3, [documentoDia2]);
+
+        filas.Should().HaveCount(3);
+        filas[0].Fecha.Should().Be(dia1);
+        filas[0].Estado.Should().Be(EstadoAsistenciaPresentado.SinDatos);
+        filas[1].Fecha.Should().Be(dia2);
+        filas[1].Estado.Should().Be(EstadoAsistenciaPresentado.Provisional);
+        filas[2].Fecha.Should().Be(dia3);
+        filas[2].Estado.Should().Be(EstadoAsistenciaPresentado.SinDatos);
+    }
+
+    [Fact]
+    public void Completar_ProduceTodasLasFilasSinteticas_CuandoNingunDocumentoExisteEnElRango()
+    {
+        var desde = new DateOnly(2026, 8, 1);
+        var hasta = new DateOnly(2026, 8, 5);
+
+        var filas = SintesisCalendarioAsistencia.Completar(desde, hasta, []);
+
+        filas.Should().HaveCount(5);
+        filas.Should().OnlyContain(f => f.Estado == EstadoAsistenciaPresentado.SinDatos);
+    }
+
+    [Fact]
+    public void Completar_IgnoraUnDocumentoFueraDelRangoAplicado_CuandoSuFechaNoPerteneceAlRango()
+    {
+        var desde = new DateOnly(2026, 8, 1);
+        var hasta = new DateOnly(2026, 8, 2);
+        var documentoFueraDeRango = DocumentoDePrueba(new DateOnly(2026, 8, 10));
+
+        var filas = SintesisCalendarioAsistencia.Completar(desde, hasta, [documentoFueraDeRango]);
+
+        filas.Should().HaveCount(2);
+        filas.Should().OnlyContain(f => f.Estado == EstadoAsistenciaPresentado.SinDatos);
+    }
+}


### PR DESCRIPTION
## Resumen

Pipeline TDD completado:
- Fase roja: tests escritos con stubs
- Fase verde: implementación completa
- Smoke tests: escritos para endpoints detectados
- Fase refactor: revisión de calidad

## Decisiones del pipeline

<details>
<summary>Projection Test Writer (fase roja) — 9m 40s</summary>

# Stage 1 (read-side) — projection-test-writer — Issue #427

## Contexto del issue

Issue #427 depende de #426 (ya cerrado: el read model `AsistenciaDiaria` y su
`AsistenciaDiariaProjection` ya existen en `ReadModels/ControlHoras` y
`Projections/ControlHoras`). Este issue declara explícitamente que **no crea read model, ni
clase de proyección, ni lifecycle**: solo agrega la Function QUERY `ListarAsistenciasDiarias`
que consulta `AsistenciaDiaria` vía (a') (`session.Query<AsistenciaDiaria>()`) y sintetiza el
calendario completo del rango (días sin documento -> fila sintética `SinDatos`).

Por eso, de las tres capas que normalmente escribo, aplican:

- **NO aplica**: unit tests de proyección (`Create`/`Apply`/`ShouldDelete`) — no hay clase de
  proyección nueva ni modificada.
- **NO aplica**: config-test del worker — este issue no toca `src/.../Projections`.
- **SÍ aplica**: test de composición de la Function GET/QUERY.
- **Adicional, fuera de las 3 categorías textuales de mi rol pero dentro de mi mandato de
  "testing read-side... y queries"**: unit tests puros de la lógica nueva del feature folder
  (síntesis del calendario y recorte de rango), que el propio issue pide explícitamente bajo
  "Capas de test esperadas" y que es la única fuente real de rojo de este issue.

## Tests creados

### `tests/.../ControlHoras.Tests/ListarAsistenciasDiarias/SintesisCalendarioAsistenciaTests.cs`

6 tests sobre `SintesisCalendarioAsistencia.Completar(desde, hastaAplicado, documentos)`,
función pura sin Marten (cubre el núcleo de CA-1/CA-2/CA-3/CA-5):

- Día con documento Provisional -> fila con sus datos reales, `Estado = Provisional`.
- Día con documento en `EstadoAsistencia.Aprobado` -> mapeo 1:1 a `Estado = Aprobado`.
- Día sin documento -> fila sintética (`SinDatos`, `Plan = SinProgramar`, `NombreTurno = null`,
  4 anomalías `false`, `HorasPorConcepto` vacío).
- Una fila por cada día del rango, orden `Fecha` ascendente, mezclando días con y sin documento.
- Rango completo sin ningún documento -> todas sintéticas (CA-5).
- Un documento con fecha fuera de `[desde, hastaAplicado]` se ignora (nunca produce una fila
  fuera del rango).

Oráculos armados a mano campo por campo (MEF-ADR-0002); `HorasPorConcepto` se verifica con
`BeEquivalentTo` (mismo motivo documentado en `AsistenciaDiariaProjectionTests` de #426:
`IReadOnlyDictionary` no tiene equality estructural de record).

### `tests/.../ControlHoras.Tests/ListarAsistenciasDiarias/RangoConsultaTests.cs`

5 tests, duplicado deliberado (ver "Desviaciones" abajo) de `RangoConsultaTests` de
`ListarTurnosVigentes` (#329), adaptado al namespace `ListarAsistenciasDiarias`.

### `tests/.../ControlHoras.Tests/Infraestructura/ComposicionServiciosTests.cs` (modificado)

Un nuevo `[Fact]` `AgregarServiciosControlHoras_ResuelveElEndpointDeListarAsistenciasDiarias_...`,
hermano exacto de los ya existentes para `ObtenerTurnoVigente`/`ListarTurnosVigentes`
(MEF-ADR-0029): `ActivatorUtilities.CreateInstance<FunctionEndpoint>` sobre el contenedor real
compuesto con connection strings dummy. Prueba solo la resolución de `IDocumentStore`/
`ITenantResolver` por constructor — no comportamiento HTTP (eso es de projection-implementer y
del smoke test).

## Stubs de compilación creados (`src/.../ControlHoras/ListarAsistenciasDiarias/`)

- `EstadoAsistenciaPresentado.cs` — enum de 3 valores (`Provisional`/`Aprobado`/`SinDatos`),
  vive en el feature folder, no en `ReadModels` (issue #427, mandato explícito).
- `FilaAsistenciaDiaria.cs` — record plano, DTO de fila de respuesta.
- `SintesisCalendarioAsistencia.cs` — `Completar(...)` con `throw new NotImplementedException()`.
- `RangoConsulta.cs` — `RangoAplicado` + `RangoConsulta.Recortar(...)` con
  `throw new NotImplementedException()`.
- `FunctionEndpoint.cs` — constructor `(IDocumentStore, ITenantResolver)`, `Run` con
  `[Function("ListarAsistenciasDiarias")]` y `HttpTrigger(AuthorizationLevel.Anonymous, "query",
  Route = "control-horas/asistencias-diarias")`, cuerpo `throw new NotImplementedException()`.

**Deliberadamente NO creados** (mis tests no los tocan; quedan a discreción de
projection-implementer): `FiltroListarAsistenciasDiarias` (DTO de filtro del body) y
`ListaAsistenciasDiarias` (envelope de respuesta). Mi regla es crear solo los stubs mínimos que
mis propios tests referencian — ninguno de los dos aparece en un assert de esta fase roja.

## Cobertura de criterios de aceptación por esta fase

- CA-1 (fila real con datos del documento, `Provisional`/`Aprobado`): cubierto por
  `SintesisCalendarioAsistenciaTests`.
- CA-2 (fila sintética `SinDatos`): cubierto.
- CA-3 (recorte hacia adelante desde `DesdeFecha`, síntesis solo del rango aplicado): cubierto
  por `RangoConsultaTests` (recorte) y el test de "ignora documento fuera de rango" (síntesis
  acotada).
- CA-5 (rango sin ningún documento -> 200 con todas sintéticas, nunca 404): cubierto por
  `SintesisCalendarioAsistenciaTests`.
- CA-4 (415/400/422) y CA-6 (tenant del resolver, nunca de la request): **no** cubiertos por
  esta fase — son comportamiento HTTP del `Run` real, fuera del guardrail de wiring del test de
  composición (mismo carve-out que el issue #329 ya documentó para `ListarTurnosVigentes`).
  Corresponden a projection-implementer y al smoke test.

## Desviaciones del plan del planner

1. **Recorte de rango — Rule of Three resuelto por duplicación** (el issue lo dejó
   explícitamente revisable). Con solo dos apariciones de la política `RangoConsulta` en el
   dominio (`ListarTurnosVigentes` #329 y esta), duplico la clase completa (`RangoAplicado` +
   `RangoConsulta.Recortar`, cota 31 días inclusive, recorte hacia adelante desde `desde`) en el
   feature folder propio de `ListarAsistenciasDiarias`, en vez de extraer a un lugar común.
   Razón: MEF-ADR-0018 tolera duplicación hasta la tercera aparición real, y extraer ahora
   cruzaría fronteras de feature folder sin un tercer consumidor que lo justifique — mismo
   criterio que el propio dominio ya aplica para `SamplerEfectivo.De` en
   `ComposicionServiciosTests.cs`. El stub de la clase duplicada usa
   `throw new NotImplementedException()` (nunca la implementación real ya conocida de
   `ListarTurnosVigentes`): mi regla de no escribir implementación real no admite excepción por
   "lógica trivial ya resuelta en otro lado" — es responsabilidad de projection-implementer
   escribir (o adaptar) el cuerpo real, aunque termine siendo idéntico al de #329.
2. **`AuthorizationLevel.Anonymous`** en el `HttpTrigger` del stub (en vez de `Function`, que usa
   el ejemplo canónico de `read-apis.md`): sigo la convención ya establecida en este dominio para
   las dos Functions GET existentes (`ObtenerTurnoVigente`, `ListarTurnosVigentes`). Es una
   decisión menor y no vinculante para projection-implementer, documentada aquí para que no la
   lea como intencional-inmutable.
3. **Sin señal no-red**: aunque el test de composición por sí solo sería un guardrail de wiring
   que pasa en verde apenas el stub compile (mismo patrón que #329), este issue sí tiene lógica
   de negocio nueva y sustancial (síntesis del calendario, recorte de rango) con stubs que lanzan
   `NotImplementedException` — la fase roja es alcanzable y la producen los 11 unit tests puros,
   no el test de composición. No aplica el punto 4 de "Que escribes" de mi rol.

## Verificación

`dotnet build` sobre `tests/Bitakora.ControlAsistencia.ControlHoras.Tests/...csproj`: compila
limpio (0 errores, 2 warnings `CS9113` esperados por los parámetros del constructor del
`FunctionEndpoint` stub sin usar — desaparecerán cuando projection-implementer escriba el cuerpo
real de `Run`). No corrí `dotnet test`: los stubs garantizan el rojo por diseño.

</details>

<details>
<summary>Projection Implementer (fase verde) — 5m 25s</summary>

# Resumen -- projection-implementer (issue #427)

## Enfoque

El issue #427 no crea proyeccion ni toca el worker (depende de #426, ya cerrado, que
materializa `AsistenciaDiaria`). El trabajo de esta etapa fue exclusivamente completar los
cinco stubs de fase roja que dejo `projection-test-writer` en el feature folder
`ListarAsistenciasDiarias/` del dominio `ControlHoras`:

1. `RangoConsulta.Recortar` -- misma formula exacta que `ListarTurnosVigentes.RangoConsulta`
   (issue #329): cota de 31 dias inclusive, recorte siempre hacia adelante desde `desde`.
2. `SintesisCalendarioAsistencia.Completar` -- funcion pura que, dado el rango aplicado y los
   documentos `AsistenciaDiaria` que trajo la consulta LINQ, produce exactamente una fila por
   dia (orden `Fecha` ascendente): mapea el documento cuando existe (con `EstadoAsistencia ->
   EstadoAsistenciaPresentado` 1:1) o sintetiza `SinDatos`/`SinProgramar`/anomalias en
   `false`/horas vacias cuando no existe.
3. `FunctionEndpoint.Run` -- Function QUERY con el guard 415/400/422 del ejemplo canonico de
   `skills/projections/read-apis.md` (415 con `HasJsonContentType()` antes de leer el body, 400
   con `catch (JsonException)`, 422 para `CodigoColaborador` ausente/vacio, fechas ausentes o
   rango invertido), `QuerySession` acotada al tenant de `ITenantResolver`, consulta LINQ via
   (a') sobre `session.Query<AsistenciaDiaria>()` y composicion del envelope de respuesta.
4. Dos DTOs nuevos, no declarados como stub porque no tenian test propio que forzara su firma:
   `FiltroListarAsistenciasDiarias` (filtro tipado del body) y `ListaAsistenciasDiarias`
   (envelope de respuesta, mismo patron que `ListaTurnosVigentes` de #329).

No se toco `Program.cs`, `ComposicionServicios` ni el worker de proyecciones: `IDocumentStore`/
`ITenantResolver` ya estaban registrados (issue #221) y Marten resuelve `AsistenciaDiaria` por
convencion sin registro adicional en este Function App (MEF-ADR-0035 seccion 4, verificado en
#497).

## Decisiones de diseno

- **Nombre del envelope de respuesta**: `ListaAsistenciasDiarias` (campos `DesdeAplicado`,
  `HastaAplicado`, `RangoRecortado`, `Filas`) -- replica el patron de `ListaTurnosVigentes`
  (#329) que el issue sugiere explicitamente ("patron ListaTurnosVigentes"). No habia test que
  oraculara este nombre; ningun test de `Run` (comportamiento HTTP) existe en esta etapa --
  `ComposicionServiciosTests` solo verifica resolucion del constructor por DI.
- **Nombre del DTO de filtro**: `FiltroListarAsistenciasDiarias`, con los tres campos nullable
  (`string?`/`DateOnly?`) para poder distinguir "campo ausente" (422 con mensaje propio) de
  "campo con formato invalido" (400 via `catch JsonException`, capturado antes de llegar al
  record).
- **`SintesisCalendarioAsistencia.Completar` re-filtra por rango** ademas de recibir ya el
  rango aplicado: es una salvaguarda de la funcion pura (el test
  `Completar_IgnoraUnDocumentoFueraDelRangoAplicado...` lo exige explicitamente), aunque en
  produccion la consulta LINQ del endpoint ya filtra por el mismo rango antes de llamarla.
- **Trigger `"query"`**: usado tal cual el stub de `projection-test-writer` ya lo declaraba
  (`HttpTriggerAttribute(AuthorizationLevel.Anonymous, "query", ...)`). No reconfirme contra
  Azure Functions Core Tools de este repo (el issue deja esa reconfirmacion como nota tecnica
  para el pipeline, no bloqueante para esta etapa de tests unitarios/build).

## ADRs y recursos consultados

- `skills/projections/read-apis.md` -- ejemplo canonico de Function QUERY (guard 415/400/422,
  sesion acotada al tenant del resolver, via (a')), usado como base literal del `FunctionEndpoint`.
- MEF-ADR-0042 -- verbo QUERY, filtros AND por defecto, mapeo 400/415/422.
- MEF-ADR-0028 / MEF-ADR-0035 seccion 4 -- tenancy del `QuerySession` y resolucion de `TView`
  sin registro adicional en el write-side.
- MEF-ADR-0041 decision 4 -- justificacion del DTO de respuesta propio (`FilaAsistenciaDiaria`,
  ya declarado por `projection-test-writer`) y del envelope `ListaAsistenciasDiarias`.
- MEF-ADR-0018 (Rule of Three) -- confirma la duplicacion deliberada de `RangoConsulta` (segunda
  aparicion de la politica, tolerada) en vez de extraerla a un lugar comun.

## Desviaciones

Ninguna desviacion consciente de un ADR, del Skill o del plan del planner. Las dos decisiones
de nombres (`ListaAsistenciasDiarias`, `FiltroListarAsistenciasDiarias`) siguen al pie de la
letra las sugerencias "delegables" del issue y el precedente `ListarTurnosVigentes`.

## Resultado

- `dotnet build` de la solucion completa (`ControlAsistencias.slnx`): compilacion correcta, 0
  errores.
- `dotnet test` del proyecto `Bitakora.ControlAsistencia.ControlHoras.Tests`: 491/491 en verde,
  incluyendo las 30 pruebas nuevas de `RangoConsultaTests`, `SintesisCalendarioAsistenciaTests`
  y el guardrail de composicion `ComposicionServiciosTests
  .AgregarServiciosControlHoras_ResuelveElEndpointDeListarAsistenciasDiarias_...`.
- Formateo aplicado con `dotnet format` (MCP de JetBrains no disponible en esta sesion) sobre
  los archivos tocados; sin cambios de comportamiento, solo estilo de llaves.
- No se toco el worker de proyecciones ni ningun test existente.

</details>
<details>
<summary>Smoke Test Writer — 5m 20s</summary>

_(El agente no generó resumen)_

</details>
<details>
<summary>Reviewer (fase refactor) — 15m 13s</summary>

## ES Reviewer - Revision

### Evaluacion general
- Calidad: **buena** (la doctrina read-side se aplico correctamente; los hallazgos son de borde, no de modelado)
- Cambios realizados: **si** (commit `18679a9`)

### Cumplimiento de ADRs aplicables

| ADR | Cumplimiento | Observacion |
|---|---|---|
| MEF-ADR-0042: verbo QUERY, DTO de filtro tipado AND, mapeo 400/415/422, sin paginacion | ok, con gate pendiente | Verbo `"query"` correcto por la seccion 1 (el filtro trae un rango -> filtro estructurado). Guard `HasJsonContentType()` **antes** de `ReadFromJsonAsync`, `catch (JsonException)` -> 400, `ObjectResult` con mensaje para 415/422 -- ninguno pelado. Sin paginacion, justificado por la cota de 31 dias. **Gate NO VERIFICADO de la seccion 6 sigue abierto**: ver "Desviaciones detectadas". |
| MEF-ADR-0035: via (a') sobre `QuerySession` | ok | `session.Query<AsistenciaDiaria>()` con LINQ; ninguna proyeccion nueva ni cambio al worker, como exige el issue. `TView` resuelto sin registro adicional en el write-side (seccion 4). |
| MEF-ADR-0028 (via read-apis.md): sesion acotada al tenant del resolver | ok | `store.QuerySession(tenantResolver.TenantId)`. `CodigoColaborador`/`DesdeFecha`/`HastaFecha` vienen del body pero son el filtro del recurso, nunca el tenant. Ningun tenant id llega de la request. |
| MEF-ADR-0041 decision 4: DTO de respuesta como excepcion justificada | ok | `FilaAsistenciaDiaria` + `ListaAsistenciasDiarias` viven en el Function App, no en `ReadModels`. La justificacion es real y no "por si acaso": la fila sintetica no existe como documento y `SinDatos` no tiene contraparte en `EstadoAsistencia`, asi que servir el read model crudo no puede expresar la respuesta. |
| MEF-ADR-0006 + naming.md: feature folder, `Route` explicita kebab-case, `FunctionEndpoint` por namespace | ok | `ListarAsistenciasDiarias/FunctionEndpoint.cs` (sin sufijo `Function`, correcto para query), `[Function("ListarAsistenciasDiarias")]`, `Route = "control-horas/asistencias-diarias"` explicita y en kebab-case. Verbo declarado explicitamente; verificado que ninguna de las 7 rutas del dominio colisiona con esta plantilla. |
| MEF-ADR-0018 (Rule of Three): segunda aparicion del recorte de rango | ok | Duplicacion deliberada de `RangoConsulta` en el feature folder propio, con el razonamiento en el comentario de clase. Es la lectura correcta del ADR con dos instancias; el issue lo dejaba explicitamente revisable y el pipeline decidio y documento. |
| MEF-ADR-0016: naming de tests | ok | `<Sujeto>_<LoQuePasa>_Cuando<Condicion>` en los 19 tests (14 heredados + 8 agregados en esta fase, menos el health check del smoke test que sigue el patron preexistente del proyecto). |
| MEF-ADR-0002: oraculos armados a mano | ok | Ningun test deriva el esperado ejecutando la funcion bajo prueba; `HorasPorConcepto` se compara con `BeEquivalentTo` por la ausencia de equality estructural en `IReadOnlyDictionary`. |
| MEF-ADR-0044: comentarios minimos | corregido en esta fase | Ver seccion "Limpieza de comentarios". |

### Desviaciones de ADRs

**Desviaciones declaradas por el implementer** (`stage-2-projection-implementer.md`): declaro explicitamente *"Ninguna desviacion consciente de un ADR, del Skill o del plan del planner"*.

**Desviaciones detectadas por el reviewer (NO declaradas por el implementer)**:

#### Desviacion: MEF-ADR-0042 seccion 6 (regla operativa de gates NO VERIFICADO)
- **Regla del ADR**: *"un agente o desarrollador que implemente el primer endpoint QUERY real de un consumidor debe tratar todo punto de la tabla que siga NO VERIFICADO como gate bloqueante de ese primer despliegue"*. El issue lo repite en "Notas tecnicas": el implementer debe confirmar el trigger `"query"` contra Core Tools de este repo antes del primer despliegue.
- **Desviacion encontrada en el diff**: el implementer no ejecuto esa reconfirmacion. Lo registro bajo "Decisiones de diseno" (*"No reconfirme contra Azure Functions Core Tools de este repo"*) pero luego declaro "Ninguna desviacion", asi que el gate quedaba sin rastro en la seccion donde el pipeline lo busca.
- **Accion tomada**: no corregible por mi (exige levantar el host local o desplegar). **Documentado en el codigo** para que no se pierda: el encabezado de `FunctionEndpoint.cs` y el del smoke test ahora dicen que el gate solo lo cierra el smoke test contra dev y que un `404` tras un deploy exitoso apunta al borde filtrando el verbo, no al endpoint. Los 8 smoke tests rojos actuales son el gate esperando ejecucion, no un defecto.
- **Evaluacion del reviewer**: **aceptable como desviacion de proceso** -- el gate real es empirico y el pipeline lo ejecuta post-deploy; lo inaceptable habria sido que quedara sin registro. Queda como riesgo abierto del primer despliegue.
- **Status**: pendiente de evaluacion del usuario.

#### Desviacion: cobertura de CA-4 atribuida a una capa que no la cubre
- **Regla**: el issue ("Cobertura de CAs por capa") afirma que *"el test de composicion de la Function cubre CA-4/CA-6"*.
- **Desviacion encontrada**: falsa para CA-4. `AgregarServiciosControlHoras_ResuelveElEndpointDeListarAsistenciasDiarias_...` solo verifica resolucion por constructor (`ActivatorUtilities.CreateInstance`), nunca invoca `Run`. CA-4 quedaba cubierto unicamente por smoke tests que dependen del deploy -- es decir, sin cobertura ejecutable en CI. El `projection-test-writer` lo habia detectado y declarado correctamente en su resumen; el issue nunca se corrigio.
- **Accion tomada**: **corregida en refactor** -- ver "Tests agregados".
- **Status**: resuelto; queda como nota para el planner sobre la fila "Capas de test esperadas" de issues futuros.

### Precedentes consultados por el implementer

| Precedente | ADR aplicable | Veredicto |
|---|---|---|
| `ListarTurnosVigentes/RangoConsulta.cs` (#329) | MEF-ADR-0018 | alineado -- la duplicacion es la lectura correcta con dos instancias |
| `ListarTurnosVigentes/ListaTurnosVigentes.cs` (#329) | MEF-ADR-0041 decision 4 | alineado -- envelope en el Function App, no en `ReadModels` |
| `ListarTurnosVigentes/FunctionEndpoint.cs` (#329/#337) | MEF-ADR-0042 seccion 1 | **VIOLA el ADR**: expone un filtro con rango de fechas sobre `GET`, cuando la seccion 1 exige QUERY. Es anterior al ADR y ya esta capturado como borrador #440. **El implementer NO propago la violacion** -- uso `"query"` correctamente. Sin accion en este PR (endpoint preexistente: migrarlo es breaking change y la decision es del humano via el planner). |
| `skills/projections/read-apis.md` (ejemplo canonico QUERY) | MEF-ADR-0042 seccion 4 | alineado -- el guard 415/400/422 es una copia fiel |

### Convenciones del pipeline (no ADRs)

| Convencion | Estado | Observacion |
|---|---|---|
| Cada test con `Then()` + `And<>()` | n/a | Ningun test del diff es de command handler: son funciones puras (`RangoConsulta`, `SintesisCalendarioAsistencia`), guards de endpoint HTTP y composicion DI. El DSL Given/When/Then aplica a `CommandHandlerAsyncTest<TCommand>` contra el event store; el precedente del repo (`Programacion.Tests/.../FunctionEndpointTests.cs`) confirma esta lectura. |
| Overloads correctos para stream IDs compuestos | n/a | Sin escritura al event store en este diff. |
| Fakes manuales (no NSubstitute) | ok | `TenantResolverFijo` real (no fake) + `IDocumentStore` `null!` deliberado en los tests de guards. Ningun mock framework -- el repo no tiene NSubstitute. |
| Feature folders (produccion y tests) | ok | `ListarAsistenciasDiarias/` en `src/`, espejo en `ControlHoras.Tests/` y en `ControlHoras.SmokeTests/`. Un archivo por responsabilidad. |
| Smoke tests: SkipWhen, secrets, cobertura | ok | El unico test que depende de `ServiceBusFixture` abre con `Assert.SkipWhen(!serviceBus.IsConfigured, ...)` (xUnit v3, correcto). `appsettings.json` sin secrets, sin tocar. Un solo archivo por endpoint. Sin suscripcion `smoke-tests` nueva: el endpoint es una query pura, sin efectos secundarios; el arrange publica al topic `dia-depurado` ya existente. Aserciones filtradas por `codigoColaborador` unico (`Guid.CreateVersion7()`), nunca por posicion. |
| Proyecciones read-side: partial, inmutabilidad, read APIs, naming, cuarta isla | ok | Este issue no crea read model ni clase de proyeccion. `ReadModels.csproj` sin `ProjectReference` nueva (sin tocar). Naming `Listar{X}s` con plural correcto del espanol; el read model consumido (`AsistenciaDiaria`) no lleva sufijo de implementacion. |
| Antipatrones de habilitacion (MEF-ADR-0039) | n/a | El diff de este issue no toca ningun `.csproj` ni declara evento nuevo. Los tres `.csproj` que aparecen en `main...HEAD` son de commits previos ya mergeados (#436): uno **quita** una `ProjectReference` (correccion, no habilitacion) y los otros dos solo cambian comentarios. |
| Compatibilidad Marten write-side/read-side | n/a | El diff no toca la version del paquete ni configuracion de Marten. |
| Identidad de stream (MEF-ADR-0037) | ok | Ningun `ToString()` con formato explicito ni `ToUpper`/`ToLower` sobre un `Guid`. El endpoint no recibe id de ruta (el filtro va en el body), asi que el parseo tipado del borde no aplica. **Corregido**: el fixture de `SintesisCalendarioAsistenciaTests` reconstruia a mano `$"dc:{codigo}:{yyyyMMdd}"`; ahora llama a `DiaCalculadoAggregateRoot.ComputarStreamId`, el punto unico de conversion. |
| Contrato HTTP de comandos (MEF-ADR-0043) | n/a | El diff no agrega ninguna Function de comando (ningun feature folder con sufijo `Function`). El gate es exclusivo del lado comando. |
| Control de volumen de telemetria (MEF-ADR-0038) | n/a | El diff toca `ComposicionServiciosTests.cs` (que matchea el glob) pero **ninguna** linea de wiring de OTel ni del callback de Wolverine: solo agrega un test de resolucion de endpoint. Verificado de todos modos que `AgregarServiciosControlHoras_ApagaLaRecoleccionDeMetricasDeDurabilidad_...` sigue presente y no vacuo. |
| Limpieza de comentarios (MEF-ADR-0044) | ok | Aplicada sobre los 11 `.cs` del diff. Ver seccion propia. |
| Tests via ToString/comportamiento | ok | Ningun getter expuesto solo para test; los asserts van contra la respuesta del endpoint y el retorno de las funciones puras. |
| Sin numeros magicos | ok | `CotaDias = 31` con nombre y doc. En los tests, el limite se afirma como literal a mano (`desde.AddDays(30)`), nunca leyendo `CotaDias` -- correcto para no tautologizar el oraculo. |
| Condiciones en positivo | ok | `if (!req.HasJsonContentType())` y `if (string.IsNullOrWhiteSpace(...))` son guard clauses con early-return, la excepcion legitima. Ninguna bifurcacion `if`/`else` en negativo. |

### Elegancia del codigo

- **Compacidad**: el endpoint quedo mas corto tras extraer la variable local del filtro y colapsar la construccion del envelope dentro del `return`. La relacion comentario/codigo paso de ~1:1 a ~1:6.
- **Idiomatismo**: `switch` de expresion para el mapeo de enum, colecciones con expresion de coleccion (`[...]`), `record`/`readonly record struct` para los DTOs, LINQ para el diccionario indexado. Nada que reescribir.
- **Eficiencia**: la sintesis es O(n) real -- diccionario por fecha en vez de un `FirstOrDefault` por dia dentro del bucle (que habria sido O(n*m)). La consulta LINQ traduce a un unico SQL con los tres predicados.
- **Robustez**: el `_ => throw` del mapeo de estado es defensivo correcto (un valor nuevo de `EstadoAsistencia` falla ruidoso en vez de mapear en silencio). Los guards del borde cubren los cuatro codigos del RFC.
- **Limpieza**: `dotnet build` sin warnings en `src/` y en los dos proyectos de test.

### Criticas y hallazgos

1. **Mayor (corregido)** -- `ListarAsistenciasDiariasSmokeTests.ConsultarAsync` declaraba `using var request` en un metodo **no-async** que retornaba la `Task` de `SendAsync`: el `HttpRequestMessage` (y su `Content`) se disponian al retornar el metodo, mientras la peticion seguia en vuelo. Es una carrera real -> `ObjectDisposedException` intermitente contra dev. Corregido a `async`/`await`.
2. **Menor (corregido)** -- el bucle de `Polling.WaitUntilAsync` no disponia el `HttpResponseMessage` de cada reintento (hasta 30 s de reintentos con backoff). Agregado `using`.
3. **Menor (corregido)** -- CA-4 sin cobertura ejecutable en CI. Ver "Desviaciones detectadas" y "Tests agregados".
4. **Menor (corregido)** -- la expresion LINQ capturaba el record `filtro` completo (`a.CodigoColaborador == filtro.CodigoColaborador`) en vez de un local. Extraido a `var codigoColaborador`, junto a `desde`: mas legible y sin depender de como el proveedor LINQ de Marten resuelve el acceso a miembro de un closure sobre un tipo nullable.
5. **Cosmetico (corregido)** -- fixture de test reconstruyendo el formato del stream id a mano (ver fila MEF-ADR-0037).
6. **Cosmetico (corregido)** -- `using Bitakora.ControlAsistencia.ControlHoras;` innecesario (IDE0005) en `ComposicionServiciosTests.cs`, archivo del diff.
7. **Observacion no bloqueante** -- `dotnet format --verify-no-changes` termina con exit 2, por seis diagnosticos IDE0005 **preexistentes en `main`** sobre archivos ajenos a este diff (`MarcacionAdicionadaSerializacionTests`, `IntervaloClasificadoSerializacionTests`, `RetardoSerializacionTests`, `IntervaloTemporalSerializacionMartenTests`, y los `ComposicionServiciosTests` de Colaboradores y Programacion). No los toco: fuera del alcance de la HU. Merece un issue de tooling propio.
8. **Observacion no bloqueante** -- CA-6 (tenant scoping) no tiene test propio: verificarlo exigiria un doble de `IDocumentStore` (interfaz de ~40 miembros) y el repo no usa mocking. Queda cubierto por lectura de codigo, por el test de composicion y por la imposibilidad estructural de que un tenant id llegue de la request (el DTO de filtro no tiene ningun campo de tenant). Consistente con el carve-out que ya declararon `projection-test-writer` y `smoke-test-writer`.
9. **Sin hallazgos** en modelado, encapsulamiento (MEF-ADR-0012), manejo de errores (MEF-ADR-0004) ni serializacion: este issue no toca aggregates, value objects ni eventos.

### Refactorings aplicados

- `FunctionEndpoint.Run`: variable local para el codigo de colaborador antes de la expresion LINQ; envelope construido dentro del `return` (elimina una variable de un solo uso); `hasta` intermedio eliminado (se pasa directo a `Recortar`).
- `ConsultarAsync` del smoke test: `async`/`await` (corrige el disposal); `using` sobre el response del polling.
- `SintesisCalendarioAsistenciaTests`: el fixture usa `DiaCalculadoAggregateRoot.ComputarStreamId`.
- `ComposicionServiciosTests`: using innecesario eliminado.
- No se toco la logica de `RangoConsulta` ni de `SintesisCalendarioAsistencia`: ambas ya eran compactas, puras y correctas.

### Limpieza de comentarios (MEF-ADR-0044)

Aplicada sobre los 11 `.cs` que el PR interviene. Ninguna poda altero comportamiento (499/499 verde antes y despues). Ningun comentario contradecia la implementacion.

**Conservado (paso el umbral doble)**, comprimido en todos los casos:
- Orden del guard 415 antes de `ReadFromJsonAsync` (Context Delta: la excepcion del Content-Type no-JSON **no** es `JsonException`; Decision Delta: sin el, alguien elimina el guard confiando en el `catch`).
- Sesion acotada al tenant del resolver / BOLA-IDOR.
- `SinDatos` nunca vive en el read model.
- DTO de respuesta como excepcion de MEF-ADR-0041 decision 4.
- Campos nullable del filtro para distinguir 422 de 400.
- Recorte hacia adelante desde `desde`, nunca relativo a hoy.
- Duplicacion deliberada de `RangoConsulta` bajo Rule of Three.
- Re-filtrado por rango en la funcion pura (no es redundante: es su contrato).
- Un dia sin documento no es anomalia -> las cuatro banderas en `false`.
- Nunca 404.
- `BeEquivalentTo` por ausencia de equality estructural en `IReadOnlyDictionary`.
- Enums locales del smoke test que replican el **orden** de produccion (STJ serializa el entero subyacente).
- `ClasificarPlan` produce `ConJornada`/`Descanso` segun la forma exacta del payload sembrado.

**Podado**:
- Provenance (`issue #427`, `#426`, `#329`, `CA-N:`) en ~30 comentarios: **Context Delta ausente** -- el issue es rastreable por `git blame`/PR, y su cita no condiciona ninguna edicion futura.
- Narracion del codigo (`// CA-3: recorte de la cota de 31 dias`, `// Act + Assert: reintentar hasta...`, `// Assert: exactamente una fila por dia`, la enumeracion de campos que `MapearConDocumento` ya lista, el detalle de `hastaMaxima = desde + (CotaDias - 1)`): **ambas condiciones ausentes** -- lo dice la linea siguiente o el nombre del test.
- Citas de ADR sueltas sin restriccion activa (`// Via (a') de MEF-ADR-0035`, `// skills/projections/read-apis.md` como pie de parrafo): provenance disfrazada segun el paso 7 del Skill.
- Rationale obvio (`// Arrange comun: publica DiaDepurado al bus interno`, ya en el encabezado del archivo; `// Reintenta la consulta hasta que...`, que es el nombre del metodo): **Context Delta ausente**.
- Especulacion futura (`cuando llegue el aval, probablemente un cuarto valor`): **Decision Delta ausente** -- no condiciona ninguna edicion de hoy.

**Agregado** (paso el umbral y no existia): la advertencia de que los smoke tests quedan rojos hasta el deploy y de que ese mismo `404` es el gate NO VERIFICADO de MEF-ADR-0042 seccion 6. El precedente `ListarTurnosVigentesSmokeTests` la tenia y este archivo la habia perdido -- sin ella, un lector futuro lee ocho rojos como defecto del endpoint.

### Cobertura de criterios de aceptacion

| Criterio | Estado | Test(s) |
|---|---|---|
| CA-1: 200 con una fila por dia, orden ascendente, dias con documento con datos reales y estado `Provisional`/`Aprobado` | cubierto | `Completar_ProduceFilaConLosDatosDelDocumento_CuandoElDiaTieneDocumentoProvisional`, `Completar_MapeaEstadoAprobado_CuandoElDocumentoEstaEnEstadoAprobado`, `Completar_ProduceUnaFilaPorCadaDiaDelRango_EnOrdenAscendentePorFecha_CuandoSoloElDiaDelMedioTieneDocumento`; smoke `ListarAsistenciasDiarias_CombinaFilasRealesYSinteticasEnElMismoRango_...` |
| CA-2: fila sintetica (`SinDatos`, `SinProgramar`, cuatro anomalias `false`, horas vacias) | cubierto | `Completar_ProduceFilaSinteticaSinDatos_CuandoElDiaNoTieneDocumento`; smoke (los dos casos de listado) |
| CA-3: recorte hacia adelante, declarado en la respuesta, sintesis solo del rango aplicado | cubierto | `RangoConsultaTests` (5 tests: dentro de cota, exactamente 31, exceso largo, exceso de un dia, un solo dia), `Completar_IgnoraUnDocumentoFueraDelRangoAplicado_...`; smoke `..._RecortaHaciaAdelanteYSintetizaSoloElRangoAplicado_...` |
| CA-4: 415 / 400 / 422 | **cubierto (agregado en esta fase)** | `FunctionEndpointTests` (8 tests: 415 x2, 400 x2, 422 x4) + los 6 smoke tests equivalentes |
| CA-5: rango sin documentos -> 200 con todas sinteticas, nunca 404 | cubierto | `Completar_ProduceTodasLasFilasSinteticas_CuandoNingunDocumentoExisteEnElRango`; smoke `..._Retorna200ConTodasLasFilasSinteticas_...` |
| CA-6: `QuerySession` acotada al tenant del resolver | parcial (por diseno) | `AgregarServiciosControlHoras_ResuelveElEndpointDeListarAsistenciasDiarias_...` cubre el wiring; el scoping se verifica por lectura de codigo. Sin superficie observable via HTTP en un entorno de un solo tenant (CA-ADR-0027) y sin doble de `IDocumentStore` disponible. Ver hallazgo 8. |

### Tests agregados

- **`tests/.../ControlHoras.Tests/ListarAsistenciasDiarias/FunctionEndpointTests.cs` (8 tests, nuevo)** -- guards del borde HTTP, la unica capa de CA-4 que corre en CI:
  - `ListarAsistenciasDiarias_Retorna415_CuandoElContentTypeNoEsJson`
  - `ListarAsistenciasDiarias_Retorna415_CuandoNoViajaContentType`
  - `ListarAsistenciasDiarias_Retorna400_CuandoElBodyNoEsJsonValido`
  - `ListarAsistenciasDiarias_Retorna400_CuandoElBodyDeserializaANull` (rama distinta del `catch`: el literal `null` es JSON valido)
  - `ListarAsistenciasDiarias_Retorna422_CuandoElCodigoDeColaboradorEstaAusente`
  - `ListarAsistenciasDiarias_Retorna422_CuandoElCodigoDeColaboradorEsSoloEspacios` (caso borde de `IsNullOrWhiteSpace` que ningun test cubria)
  - `ListarAsistenciasDiarias_Retorna422_CuandoFaltaAlgunaDeLasDosFechas`
  - `ListarAsistenciasDiarias_Retorna422_CuandoElRangoEstaInvertido`

  El `IDocumentStore` se pasa `null!` deliberadamente: los tres guards deben retornar **antes** de abrir la `QuerySession`, asi que mover la apertura de sesion por encima de ellos rompe estos tests con `NullReferenceException` en vez de pasar inadvertido. Es un oraculo adicional sobre el orden de los guards, documentado en el encabezado del archivo.
- No se agregaron tests de igualdad ni de serializacion round-trip: el diff no contiene value objects (`IEquatable`/`ConfigurarSerializacion`) ni eventos con marker de bus.

### Estado de la suite

- `Bitakora.ControlAsistencia.ControlHoras.Tests`: **499/499 en verde** (491 heredados + 8 agregados).
- Solucion completa: en verde salvo los **8 smoke tests de `ListarAsistenciasDiarias`**, todos con `404` contra dev porque la Function todavia no esta desplegada. Es el estado esperado del pipeline (mismo precedente documentado en `ListarTurnosVigentesSmokeTests`: el CI de PR corre solo `*.Tests`; el veredicto de los smoke tests se lee tras el deploy). **No** requirio reporte de bloqueo: no hay defecto de codigo que corregir.
- `dotnet build`: 0 warnings en los proyectos tocados.

</details>

## Cobertura

| Archivo | Cobertura | Umbral | Estado |
|---|---|---|---|
| FilaAsistenciaDiaria.cs | - | excluido | - |
| FiltroListarAsistenciasDiarias.cs | - | excluido | - |
| FunctionEndpoint.cs | - | excluido | - |
| ListaAsistenciasDiarias.cs | - | excluido | - |
| EstadoAsistenciaPresentado.cs | - | sin clasificar | ⚠ revisar |
| RangoConsulta.cs | - | sin clasificar | ⚠ revisar |
| SintesisCalendarioAsistencia.cs | - | sin clasificar | ⚠ revisar |

> **Archivos sin clasificar** (`⚠ revisar`): ninguna regla de clasificacion los reconocio — el gate **no los midio**. No es una exclusion deliberada (a diferencia de `excluido`, donde si se decidio que no requieren cobertura): requieren revision humana para confirmar si necesitan tests.
## Commits

18679a9 refactor(hu-427): poda comentarios, corrige el disposal del request y cubre CA-4 en CI
67a96d9 test(hu-427): smoke tests para endpoints
1e782ee feat(hu-427): proyeccion read-side ListarAsistenciasDiarias (fase verde)
5a808bc test(hu-427): tests read-side para listar asistencias diarias por rango (fase roja)

Closes #427