### PR TITLE
Exponer el resumen del periodo de asistencia por colaborador

### DIFF
--- a/src/Bitakora.ControlAsistencia.ControlHoras/ListarResumenesAsistencia/AgregadorResumenAsistencia.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ListarResumenesAsistencia/AgregadorResumenAsistencia.cs
@@ -1,0 +1,30 @@
+using Bitakora.ControlAsistencia.ReadModels.ControlHoras;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.ListarResumenesAsistencia;
+
+/// <summary>
+/// Agregacion en query-time (issue #428, "Necesidad de lectura", via a'): dado el rango aplicado,
+/// los codigos pedidos (o descubiertos) y las filas AsistenciaDiaria del rango, produce una fila
+/// ResumenAsistencia por colaborador. Funcion pura, sin Marten -- mismo patron que
+/// SintesisCalendarioAsistencia.Completar (#427).
+///
+/// Contrato fijado por este test-writer (interfaz publica delegable del issue):
+/// - CodigosColaborador presente (no null): una fila por CADA codigo de esa lista, en el mismo
+///   orden -- incluida la fila sintetica (todo SinDatos/ceros) para un codigo sin documentos en el
+///   rango.
+/// - CodigosColaborador ausente (null): el universo es "colaboradores con &gt;= 1 fila en el
+///   rango" -- se descubre de <paramref name="documentos"/> tras re-filtrar por rango (mismo
+///   contrato defensivo que Completar frente a un llamador que traiga documentos de mas), en orden
+///   ascendente de CodigoColaborador (mismo orden que exige la paginacion keyset del endpoint).
+/// - HorasPorConcepto se suma sparse (union de claves) sobre los documentos del colaborador en el
+///   rango.
+/// </summary>
+public static class AgregadorResumenAsistencia
+{
+    public static IReadOnlyList<ResumenAsistencia> Agregar(
+        DateOnly desde,
+        DateOnly hastaAplicado,
+        IReadOnlyList<string>? codigosPedidos,
+        IReadOnlyList<AsistenciaDiaria> documentos) =>
+        throw new NotImplementedException();
+}

--- a/src/Bitakora.ControlAsistencia.ControlHoras/ListarResumenesAsistencia/AgregadorResumenAsistencia.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ListarResumenesAsistencia/AgregadorResumenAsistencia.cs
@@ -25,6 +25,61 @@ public static class AgregadorResumenAsistencia
         DateOnly desde,
         DateOnly hastaAplicado,
         IReadOnlyList<string>? codigosPedidos,
-        IReadOnlyList<AsistenciaDiaria> documentos) =>
-        throw new NotImplementedException();
+        IReadOnlyList<AsistenciaDiaria> documentos)
+    {
+        // Re-filtrar por rango no es redundante con el llamador: es el contrato defensivo de esta
+        // funcion frente a un llamador que traiga documentos de mas (mismo patron que
+        // SintesisCalendarioAsistencia.Completar, #427).
+        var documentosPorCodigo = documentos
+            .Where(d => d.Fecha >= desde && d.Fecha <= hastaAplicado)
+            .GroupBy(d => d.CodigoColaborador)
+            .ToDictionary(g => g.Key, g => (IReadOnlyList<AsistenciaDiaria>)g.ToList());
+
+        // CodigosColaborador presente: una fila por cada codigo pedido, EN EL MISMO ORDEN de la
+        // lista (incluida la sintetica de un codigo sin documentos). Ausente: universo descubierto
+        // de los documentos, ordenado ascendente por CodigoColaborador -- mismo orden que exige la
+        // paginacion keyset del endpoint.
+        var codigos = codigosPedidos
+            ?? documentosPorCodigo.Keys.OrderBy(codigo => codigo, StringComparer.Ordinal).ToList();
+
+        var diasDelRango = hastaAplicado.DayNumber - desde.DayNumber + 1;
+
+        return codigos
+            .Select(codigo => MapearFila(
+                codigo,
+                diasDelRango,
+                documentosPorCodigo.TryGetValue(codigo, out var documentosDelCodigo)
+                    ? documentosDelCodigo
+                    : []))
+            .ToList();
+    }
+
+    private static ResumenAsistencia MapearFila(
+        string codigo, int diasDelRango, IReadOnlyList<AsistenciaDiaria> documentos)
+    {
+        // Un dia sin fila (sin documento) es sin programacion Y SinDatos -- se avala, no se
+        // aprueba (issue #428, "Necesidad de lectura"). Un documento con Plan.SinProgramar tambien
+        // cuenta como "sin programar" en el eje programacion.
+        var diasSinFila = diasDelRango - documentos.Count;
+
+        var totalHorasPorConcepto = new Dictionary<string, decimal>();
+        foreach (var documento in documentos)
+            foreach (var (concepto, horas) in documento.HorasPorConcepto)
+                totalHorasPorConcepto[concepto] =
+                    totalHorasPorConcepto.GetValueOrDefault(concepto) + horas;
+
+        return new ResumenAsistencia(
+            codigo,
+            documentos.Count(d => d.Plan == PlanDelDia.ConJornada),
+            documentos.Count(d => d.Plan == PlanDelDia.Descanso),
+            documentos.Count(d => d.Plan == PlanDelDia.SinProgramar) + diasSinFila,
+            documentos.Count(d => d.NoSePresento),
+            documentos.Count(d => d.FranjasIncompletas),
+            documentos.Count(d => d.VinoEnDescanso),
+            documentos.Count(d => d.TrabajoSinProgramacion),
+            documentos.Count(d => d.Estado == EstadoAsistencia.Aprobado),
+            documentos.Count(d => d.Estado == EstadoAsistencia.Provisional),
+            diasSinFila,
+            totalHorasPorConcepto);
+    }
 }

--- a/src/Bitakora.ControlAsistencia.ControlHoras/ListarResumenesAsistencia/AgregadorResumenAsistencia.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ListarResumenesAsistencia/AgregadorResumenAsistencia.cs
@@ -3,21 +3,15 @@ using Bitakora.ControlAsistencia.ReadModels.ControlHoras;
 namespace Bitakora.ControlAsistencia.ControlHoras.ListarResumenesAsistencia;
 
 /// <summary>
-/// Agregacion en query-time (issue #428, "Necesidad de lectura", via a'): dado el rango aplicado,
-/// los codigos pedidos (o descubiertos) y las filas AsistenciaDiaria del rango, produce una fila
-/// ResumenAsistencia por colaborador. Funcion pura, sin Marten -- mismo patron que
-/// SintesisCalendarioAsistencia.Completar (#427).
+/// Agregacion en query-time: dado el rango aplicado, los codigos pedidos (o descubiertos) y las
+/// filas AsistenciaDiaria del rango, produce una fila <see cref="ResumenAsistencia"/> por
+/// colaborador. Funcion pura, sin Marten.
 ///
-/// Contrato fijado por este test-writer (interfaz publica delegable del issue):
-/// - CodigosColaborador presente (no null): una fila por CADA codigo de esa lista, en el mismo
-///   orden -- incluida la fila sintetica (todo SinDatos/ceros) para un codigo sin documentos en el
-///   rango.
-/// - CodigosColaborador ausente (null): el universo es "colaboradores con &gt;= 1 fila en el
-///   rango" -- se descubre de <paramref name="documentos"/> tras re-filtrar por rango (mismo
-///   contrato defensivo que Completar frente a un llamador que traiga documentos de mas), en orden
-///   ascendente de CodigoColaborador (mismo orden que exige la paginacion keyset del endpoint).
-/// - HorasPorConcepto se suma sparse (union de claves) sobre los documentos del colaborador en el
-///   rango.
+/// El universo de filas lo decide <c>codigosPedidos</c>, y las dos ramas NO son intercambiables:
+/// - Presente: una fila por CADA codigo de la lista, en el mismo orden -- incluida la sintetica
+///   (todo SinDatos/ceros) de un codigo sin documentos en el rango.
+/// - Null: el universo son los colaboradores con al menos una fila en el rango, ascendente por
+///   CodigoColaborador. Sin lista no hay a quien sintetizar: esta funcion no conoce la poblacion.
 /// </summary>
 public static class AgregadorResumenAsistencia
 {
@@ -27,18 +21,14 @@ public static class AgregadorResumenAsistencia
         IReadOnlyList<string>? codigosPedidos,
         IReadOnlyList<AsistenciaDiaria> documentos)
     {
-        // Re-filtrar por rango no es redundante con el llamador: es el contrato defensivo de esta
-        // funcion frente a un llamador que traiga documentos de mas (mismo patron que
-        // SintesisCalendarioAsistencia.Completar, #427).
+        // Re-filtrar por rango NO es redundante con el llamador: es el contrato defensivo de esta
+        // funcion frente a uno que traiga documentos de mas. Sin el, esos documentos descuadrarian
+        // los tres ejes contra los dias del rango.
         var documentosPorCodigo = documentos
             .Where(d => d.Fecha >= desde && d.Fecha <= hastaAplicado)
             .GroupBy(d => d.CodigoColaborador)
             .ToDictionary(g => g.Key, g => (IReadOnlyList<AsistenciaDiaria>)g.ToList());
 
-        // CodigosColaborador presente: una fila por cada codigo pedido, EN EL MISMO ORDEN de la
-        // lista (incluida la sintetica de un codigo sin documentos). Ausente: universo descubierto
-        // de los documentos, ordenado ascendente por CodigoColaborador -- mismo orden que exige la
-        // paginacion keyset del endpoint.
         var codigos = codigosPedidos
             ?? documentosPorCodigo.Keys.OrderBy(codigo => codigo, StringComparer.Ordinal).ToList();
 
@@ -57,9 +47,9 @@ public static class AgregadorResumenAsistencia
     private static ResumenAsistencia MapearFila(
         string codigo, int diasDelRango, IReadOnlyList<AsistenciaDiaria> documentos)
     {
-        // Un dia sin fila (sin documento) es sin programacion Y SinDatos -- se avala, no se
-        // aprueba (issue #428, "Necesidad de lectura"). Un documento con Plan.SinProgramar tambien
-        // cuenta como "sin programar" en el eje programacion.
+        // Un dia sin documento es a la vez "sin programar" y SinDatos: se avala, no se aprueba. Un
+        // documento con Plan.SinProgramar suma al primero pero no al segundo -- si existe, hubo
+        // marcaciones que mirar.
         var diasSinFila = diasDelRango - documentos.Count;
 
         var totalHorasPorConcepto = new Dictionary<string, decimal>();

--- a/src/Bitakora.ControlAsistencia.ControlHoras/ListarResumenesAsistencia/FiltroListarResumenesAsistencia.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ListarResumenesAsistencia/FiltroListarResumenesAsistencia.cs
@@ -1,16 +1,15 @@
 namespace Bitakora.ControlAsistencia.ControlHoras.ListarResumenesAsistencia;
 
 /// <summary>
-/// Filtro tipado del body (QUERY, MEF-ADR-0042), campos combinados con AND. DesdeFecha/HastaFecha
-/// son obligatorias pese a declararse nullable -- nullable distingue "el campo no vino" (422 con
-/// mensaje propio) de "el campo vino con un valor invalido para su tipo" (400 del catch de
-/// JsonException, antes de llegar a este record). CodigosColaborador es el patron de recorte de
-/// poblacion fijado en sesion 2026-08-24 (issue #428): sin el, el universo es "colaboradores con
-/// &gt;= 1 fila en el rango"; con el, una fila por codigo pedido (incluida la sintetica).
+/// Filtro tipado del body (QUERY, MEF-ADR-0042), campos combinados con AND.
 ///
-/// Cursor keyset de un solo campo: el CodigoColaborador de la ultima fila recibida (el codigo es
-/// unico por fila del resumen, sin desempate -- a diferencia del cursor compuesto de
-/// ListarFichasColaborador). Take/TakeMaximo, mismo patron heredado de #373.
+/// DesdeFecha/HastaFecha son obligatorias pese a declararse nullable: el nullable es lo que
+/// distingue "el campo no vino" (422 con mensaje propio) de "vino con un valor invalido para su
+/// tipo" (400 del catch de JsonException, antes de llegar a este record). Quitarles el '?' colapsa
+/// el primer caso en el default de DateOnly y el 422 deja de emitirse.
+///
+/// Cursor keyset de un solo campo -- el CodigoColaborador de la ultima fila recibida --, sin
+/// desempate: el codigo es unico por fila del resumen.
 /// </summary>
 public sealed record FiltroListarResumenesAsistencia(
     DateOnly? DesdeFecha,

--- a/src/Bitakora.ControlAsistencia.ControlHoras/ListarResumenesAsistencia/FiltroListarResumenesAsistencia.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ListarResumenesAsistencia/FiltroListarResumenesAsistencia.cs
@@ -1,0 +1,20 @@
+namespace Bitakora.ControlAsistencia.ControlHoras.ListarResumenesAsistencia;
+
+/// <summary>
+/// Filtro tipado del body (QUERY, MEF-ADR-0042), campos combinados con AND. DesdeFecha/HastaFecha
+/// son obligatorias pese a declararse nullable -- nullable distingue "el campo no vino" (422 con
+/// mensaje propio) de "el campo vino con un valor invalido para su tipo" (400 del catch de
+/// JsonException, antes de llegar a este record). CodigosColaborador es el patron de recorte de
+/// poblacion fijado en sesion 2026-08-24 (issue #428): sin el, el universo es "colaboradores con
+/// &gt;= 1 fila en el rango"; con el, una fila por codigo pedido (incluida la sintetica).
+///
+/// Cursor keyset de un solo campo: el CodigoColaborador de la ultima fila recibida (el codigo es
+/// unico por fila del resumen, sin desempate -- a diferencia del cursor compuesto de
+/// ListarFichasColaborador). Take/TakeMaximo, mismo patron heredado de #373.
+/// </summary>
+public sealed record FiltroListarResumenesAsistencia(
+    DateOnly? DesdeFecha,
+    DateOnly? HastaFecha,
+    IReadOnlyList<string>? CodigosColaborador,
+    string? Cursor,
+    int Take = 50);

--- a/src/Bitakora.ControlAsistencia.ControlHoras/ListarResumenesAsistencia/FunctionEndpoint.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ListarResumenesAsistencia/FunctionEndpoint.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+using Bitakora.ControlAsistencia.ReadModels.ControlHoras;
 using Cosmos.MultiTenancy;
 using Marten;
 using Microsoft.AspNetCore.Http;
@@ -10,16 +12,118 @@ namespace Bitakora.ControlAsistencia.ControlHoras.ListarResumenesAsistencia;
 // (#426), via (a') de MEF-ADR-0035, con agregacion en query-time (AgregadorResumenAsistencia) --
 // este issue NO crea proyeccion, read model ni lifecycle nuevos.
 //
-// Fase roja (projection-test-writer): Run() hoy SOLO lanza NotImplementedException (MEF-ADR-0033,
-// stub minimo de compilacion). El COMPORTAMIENTO completo (415/400/422, keyset por
-// CodigoColaborador, recorte de rango, agregacion, sintesis de la fila pedida sin datos) es
-// responsabilidad de projection-implementer.
+// Paginacion keyset en DOS PASOS (riesgo tecnico anotado por el planner, "Investigacion del
+// planner"): (1) pagina de codigos de colaborador -- de la lista pedida si CodigosColaborador viene
+// explicito (sin consultar Marten: el cliente ya trae el universo), o descubierta con un distinct
+// sobre AsistenciaDiaria en el rango si no viene -- ordenada ascendente y acotada por cursor/Take;
+// (2) documentos de esos codigos en el rango, agregados en memoria (AgregadorResumenAsistencia). La
+// traducibilidad exacta del Select().Distinct() del paso de descubrimiento a SQL queda NO VERIFICADA
+// (sin spike propio, a diferencia del CompareTo de string que #373 si verifico) -- el smoke test
+// contra dev es quien la confirma end-to-end (ver resumen de este stage, "Desviaciones").
 public class FunctionEndpoint(IDocumentStore store, ITenantResolver tenantResolver)
 {
+    // MEF-ADR-0042 seccion 2 / patron heredado de #373: el Take del cliente jamas llega crudo a
+    // Marten.
+    private const int TakeMaximo = 200;
+
     [Function("ListarResumenesAsistencia")]
-    public Task<IActionResult> Run(
+    public async Task<IActionResult> Run(
         [HttpTrigger(AuthorizationLevel.Anonymous, "query", Route = "control-horas/resumenes-asistencia")]
         HttpRequest req,
-        CancellationToken ct) =>
-        throw new NotImplementedException();
+        CancellationToken ct)
+    {
+        // El 415 va ANTES de leer el body: ante un Content-Type no-JSON, ReadFromJsonAsync lanza
+        // una excepcion que NO es JsonException y escaparia como 500 pese al catch de abajo.
+        if (!req.HasJsonContentType())
+            return new ObjectResult("La query exige Content-Type: application/json")
+            { StatusCode = StatusCodes.Status415UnsupportedMediaType };
+
+        FiltroListarResumenesAsistencia? filtro;
+        try
+        {
+            filtro = await req.ReadFromJsonAsync<FiltroListarResumenesAsistencia>(ct);
+        }
+        catch (JsonException)
+        {
+            return new BadRequestObjectResult("El body de la query no es un JSON valido");
+        }
+
+        if (filtro is null)
+            return new BadRequestObjectResult("El body de la query es obligatorio");
+
+        if (filtro.DesdeFecha is null || filtro.HastaFecha is null)
+            return NoProcesable("DesdeFecha y HastaFecha son obligatorios");
+
+        if (filtro.DesdeFecha > filtro.HastaFecha)
+            return NoProcesable("DesdeFecha no puede ser posterior a HastaFecha");
+
+        var desde = filtro.DesdeFecha.Value;
+        var rangoAplicado = RangoConsulta.Recortar(desde, filtro.HastaFecha.Value);
+        var hastaAplicado = rangoAplicado.HastaAplicado;
+        var take = Math.Clamp(filtro.Take, 1, TakeMaximo);
+
+        // Sesion acotada al tenant que resuelve ITenantResolver, nunca a un dato de la request
+        // (mitigacion estructural contra BOLA/IDOR, MEF-ADR-0028).
+        await using var session = store.QuerySession(tenantResolver.TenantId);
+
+        var codigosPagina = await DeterminarCodigosPaginaAsync(
+            session, filtro.CodigosColaborador, filtro.Cursor, desde, hastaAplicado, take, ct);
+
+        var documentos = await session.Query<AsistenciaDiaria>()
+            .Where(a => a.Fecha >= desde
+                        && a.Fecha <= hastaAplicado
+                        && codigosPagina.Contains(a.CodigoColaborador))
+            .ToListAsync(ct);
+
+        var filas = AgregadorResumenAsistencia.Agregar(desde, hastaAplicado, codigosPagina, documentos);
+
+        // Nunca 404: un rango sin datos son filas SinDatos (o una lista vacia cuando no hay
+        // CodigosColaborador pedido), no un error.
+        return new OkObjectResult(new ListaResumenesAsistencia(
+            desde, hastaAplicado, rangoAplicado.RangoRecortado, filas));
+    }
+
+    // CA-3/CA-4: con CodigosColaborador explicito, la pagina keyset se recorta sobre la lista
+    // pedida (el cliente ya trae el universo, sin consultar Marten para descubrirlo); sin el, se
+    // descubre con un distinct sobre los documentos del rango. Ambas ramas ordenan ascendente por
+    // CodigoColaborador y acotan por cursor (">") y Take -- mismo contrato keyset que #373.
+    private static async Task<IReadOnlyList<string>> DeterminarCodigosPaginaAsync(
+        IQuerySession session,
+        IReadOnlyList<string>? codigosSolicitados,
+        string? cursor,
+        DateOnly desde,
+        DateOnly hastaAplicado,
+        int take,
+        CancellationToken ct)
+    {
+        if (codigosSolicitados is not null)
+        {
+            IEnumerable<string> ordenados = codigosSolicitados
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(codigo => codigo, StringComparer.Ordinal);
+
+            if (cursor is not null)
+                ordenados = ordenados.Where(codigo => string.CompareOrdinal(codigo, cursor) > 0);
+
+            return ordenados.Take(take).ToList();
+        }
+
+        IQueryable<AsistenciaDiaria> query = session.Query<AsistenciaDiaria>()
+            .Where(a => a.Fecha >= desde && a.Fecha <= hastaAplicado);
+
+        if (cursor is not null)
+            query = query.Where(a => a.CodigoColaborador.CompareTo(cursor) > 0);
+
+        return await query
+            .Select(a => a.CodigoColaborador)
+            .Distinct()
+            .OrderBy(codigo => codigo)
+            .Take(take)
+            .ToListAsync(ct);
+    }
+
+    // RFC 10008 seccion 2.1 / MEF-ADR-0042 seccion 3: el 422 se emite como ObjectResult con mensaje,
+    // nunca como codigo pelado.
+    private static ObjectResult NoProcesable(string mensaje) =>
+        new(mensaje) { StatusCode = StatusCodes.Status422UnprocessableEntity };
 }

--- a/src/Bitakora.ControlAsistencia.ControlHoras/ListarResumenesAsistencia/FunctionEndpoint.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ListarResumenesAsistencia/FunctionEndpoint.cs
@@ -8,24 +8,17 @@ using Microsoft.Azure.Functions.Worker;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.ListarResumenesAsistencia;
 
-// Issue #428: Function QUERY (RFC 10008, MEF-ADR-0042) sobre la vista materializada AsistenciaDiaria
-// (#426), via (a') de MEF-ADR-0035, con agregacion en query-time (AgregadorResumenAsistencia) --
-// este issue NO crea proyeccion, read model ni lifecycle nuevos.
+// Function QUERY (RFC 10008, MEF-ADR-0042) sobre la vista materializada AsistenciaDiaria, via (a')
+// de MEF-ADR-0035, con agregacion en query-time.
 //
-// Paginacion keyset en DOS PASOS (riesgo tecnico anotado por el planner, "Investigacion del
-// planner"): (1) pagina de codigos de colaborador -- de la lista pedida si CodigosColaborador viene
-// explicito (sin consultar Marten: el cliente ya trae el universo), o descubierta con un distinct
-// sobre AsistenciaDiaria en el rango si no viene -- ordenada ascendente y acotada por cursor/Take;
-// (2) documentos de esos codigos en el rango, agregados en memoria (AgregadorResumenAsistencia). La
-// traducibilidad exacta del Select().Distinct() del paso de descubrimiento a SQL queda NO VERIFICADA
-// (sin spike propio, a diferencia del CompareTo de string que #373 si verifico) -- el smoke test
-// contra dev es quien la confirma end-to-end (ver resumen de este stage, "Desviaciones").
+// La paginacion keyset va en DOS PASOS y no en un GroupBy: Marten no lo traduce a SQL, asi que la
+// pagina se resuelve primero sobre los CODIGOS -- de la lista pedida, o descubiertos con un distinct
+// sobre el rango -- y solo despues se traen los documentos de esos codigos para agregarlos en
+// memoria. Verificado contra Marten 9.12.0 + Postgres 16 (revision de este PR): el paso de
+// descubrimiento -- Select + Distinct + OrderBy + Take, con el filtro de cursor CompareTo(...) > 0
+// aplicado antes del Select -- traduce y pagina sobre codigos distintos, no sobre filas.
 public class FunctionEndpoint(IDocumentStore store, ITenantResolver tenantResolver)
 {
-    // MEF-ADR-0042 seccion 2 / patron heredado de #373: el Take del cliente jamas llega crudo a
-    // Marten.
-    private const int TakeMaximo = 200;
-
     [Function("ListarResumenesAsistencia")]
     public async Task<IActionResult> Run(
         [HttpTrigger(AuthorizationLevel.Anonymous, "query", Route = "control-horas/resumenes-asistencia")]
@@ -60,7 +53,7 @@ public class FunctionEndpoint(IDocumentStore store, ITenantResolver tenantResolv
         var desde = filtro.DesdeFecha.Value;
         var rangoAplicado = RangoConsulta.Recortar(desde, filtro.HastaFecha.Value);
         var hastaAplicado = rangoAplicado.HastaAplicado;
-        var take = Math.Clamp(filtro.Take, 1, TakeMaximo);
+        var take = PaginaDeCodigos.AcotarTake(filtro.Take);
 
         // Sesion acotada al tenant que resuelve ITenantResolver, nunca a un dato de la request
         // (mitigacion estructural contra BOLA/IDOR, MEF-ADR-0028).
@@ -69,11 +62,13 @@ public class FunctionEndpoint(IDocumentStore store, ITenantResolver tenantResolv
         var codigosPagina = await DeterminarCodigosPaginaAsync(
             session, filtro.CodigosColaborador, filtro.Cursor, desde, hastaAplicado, take, ct);
 
-        var documentos = await session.Query<AsistenciaDiaria>()
-            .Where(a => a.Fecha >= desde
-                        && a.Fecha <= hastaAplicado
-                        && codigosPagina.Contains(a.CodigoColaborador))
-            .ToListAsync(ct);
+        IReadOnlyList<AsistenciaDiaria> documentos = codigosPagina.Count == 0
+            ? []
+            : await session.Query<AsistenciaDiaria>()
+                .Where(a => a.Fecha >= desde
+                            && a.Fecha <= hastaAplicado
+                            && codigosPagina.Contains(a.CodigoColaborador))
+                .ToListAsync(ct);
 
         var filas = AgregadorResumenAsistencia.Agregar(desde, hastaAplicado, codigosPagina, documentos);
 
@@ -83,10 +78,16 @@ public class FunctionEndpoint(IDocumentStore store, ITenantResolver tenantResolv
             desde, hastaAplicado, rangoAplicado.RangoRecortado, filas));
     }
 
-    // CA-3/CA-4: con CodigosColaborador explicito, la pagina keyset se recorta sobre la lista
-    // pedida (el cliente ya trae el universo, sin consultar Marten para descubrirlo); sin el, se
-    // descubre con un distinct sobre los documentos del rango. Ambas ramas ordenan ascendente por
-    // CodigoColaborador y acotan por cursor (">") y Take -- mismo contrato keyset que #373.
+    // Con CodigosColaborador explicito la pagina se recorta sobre la lista pedida, sin consultar
+    // Marten: el cliente ya trae el universo. Sin ella, se descubre con un distinct sobre el rango.
+    //
+    // Las dos ramas ordenan ascendente y acotan por cursor (">") y Take, pero NO con el mismo
+    // comparador, y no pueden: en memoria es ordinal y en Marten es la collation de Postgres.
+    // Medido en la revision de este PR sobre un mismo conjunto: Postgres devuelve
+    // emp-1, EMP_1, EMP-10, EMP-2, EMP-9, EMPA y el ordinal EMP-10, EMP-2, EMP-9, EMPA, EMP_1,
+    // emp-1 -- coinciden solo mientras los codigos sean homogeneos en case y separadores. Cada rama
+    // si es coherente consigo misma (su filtro de cursor usa el mismo comparador que su orden), que
+    // es lo que sostiene la paginacion: alinear una sola de las dos la romperia.
     private static async Task<IReadOnlyList<string>> DeterminarCodigosPaginaAsync(
         IQuerySession session,
         IReadOnlyList<string>? codigosSolicitados,
@@ -97,16 +98,7 @@ public class FunctionEndpoint(IDocumentStore store, ITenantResolver tenantResolv
         CancellationToken ct)
     {
         if (codigosSolicitados is not null)
-        {
-            IEnumerable<string> ordenados = codigosSolicitados
-                .Distinct(StringComparer.Ordinal)
-                .OrderBy(codigo => codigo, StringComparer.Ordinal);
-
-            if (cursor is not null)
-                ordenados = ordenados.Where(codigo => string.CompareOrdinal(codigo, cursor) > 0);
-
-            return ordenados.Take(take).ToList();
-        }
+            return PaginaDeCodigos.Recortar(codigosSolicitados, cursor, take);
 
         IQueryable<AsistenciaDiaria> query = session.Query<AsistenciaDiaria>()
             .Where(a => a.Fecha >= desde && a.Fecha <= hastaAplicado);

--- a/src/Bitakora.ControlAsistencia.ControlHoras/ListarResumenesAsistencia/FunctionEndpoint.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ListarResumenesAsistencia/FunctionEndpoint.cs
@@ -1,0 +1,25 @@
+using Cosmos.MultiTenancy;
+using Marten;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.ListarResumenesAsistencia;
+
+// Issue #428: Function QUERY (RFC 10008, MEF-ADR-0042) sobre la vista materializada AsistenciaDiaria
+// (#426), via (a') de MEF-ADR-0035, con agregacion en query-time (AgregadorResumenAsistencia) --
+// este issue NO crea proyeccion, read model ni lifecycle nuevos.
+//
+// Fase roja (projection-test-writer): Run() hoy SOLO lanza NotImplementedException (MEF-ADR-0033,
+// stub minimo de compilacion). El COMPORTAMIENTO completo (415/400/422, keyset por
+// CodigoColaborador, recorte de rango, agregacion, sintesis de la fila pedida sin datos) es
+// responsabilidad de projection-implementer.
+public class FunctionEndpoint(IDocumentStore store, ITenantResolver tenantResolver)
+{
+    [Function("ListarResumenesAsistencia")]
+    public Task<IActionResult> Run(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "query", Route = "control-horas/resumenes-asistencia")]
+        HttpRequest req,
+        CancellationToken ct) =>
+        throw new NotImplementedException();
+}

--- a/src/Bitakora.ControlAsistencia.ControlHoras/ListarResumenesAsistencia/ListaResumenesAsistencia.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ListarResumenesAsistencia/ListaResumenesAsistencia.cs
@@ -1,11 +1,10 @@
 namespace Bitakora.ControlAsistencia.ControlHoras.ListarResumenesAsistencia;
 
 /// <summary>
-/// Envelope de respuesta (mismo patron que ListaAsistenciasDiarias/ListaTurnosVigentes): el rango
-/// que declara es el efectivamente APLICADO -- ya recortado por <see cref="RangoConsulta.Recortar"/>
-/// --, nunca el que pidio el cliente. Sin campo de cursor de pagina siguiente (patron #373): el
-/// cliente deriva el proximo cursor del CodigoColaborador de la ultima fila; fin de lista = pagina
-/// con menos de Take filas.
+/// Envelope de respuesta. El rango que declara es el efectivamente APLICADO -- ya recortado por
+/// <see cref="RangoConsulta.Recortar"/> --, nunca el que pidio el cliente. Sin campo de cursor de
+/// pagina siguiente: el cliente lo deriva del CodigoColaborador de la ultima fila, y el fin de
+/// lista es una pagina con menos de Take filas.
 /// </summary>
 public sealed record ListaResumenesAsistencia(
     DateOnly DesdeAplicado,

--- a/src/Bitakora.ControlAsistencia.ControlHoras/ListarResumenesAsistencia/ListaResumenesAsistencia.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ListarResumenesAsistencia/ListaResumenesAsistencia.cs
@@ -1,0 +1,14 @@
+namespace Bitakora.ControlAsistencia.ControlHoras.ListarResumenesAsistencia;
+
+/// <summary>
+/// Envelope de respuesta (mismo patron que ListaAsistenciasDiarias/ListaTurnosVigentes): el rango
+/// que declara es el efectivamente APLICADO -- ya recortado por <see cref="RangoConsulta.Recortar"/>
+/// --, nunca el que pidio el cliente. Sin campo de cursor de pagina siguiente (patron #373): el
+/// cliente deriva el proximo cursor del CodigoColaborador de la ultima fila; fin de lista = pagina
+/// con menos de Take filas.
+/// </summary>
+public sealed record ListaResumenesAsistencia(
+    DateOnly DesdeAplicado,
+    DateOnly HastaAplicado,
+    bool RangoRecortado,
+    IReadOnlyList<ResumenAsistencia> Filas);

--- a/src/Bitakora.ControlAsistencia.ControlHoras/ListarResumenesAsistencia/PaginaDeCodigos.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ListarResumenesAsistencia/PaginaDeCodigos.cs
@@ -1,0 +1,36 @@
+namespace Bitakora.ControlAsistencia.ControlHoras.ListarResumenesAsistencia;
+
+/// <summary>
+/// Paso 1 de la paginacion keyset: la pagina de codigos de colaborador sobre la que despues se
+/// agregan los documentos. Logica pura -- la rama que descubre el universo en Marten vive en el
+/// endpoint, pero la cota del Take es de las dos.
+/// </summary>
+public static class PaginaDeCodigos
+{
+    /// <summary>Tope de pagina del servidor (MEF-ADR-0042 seccion 2).</summary>
+    public const int TakeMaximo = 200;
+
+    /// <summary>
+    /// El Take llega en el body y es entrada del cliente como cualquier otra: sin esta cota, un
+    /// cliente pide una pagina sin limite y el Take deja de acotar nada.
+    /// </summary>
+    public static int AcotarTake(int take) => Math.Clamp(take, 1, TakeMaximo);
+
+    /// <summary>
+    /// Recorta la lista de codigos que el cliente ya trajo -- sin consultar Marten: quien manda
+    /// CodigosColaborador ya conoce el universo. Ordena ascendente ordinal, descarta lo que el
+    /// cursor deja atras y corta en <paramref name="take"/>.
+    /// </summary>
+    public static IReadOnlyList<string> Recortar(
+        IReadOnlyList<string> codigos, string? cursor, int take)
+    {
+        IEnumerable<string> ordenados = codigos
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(codigo => codigo, StringComparer.Ordinal);
+
+        if (cursor is not null)
+            ordenados = ordenados.Where(codigo => string.CompareOrdinal(codigo, cursor) > 0);
+
+        return ordenados.Take(AcotarTake(take)).ToList();
+    }
+}

--- a/src/Bitakora.ControlAsistencia.ControlHoras/ListarResumenesAsistencia/RangoConsulta.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ListarResumenesAsistencia/RangoConsulta.cs
@@ -25,6 +25,12 @@ public static class RangoConsulta
     /// <summary>Cota maxima del rango, en dias, INCLUSIVE: desde y desde + 30 dias caben.</summary>
     public const int CotaDias = 31;
 
-    public static RangoAplicado Recortar(DateOnly desde, DateOnly hasta) =>
-        throw new NotImplementedException();
+    public static RangoAplicado Recortar(DateOnly desde, DateOnly hasta)
+    {
+        var hastaMaxima = desde.AddDays(CotaDias - 1);
+
+        return hasta > hastaMaxima
+            ? new RangoAplicado(hastaMaxima, true)
+            : new RangoAplicado(hasta, false);
+    }
 }

--- a/src/Bitakora.ControlAsistencia.ControlHoras/ListarResumenesAsistencia/RangoConsulta.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ListarResumenesAsistencia/RangoConsulta.cs
@@ -1,0 +1,30 @@
+namespace Bitakora.ControlAsistencia.ControlHoras.ListarResumenesAsistencia;
+
+/// <summary>
+/// Rango efectivamente aplicado tras acotar el pedido a <see cref="RangoConsulta.CotaDias"/>.
+/// </summary>
+public readonly record struct RangoAplicado(DateOnly HastaAplicado, bool RangoRecortado);
+
+/// <summary>
+/// Recorte del rango de consulta: SIEMPRE hacia adelante desde <c>desde</c> -- nunca hacia atras
+/// desde <c>hasta</c> ni relativo a la fecha de hoy, que haria que la misma consulta devolviera
+/// datos distintos segun el dia en que se ejecuta.
+///
+/// TERCERA aparicion de esta politica en ControlHoras (ListarTurnosVigentes, #329;
+/// ListarAsistenciasDiarias, #427; este feature, #428) -- Rule of Three (MEF-ADR-0018): el propio
+/// issue lo marca como "propuesta revisable" y deja la extraccion a un lugar comun del dominio como
+/// decision del pipeline (fase verde), no del test-writer -- mover codigo de produccion ya
+/// implementado en los dos feature folders anteriores es implementacion, fuera del alcance de este
+/// agente (ver resumen de stage, "Desviaciones del plan del planner"). Este archivo es el STUB
+/// minimo de compilacion de la fase roja: NotImplementedException hasta que projection-implementer
+/// decida duplicar la logica una tercera vez o ejecutar la extraccion y actualizar los tres
+/// consumidores.
+/// </summary>
+public static class RangoConsulta
+{
+    /// <summary>Cota maxima del rango, en dias, INCLUSIVE: desde y desde + 30 dias caben.</summary>
+    public const int CotaDias = 31;
+
+    public static RangoAplicado Recortar(DateOnly desde, DateOnly hasta) =>
+        throw new NotImplementedException();
+}

--- a/src/Bitakora.ControlAsistencia.ControlHoras/ListarResumenesAsistencia/RangoConsulta.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ListarResumenesAsistencia/RangoConsulta.cs
@@ -10,15 +10,9 @@ public readonly record struct RangoAplicado(DateOnly HastaAplicado, bool RangoRe
 /// desde <c>hasta</c> ni relativo a la fecha de hoy, que haria que la misma consulta devolviera
 /// datos distintos segun el dia en que se ejecuta.
 ///
-/// TERCERA aparicion de esta politica en ControlHoras (ListarTurnosVigentes, #329;
-/// ListarAsistenciasDiarias, #427; este feature, #428) -- Rule of Three (MEF-ADR-0018): el propio
-/// issue lo marca como "propuesta revisable" y deja la extraccion a un lugar comun del dominio como
-/// decision del pipeline (fase verde), no del test-writer -- mover codigo de produccion ya
-/// implementado en los dos feature folders anteriores es implementacion, fuera del alcance de este
-/// agente (ver resumen de stage, "Desviaciones del plan del planner"). Este archivo es el STUB
-/// minimo de compilacion de la fase roja: NotImplementedException hasta que projection-implementer
-/// decida duplicar la logica una tercera vez o ejecutar la extraccion y actualizar los tres
-/// consumidores.
+/// Tercera copia deliberada de esta politica en ControlHoras (ListarTurnosVigentes,
+/// ListarAsistenciasDiarias, esta): cada listado es dueno de su propia cota y puede divergir
+/// (MEF-ADR-0018). Cambiar CotaDias aqui NO alcanza a las otras dos.
 /// </summary>
 public static class RangoConsulta
 {

--- a/src/Bitakora.ControlAsistencia.ControlHoras/ListarResumenesAsistencia/ResumenAsistencia.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ListarResumenesAsistencia/ResumenAsistencia.cs
@@ -2,20 +2,19 @@ namespace Bitakora.ControlAsistencia.ControlHoras.ListarResumenesAsistencia;
 
 /// <summary>
 /// DTO de respuesta -- excepcion justificada de MEF-ADR-0041 decision 4: no existe read model del
-/// resumen (agregacion query-time sobre AsistenciaDiaria, #426) y la fila sintetica del codigo
-/// pedido sin datos no existe en ninguna vista.
+/// resumen (agregacion query-time sobre AsistenciaDiaria) y la fila sintetica del codigo pedido sin
+/// datos no existe en ninguna vista.
 ///
-/// Los tres ejes del Aprobador (sesion 2026-08-17/2026-08-24), cada uno cerrando por separado
-/// contra los dias del rango aplicado, sin mezclarse:
+/// Los tres ejes del Aprobador no se mezclan y cada uno cierra por separado contra los dias del
+/// rango aplicado:
 /// - Programacion: DiasConTurno + DiasConDescanso + DiasSinProgramar = dias del rango.
-/// - Aprobacion (tres contadores, ratificados en el refinamiento del 2026-08-24): Aprobados +
-///   Pendientes + SinDatos = dias del rango. Un dia vacio se AVALA (SinDatos), un provisional se
-///   APRUEBA (Pendientes) -- colapsarlos descuadraria el drill-down de #427.
-/// - Anomalias: conteo de cada una de las 4 banderas de AsistenciaDiaria; los dias sin fila no
-///   aportan (no vino y no debia venir).
+/// - Aprobacion: Aprobados + Pendientes + SinDatos = dias del rango. Un dia vacio se AVALA
+///   (SinDatos), un provisional se APRUEBA (Pendientes) -- colapsarlos en un solo contador
+///   descuadraria el drill-down contra la pantalla de detalle, que presenta los tres estados.
+/// - Anomalias: conteo de cada bandera de AsistenciaDiaria; los dias sin fila no aportan ninguna
+///   (no vino y no debia venir), asi que este eje NO cierra contra los dias del rango.
 ///
-/// TotalHorasPorConcepto es la suma sparse (union de claves) de HorasPorConcepto de las filas del
-/// colaborador en el rango.
+/// TotalHorasPorConcepto es la suma sparse (union de claves) de las filas del colaborador.
 /// </summary>
 public sealed record ResumenAsistencia(
     string CodigoColaborador,

--- a/src/Bitakora.ControlAsistencia.ControlHoras/ListarResumenesAsistencia/ResumenAsistencia.cs
+++ b/src/Bitakora.ControlAsistencia.ControlHoras/ListarResumenesAsistencia/ResumenAsistencia.cs
@@ -1,0 +1,32 @@
+namespace Bitakora.ControlAsistencia.ControlHoras.ListarResumenesAsistencia;
+
+/// <summary>
+/// DTO de respuesta -- excepcion justificada de MEF-ADR-0041 decision 4: no existe read model del
+/// resumen (agregacion query-time sobre AsistenciaDiaria, #426) y la fila sintetica del codigo
+/// pedido sin datos no existe en ninguna vista.
+///
+/// Los tres ejes del Aprobador (sesion 2026-08-17/2026-08-24), cada uno cerrando por separado
+/// contra los dias del rango aplicado, sin mezclarse:
+/// - Programacion: DiasConTurno + DiasConDescanso + DiasSinProgramar = dias del rango.
+/// - Aprobacion (tres contadores, ratificados en el refinamiento del 2026-08-24): Aprobados +
+///   Pendientes + SinDatos = dias del rango. Un dia vacio se AVALA (SinDatos), un provisional se
+///   APRUEBA (Pendientes) -- colapsarlos descuadraria el drill-down de #427.
+/// - Anomalias: conteo de cada una de las 4 banderas de AsistenciaDiaria; los dias sin fila no
+///   aportan (no vino y no debia venir).
+///
+/// TotalHorasPorConcepto es la suma sparse (union de claves) de HorasPorConcepto de las filas del
+/// colaborador en el rango.
+/// </summary>
+public sealed record ResumenAsistencia(
+    string CodigoColaborador,
+    int DiasConTurno,
+    int DiasConDescanso,
+    int DiasSinProgramar,
+    int NoSePresento,
+    int FranjasIncompletas,
+    int VinoEnDescanso,
+    int TrabajoSinProgramacion,
+    int Aprobados,
+    int Pendientes,
+    int SinDatos,
+    IReadOnlyDictionary<string, decimal> TotalHorasPorConcepto);

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/ListarResumenesAsistencia/ListarResumenesAsistenciaSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/ListarResumenesAsistencia/ListarResumenesAsistenciaSmokeTests.cs
@@ -1,0 +1,514 @@
+// Smoke tests de ListarResumenesAsistencia -- QUERY control-horas/resumenes-asistencia: una fila
+// ResumenAsistencia por colaborador con los tres ejes del Aprobador (programacion, aprobacion,
+// anomalias) mas totales de horas, agregados en query-time sobre AsistenciaDiaria (#426).
+//
+// Quedan ROJOS hasta que el deploy publique la Function en dev: mientras tanto la ruta no existe y
+// el host responde 404 a todo. El CI de PR no los ejecuta (solo corre *.Tests); su veredicto real
+// se lee despues del deploy.
+//
+// Arrange via el bus interno, nunca sembrando el event store por fuera de el: cada dia real se
+// publica como DiaDepurado al topic "dia-depurado" (mismo mecanismo que
+// ListarAsistenciasDiariasSmokeTests, #427). La proyeccion AsistenciaDiaria tiene lifecycle Async
+// (MEF-ADR-0034 seccion 3), asi que los casos que dependen del arrange envuelven la consulta en
+// Polling.WaitUntilAsync -- agotar el timeout es un fallo real, nunca un skip.
+//
+// La mayoria de los casos con datos reales fijan CodigosColaborador explicito en el filtro: ese modo
+// pagina sobre la lista pedida sin descubrir el universo con un Distinct() sobre Marten, asi que el
+// resultado no se mezcla con colaboradores de otras corridas de este mismo smoke test que compartan
+// el mismo rango de fechas fijo en ejecuciones futuras. Solo el caso dedicado a la rama "sin filtro"
+// (universo descubierto) corre ese riesgo, y lo hace a proposito -- es lo unico que ejercita esa
+// rama sin sembrar por fuera del API.
+//
+// Formas locales DESACOPLADAS del read model y del DTO de respuesta de produccion (isla,
+// MEF-ADR-0034 seccion 5): el smoke test no referencia ReadModels ni el Function App.
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.ControlHoras.SmokeTests.Fixtures;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.SmokeTests.ListarResumenesAsistencia;
+
+public class ListarResumenesAsistenciaSmokeTests(ApiFixture api, ServiceBusFixture serviceBus)
+{
+    private readonly HttpClient _client = api.Client;
+
+    private const string RutaListado = "/api/control-horas/resumenes-asistencia";
+    private const string TopicDiaDepurado = "dia-depurado";
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
+    private static readonly HttpMethod MetodoQuery = new("QUERY");
+
+    // La respuesta viaja en camelCase (ComposicionServicios fija JsonNamingPolicy.CamelCase) y las
+    // formas locales de este archivo son PascalCase.
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    private sealed record ResumenAsistenciaSmoke(
+        string CodigoColaborador,
+        int DiasConTurno,
+        int DiasConDescanso,
+        int DiasSinProgramar,
+        int NoSePresento,
+        int FranjasIncompletas,
+        int VinoEnDescanso,
+        int TrabajoSinProgramacion,
+        int Aprobados,
+        int Pendientes,
+        int SinDatos,
+        IReadOnlyDictionary<string, decimal> TotalHorasPorConcepto);
+
+    private sealed record ListaResumenesAsistenciaSmoke(
+        DateOnly DesdeAplicado,
+        DateOnly HastaAplicado,
+        bool RangoRecortado,
+        IReadOnlyList<ResumenAsistenciaSmoke> Filas);
+
+    private async Task<HttpResponseMessage> ConsultarAsync(object filtro, CancellationToken ct)
+    {
+        using var request = new HttpRequestMessage(MetodoQuery, RutaListado)
+        {
+            Content = JsonContent.Create(filtro)
+        };
+        return await _client.SendAsync(request, ct);
+    }
+
+    private async Task<ListaResumenesAsistenciaSmoke> ConsultarOkAsync(object filtro, CancellationToken ct)
+    {
+        var response = await ConsultarAsync(filtro, ct);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadFromJsonAsync<ListaResumenesAsistenciaSmoke>(
+            JsonOptions, cancellationToken: ct);
+        body.Should().NotBeNull();
+        return body!;
+    }
+
+    private Task<ListaResumenesAsistenciaSmoke> ConsultarHastaQueAsync(
+        object filtro, Func<ListaResumenesAsistenciaSmoke, bool> condicion, CancellationToken ct) =>
+        Polling.WaitUntilAsync(async () =>
+        {
+            using var response = await ConsultarAsync(filtro, ct);
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+            var body = await response.Content.ReadFromJsonAsync<ListaResumenesAsistenciaSmoke>(
+                JsonOptions, cancellationToken: ct);
+            return body is not null && condicion(body) ? body : null;
+        }, Timeout);
+
+    private async Task PublicarDiaDepuradoAsync(
+        string codigoColaborador, DateOnly fecha, string? nombreTurno,
+        object[] franjas, object[] marcaciones, IReadOnlyDictionary<string, decimal> horasPorConcepto)
+    {
+        var evento = new
+        {
+            CodigoColaborador = codigoColaborador,
+            Fecha = fecha.ToString("yyyy-MM-dd"),
+            Colaborador = new
+            {
+                Identificacion = "CC-777888999",
+                CodigoColaborador = codigoColaborador,
+                NombreCompleto = "[TEST] Smoke Resumenes Asistencia"
+            },
+            NombreTurno = nombreTurno,
+            Franjas = franjas,
+            Marcaciones = marcaciones,
+            HorasDiscriminadas = new
+            {
+                HorasPorConcepto = horasPorConcepto,
+                Trazabilidad = Array.Empty<string>()
+            }
+        };
+
+        await serviceBus.PublishAsync(TopicDiaDepurado, evento, Guid.CreateVersion7().ToString());
+    }
+
+    // ClasificarPlan produce ConJornada con nombreTurno Y al menos una franja.
+    private Task PublicarDiaConJornadaAsync(string codigoColaborador, DateOnly fecha, string nombreTurno) =>
+        PublicarDiaDepuradoAsync(
+            codigoColaborador, fecha, nombreTurno,
+            franjas:
+            [
+                new
+                {
+                    HoraInicioProgramada = "08:00:00",
+                    HoraFinProgramada = "16:00:00",
+                    DiaOffsetFin = 0,
+                    Entrada = $"{fecha:yyyy-MM-dd}T08:00:00",
+                    Salida = $"{fecha:yyyy-MM-dd}T16:00:00",
+                    EsAnomala = false
+                }
+            ],
+            marcaciones:
+            [
+                new { Timestamp = $"{fecha:yyyy-MM-dd}T08:00:00", Tipo = "ENTRADA" },
+                new { Timestamp = $"{fecha:yyyy-MM-dd}T16:00:00", Tipo = "SALIDA" }
+            ],
+            horasPorConcepto: new Dictionary<string, decimal> { ["OrdinariaDiurna"] = 8.00m });
+
+    // ClasificarPlan produce Descanso con nombreTurno presente y sin franjas; una marcacion ese dia
+    // dispara la bandera VinoEnDescanso (AsistenciaDiariaProjection.EsVinoEnDescanso).
+    private Task PublicarDiaVinoEnDescansoAsync(string codigoColaborador, DateOnly fecha, string nombreTurno) =>
+        PublicarDiaDepuradoAsync(
+            codigoColaborador, fecha, nombreTurno,
+            franjas: [],
+            marcaciones: [new { Timestamp = $"{fecha:yyyy-MM-dd}T09:00:00", Tipo = "ENTRADA" }],
+            horasPorConcepto: new Dictionary<string, decimal>());
+
+    // ClasificarPlan produce SinProgramar con nombreTurno null; una marcacion ese dia dispara la
+    // bandera TrabajoSinProgramacion (AsistenciaDiariaProjection.EsTrabajoSinProgramacion).
+    private Task PublicarDiaTrabajoSinProgramacionAsync(string codigoColaborador, DateOnly fecha) =>
+        PublicarDiaDepuradoAsync(
+            codigoColaborador, fecha, nombreTurno: null,
+            franjas: [],
+            marcaciones: [new { Timestamp = $"{fecha:yyyy-MM-dd}T10:00:00", Tipo = "ENTRADA" }],
+            horasPorConcepto: new Dictionary<string, decimal>());
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task DebeEstarDisponible_CuandoSeConsultaHealthCheck()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var response = await _client.GetAsync("/api/health", ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarResumenesAsistencia_Retorna415_CuandoContentTypeNoEsJson()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        using var request = new HttpRequestMessage(MetodoQuery, RutaListado)
+        {
+            Content = new StringContent("{}", Encoding.UTF8, "text/plain")
+        };
+
+        var response = await _client.SendAsync(request, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnsupportedMediaType);
+    }
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarResumenesAsistencia_Retorna400_CuandoElBodyNoEsJsonValido()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        using var request = new HttpRequestMessage(MetodoQuery, RutaListado)
+        {
+            Content = new StringContent("{ esto no es json valido", Encoding.UTF8, "application/json")
+        };
+
+        var response = await _client.SendAsync(request, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarResumenesAsistencia_Retorna400_CuandoElBodyEstaVacio()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        using var request = new HttpRequestMessage(MetodoQuery, RutaListado)
+        {
+            Content = new StringContent(string.Empty, Encoding.UTF8, "application/json")
+        };
+
+        var response = await _client.SendAsync(request, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarResumenesAsistencia_Retorna422_CuandoLasFechasEstanAusentes()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        var filtro = new { codigosColaborador = new[] { Guid.CreateVersion7().ToString() } };
+
+        var response = await ConsultarAsync(filtro, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarResumenesAsistencia_Retorna422_CuandoElRangoEstaInvertido()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        var filtro = new
+        {
+            desdeFecha = new DateOnly(2026, 7, 10),
+            hastaFecha = new DateOnly(2026, 7, 1)
+        };
+
+        var response = await ConsultarAsync(filtro, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarResumenesAsistencia_Retorna200ConListaVacia_CuandoNoHayCodigosColaboradorNiDatosEnElRango()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        // Rango exclusivo de este caso: sin CodigosColaborador el universo se descubre entre TODOS
+        // los documentos del rango, asi que debe quedar libre de cualquier otro arrange del archivo.
+        var desde = new DateOnly(2025, 9, 1);
+        var hasta = new DateOnly(2025, 9, 3);
+
+        var filtro = new { desdeFecha = desde, hastaFecha = hasta };
+        var respuesta = await ConsultarOkAsync(filtro, ct);
+
+        respuesta.DesdeAplicado.Should().Be(desde);
+        respuesta.HastaAplicado.Should().Be(hasta);
+        respuesta.RangoRecortado.Should().BeFalse();
+        respuesta.Filas.Should().BeEmpty();
+    }
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarResumenesAsistencia_Retorna200ConFilaSinteticaPorCadaCodigo_CuandoCodigosColaboradorNoTienenDatos()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        // Codigos nunca sembrados por ningun test: no pueden tener documento en dev.
+        var codigoUno = Guid.CreateVersion7().ToString();
+        var codigoDos = Guid.CreateVersion7().ToString();
+        var desde = new DateOnly(2025, 9, 10);
+        var hasta = new DateOnly(2025, 9, 12);
+
+        var filtro = new
+        {
+            desdeFecha = desde,
+            hastaFecha = hasta,
+            codigosColaborador = new[] { codigoUno, codigoDos }
+        };
+        var respuesta = await ConsultarOkAsync(filtro, ct);
+
+        respuesta.Filas.Should().HaveCount(2);
+        respuesta.Filas.Select(f => f.CodigoColaborador).Should().Equal(codigoUno, codigoDos);
+
+        respuesta.Filas.Should().OnlyContain(f =>
+            f.DiasSinProgramar == 3
+            && f.SinDatos == 3
+            && f.DiasConTurno == 0
+            && f.DiasConDescanso == 0
+            && f.NoSePresento == 0
+            && f.FranjasIncompletas == 0
+            && f.VinoEnDescanso == 0
+            && f.TrabajoSinProgramacion == 0
+            && f.Aprobados == 0
+            && f.Pendientes == 0
+            && f.TotalHorasPorConcepto.Count == 0);
+    }
+
+    // Cubre CA-1 y CA-2: los tres dias reales (jornada, vino en descanso, trabajo sin programacion)
+    // mas los tres dias vacios del rango deben cerrar los tres ejes exactamente contra los 6 dias.
+    // CodigosColaborador explicito evita que el resultado dependa de descubrir el universo.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarResumenesAsistencia_CalculaTresEjesAnomaliasYTotales_CuandoElColaboradorTieneDiasRealesYVaciosEnElRango()
+    {
+        Assert.SkipWhen(!serviceBus.IsConfigured,
+            "ServiceBus no configurado. Usa appsettings.local.json o variable ServiceBus__ConnectionString.");
+
+        var ct = TestContext.Current.CancellationToken;
+
+        var codigoColaborador = Guid.CreateVersion7().ToString();
+        var desde = new DateOnly(2026, 7, 20);
+        var hasta = new DateOnly(2026, 7, 25);
+        var fechaJornada = new DateOnly(2026, 7, 21);
+        var fechaVinoEnDescanso = new DateOnly(2026, 7, 22);
+        var fechaTrabajoSinProgramacion = new DateOnly(2026, 7, 23);
+
+        await PublicarDiaConJornadaAsync(codigoColaborador, fechaJornada, "[TEST] Turno Jornada");
+        await PublicarDiaVinoEnDescansoAsync(codigoColaborador, fechaVinoEnDescanso, "[TEST] Turno Descanso");
+        await PublicarDiaTrabajoSinProgramacionAsync(codigoColaborador, fechaTrabajoSinProgramacion);
+
+        var filtro = new
+        {
+            desdeFecha = desde,
+            hastaFecha = hasta,
+            codigosColaborador = new[] { codigoColaborador }
+        };
+
+        // Los tres dias reales son Provisional, asi que SinDatos baja de 6 (todo vacio) a 3 una vez
+        // que el worker materializa las tres filas.
+        var respuesta = await ConsultarHastaQueAsync(
+            filtro, lista => lista.Filas.Single().SinDatos == 3, ct);
+
+        var fila = respuesta.Filas.Single();
+        fila.CodigoColaborador.Should().Be(codigoColaborador);
+
+        // Eje programacion: turno + descanso + sin programar (1 real + 3 vacios) = 6 dias del rango.
+        fila.DiasConTurno.Should().Be(1);
+        fila.DiasConDescanso.Should().Be(1);
+        fila.DiasSinProgramar.Should().Be(4);
+
+        // Eje anomalias: solo las banderas sembradas a proposito, los vacios no aportan ninguna.
+        fila.NoSePresento.Should().Be(0);
+        fila.FranjasIncompletas.Should().Be(0);
+        fila.VinoEnDescanso.Should().Be(1);
+        fila.TrabajoSinProgramacion.Should().Be(1);
+
+        // Eje aprobacion: Aprobado todavia no lo produce ningun evento (EstadoAsistencia); los tres
+        // dias reales son Pendientes y los tres vacios se avalan como SinDatos = 6 dias del rango.
+        fila.Aprobados.Should().Be(0);
+        fila.Pendientes.Should().Be(3);
+        fila.SinDatos.Should().Be(3);
+
+        fila.TotalHorasPorConcepto.Should().ContainKey("OrdinariaDiurna").WhoseValue.Should().Be(8.00m);
+    }
+
+    // CA-3: con CodigosColaborador explicito hay una fila por codigo pedido, EN EL ORDEN pedido,
+    // incluida la sintetica del codigo sin datos -- nunca solo la del codigo que si tiene filas.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarResumenesAsistencia_DevuelveSoloLosCodigosPedidosEnOrden_CuandoUnoTieneDatosYOtroNo()
+    {
+        Assert.SkipWhen(!serviceBus.IsConfigured,
+            "ServiceBus no configurado. Usa appsettings.local.json o variable ServiceBus__ConnectionString.");
+
+        var ct = TestContext.Current.CancellationToken;
+
+        var codigoConDatos = Guid.CreateVersion7().ToString();
+        var codigoSinDatos = Guid.CreateVersion7().ToString();
+        var desde = new DateOnly(2026, 7, 30);
+        var hasta = new DateOnly(2026, 8, 2);
+        var fechaJornada = new DateOnly(2026, 7, 31);
+
+        await PublicarDiaConJornadaAsync(codigoConDatos, fechaJornada, "[TEST] Turno Mezcla");
+
+        var filtro = new
+        {
+            desdeFecha = desde,
+            hastaFecha = hasta,
+            codigosColaborador = new[] { codigoConDatos, codigoSinDatos }
+        };
+
+        var respuesta = await ConsultarHastaQueAsync(
+            filtro, lista => lista.Filas.First().DiasConTurno == 1, ct);
+
+        respuesta.Filas.Should().HaveCount(2);
+        respuesta.Filas.Select(f => f.CodigoColaborador).Should().Equal(codigoConDatos, codigoSinDatos);
+
+        var filaConDatos = respuesta.Filas[0];
+        filaConDatos.DiasConTurno.Should().Be(1);
+        filaConDatos.DiasSinProgramar.Should().Be(3);
+        filaConDatos.Pendientes.Should().Be(1);
+        filaConDatos.SinDatos.Should().Be(3);
+        filaConDatos.TotalHorasPorConcepto.Should().ContainKey("OrdinariaDiurna").WhoseValue.Should().Be(8.00m);
+
+        var filaSinDatos = respuesta.Filas[1];
+        filaSinDatos.DiasConTurno.Should().Be(0);
+        filaSinDatos.DiasSinProgramar.Should().Be(4);
+        filaSinDatos.SinDatos.Should().Be(4);
+        filaSinDatos.TotalHorasPorConcepto.Should().BeEmpty();
+    }
+
+    // CA-3, rama sin filtro: el universo se descubre entre los documentos del rango. Take=200 (el
+    // maximo) reduce el riesgo de que el colaborador sembrado quede fuera de la pagina si el rango
+    // acumula colaboradores de otras corridas futuras de este mismo test -- si eso llegara a pasar,
+    // el timeout de Polling lo delata como fallo real, no como skip.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarResumenesAsistencia_ApareceEnElUniversoDescubierto_CuandoNoSeEnviaCodigosColaboradorYElColaboradorTieneDatos()
+    {
+        Assert.SkipWhen(!serviceBus.IsConfigured,
+            "ServiceBus no configurado. Usa appsettings.local.json o variable ServiceBus__ConnectionString.");
+
+        var ct = TestContext.Current.CancellationToken;
+
+        var codigoColaborador = Guid.CreateVersion7().ToString();
+        var desde = new DateOnly(2026, 8, 10);
+        var hasta = new DateOnly(2026, 8, 11);
+
+        await PublicarDiaConJornadaAsync(codigoColaborador, desde, "[TEST] Turno Universo Descubierto");
+
+        var filtro = new { desdeFecha = desde, hastaFecha = hasta, take = 200 };
+
+        var respuesta = await ConsultarHastaQueAsync(
+            filtro, lista => lista.Filas.Any(f => f.CodigoColaborador == codigoColaborador), ct);
+
+        var fila = respuesta.Filas.Single(f => f.CodigoColaborador == codigoColaborador);
+        fila.DiasConTurno.Should().Be(1);
+        fila.Pendientes.Should().Be(1);
+    }
+
+    // CA-4: keyset por CodigoColaborador ascendente sobre la lista pedida -- cursor ">" y fin de
+    // lista = pagina con menos filas que Take. No siembra ningun documento real: el modo con
+    // CodigosColaborador explicito pagina sobre la lista dada sin descubrir nada en Marten, asi que
+    // el mecanismo de paginacion es verificable sin depender de la consistencia eventual del worker.
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarResumenesAsistencia_PaginaConKeysetPorCodigoColaborador_CuandoSeEnviaCursor()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        var codigos = new[]
+            {
+                Guid.CreateVersion7().ToString(),
+                Guid.CreateVersion7().ToString(),
+                Guid.CreateVersion7().ToString()
+            }
+            .OrderBy(codigo => codigo, StringComparer.Ordinal)
+            .ToArray();
+
+        var desde = new DateOnly(2025, 2, 1);
+        var hasta = new DateOnly(2025, 2, 1);
+
+        var filtroPagina1 = new
+        {
+            desdeFecha = desde,
+            hastaFecha = hasta,
+            codigosColaborador = codigos,
+            take = 2
+        };
+        var pagina1 = await ConsultarOkAsync(filtroPagina1, ct);
+
+        pagina1.Filas.Should().HaveCount(2);
+        pagina1.Filas.Select(f => f.CodigoColaborador).Should().Equal(codigos[0], codigos[1]);
+
+        var filtroPagina2 = new
+        {
+            desdeFecha = desde,
+            hastaFecha = hasta,
+            codigosColaborador = codigos,
+            cursor = codigos[1],
+            take = 2
+        };
+        var pagina2 = await ConsultarOkAsync(filtroPagina2, ct);
+
+        // Fin de lista: la pagina trae menos filas que el Take pedido.
+        pagina2.Filas.Should().HaveCount(1);
+        pagina2.Filas.Single().CodigoColaborador.Should().Be(codigos[2]);
+    }
+
+    [Fact]
+    [Trait("Category", "Smoke")]
+    public async Task ListarResumenesAsistencia_RecortaRangoHaciaAdelante_CuandoElRangoExcedeLaCotaDe31Dias()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        var desde = new DateOnly(2026, 1, 1);
+        var hastaSolicitado = new DateOnly(2026, 12, 31);
+        // La cota son 31 dias INCLUSIVE; el literal se afirma a mano, nunca leyendo CotaDias.
+        var hastaAplicadaEsperada = desde.AddDays(30);
+
+        var filtro = new { desdeFecha = desde, hastaFecha = hastaSolicitado };
+        var respuesta = await ConsultarOkAsync(filtro, ct);
+
+        respuesta.DesdeAplicado.Should().Be(desde);
+        respuesta.HastaAplicado.Should().Be(hastaAplicadaEsperada);
+        respuesta.RangoRecortado.Should().BeTrue();
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/ListarResumenesAsistencia/ListarResumenesAsistenciaSmokeTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.SmokeTests/ListarResumenesAsistencia/ListarResumenesAsistenciaSmokeTests.cs
@@ -1,23 +1,17 @@
-// Smoke tests de ListarResumenesAsistencia -- QUERY control-horas/resumenes-asistencia: una fila
-// ResumenAsistencia por colaborador con los tres ejes del Aprobador (programacion, aprobacion,
-// anomalias) mas totales de horas, agregados en query-time sobre AsistenciaDiaria (#426).
+// Smoke tests de ListarResumenesAsistencia -- QUERY control-horas/resumenes-asistencia.
 //
 // Quedan ROJOS hasta que el deploy publique la Function en dev: mientras tanto la ruta no existe y
-// el host responde 404 a todo. El CI de PR no los ejecuta (solo corre *.Tests); su veredicto real
-// se lee despues del deploy.
+// el host responde 404 a todo. El CI de PR no los ejecuta (solo corre *.Tests).
 //
 // Arrange via el bus interno, nunca sembrando el event store por fuera de el: cada dia real se
-// publica como DiaDepurado al topic "dia-depurado" (mismo mecanismo que
-// ListarAsistenciasDiariasSmokeTests, #427). La proyeccion AsistenciaDiaria tiene lifecycle Async
-// (MEF-ADR-0034 seccion 3), asi que los casos que dependen del arrange envuelven la consulta en
-// Polling.WaitUntilAsync -- agotar el timeout es un fallo real, nunca un skip.
+// publica como DiaDepurado al topic "dia-depurado". La proyeccion AsistenciaDiaria tiene lifecycle
+// Async (MEF-ADR-0034 seccion 3), asi que los casos que dependen del arrange envuelven la consulta
+// en Polling.WaitUntilAsync -- agotar el timeout es un fallo real, nunca un skip.
 //
-// La mayoria de los casos con datos reales fijan CodigosColaborador explicito en el filtro: ese modo
-// pagina sobre la lista pedida sin descubrir el universo con un Distinct() sobre Marten, asi que el
-// resultado no se mezcla con colaboradores de otras corridas de este mismo smoke test que compartan
-// el mismo rango de fechas fijo en ejecuciones futuras. Solo el caso dedicado a la rama "sin filtro"
-// (universo descubierto) corre ese riesgo, y lo hace a proposito -- es lo unico que ejercita esa
-// rama sin sembrar por fuera del API.
+// Casi todos los casos con datos reales fijan CodigosColaborador explicito: ese modo pagina sobre la
+// lista pedida sin descubrir el universo, asi que el resultado no se mezcla con colaboradores de
+// otras corridas que compartan el mismo rango de fechas fijo. El caso dedicado a la rama "sin
+// filtro" corre ese riesgo a proposito -- es lo unico que la ejercita sin sembrar por fuera del API.
 //
 // Formas locales DESACOPLADAS del read model y del DTO de respuesta de produccion (isla,
 // MEF-ADR-0034 seccion 5): el smoke test no referencia ReadModels ni el Function App.
@@ -280,9 +274,14 @@ public class ListarResumenesAsistenciaSmokeTests(ApiFixture api, ServiceBusFixtu
     {
         var ct = TestContext.Current.CancellationToken;
 
-        // Codigos nunca sembrados por ningun test: no pueden tener documento en dev.
-        var codigoUno = Guid.CreateVersion7().ToString();
-        var codigoDos = Guid.CreateVersion7().ToString();
+        // Codigos nunca sembrados por ningun test: no pueden tener documento en dev. Se ordenan a
+        // mano porque Guid.CreateVersion7() no garantiza orden entre dos llamadas del mismo
+        // milisegundo, y la asercion de abajo es posicional.
+        var codigos = new[] { Guid.CreateVersion7().ToString(), Guid.CreateVersion7().ToString() }
+            .OrderBy(codigo => codigo, StringComparer.Ordinal)
+            .ToArray();
+        var codigoUno = codigos[0];
+        var codigoDos = codigos[1];
         var desde = new DateOnly(2025, 9, 10);
         var hasta = new DateOnly(2025, 9, 12);
 
@@ -311,9 +310,8 @@ public class ListarResumenesAsistenciaSmokeTests(ApiFixture api, ServiceBusFixtu
             && f.TotalHorasPorConcepto.Count == 0);
     }
 
-    // Cubre CA-1 y CA-2: los tres dias reales (jornada, vino en descanso, trabajo sin programacion)
-    // mas los tres dias vacios del rango deben cerrar los tres ejes exactamente contra los 6 dias.
-    // CodigosColaborador explicito evita que el resultado dependa de descubrir el universo.
+    // Los tres dias reales (jornada, vino en descanso, trabajo sin programacion) mas los tres dias
+    // vacios del rango deben cerrar los tres ejes exactamente contra los 6 dias.
     [Fact]
     [Trait("Category", "Smoke")]
     public async Task ListarResumenesAsistencia_CalculaTresEjesAnomaliasYTotales_CuandoElColaboradorTieneDiasRealesYVaciosEnElRango()
@@ -369,8 +367,8 @@ public class ListarResumenesAsistenciaSmokeTests(ApiFixture api, ServiceBusFixtu
         fila.TotalHorasPorConcepto.Should().ContainKey("OrdinariaDiurna").WhoseValue.Should().Be(8.00m);
     }
 
-    // CA-3: con CodigosColaborador explicito hay una fila por codigo pedido, EN EL ORDEN pedido,
-    // incluida la sintetica del codigo sin datos -- nunca solo la del codigo que si tiene filas.
+    // Con CodigosColaborador explicito hay una fila por codigo pedido, incluida la sintetica del
+    // codigo sin datos -- nunca solo la del codigo que si tiene filas.
     [Fact]
     [Trait("Category", "Smoke")]
     public async Task ListarResumenesAsistencia_DevuelveSoloLosCodigosPedidosEnOrden_CuandoUnoTieneDatosYOtroNo()
@@ -380,8 +378,15 @@ public class ListarResumenesAsistenciaSmokeTests(ApiFixture api, ServiceBusFixtu
 
         var ct = TestContext.Current.CancellationToken;
 
-        var codigoConDatos = Guid.CreateVersion7().ToString();
-        var codigoSinDatos = Guid.CreateVersion7().ToString();
+        // El endpoint devuelve la pagina ordenada ascendente, no en el orden pedido: el codigo con
+        // datos tiene que ser el menor para que las aserciones posicionales de abajo (y el
+        // predicado de polling sobre First()) sean deterministas. Guid.CreateVersion7() no lo
+        // garantiza por si solo entre dos llamadas del mismo milisegundo.
+        var codigos = new[] { Guid.CreateVersion7().ToString(), Guid.CreateVersion7().ToString() }
+            .OrderBy(codigo => codigo, StringComparer.Ordinal)
+            .ToArray();
+        var codigoConDatos = codigos[0];
+        var codigoSinDatos = codigos[1];
         var desde = new DateOnly(2026, 7, 30);
         var hasta = new DateOnly(2026, 8, 2);
         var fechaJornada = new DateOnly(2026, 7, 31);
@@ -415,10 +420,9 @@ public class ListarResumenesAsistenciaSmokeTests(ApiFixture api, ServiceBusFixtu
         filaSinDatos.TotalHorasPorConcepto.Should().BeEmpty();
     }
 
-    // CA-3, rama sin filtro: el universo se descubre entre los documentos del rango. Take=200 (el
-    // maximo) reduce el riesgo de que el colaborador sembrado quede fuera de la pagina si el rango
-    // acumula colaboradores de otras corridas futuras de este mismo test -- si eso llegara a pasar,
-    // el timeout de Polling lo delata como fallo real, no como skip.
+    // Rama sin filtro: el universo se descubre entre los documentos del rango. Take=200 (el maximo)
+    // reduce el riesgo de que el colaborador sembrado quede fuera de la pagina si el rango acumula
+    // colaboradores de otras corridas futuras de este mismo test.
     [Fact]
     [Trait("Category", "Smoke")]
     public async Task ListarResumenesAsistencia_ApareceEnElUniversoDescubierto_CuandoNoSeEnviaCodigosColaboradorYElColaboradorTieneDatos()
@@ -444,8 +448,8 @@ public class ListarResumenesAsistenciaSmokeTests(ApiFixture api, ServiceBusFixtu
         fila.Pendientes.Should().Be(1);
     }
 
-    // CA-4: keyset por CodigoColaborador ascendente sobre la lista pedida -- cursor ">" y fin de
-    // lista = pagina con menos filas que Take. No siembra ningun documento real: el modo con
+    // Keyset por CodigoColaborador ascendente sobre la lista pedida -- cursor ">" y fin de lista =
+    // pagina con menos filas que Take. No siembra ningun documento real: el modo con
     // CodigosColaborador explicito pagina sobre la lista dada sin descubrir nada en Marten, asi que
     // el mecanismo de paginacion es verificable sin depender de la consistencia eventual del worker.
     [Fact]

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/ComposicionServiciosTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/ComposicionServiciosTests.cs
@@ -40,6 +40,7 @@ using Wolverine;
 using ObtenerTurnoVigenteEndpoint = Bitakora.ControlAsistencia.ControlHoras.ObtenerTurnoVigente.FunctionEndpoint;
 using ListarTurnosVigentesEndpoint = Bitakora.ControlAsistencia.ControlHoras.ListarTurnosVigentes.FunctionEndpoint;
 using ListarAsistenciasDiariasEndpoint = Bitakora.ControlAsistencia.ControlHoras.ListarAsistenciasDiarias.FunctionEndpoint;
+using ListarResumenesAsistenciaEndpoint = Bitakora.ControlAsistencia.ControlHoras.ListarResumenesAsistencia.FunctionEndpoint;
 
 namespace Bitakora.ControlAsistencia.ControlHoras.Tests.Infraestructura;
 
@@ -364,6 +365,30 @@ public class ComposicionServiciosTests
         await using var scope = provider.CreateAsyncScope();
 
         var act = () => ActivatorUtilities.CreateInstance<ListarAsistenciasDiariasEndpoint>(scope.ServiceProvider);
+
+        act.Should().NotThrow();
+    }
+
+    // Issue #428: test de composicion de la Function QUERY ListarResumenesAsistencia, hermano de
+    // los de ListarTurnosVigentes/ListarAsistenciasDiarias (arriba) y de MEF-ADR-0029. Este issue no
+    // crea proyeccion ni read model (agregacion query-time sobre AsistenciaDiaria, #426): esta es la
+    // UNICA capa de composicion/wiring declarada para el, junto con las guardas HTTP puras de
+    // FunctionEndpointTests.cs y los unit tests de AgregadorResumenAsistencia/RangoConsulta (CA-1,
+    // CA-2, CA-3, CA-5), sin config-test del worker (carve-out de MEF-ADR-0035/issue #371, mismo que
+    // sus hermanos).
+    //
+    // Se prueba solo la RESOLUCION de IDocumentStore/ITenantResolver por constructor -- no el
+    // comportamiento de Run (guards 415/422, agregacion, keyset, recorte), que cubren los unit tests
+    // puros del feature folder y el smoke test. Por eso este test queda en verde tan pronto exista
+    // el FunctionEndpoint stub con el constructor correcto -- no es la guarda que fuerza el rojo de
+    // este issue (esa la dan AgregadorResumenAsistenciaTests/RangoConsultaTests/FunctionEndpointTests).
+    [Fact]
+    public async Task AgregarServiciosControlHoras_ResuelveElEndpointDeListarResumenesAsistencia_CuandoElContenedorEstaCompuesto()
+    {
+        await using var provider = ComponerServiceProvider();
+        await using var scope = provider.CreateAsyncScope();
+
+        var act = () => ActivatorUtilities.CreateInstance<ListarResumenesAsistenciaEndpoint>(scope.ServiceProvider);
 
         act.Should().NotThrow();
     }

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/ComposicionServiciosTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/Infraestructura/ComposicionServiciosTests.cs
@@ -369,19 +369,9 @@ public class ComposicionServiciosTests
         act.Should().NotThrow();
     }
 
-    // Issue #428: test de composicion de la Function QUERY ListarResumenesAsistencia, hermano de
-    // los de ListarTurnosVigentes/ListarAsistenciasDiarias (arriba) y de MEF-ADR-0029. Este issue no
-    // crea proyeccion ni read model (agregacion query-time sobre AsistenciaDiaria, #426): esta es la
-    // UNICA capa de composicion/wiring declarada para el, junto con las guardas HTTP puras de
-    // FunctionEndpointTests.cs y los unit tests de AgregadorResumenAsistencia/RangoConsulta (CA-1,
-    // CA-2, CA-3, CA-5), sin config-test del worker (carve-out de MEF-ADR-0035/issue #371, mismo que
-    // sus hermanos).
-    //
-    // Se prueba solo la RESOLUCION de IDocumentStore/ITenantResolver por constructor -- no el
-    // comportamiento de Run (guards 415/422, agregacion, keyset, recorte), que cubren los unit tests
-    // puros del feature folder y el smoke test. Por eso este test queda en verde tan pronto exista
-    // el FunctionEndpoint stub con el constructor correcto -- no es la guarda que fuerza el rojo de
-    // este issue (esa la dan AgregadorResumenAsistenciaTests/RangoConsultaTests/FunctionEndpointTests).
+    // Hermano de los de ListarTurnosVigentes/ListarAsistenciasDiarias (MEF-ADR-0029). Prueba solo la
+    // RESOLUCION de IDocumentStore/ITenantResolver por constructor; el comportamiento de Run
+    // (guards, agregacion, keyset, recorte) lo cubren los unit tests puros del feature folder.
     [Fact]
     public async Task AgregarServiciosControlHoras_ResuelveElEndpointDeListarResumenesAsistencia_CuandoElContenedorEstaCompuesto()
     {

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ListarResumenesAsistencia/AgregadorResumenAsistenciaTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ListarResumenesAsistencia/AgregadorResumenAsistenciaTests.cs
@@ -1,14 +1,10 @@
-// Funcion pura documentos+rango+codigos pedidos -> filas del resumen (issue #428): se invoca
-// directamente, sin QuerySession/Marten y sin el DSL Given/When/Then de CommandHandlerTestBase,
-// reservado a command handlers contra el event store (MEF-ADR-0002). Cada oraculo se arma a mano,
-// campo por campo: nunca se reusa el mapeo bajo prueba para construir el esperado.
+// Funcion pura, invocada directamente: sin QuerySession/Marten y sin el DSL Given/When/Then, que
+// MEF-ADR-0002 reserva a command handlers contra el event store. Cada oraculo se arma a mano, campo
+// por campo -- nunca reusando el mapeo bajo prueba para construir el esperado.
 //
 // TotalHorasPorConcepto se verifica con BeEquivalentTo y nunca comparando la fila entera con
 // Should().Be(...): IReadOnlyDictionary<string, decimal> no recibe equality estructural del
-// compilador de records (mismo gotcha que SintesisCalendarioAsistenciaTests, #427).
-//
-// CA-1/CA-2/CA-3 del issue #428 -- el recorte de rango (CA-5) vive en RangoConsultaTests.cs, hermano
-// de este archivo.
+// compilador de records, asi que esa comparacion pasaria a ser por referencia.
 
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.ControlHoras.Entities;
@@ -41,8 +37,6 @@ public class AgregadorResumenAsistenciaTests
             vinoEnDescanso,
             trabajoSinProgramacion,
             horasPorConcepto ?? new Dictionary<string, decimal>());
-
-    // --- CA-1: los tres ejes cierran contra los dias del rango aplicado ---
 
     [Fact]
     public void Agregar_ProduceUnaFilaConLosTresEjesCerrandoContraLosDiasDelRango_CuandoTodosLosDiasTienenDocumento()
@@ -79,8 +73,6 @@ public class AgregadorResumenAsistenciaTests
         fila.TotalHorasPorConcepto.Should().BeEquivalentTo(
             new Dictionary<string, decimal> { ["OrdinariaDiurna"] = 8.00m });
     }
-
-    // --- CA-2: los dias sin fila cuentan como SinDatos/sin programar y no aportan anomalias ---
 
     [Fact]
     public void Agregar_CuentaLosDiasSinFilaComoSinDatosYSinProgramar_SinAportarAnomalias()
@@ -128,8 +120,6 @@ public class AgregadorResumenAsistenciaTests
         fila.TrabajoSinProgramacion.Should().Be(0);
         fila.TotalHorasPorConcepto.Should().BeEmpty();
     }
-
-    // --- CA-3: universo con CodigosColaborador explicito (fila sintetica incluida) vs descubierto ---
 
     [Fact]
     public void Agregar_ProduceUnaFilaSinteticaConTodoSinDatosYCeros_ParaElCodigoPedidoSinDocumentos()
@@ -199,8 +189,6 @@ public class AgregadorResumenAsistenciaTests
 
         filas.Should().BeEmpty();
     }
-
-    // --- Totales de horas por concepto: suma sparse, union de claves ---
 
     [Fact]
     public void Agregar_SumaHorasPorConceptoConUnionDeClaves_CuandoLosDocumentosTraenConceptosDistintos()

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ListarResumenesAsistencia/AgregadorResumenAsistenciaTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ListarResumenesAsistencia/AgregadorResumenAsistenciaTests.cs
@@ -1,0 +1,244 @@
+// Funcion pura documentos+rango+codigos pedidos -> filas del resumen (issue #428): se invoca
+// directamente, sin QuerySession/Marten y sin el DSL Given/When/Then de CommandHandlerTestBase,
+// reservado a command handlers contra el event store (MEF-ADR-0002). Cada oraculo se arma a mano,
+// campo por campo: nunca se reusa el mapeo bajo prueba para construir el esperado.
+//
+// TotalHorasPorConcepto se verifica con BeEquivalentTo y nunca comparando la fila entera con
+// Should().Be(...): IReadOnlyDictionary<string, decimal> no recibe equality estructural del
+// compilador de records (mismo gotcha que SintesisCalendarioAsistenciaTests, #427).
+//
+// CA-1/CA-2/CA-3 del issue #428 -- el recorte de rango (CA-5) vive en RangoConsultaTests.cs, hermano
+// de este archivo.
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.ControlHoras.Entities;
+using Bitakora.ControlAsistencia.ControlHoras.ListarResumenesAsistencia;
+using Bitakora.ControlAsistencia.ReadModels.ControlHoras;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Tests.ListarResumenesAsistencia;
+
+public class AgregadorResumenAsistenciaTests
+{
+    private static AsistenciaDiaria DocumentoDePrueba(
+        string codigoColaborador,
+        DateOnly fecha,
+        EstadoAsistencia estado = EstadoAsistencia.Provisional,
+        PlanDelDia plan = PlanDelDia.ConJornada,
+        bool noSePresento = false,
+        bool franjasIncompletas = false,
+        bool vinoEnDescanso = false,
+        bool trabajoSinProgramacion = false,
+        IReadOnlyDictionary<string, decimal>? horasPorConcepto = null) =>
+        new(
+            DiaCalculadoAggregateRoot.ComputarStreamId(codigoColaborador, fecha),
+            codigoColaborador,
+            fecha,
+            estado,
+            plan,
+            "Turno Manana",
+            noSePresento,
+            franjasIncompletas,
+            vinoEnDescanso,
+            trabajoSinProgramacion,
+            horasPorConcepto ?? new Dictionary<string, decimal>());
+
+    // --- CA-1: los tres ejes cierran contra los dias del rango aplicado ---
+
+    [Fact]
+    public void Agregar_ProduceUnaFilaConLosTresEjesCerrandoContraLosDiasDelRango_CuandoTodosLosDiasTienenDocumento()
+    {
+        const string codigo = "EMP-001";
+        var dia1 = new DateOnly(2026, 8, 1);
+        var dia2 = new DateOnly(2026, 8, 2);
+        var dia3 = new DateOnly(2026, 8, 3);
+        var documentos = new[]
+        {
+            DocumentoDePrueba(codigo, dia1, EstadoAsistencia.Provisional, PlanDelDia.ConJornada,
+                horasPorConcepto: new Dictionary<string, decimal> { ["OrdinariaDiurna"] = 8.00m }),
+            DocumentoDePrueba(codigo, dia2, EstadoAsistencia.Aprobado, PlanDelDia.Descanso),
+            DocumentoDePrueba(codigo, dia3, EstadoAsistencia.Provisional, PlanDelDia.ConJornada,
+                noSePresento: true),
+        };
+
+        var filas = AgregadorResumenAsistencia.Agregar(dia1, dia3, null, documentos);
+
+        var fila = filas.Should().ContainSingle().Which;
+        fila.CodigoColaborador.Should().Be(codigo);
+        (fila.DiasConTurno + fila.DiasConDescanso + fila.DiasSinProgramar).Should().Be(3);
+        fila.DiasConTurno.Should().Be(2);
+        fila.DiasConDescanso.Should().Be(1);
+        fila.DiasSinProgramar.Should().Be(0);
+        (fila.Aprobados + fila.Pendientes + fila.SinDatos).Should().Be(3);
+        fila.Aprobados.Should().Be(1);
+        fila.Pendientes.Should().Be(2);
+        fila.SinDatos.Should().Be(0);
+        fila.NoSePresento.Should().Be(1);
+        fila.FranjasIncompletas.Should().Be(0);
+        fila.VinoEnDescanso.Should().Be(0);
+        fila.TrabajoSinProgramacion.Should().Be(0);
+        fila.TotalHorasPorConcepto.Should().BeEquivalentTo(
+            new Dictionary<string, decimal> { ["OrdinariaDiurna"] = 8.00m });
+    }
+
+    // --- CA-2: los dias sin fila cuentan como SinDatos/sin programar y no aportan anomalias ---
+
+    [Fact]
+    public void Agregar_CuentaLosDiasSinFilaComoSinDatosYSinProgramar_SinAportarAnomalias()
+    {
+        const string codigo = "EMP-001";
+        var dia1 = new DateOnly(2026, 8, 1);
+        var dia2 = new DateOnly(2026, 8, 2);
+        var dia3 = new DateOnly(2026, 8, 3);
+        var documentos = new[] { DocumentoDePrueba(codigo, dia2, franjasIncompletas: true) };
+
+        var filas = AgregadorResumenAsistencia.Agregar(dia1, dia3, null, documentos);
+
+        var fila = filas.Should().ContainSingle().Which;
+        fila.DiasSinProgramar.Should().Be(2);
+        fila.DiasConTurno.Should().Be(1);
+        fila.DiasConDescanso.Should().Be(0);
+        fila.SinDatos.Should().Be(2);
+        fila.Pendientes.Should().Be(1);
+        fila.Aprobados.Should().Be(0);
+        fila.FranjasIncompletas.Should().Be(1);
+        fila.NoSePresento.Should().Be(0);
+        fila.VinoEnDescanso.Should().Be(0);
+        fila.TrabajoSinProgramacion.Should().Be(0);
+    }
+
+    [Fact]
+    public void Agregar_ProduceTodosLosDiasSinDatos_CuandoNingunDocumentoExisteParaElCodigoPedido()
+    {
+        var desde = new DateOnly(2026, 8, 1);
+        var hasta = new DateOnly(2026, 8, 3);
+
+        var filas = AgregadorResumenAsistencia.Agregar(desde, hasta, ["EMP-Z"], []);
+
+        var fila = filas.Should().ContainSingle().Which;
+        fila.CodigoColaborador.Should().Be("EMP-Z");
+        fila.DiasSinProgramar.Should().Be(3);
+        fila.SinDatos.Should().Be(3);
+        fila.Aprobados.Should().Be(0);
+        fila.Pendientes.Should().Be(0);
+        fila.DiasConTurno.Should().Be(0);
+        fila.DiasConDescanso.Should().Be(0);
+        fila.NoSePresento.Should().Be(0);
+        fila.FranjasIncompletas.Should().Be(0);
+        fila.VinoEnDescanso.Should().Be(0);
+        fila.TrabajoSinProgramacion.Should().Be(0);
+        fila.TotalHorasPorConcepto.Should().BeEmpty();
+    }
+
+    // --- CA-3: universo con CodigosColaborador explicito (fila sintetica incluida) vs descubierto ---
+
+    [Fact]
+    public void Agregar_ProduceUnaFilaSinteticaConTodoSinDatosYCeros_ParaElCodigoPedidoSinDocumentos()
+    {
+        var desde = new DateOnly(2026, 8, 1);
+        var hasta = new DateOnly(2026, 8, 2);
+        var documentos = new[] { DocumentoDePrueba("EMP-A", desde) };
+
+        var filas = AgregadorResumenAsistencia.Agregar(desde, hasta, ["EMP-A", "EMP-B"], documentos);
+
+        filas.Should().HaveCount(2);
+        var filaB = filas.Should().ContainSingle(f => f.CodigoColaborador == "EMP-B").Which;
+        filaB.DiasSinProgramar.Should().Be(2);
+        filaB.DiasConTurno.Should().Be(0);
+        filaB.DiasConDescanso.Should().Be(0);
+        filaB.SinDatos.Should().Be(2);
+        filaB.Aprobados.Should().Be(0);
+        filaB.Pendientes.Should().Be(0);
+        filaB.NoSePresento.Should().Be(0);
+        filaB.FranjasIncompletas.Should().Be(0);
+        filaB.VinoEnDescanso.Should().Be(0);
+        filaB.TrabajoSinProgramacion.Should().Be(0);
+        filaB.TotalHorasPorConcepto.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Agregar_DevuelveUnaFilaPorCadaCodigoPedido_EnElOrdenDeLaListaPedida()
+    {
+        var desde = new DateOnly(2026, 8, 1);
+        var documentos = new[] { DocumentoDePrueba("EMP-A", desde), DocumentoDePrueba("EMP-B", desde) };
+
+        var filas = AgregadorResumenAsistencia.Agregar(desde, desde, ["EMP-B", "EMP-A"], documentos);
+
+        filas.Select(f => f.CodigoColaborador).Should().Equal("EMP-B", "EMP-A");
+    }
+
+    [Fact]
+    public void Agregar_DevuelveSoloColaboradoresConAlMenosUnaFilaEnElRango_CuandoNoHayCodigosPedidos()
+    {
+        var desde = new DateOnly(2026, 8, 1);
+        var documentos = new[] { DocumentoDePrueba("EMP-A", desde), DocumentoDePrueba("EMP-C", desde) };
+
+        var filas = AgregadorResumenAsistencia.Agregar(desde, desde, null, documentos);
+
+        filas.Select(f => f.CodigoColaborador).Should().BeEquivalentTo(["EMP-A", "EMP-C"]);
+    }
+
+    [Fact]
+    public void Agregar_OrdenaAscendentePorCodigoColaborador_CuandoNoHayCodigosPedidos()
+    {
+        var desde = new DateOnly(2026, 8, 1);
+        var documentos = new[] { DocumentoDePrueba("EMP-C", desde), DocumentoDePrueba("EMP-A", desde) };
+
+        var filas = AgregadorResumenAsistencia.Agregar(desde, desde, null, documentos);
+
+        filas.Select(f => f.CodigoColaborador).Should().Equal("EMP-A", "EMP-C");
+    }
+
+    [Fact]
+    public void Agregar_NoProduceNingunaFila_CuandoNoHayCodigosPedidosYNingunDocumentoCaeDentroDelRango()
+    {
+        var desde = new DateOnly(2026, 8, 1);
+        var hasta = new DateOnly(2026, 8, 2);
+        var documentoFueraDeRango = DocumentoDePrueba("EMP-001", new DateOnly(2026, 8, 10));
+
+        var filas = AgregadorResumenAsistencia.Agregar(desde, hasta, null, [documentoFueraDeRango]);
+
+        filas.Should().BeEmpty();
+    }
+
+    // --- Totales de horas por concepto: suma sparse, union de claves ---
+
+    [Fact]
+    public void Agregar_SumaHorasPorConceptoConUnionDeClaves_CuandoLosDocumentosTraenConceptosDistintos()
+    {
+        const string codigo = "EMP-001";
+        var dia1 = new DateOnly(2026, 8, 1);
+        var dia2 = new DateOnly(2026, 8, 2);
+        var documentos = new[]
+        {
+            DocumentoDePrueba(codigo, dia1,
+                horasPorConcepto: new Dictionary<string, decimal> { ["OrdinariaDiurna"] = 8.00m }),
+            DocumentoDePrueba(codigo, dia2,
+                horasPorConcepto: new Dictionary<string, decimal> { ["Retardo"] = 0.5m }),
+        };
+
+        var filas = AgregadorResumenAsistencia.Agregar(dia1, dia2, null, documentos);
+
+        filas.Should().ContainSingle().Which.TotalHorasPorConcepto.Should().BeEquivalentTo(
+            new Dictionary<string, decimal> { ["OrdinariaDiurna"] = 8.00m, ["Retardo"] = 0.5m });
+    }
+
+    [Fact]
+    public void Agregar_SumaLosValoresDeUnaMismaClave_CuandoVariosDiasAportanElMismoConcepto()
+    {
+        const string codigo = "EMP-001";
+        var dia1 = new DateOnly(2026, 8, 1);
+        var dia2 = new DateOnly(2026, 8, 2);
+        var documentos = new[]
+        {
+            DocumentoDePrueba(codigo, dia1,
+                horasPorConcepto: new Dictionary<string, decimal> { ["OrdinariaDiurna"] = 8.00m }),
+            DocumentoDePrueba(codigo, dia2,
+                horasPorConcepto: new Dictionary<string, decimal> { ["OrdinariaDiurna"] = 4.00m }),
+        };
+
+        var filas = AgregadorResumenAsistencia.Agregar(dia1, dia2, null, documentos);
+
+        filas.Should().ContainSingle().Which.TotalHorasPorConcepto.Should().BeEquivalentTo(
+            new Dictionary<string, decimal> { ["OrdinariaDiurna"] = 12.00m });
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ListarResumenesAsistencia/FunctionEndpointTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ListarResumenesAsistencia/FunctionEndpointTests.cs
@@ -1,0 +1,108 @@
+// Guards del borde HTTP (415/400/422, CA-6) de la Function QUERY ListarResumenesAsistencia (issue
+// #428, MEF-ADR-0042, RFC 10008) -- la unica capa de CA-6 que corre en CI: el smoke test que lo
+// cubre end-to-end depende del deploy y el test de composicion (ComposicionServiciosTests) solo
+// verifica wiring de IDocumentStore/ITenantResolver.
+//
+// El IDocumentStore y el ITenantResolver se pasan null! a proposito: los guards deben retornar
+// ANTES de abrir la QuerySession, asi que mover la apertura de sesion por encima de ellos rompe
+// estos tests con NullReferenceException en vez de pasar inadvertido -- mismo patron que
+// ListarAsistenciasDiarias/FunctionEndpointTests.cs (#427) y ListarFichasColaborador/
+// FunctionEndpointTests.cs (#373).
+//
+// Fase roja (projection-test-writer): FunctionEndpoint.Run() hoy SOLO lanza NotImplementedException
+// (MEF-ADR-0033, stub minimo de compilacion) -- ninguno de estos tests puede pasar todavia. El
+// COMPORTAMIENTO (que status code y que rama dispara cada uno, la agregacion, el keyset y el
+// recorte) es responsabilidad de projection-implementer.
+//
+// No hay guard de "CodigoColaborador obligatorio" (a diferencia de ListarAsistenciasDiarias):
+// CodigosColaborador es opcional en este filtro (issue #428, "Universo (ratificado, opcion a)").
+
+using System.Text;
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.ControlHoras.Infraestructura;
+using Bitakora.ControlAsistencia.ControlHoras.ListarResumenesAsistencia;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Tests.ListarResumenesAsistencia;
+
+public class FunctionEndpointTests
+{
+    private static FunctionEndpoint Endpoint() => new(null!, new TenantResolverFijo());
+
+    private static HttpRequest Request(string? contentType, string body)
+    {
+        var context = new DefaultHttpContext();
+        var bytes = Encoding.UTF8.GetBytes(body);
+        context.Request.ContentType = contentType;
+        context.Request.ContentLength = bytes.Length;
+        context.Request.Body = new MemoryStream(bytes);
+        return context.Request;
+    }
+
+    private static HttpRequest RequestJson(string body) => Request("application/json", body);
+
+    private static async Task<int?> EjecutarAsync(HttpRequest request)
+    {
+        var resultado = await Endpoint().Run(request, CancellationToken.None);
+        return resultado.Should().BeAssignableTo<ObjectResult>().Subject.StatusCode;
+    }
+
+    [Fact]
+    public async Task ListarResumenesAsistencia_Retorna415_CuandoElContentTypeNoEsJson()
+    {
+        var codigo = await EjecutarAsync(Request("text/plain", "{}"));
+
+        codigo.Should().Be(StatusCodes.Status415UnsupportedMediaType);
+    }
+
+    [Fact]
+    public async Task ListarResumenesAsistencia_Retorna415_CuandoNoViajaContentType()
+    {
+        var codigo = await EjecutarAsync(Request(contentType: null, body: "{}"));
+
+        codigo.Should().Be(StatusCodes.Status415UnsupportedMediaType);
+    }
+
+    [Fact]
+    public async Task ListarResumenesAsistencia_Retorna400_CuandoElBodyNoEsJsonValido()
+    {
+        var codigo = await EjecutarAsync(RequestJson("{ esto no es json valido"));
+
+        codigo.Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    // El literal null es JSON valido y deserializa a null: rama distinta del catch de JsonException.
+    [Fact]
+    public async Task ListarResumenesAsistencia_Retorna400_CuandoElBodyDeserializaANull()
+    {
+        var codigo = await EjecutarAsync(RequestJson("null"));
+
+        codigo.Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    [Fact]
+    public async Task ListarResumenesAsistencia_Retorna422_CuandoFaltanAmbasFechas()
+    {
+        var codigo = await EjecutarAsync(RequestJson("""{"take":10}"""));
+
+        codigo.Should().Be(StatusCodes.Status422UnprocessableEntity);
+    }
+
+    [Fact]
+    public async Task ListarResumenesAsistencia_Retorna422_CuandoFaltaAlgunaDeLasDosFechas()
+    {
+        var codigo = await EjecutarAsync(RequestJson("""{"desdeFecha":"2026-07-01"}"""));
+
+        codigo.Should().Be(StatusCodes.Status422UnprocessableEntity);
+    }
+
+    [Fact]
+    public async Task ListarResumenesAsistencia_Retorna422_CuandoElRangoEstaInvertido()
+    {
+        var codigo = await EjecutarAsync(RequestJson(
+            """{"desdeFecha":"2026-07-10","hastaFecha":"2026-07-01"}"""));
+
+        codigo.Should().Be(StatusCodes.Status422UnprocessableEntity);
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ListarResumenesAsistencia/FunctionEndpointTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ListarResumenesAsistencia/FunctionEndpointTests.cs
@@ -1,21 +1,13 @@
-// Guards del borde HTTP (415/400/422, CA-6) de la Function QUERY ListarResumenesAsistencia (issue
-// #428, MEF-ADR-0042, RFC 10008) -- la unica capa de CA-6 que corre en CI: el smoke test que lo
-// cubre end-to-end depende del deploy y el test de composicion (ComposicionServiciosTests) solo
-// verifica wiring de IDocumentStore/ITenantResolver.
+// Guards del borde HTTP (415/400/422) de la Function QUERY ListarResumenesAsistencia -- la unica
+// capa que los cubre en CI: el smoke test depende del deploy y el test de composicion solo verifica
+// el wiring por constructor.
 //
-// El IDocumentStore y el ITenantResolver se pasan null! a proposito: los guards deben retornar
-// ANTES de abrir la QuerySession, asi que mover la apertura de sesion por encima de ellos rompe
-// estos tests con NullReferenceException en vez de pasar inadvertido -- mismo patron que
-// ListarAsistenciasDiarias/FunctionEndpointTests.cs (#427) y ListarFichasColaborador/
-// FunctionEndpointTests.cs (#373).
+// El IDocumentStore se pasa null! a proposito: los guards deben retornar ANTES de abrir la
+// QuerySession, asi que mover la apertura de sesion por encima de ellos rompe estos tests con
+// NullReferenceException en vez de pasar inadvertido.
 //
-// Fase roja (projection-test-writer): FunctionEndpoint.Run() hoy SOLO lanza NotImplementedException
-// (MEF-ADR-0033, stub minimo de compilacion) -- ninguno de estos tests puede pasar todavia. El
-// COMPORTAMIENTO (que status code y que rama dispara cada uno, la agregacion, el keyset y el
-// recorte) es responsabilidad de projection-implementer.
-//
-// No hay guard de "CodigoColaborador obligatorio" (a diferencia de ListarAsistenciasDiarias):
-// CodigosColaborador es opcional en este filtro (issue #428, "Universo (ratificado, opcion a)").
+// No hay guard de "CodigoColaborador obligatorio" como en ListarAsistenciasDiarias:
+// CodigosColaborador es opcional en este filtro.
 
 using System.Text;
 using AwesomeAssertions;

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ListarResumenesAsistencia/PaginaDeCodigosTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ListarResumenesAsistencia/PaginaDeCodigosTests.cs
@@ -1,0 +1,91 @@
+// Paso 1 de la paginacion keyset sobre la lista de codigos que el cliente trae (CA-4). El resto del
+// keyset -- la rama que descubre el universo con un distinct sobre Marten -- solo lo cubre el smoke
+// test: exige Postgres real.
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.ControlHoras.ListarResumenesAsistencia;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Tests.ListarResumenesAsistencia;
+
+public class PaginaDeCodigosTests
+{
+    [Fact]
+    public void AcotarTake_DevuelveElTakePedido_CuandoEstaDentroDeLaCota()
+    {
+        PaginaDeCodigos.AcotarTake(50).Should().Be(50);
+    }
+
+    [Fact]
+    public void AcotarTake_RecortaAlTopeDelServidor_CuandoElClientePideMasDe200()
+    {
+        PaginaDeCodigos.AcotarTake(5000).Should().Be(200);
+    }
+
+    [Fact]
+    public void AcotarTake_DevuelveUno_CuandoElClientePideCeroONegativo()
+    {
+        PaginaDeCodigos.AcotarTake(0).Should().Be(1);
+        PaginaDeCodigos.AcotarTake(-10).Should().Be(1);
+    }
+
+    [Fact]
+    public void Recortar_OrdenaAscendenteYCortaEnTake_CuandoNoHayCursor()
+    {
+        var pagina = PaginaDeCodigos.Recortar(["EMP-C", "EMP-A", "EMP-B"], cursor: null, take: 2);
+
+        pagina.Should().Equal("EMP-A", "EMP-B");
+    }
+
+    [Fact]
+    public void Recortar_DevuelveSoloLosCodigosPosterioresAlCursor_CuandoSeEnviaCursor()
+    {
+        var pagina = PaginaDeCodigos.Recortar(["EMP-A", "EMP-B", "EMP-C"], "EMP-A", take: 50);
+
+        pagina.Should().Equal("EMP-B", "EMP-C");
+    }
+
+    // El cursor es el codigo de la ULTIMA fila recibida: esa fila no puede repetirse en la pagina
+    // siguiente.
+    [Fact]
+    public void Recortar_ExcluyeElCodigoDelCursor_CuandoElCursorCoincideExactamenteConUnCodigo()
+    {
+        var pagina = PaginaDeCodigos.Recortar(["EMP-A", "EMP-B"], "EMP-B", take: 50);
+
+        pagina.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Recortar_DevuelveMenosFilasQueTake_CuandoEsLaUltimaPagina()
+    {
+        var pagina = PaginaDeCodigos.Recortar(["EMP-A", "EMP-B", "EMP-C"], "EMP-B", take: 2);
+
+        pagina.Should().Equal("EMP-C");
+    }
+
+    [Fact]
+    public void Recortar_ColapsaLosCodigosRepetidos_CuandoElClienteEnviaElMismoCodigoDosVeces()
+    {
+        var pagina = PaginaDeCodigos.Recortar(["EMP-A", "EMP-A", "EMP-B"], cursor: null, take: 50);
+
+        pagina.Should().Equal("EMP-A", "EMP-B");
+    }
+
+    // El Take crudo del cliente nunca alcanza la pagina, ni por esta via ni por el endpoint.
+    [Fact]
+    public void Recortar_AcotaElTakeAlTopeDelServidor_CuandoElClientePideMasDe200()
+    {
+        var codigos = Enumerable.Range(1, 300).Select(n => $"EMP-{n:D4}").ToList();
+
+        var pagina = PaginaDeCodigos.Recortar(codigos, cursor: null, take: 5000);
+
+        pagina.Should().HaveCount(200);
+    }
+
+    [Fact]
+    public void Recortar_NoDevuelveNingunCodigo_CuandoLaListaPedidaEstaVacia()
+    {
+        var pagina = PaginaDeCodigos.Recortar([], cursor: null, take: 50);
+
+        pagina.Should().BeEmpty();
+    }
+}

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ListarResumenesAsistencia/RangoConsultaTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ListarResumenesAsistencia/RangoConsultaTests.cs
@@ -1,7 +1,6 @@
-// Duplicado a proposito de RangoConsultaTests de ListarTurnosVigentes/ListarAsistenciasDiarias --
-// ver el comentario de clase de RangoConsulta.cs en este feature folder (issue #428, tercera
-// aparicion de la politica, Rule of Three). Cada oraculo se arma a mano (MEF-ADR-0002): nunca se
-// deriva ejecutando Recortar sobre si mismo.
+// Duplicado a proposito de los RangoConsultaTests de ListarTurnosVigentes/ListarAsistenciasDiarias
+// -- ver el comentario de clase de RangoConsulta.cs en este feature folder. Cada oraculo se arma a
+// mano (MEF-ADR-0002): nunca se deriva ejecutando Recortar sobre si mismo.
 
 using AwesomeAssertions;
 using Bitakora.ControlAsistencia.ControlHoras.ListarResumenesAsistencia;

--- a/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ListarResumenesAsistencia/RangoConsultaTests.cs
+++ b/tests/Bitakora.ControlAsistencia.ControlHoras.Tests/ListarResumenesAsistencia/RangoConsultaTests.cs
@@ -1,0 +1,66 @@
+// Duplicado a proposito de RangoConsultaTests de ListarTurnosVigentes/ListarAsistenciasDiarias --
+// ver el comentario de clase de RangoConsulta.cs en este feature folder (issue #428, tercera
+// aparicion de la politica, Rule of Three). Cada oraculo se arma a mano (MEF-ADR-0002): nunca se
+// deriva ejecutando Recortar sobre si mismo.
+
+using AwesomeAssertions;
+using Bitakora.ControlAsistencia.ControlHoras.ListarResumenesAsistencia;
+
+namespace Bitakora.ControlAsistencia.ControlHoras.Tests.ListarResumenesAsistencia;
+
+public class RangoConsultaTests
+{
+    [Fact]
+    public void Recortar_DevuelveHastaSinCambios_CuandoElRangoEstaDentroDeLaCotaDe31Dias()
+    {
+        var desde = new DateOnly(2026, 8, 1);
+        var hasta = new DateOnly(2026, 8, 10);
+
+        var resultado = RangoConsulta.Recortar(desde, hasta);
+
+        resultado.Should().Be(new RangoAplicado(new DateOnly(2026, 8, 10), false));
+    }
+
+    [Fact]
+    public void Recortar_DevuelveHastaSinCambios_CuandoElRangoEsExactamente31DiasInclusive()
+    {
+        var desde = new DateOnly(2026, 8, 1);
+        var hasta = new DateOnly(2026, 8, 31);
+
+        var resultado = RangoConsulta.Recortar(desde, hasta);
+
+        resultado.Should().Be(new RangoAplicado(new DateOnly(2026, 8, 31), false));
+    }
+
+    [Fact]
+    public void Recortar_RecortaHaciaAdelanteDesdeDesde_CuandoElRangoExcedeLargamenteLaCotaDe31Dias()
+    {
+        var desde = new DateOnly(2026, 8, 1);
+        var hasta = new DateOnly(2026, 12, 31);
+
+        var resultado = RangoConsulta.Recortar(desde, hasta);
+
+        resultado.Should().Be(new RangoAplicado(new DateOnly(2026, 8, 31), true));
+    }
+
+    [Fact]
+    public void Recortar_RecortaUnSoloDiaDeExceso_CuandoElRangoSuperaLaCotaPorUnSoloDia()
+    {
+        var desde = new DateOnly(2026, 8, 1);
+        var hasta = new DateOnly(2026, 9, 1); // 32 dias inclusive: un dia por encima de la cota
+
+        var resultado = RangoConsulta.Recortar(desde, hasta);
+
+        resultado.Should().Be(new RangoAplicado(new DateOnly(2026, 8, 31), true));
+    }
+
+    [Fact]
+    public void Recortar_DevuelveElMismoDia_CuandoDesdeYHastaCoinciden()
+    {
+        var desde = new DateOnly(2026, 8, 5);
+
+        var resultado = RangoConsulta.Recortar(desde, desde);
+
+        resultado.Should().Be(new RangoAplicado(desde, false));
+    }
+}


### PR DESCRIPTION
## Resumen

Pipeline TDD completado:
- Fase roja: tests escritos con stubs
- Fase verde: implementación completa
- Smoke tests: escritos para endpoints detectados
- Fase refactor: revisión de calidad

## Decisiones del pipeline

<details>
<summary>Projection Test Writer (fase roja) — 7m 53s</summary>

# Stage 1 (projection-test-writer) -- Issue #428

## Contexto y clasificacion

Issue `tipo:projection` pero **read-side puro sin proyeccion nueva**: el propio issue declara
explicitamente "Este issue NO crea read model, ni proyeccion, ni lifecycle" (agregacion en
query-time sobre la vista materializada `AsistenciaDiaria`, #426, via (a') de MEF-ADR-0035). Las
"Capas de test esperadas" del issue confirman el carve-out: solo unit tests puros de agregacion y
test de composicion de la Function; unit tests de proyeccion y config-test del worker **no
aplican**.

## Tests creados

### `tests/.../ListarResumenesAsistencia/AgregadorResumenAsistenciaTests.cs` (CA-1, CA-2, CA-3)
10 tests sobre la funcion pura `AgregadorResumenAsistencia.Agregar` (sin Marten, oraculo armado a
mano por caso):
- Los tres ejes (programacion, aprobacion, anomalias) cerrando contra los dias del rango cuando
  todos los dias tienen documento.
- Dias sin fila contando como `SinDatos`/`DiasSinProgramar` sin aportar anomalias.
- Universo con `CodigosColaborador` explicito: fila sintetica (todo `SinDatos`, ceros) para el
  codigo sin documentos, y orden que preserva el de la lista pedida.
- Universo sin `CodigosColaborador`: solo colaboradores con >=1 fila en el rango, en orden
  ascendente por `CodigoColaborador` (coherente con el keyset del endpoint).
- Suma sparse de `HorasPorConcepto`: union de claves entre documentos y suma de valores de una
  misma clave.
- Documento fuera del rango aplicado se ignora (mismo contrato defensivo que
  `SintesisCalendarioAsistencia.Completar` de #427).

### `tests/.../ListarResumenesAsistencia/RangoConsultaTests.cs` (CA-5)
5 tests, duplicado literal de los ya existentes en `ListarTurnosVigentes`/`ListarAsistenciasDiarias`
-- misma cota de 31 dias, recorte siempre hacia adelante desde `desde`.

### `tests/.../ListarResumenesAsistencia/FunctionEndpointTests.cs` (CA-6, guards HTTP)
7 tests de los guards 415/400/422 del borde HTTP QUERY, mismo patron que
`ListarAsistenciasDiarias`/`ListarFichasColaborador`: `store` se pasa `null!` para forzar que los
guards retornen antes de abrir la `QuerySession`. Sin guard de "codigo obligatorio" -- a diferencia
de `ListarAsistenciasDiarias`, `CodigosColaborador` es opcional en este filtro.

### `ComposicionServiciosTests.cs` (CA-4/CA-7, cableado)
1 test nuevo, hermano de los de `ObtenerTurnoVigente`/`ListarTurnosVigentes`/
`ListarAsistenciasDiarias`: verifica que `ActivatorUtilities.CreateInstance<FunctionEndpoint>`
resuelve `IDocumentStore`/`ITenantResolver` desde el contenedor real compuesto con connection
strings dummy, sin excepcion. No cubre comportamiento de `Run` (eso es projection-implementer +
smoke test).

## Stubs de compilacion creados (todos `NotImplementedException` salvo DTOs planos)

- `FiltroListarResumenesAsistencia.cs`, `ResumenAsistencia.cs`, `ListaResumenesAsistencia.cs`:
  records planos sin logica, sin stub necesario.
- `RangoConsulta.cs`: `Recortar` -> `NotImplementedException`.
- `AgregadorResumenAsistencia.cs`: `Agregar` -> `NotImplementedException`.
- `FunctionEndpoint.cs`: `Run` -> `NotImplementedException`.

## Senal no-red: NO aplica

Aunque el issue no crea proyeccion, SI se escribieron unit tests puros nuevos
(`AgregadorResumenAsistenciaTests`, `RangoConsultaTests`) y guards HTTP (`FunctionEndpointTests`)
que fallan contra los stubs `NotImplementedException` -- la fase roja es alcanzable. El unico caso
que amerita la senal (solo composicion/config-test) no aplica aqui.

## Desviaciones del plan del planner

1. **Interfaz publica de `ResumenAsistencia`**: el planner dejo los nombres de campos "delegables".
   Fije: `DiasConTurno`/`DiasConDescanso`/`DiasSinProgramar` (eje programacion),
   `NoSePresento`/`FranjasIncompletas`/`VinoEnDescanso`/`TrabajoSinProgramacion` (eje anomalias, un
   int por bandera), `Aprobados`/`Pendientes`/`SinDatos` (eje aprobacion), y
   `TotalHorasPorConcepto` (suma sparse). Documentado en el XML-doc del record.

2. **Contrato de `AgregadorResumenAsistencia.Agregar`**: fije que con `CodigosColaborador` explicito
   el orden de las filas resultantes preserva el orden de la lista pedida (test
   `Agregar_DevuelveUnaFilaPorCadaCodigoPedido_EnElOrdenDeLaListaPedida`); sin filtro, el orden es
   ascendente por `CodigoColaborador` (coherente con el keyset del endpoint, que
   `projection-implementer` debe respetar al armar la query de Marten antes de agregar).

3. **Rule of Three de `RangoConsulta` (MEF-ADR-0018, tercera aparicion)**: el issue lo marca como
   "propuesta revisable" y deja la decision de extraer a un lugar comun del dominio al "pipeline".
   Como test-writer NO tengo mandato para tocar produccion ya implementada en los dos feature
   folders anteriores (`ListarTurnosVigentes`, `ListarAsistenciasDiarias`) -- eso es refactor de
   codigo real, fuera de mi alcance ("nunca escribes implementacion real"). Deje un TERCER duplicado
   de `RangoConsulta.cs` (stub `NotImplementedException`) en el nuevo feature folder, con su propio
   `RangoConsultaTests.cs` duplicado literal. `projection-implementer` decide en fase verde si
   duplica la logica una tercera vez (tolerado por Rule of Three hasta que el llegue) o ejecuta la
   extraccion real actualizando los tres consumidores -- documentado en el comentario de clase del
   stub.

4. **`FunctionEndpointTests.cs` como capa propia** (ademas del test de composicion): el issue solo
   lista explicitamente "unit tests puros de agregacion" y "test de composicion" en sus "Capas de
   test esperadas", pero el precedente de #373/#427 (mismo rol, mismo repo) escribe ademas un
   `FunctionEndpointTests.cs` con los guards 415/400/422 como archivo separado del test de
   composicion DI -- confirmado por el propio comentario de fase roja que ese archivo ya trae
   ("Fase roja (projection-test-writer): FunctionEndpoint.Run() hoy SOLO lanza
   NotImplementedException"). Mantuve el patron por consistencia y porque CA-6 (415/400/422) no
   tiene otra capa de test que lo cubra en CI.

## Verificacion

`dotnet build ControlAsistencias.slnx` -- compilacion correcta, 0 errores (solo warnings
preexistentes de NU1902/CS0414 y los CS9113 esperados de los parametros del constructor del stub
`FunctionEndpoint` sin usar). No se corrio `dotnet test`: los tests nuevos fallan por diseno contra
los stubs `NotImplementedException`.

</details>

<details>
<summary>Projection Implementer (fase verde) — 7m 48s</summary>

# Stage: projection-implementer (issue #428)

## Enfoque

El issue #428 no crea proyeccion ni read model nuevos (via a' de MEF-ADR-0035): agrega
sobre la vista materializada `AsistenciaDiaria` (#426) con **agregacion en query-time**.
Mi trabajo se limito a implementar el cuerpo de los tres stubs que dejo
`projection-test-writer`, sin crear ni modificar ningun test:

1. **`RangoConsulta.Recortar`** (`ListarResumenesAsistencia/RangoConsulta.cs`): misma
   politica de recorte hacia adelante que `ListarTurnosVigentes`/`ListarAsistenciasDiarias`
   (#329/#427) -- tercera aparicion, Rule of Three (MEF-ADR-0018). Copie la implementacion
   verbatim del precedente de #427, sin extraerla a un lugar comun: el propio stub de
   `RangoConsulta.cs` ya documentaba que esa decision de extraccion es explicitamente del
   pipeline y "no del test-writer", y el issue permite duplicar una tercera vez si la
   extraccion no se ejecuta en este stage. No encontre senal de que #427 hubiera sido el
   punto de coordinacion para la extraccion (no hay commit de refactor en el historial de
   este worktree), asi que mantuve la tercera duplicacion tal como el propio comentario del
   stub lo anticipaba.

2. **`AgregadorResumenAsistencia.Agregar`** (funcion pura, sin Marten): agrupa los
   documentos `AsistenciaDiaria` por `CodigoColaborador` (re-filtrando por rango, mismo
   contrato defensivo que `SintesisCalendarioAsistencia.Completar` de #427), determina el
   universo de codigos (la lista pedida preservando su orden, o el descubierto ordenado
   ascendente por `CodigoColaborador` cuando no hay lista) y mapea cada codigo a una fila
   `ResumenAsistencia` con los tres ejes (programacion, aprobacion, anomalias) cerrando
   contra los dias del rango aplicado, mas la suma sparse de `HorasPorConcepto`. Los dias
   sin fila cuentan como `SinDatos`/"sin programar" y no aportan anomalias.

3. **`FunctionEndpoint.Run`**: guards 415 (Content-Type no-JSON) / 400 (JSON invalido o
   `null`) / 422 (fechas ausentes o rango invertido) en el mismo orden que
   `ListarAsistenciasDiarias`/`ListarFichasColaborador`; `QuerySession` acotada al tenant de
   `ITenantResolver` (MEF-ADR-0028); `Take` acotado con `Math.Clamp(_, 1, 200)`;
   paginacion keyset **en dos pasos** (documentado en el propio archivo y en "Desviaciones"
   abajo): (1) pagina de codigos -- de la lista pedida si `CodigosColaborador` viene
   explicito, o descubierta con un `Select().Distinct().OrderBy()` sobre `AsistenciaDiaria`
   en el rango si no viene --, acotada por cursor (`>`) y `Take`; (2) documentos de esos
   codigos en el rango, agregados en memoria con `AgregadorResumenAsistencia.Agregar`.
   Nunca 404: respuesta 200 siempre, con filas `SinDatos`/lista vacia segun el caso.

## Decisiones de diseño

- **`Agregar` produce sintesis (fila con todo `SinDatos`/ceros) cuando `codigosPedidos` no
  es null**, incluso para codigos sin ningun documento en el rango -- verificado contra los
  tests `Agregar_ProduceUnaFilaSinteticaConTodoSinDatosYCeros...` y
  `Agregar_ProduceTodosLosDiasSinDatos...`.
- **El endpoint siempre pasa una lista NO-nula a `Agregar`** (la pagina de codigos, sea la
  pedida o la descubierta): la rama `codigosPedidos == null` de `Agregar` solo la ejercitan
  directamente los unit tests puros; en produccion el endpoint ya resolvio el universo antes
  de agregar, asi que nunca le pasa `null`. Esto simplifica el endpoint sin violar el
  contrato publico de `Agregar` (documentado en su propio XML doc, escrito por
  `projection-test-writer`, que contempla ambos casos).
- **Plan.SinProgramar** (tercer valor del enum `PlanDelDia`, sin cobertura de test directa
  en este issue) se mapeo igual que "dia sin fila" en el eje programacion (suma a
  `DiasSinProgramar`) por consistencia semantica con el nombre del campo, aunque ningun CA
  ni test ejercita ese valor sobre un documento existente hoy (la proyeccion de #426 aun no
  lo emite, segun el comentario de `EstadoAsistencia` en el read model).

## ADRs consultados

- MEF-ADR-0035 (via a', doctrina query read-side), MEF-ADR-0041 decision 4 (DTO de
  respuesta como excepcion justificada), MEF-ADR-0028 (tenancy: `QuerySession` acotada al
  `ITenantResolver`), MEF-ADR-0042 (contrato QUERY: 415/400/422, keyset, `Take`/Clamp),
  MEF-ADR-0018 (Rule of Three, tercera duplicacion de `RangoConsulta`), MEF-ADR-0006 +
  `naming.md` (feature folder, ruta kebab-case).
- No hubo necesidad de tocar el worker (`Configuracion Marten Projections`) ni ningun read
  model/proyeccion: el issue lo declara explicitamente fuera de alcance y lo confirme
  leyendo `ComposicionServiciosTests.cs` (comentario "este issue no crea proyeccion... la
  UNICA capa de composicion/wiring declarada para el").

## Desviaciones

- **Regla/ADR**: el planner senalo como "riesgo tecnico" (no como contrato cerrado) la
  traducibilidad a SQL de la paginacion keyset sobre codigos descubiertos por distinct,
  pidiendo que "la eleccion exacta y su traducibilidad se verifican en el pipeline (mismo
  espiritu del spike de #373)".
  **Desviacion aplicada**: implemente el paso de descubrimiento con
  `session.Query<AsistenciaDiaria>().Where(...).Select(a => a.CodigoColaborador).Distinct().OrderBy(...).Take(...)`
  y el filtro de cursor con `a.CodigoColaborador.CompareTo(cursor) > 0` sobre el documento
  completo (antes del `Select`), sin ejecutar el spike de verificacion contra Postgres real
  que #373 si hizo para su propio `CompareTo`.
  **Razon tecnica**: ningun test de este issue (guards HTTP con `store: null!`, unit tests
  puros del agregador, test de composicion que solo resuelve el constructor) ejercita esta
  query contra una instancia real de Marten/Postgres -- no hay forma de verificarla en este
  stage con las herramientas y datos disponibles, y el propio comentario del test-writer en
  `FunctionEndpointTests.cs` confirma que "el smoke test... depende del deploy" es la unica
  capa que cierra ese NO VERIFICADO end-to-end.
  **Consecuencia**: si el smoke test contra dev (fuera del alcance de este stage) revela que
  Marten no traduce `Select().Distinct()` como se espera, la correccion recae en un issue de
  seguimiento (o en el propio smoke-test-writer/bug-investigator), igual que el precedente
  de #373 documenta para su propio spike.

## Resultado

- `dotnet build` sobre la solucion completa: correcto, 0 errores.
- `dotnet test` del proyecto `Bitakora.ControlAsistencia.ControlHoras.Tests`: 522/522 en
  verde (incluye los 10 tests que dejo `projection-test-writer` para #428:
  `AgregadorResumenAsistenciaTests`, `RangoConsultaTests`, `FunctionEndpointTests` y el test
  de composicion nuevo en `ComposicionServiciosTests`).
- `dotnet test` de la solucion completa: 1454 correcto, 53 omitido (smoke tests que
  requieren Postgres/ServiceBus real, ausentes en este entorno), 2 error (fixture de
  WARM-UP de los mismos smoke tests, issue#166, por la misma falta de infra local) --
  ninguno de esos 2 errores esta relacionado con el codigo de este stage; son
  preexistentes al no haber Postgres/ServiceBus configurados localmente.
- Archivos modificados (todos ya declarados por `projection-test-writer`, ningun archivo
  nuevo creado por este agente):
  - `src/Bitakora.ControlAsistencia.ControlHoras/ListarResumenesAsistencia/RangoConsulta.cs`
  - `src/Bitakora.ControlAsistencia.ControlHoras/ListarResumenesAsistencia/AgregadorResumenAsistencia.cs`
  - `src/Bitakora.ControlAsistencia.ControlHoras/ListarResumenesAsistencia/FunctionEndpoint.cs`
- No se toco `ComposicionServicios.cs` del dominio ControlHoras: ninguna Function de este
  ensamblado se registra explicitamente en el contenedor (el host de Azure Functions
  isolated worker las activa por tipo), confirmado por el comentario del test de composicion
  correspondiente.

</details>
<details>
<summary>Smoke Test Writer — 6m 35s</summary>

_(El agente no generó resumen)_

</details>
<details>
<summary>Reviewer (fase refactor) — 19m 29s</summary>

## ES Reviewer - Revision

### Evaluacion general
- Calidad: **buena**
- Cambios realizados: **si** (commit `79d8e31`)

El diff sigue el precedente QUERY del repo (#373 / #427) con fidelidad y sin desviaciones
arquitectonicas. Los hallazgos que corregi no son de patrones ES sino de cobertura, eficiencia y
determinismo de tests. Ademas **cerre empiricamente el unico NO VERIFICADO que la fase verde dejo
abierto**.

### Cumplimiento de ADRs aplicables

| ADR | Cumplimiento | Observacion |
|---|---|---|
| MEF-ADR-0042: QUERY, keyset, DTO de filtro AND, 400/415/422, Take acotado | ok | `"query"` + `Route` explicita; 415 antes de leer el body; 400 por `JsonException` y por body `null`; 422 por fechas ausentes/rango invertido, todos como `ObjectResult` con mensaje. `Math.Clamp(_, 1, 200)` presente (ahora ademas con test propio). Keyset por cursor, sin offset. |
| MEF-ADR-0035: via (a') sobre `QuerySession` | ok | `session.Query<AsistenciaDiaria>()` sobre la vista materializada de #426. No crea proyeccion, read model ni lifecycle, como declara el issue. |
| MEF-ADR-0028 (via `read-apis.md`): sesion acotada al tenant del resolver | ok | `store.QuerySession(tenantResolver.TenantId)`. Ningun dato de la request alcanza el scope de tenant. |
| MEF-ADR-0041 decision 4: DTO de respuesta como excepcion justificada | ok | `ResumenAsistencia`/`ListaResumenesAsistencia` viven en el feature folder, no en `ReadModels`. La justificacion (no existe read model del resumen + fila sintetica inexistente en toda vista) es correcta y esta documentada en el tipo. Ningun `<ProjectReference>` nuevo en `ReadModels`. |
| MEF-ADR-0006 + `naming.md`: feature folder, `Route` kebab-case | ok | `ListarResumenesAsistencia/` sin sufijo `Function` (correcto: es query, no comando). `Route = "control-horas/resumenes-asistencia"`, kebab-case minusculo, verbo declarado explicitamente. Sin colision de segmento con otra Function del BC. |
| MEF-ADR-0018 (Rule of Three): tercera aparicion de `RangoConsulta` | desviacion declarada | Ver "Desviaciones" -- evaluada como **aceptable**. |
| MEF-ADR-0016: naming de tests | ok | `<Sujeto>_<LoQuePasa>_Cuando<Condicion>` en los cuatro archivos; solo `[Fact]`, ningun `[Theory]`. |
| MEF-ADR-0044: comentarios minimos | falla -> corregido | Ver "Limpieza de comentarios". |

### Desviaciones de ADRs

**Desviaciones declaradas por el implementer:**

#### Desviacion 1: MEF-ADR-0018 (Rule of Three) -- no extraer `RangoConsulta` en su tercera aparicion
- **Regla del ADR**: "Tolerar duplicacion hasta la tercera repeticion... recien al tercer caso vale la pena evaluar si la abstraccion es estable y aporta."
- **Desviacion aplicada**: se dejo una tercera copia identica de `RangoConsulta`/`RangoAplicado` en el nuevo feature folder, sin extraer a un lugar comun ni migrar `ListarTurnosVigentes`/`ListarAsistenciasDiarias`.
- **Razon del implementer**: el issue deja la extraccion como decision del pipeline y tolera duplicar una tercera vez; no hubo coordinacion previa con #427.
- **Consecuencia conocida**: cambiar la cota en un feature folder no alcanza a los otros dos.
- **Evaluacion del reviewer**: **aceptable**. Tres razones, todas del mismo ADR: (1) la clausula "Autoridad de extraccion" es explicita en que *"el reviewer no debe pedir extraccion si el implementer no la ofrece"* y que su excepcion es *"cuando un cambio reciente toco simultaneamente los dos sitios"* -- este PR crea el tercero, no toca los dos previos; (2) la clausula "Riesgo de divergencia del dominio" aplica de lleno: la cota de un listado de turnos vigentes no tiene por que seguir siendo la misma que la de un resumen de periodo (un reporte trimestral pediria 90 dias), y encerrarlas en una constante comun forzaria un contrato artificial; (3) el propio ADR advierte que *"la Rule of Three no es mecanica"*. **Accion tomada**: no extraje, pero reescribi el comentario de clase para que la restriccion quede activa -- decia que era un stub de fase roja pendiente de decision (falso ya) y ahora dice que es copia deliberada y que cambiar `CotaDias` aqui no alcanza a las otras dos.
- **Status**: pendiente de evaluacion del usuario

#### Desviacion 2: traducibilidad LINQ del paso de descubrimiento declarada NO VERIFICADA
- **Regla del ADR**: MEF-ADR-0042 seccion 6 exige tratar todo punto NO VERIFICADO como **gate bloqueante** del primer despliegue, no como nota informativa.
- **Desviacion aplicada**: el implementer implemento `Select().Distinct().OrderBy().Take()` sin spike propio, delegando la verificacion al smoke test post-deploy.
- **Razon del implementer**: ningun test del issue ejercita esa query contra Marten/Postgres real.
- **Evaluacion del reviewer**: la razon era correcta para su stage, pero la consecuencia (descubrir en dev que Marten no traduce la query) era evitable. **La cerre yo**: levante Postgres 16 en Docker, compuse el contenedor real del dominio (`AgregarServiciosControlHoras`) contra el, sembre documentos y ejecute las dos queries del endpoint. Resultado: **traduce y pagina correctamente**.
  - Descubrimiento sin cursor -> `EMP-001, EMP-002, EMP-003` (distintos, ordenados; el documento fuera de rango excluido).
  - Con cursor `EMP-001` -> `EMP-002, EMP-003` (el `CompareTo(...) > 0` antes del `Select` traduce).
  - `Take(1)` -> `EMP-001`: el `Take` corta **codigos distintos**, no filas, pese a que `EMP-001` tenia dos documentos.
  - `Contains` sobre `IReadOnlyList<string>` traduce, incluida la lista **vacia** (0 filas, sin excepcion).
  - El scratch se elimino y el contenedor se destruyo; el resultado quedo como comentario en el endpoint.
- **Status**: **resuelta** -- el gate de MEF-ADR-0042 seccion 6 ya no bloquea este despliegue.

**Desviaciones detectadas por el reviewer (NO declaradas por el implementer)**: ninguna de patron
arquitectonico. Los hallazgos que encontre estan en "Criticas y hallazgos" (cobertura, eficiencia,
determinismo, comentarios), no son incumplimientos de ADR.

### Precedentes consultados por el implementer

| Precedente | ADR aplicable | Veredicto |
|---|---|---|
| `ListarAsistenciasDiarias/FunctionEndpoint.cs` (#427) | MEF-ADR-0042 / 0035 / 0028 | alineado -- mismo orden de guards, misma sesion por tenant |
| `ListarFichasColaborador/FunctionEndpoint.cs` (#373) | MEF-ADR-0042 | alineado -- `Math.Clamp`, `NoProcesable`, keyset por cursor |
| `SintesisCalendarioAsistencia.Completar` (#427) | MEF-ADR-0002 | alineado -- contrato defensivo de re-filtrado por rango |
| `ListarTurnosVigentes/RangoConsulta.cs` (#329) | MEF-ADR-0018 | alineado -- duplicacion deliberada ya documentada en el sitio 2 |

### Convenciones del pipeline (no ADRs)

| Convencion | Estado | Observacion |
|---|---|---|
| Cada test con `Then()` + `And<>()` | n/a | No hay command handler tests: son funciones puras y guards HTTP. El DSL Given/When/Then esta reservado a handlers contra el event store (MEF-ADR-0002). |
| Overloads correctos para stream IDs compuestos | n/a | El diff no escribe streams. El unico uso de identidad es `DiaCalculadoAggregateRoot.ComputarStreamId(...)` en el factory de documentos de prueba -- punto unico de conversion, correcto. |
| Fakes manuales (no NSubstitute) | ok | `TenantResolverFijo` real; `IDocumentStore` como `null!` deliberado para forzar que los guards retornen antes de abrir sesion. Cero NSubstitute. |
| Feature folders (produccion y tests) | ok | Espejo exacto; un archivo por responsabilidad (filtro / respuesta / envelope / agregacion / recorte / paginacion / endpoint). |
| Smoke tests: SkipWhen, secrets, cobertura | ok (2 corregidos) | `Assert.SkipWhen(!serviceBus.IsConfigured, ...)` en los cuatro casos que siembran por el bus; `appsettings.json` con connection strings vacios; aserciones filtradas por codigo unico, nunca posicional-sobre-el-topic. Corregi flakiness de orden en dos casos (ver hallazgos). Endpoint de solo lectura: sin efectos secundarios que exijan suscripcion nueva. |
| Proyecciones read-side: partial, inmutabilidad, read APIs, naming, cuarta isla | ok | El issue no crea proyeccion ni read model. `ReadModels` no gana ninguna `<ProjectReference>`. Nombres `Listar{X}s`, sin sufijo `Function`, sin sufijo de implementacion. |
| Antipatrones de habilitacion (MEF-ADR-0039) | n/a | El diff no toca ningun `.csproj` ni declara tipo de evento nuevo. |
| Compatibilidad Marten write-side/read-side | n/a | El diff no toca version del paquete ni configuracion de Marten. |
| Identidad de stream (MEF-ADR-0037) | ok | Sin `ToString` con formato explicito; sin construccion manual de clave fuera de `ComputarStreamId`. El endpoint no recibe id por ruta (QUERY con filtro en body), asi que el parseo tipado del borde no aplica. |
| Contrato HTTP de comandos (MEF-ADR-0043) | n/a | El diff no agrega ningun endpoint de comando (`**/*Function/FunctionEndpoint.cs`). Es una query. |
| Control de volumen de telemetria (MEF-ADR-0038) | n/a | El diff no toca `ComposicionServicios*`, `ConfiguracionObservabilidad*` ni el callback de Wolverine. |
| Limpieza de comentarios (MEF-ADR-0044) | ok (corregido) | Ver seccion propia. |
| Tests via ToString/comportamiento | ok | Sin getters expuestos solo para test. |
| Sin numeros magicos | ok (mejorado) | `CotaDias = 31` y `TakeMaximo = 200` con nombre. El `TakeMaximo` paso a `PaginaDeCodigos`, unico dueno de la cota. |
| Condiciones en positivo | ok | Los `if` negativos que quedan son guard clauses de early-return, la excepcion prevista. |

### Elegancia del codigo

El codigo entregado ya era compacto e idiomatico: LINQ en vez de bucles, `record` para todos los
DTOs, colecciones con target-typed `[]`, pattern matching en los guards. Mejoras aplicadas:

- **Cohesion**: `DeterminarCodigosPaginaAsync` hacia dos cosas incomparables en un solo metodo
  privado (recortar una lista en memoria vs. descubrir el universo en Marten). La primera mitad es
  logica pura y ahora vive en `PaginaDeCodigos`, con nombre que revela intencion; el metodo del
  endpoint queda con una sola responsabilidad visible.
- **Eficiencia**: el endpoint hacia siempre dos viajes a Postgres, incluso cuando la pagina de
  codigos quedaba vacia (rango sin datos, o `codigosColaborador: []`). Ahora el segundo se omite.
- **Duenos unicos**: `TakeMaximo` estaba en el endpoint pero gobierna las dos ramas; movido a
  `PaginaDeCodigos.AcotarTake`, que es lo que ambas invocan.
- Sin warnings del compilador en los archivos del diff, sin debug cruft, sin imports innecesarios,
  sin `─` (U+2500).

### Criticas y hallazgos

1. **[mayor - corregido] CA-4 no tenia ninguna cobertura en CI.** El `Math.Clamp(_, 1, 200)` que
   MEF-ADR-0042 seccion 2 exige como cota de servidor, y el filtro de cursor `>`, solo los
   verificaba el smoke test -- que esta rojo hasta el deploy y no corre en el CI del PR. Una
   regresion (p. ej. pasar `filtro.Take` crudo a Marten) habria pasado el pipeline entero sin que
   nada la delatara. Extraje `PaginaDeCodigos` y agregue 10 unit tests.
2. **[mayor - resuelto] El NO VERIFICADO de la traduccion LINQ.** Verificado contra Postgres real
   (detalle en "Desviaciones", desviacion 2). Ya no es un gate abierto.
3. **[mayor - corregido] Dos smoke tests flaky por orden de `Guid.CreateVersion7()`.** Ambos
   afirmaban orden **posicional** sobre dos GUIDs recien creados
   (`Should().Equal(codigoUno, codigoDos)`, `Filas[0]`, y un predicado de polling sobre `First()`),
   pero `Guid.CreateVersion7()` solo garantiza monotonicidad entre milisegundos distintos: dos
   llamadas consecutivas caen normalmente en el mismo ms y su orden relativo es aleatorio. En el
   caso de `..._CuandoUnoTieneDatosYOtroNo` el sintoma no habria sido un assert claro sino un
   **timeout de polling de 30 s** (el predicado `First().DiasConTurno == 1` nunca se cumpliria).
   Corregido ordenando los codigos con `StringComparer.Ordinal` antes de usarlos.
4. **[menor - documentado, no corregido] Las dos ramas del keyset no ordenan con el mismo
   comparador.** Medido en esta revision sobre el mismo conjunto de codigos: Postgres devuelve
   `emp-1, EMP_1, EMP-10, EMP-2, EMP-9, EMPA` y `StringComparer.Ordinal` devuelve
   `EMP-10, EMP-2, EMP-9, EMPA, EMP_1, emp-1`. **No lo corregi y no debe corregirse a medias**:
   cada rama es coherente consigo misma (su filtro de cursor usa el mismo comparador que su orden),
   que es exactamente lo que sostiene la paginacion -- alinear solo una la romperia. Alinear las dos
   de verdad exige decidir la collation del keyset (`COLLATE "C"` en Postgres via SQL crudo o
   indice), que es un cambio de contrato con su propio riesgo. Deje la medicion como restriccion
   activa en el codigo y **lo escalo al planner** como candidato a issue propio. Impacto practico
   hoy: nulo mientras los codigos de colaborador sean homogeneos en case y separadores.
5. **[informativo - ajeno a este PR] Dos smoke tests de `ListarAsistenciasDiarias` (#427) fallan
   con HTTP 500 contra dev**, en el baseline y despues de mis cambios:
   `..._CuandoElColaboradorNoTieneNingunDocumentoEnElRango` y
   `..._CuandoElRangoExcedeLaCotaDe31Dias`. No los toque (fuera del diff), pero **no son un 404 de
   "no desplegado": son un 500 de un endpoint que si esta publicado**, asi que parecen un defecto
   real del feature hermano. Lo escalo para issue de investigacion propio.

### Refactorings aplicados

- **Extraccion de `PaginaDeCodigos`** (`src/.../ListarResumenesAsistencia/PaginaDeCodigos.cs`):
  `AcotarTake` + `Recortar` desde el metodo privado del endpoint. Justificacion: hacer testeable
  CA-4 en CI y dar un dueno unico a la cota de pagina que ambas ramas comparten.
- **Corto-circuito del segundo viaje a Postgres** cuando la pagina de codigos esta vacia.
- **Reescritura del comentario de clase de `RangoConsulta`** para que exprese la restriccion vigente
  (copia deliberada, `CotaDias` no se propaga) en vez del estado de fase roja ya superado.
- No aplique la extraccion Rule-of-Three de `RangoConsulta` -- justificacion completa en
  "Desviaciones", desviacion 1.

### Limpieza de comentarios (MEF-ADR-0044)

Aplicada sobre los 10 `.cs` del diff. Behavior-preserving: suite verde antes y despues.

| Archivo | Poda / compresion | Condicion del umbral que no se cumplia |
|---|---|---|
| `FunctionEndpoint.cs` | Parrafo "traducibilidad ... queda NO VERIFICADA ... el smoke test contra dev es quien la confirma" | Context Delta -- ademas **factualmente falso** tras la verificacion de esta revision; reemplazado por el resultado medido |
| `FunctionEndpoint.cs` | "Issue #428: ...", "riesgo tecnico anotado por el planner", "patron heredado de #373", "(ver resumen de este stage, 'Desviaciones')" | Ambas -- provenance de issue y de proceso de pipeline |
| `RangoConsulta.cs` | "Este archivo es el STUB minimo de compilacion de la fase roja: NotImplementedException hasta que projection-implementer decida..." + toda la narracion de reparto de responsabilidades entre agentes | Ambas -- andamiaje de pipeline, **contradecia la implementacion actual** (el metodo ya esta implementado). No es la contradiccion "que puede senalar un bug" del paso 6 del Skill: es texto de proceso que la fase verde dejo sin actualizar |
| `FunctionEndpointTests.cs` | "Fase roja (projection-test-writer): FunctionEndpoint.Run() hoy SOLO lanza NotImplementedException -- ninguno de estos tests puede pasar todavia" | Ambas -- mismo caso: hoy los 7 tests pasan |
| `AgregadorResumenAsistencia.cs` | "Contrato fijado por este test-writer (interfaz publica delegable del issue)"; comentario inline que repetia el contrato ya escrito en el XML doc | Context Delta -- provenance de proceso y duplicacion interna |
| `ComposicionServiciosTests.cs` | "Por eso este test queda en verde tan pronto exista el FunctionEndpoint stub... no es la guarda que fuerza el rojo de este issue" | Ambas -- andamiaje de pipeline |
| `AgregadorResumenAsistenciaTests.cs` | 4 headings `// --- CA-N: ... ---` | Ambas -- heading estructural + provenance; el nombre de cada test ya dice que verifica |
| `ResumenAsistencia.cs`, `FiltroListarResumenesAsistencia.cs`, `ListaResumenesAsistencia.cs`, `RangoConsultaTests.cs`, smoke tests | Comprimidos: podada la provenance (numeros de issue, fechas de sesion, "ratificado en el refinamiento del 2026-08-24") conservando integra la restriccion | Context Delta sobre la parte podada |

**Conservados integros por Decision Delta alto** (un editor competente haria un cambio plausible
pero incorrecto sin ellos): el 415 antes de leer el body; el `null!` deliberado del `IDocumentStore`;
el re-filtrado por rango del agregador; el nullable de `DesdeFecha`/`HastaFecha` como discriminante
400/422; el "arrange via el bus, nunca sembrando el event store"; el rango exclusivo del caso sin
filtro; el "la cota se afirma a mano, nunca leyendo `CotaDias`"; el gotcha de igualdad estructural de
`IReadOnlyDictionary` en records.

**Comentarios que contradicen la implementacion**: los dos casos encontrados (`RangoConsulta.cs`,
`FunctionEndpointTests.cs`) eran andamiaje de fase roja no actualizado, no discrepancias semanticas
que pudieran senalar un bug -- por eso los resolvi en vez de solo reportarlos.

### Cobertura de criterios de aceptacion

| Criterio | Estado | Test(s) |
|---|---|---|
| CA-1: tres ejes cerrando contra los dias del rango + 4 anomalias + totales sparse | cubierto | `Agregar_ProduceUnaFilaConLosTresEjesCerrandoContraLosDiasDelRango_CuandoTodosLosDiasTienenDocumento`, `Agregar_SumaHorasPorConceptoConUnionDeClaves_...`, `Agregar_SumaLosValoresDeUnaMismaClave_...` |
| CA-2: dias sin fila = `SinDatos` + "sin programar", sin aportar anomalias | cubierto | `Agregar_CuentaLosDiasSinFilaComoSinDatosYSinProgramar_SinAportarAnomalias`, `Agregar_ProduceTodosLosDiasSinDatos_CuandoNingunDocumentoExisteParaElCodigoPedido` |
| CA-3: fila por codigo pedido (sintetica incluida); sin filtro, solo con >= 1 fila | cubierto | `Agregar_ProduceUnaFilaSinteticaConTodoSinDatosYCeros_...`, `Agregar_DevuelveUnaFilaPorCadaCodigoPedido_EnElOrdenDeLaListaPedida`, `Agregar_DevuelveSoloColaboradoresConAlMenosUnaFilaEnElRango_...`, `Agregar_OrdenaAscendentePorCodigoColaborador_...`, `Agregar_NoProduceNingunaFila_...` |
| CA-4: keyset ascendente, cursor `>`, `Math.Clamp(_, 1, 200)`, fin de lista | cubierto **(era el gap)** | `PaginaDeCodigosTests` (10 tests, nuevos) + smoke `..._PaginaConKeysetPorCodigoColaborador_CuandoSeEnviaCursor`. La rama de descubrimiento en Marten sigue solo en smoke (exige Postgres), pero quedo **verificada a mano** contra Postgres 16 en esta revision |
| CA-5: recorte hacia adelante + `RangoRecortado`/`HastaAplicado` | cubierto | `RangoConsultaTests` (5 tests) + smoke `..._RecortaRangoHaciaAdelante_...` |
| CA-6: 415 / 400 / 422 / 200 nunca 404 | cubierto | `FunctionEndpointTests` (7 tests) + 5 smoke tests |
| CA-7: `QuerySession` acotada al tenant del resolver | cubierto | `AgregarServiciosControlHoras_ResuelveElEndpointDeListarResumenesAsistencia_...` (composicion) + inspeccion directa del endpoint |

### Tests agregados

- `tests/.../ListarResumenesAsistencia/PaginaDeCodigosTests.cs` -- **10 tests nuevos** para CA-4:
  `AcotarTake` dentro de la cota / por encima de 200 / en 0 y negativos; `Recortar` ordenando y
  cortando en `Take`, filtrando por cursor, excluyendo el propio codigo del cursor (la ultima fila
  recibida no puede repetirse), ultima pagina incompleta, codigos repetidos colapsados, `Take`
  crudo acotado al tope, y lista pedida vacia.
- Tests de contrato de igualdad/serializacion: **no aplican** -- el diff no introduce ningun
  `IEquatable<T>` ni `ConfigurarSerializacion`, ni ningun evento con marker de bus
  (`IPrivateEvent`/`IPublicEvent`). Es un feature de solo lectura.

### Estado de la suite

- `dotnet test` (solucion completa): **1465 correcto / 56 omitido / 11 error**.
- Los 11 errores son **identicos al baseline** de esta fase, y ninguno es un test unitario:
  - 9 de `ListarResumenesAsistenciaSmokeTests` -> HTTP **404**, la Function aun no esta desplegada
    en dev. Esperado y documentado en el propio archivo.
  - 2 de `ListarAsistenciasDiariasSmokeTests` -> HTTP **500**, preexistentes y ajenos a este diff
    (hallazgo 5).
- Proyectos `*.Tests` (los que corre el CI del PR): **todos en verde**;
  `ControlHoras.Tests` 532/532.
- `dotnet format --verify-no-changes`: sin hallazgos en ningun archivo del diff (los IDE0005
  reportados son preexistentes en archivos ajenos).

### Para el planner (escalamientos)

1. **Collation del keyset** (hallazgo 4): decidir si el orden de `CodigoColaborador` debe ser
   ordinal en las dos ramas (exigiria `COLLATE "C"` en Postgres) o si se acepta la asimetria actual.
   Candidato a issue propio; hoy sin impacto practico.
2. **HTTP 500 en dos smoke tests de `ListarAsistenciasDiarias`** (hallazgo 5): defecto aparente de
   #427 ya desplegado, candidato a `/bug`.

</details>

## Cobertura

| Archivo | Cobertura | Umbral | Estado |
|---|---|---|---|
| FiltroListarResumenesAsistencia.cs | - | excluido | - |
| FunctionEndpoint.cs | - | excluido | - |
| ListaResumenesAsistencia.cs | - | excluido | - |
| ResumenAsistencia.cs | - | excluido | - |
| AgregadorResumenAsistencia.cs | - | sin clasificar | ⚠ revisar |
| PaginaDeCodigos.cs | - | sin clasificar | ⚠ revisar |
| RangoConsulta.cs | - | sin clasificar | ⚠ revisar |

> **Archivos sin clasificar** (`⚠ revisar`): ninguna regla de clasificacion los reconocio — el gate **no los midio**. No es una exclusion deliberada (a diferencia de `excluido`, donde si se decidio que no requieren cobertura): requieren revision humana para confirmar si necesitan tests.
## Commits

79d8e31 refactor(#428): cubrir CA-4 en CI, evitar round trip vacio y podar comentarios
cf2db19 Agregar smoke tests de ListarResumenesAsistencia (issue #428)
ac3f513 feat(hu-428): resumen de asistencia por colaborador con agregacion query-time (fase verde)
c034211 test(hu-428): tests read-side para ListarResumenesAsistencia (fase roja)

Closes #428